### PR TITLE
Restore 7083 translations the flat src/* gettext glob had dropped

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -545,6 +545,27 @@ tried without rebuilding.
   the union of a fresh source scan and `locales/manual/wxmaxima.md.pot`
   (`msgcat --use-first`, preferring `wxMaxima.pot`'s own header) by the
   `update-locale` CMake target.
+- **The xgettext source list is an explicit glob, not a recursive one, and a
+  file it misses loses its strings silently.** `POT_SOURCE_FILES`/
+  `POT_SOURCE_FILES_REL` in `locales/wxMaxima/CMakeLists.txt` list
+  `src/*.cpp;src/*.h;src/*/*.cpp;src/*/*.h` -- exactly two levels. It was
+  flat `src/*` until `03b16f2d8`, so every string under `src/cells`,
+  `src/wizards` and `src/graphical_io` was missing from the POT from
+  2020-08-05, and `src/sidebars`/`src/dialogs` from 2024-01. Cost: ~7000
+  translations across 21 languages, restored from git history only in
+  2026-08. **Nothing warns about this**: xgettext is happy with a short file
+  list, and the POT-drift check in CI regenerates the POT and diffs it, so a
+  broken glob truncates both sides identically and the check passes. Adding
+  a `src/<a>/<b>/` nesting level would break it again -- `check-pot-coverage`
+  (a `ctest`, needs neither a build nor gettext) now fails the build if any
+  source file sits deeper than the glob reaches, or if a file containing a
+  `_("...")` marker is unreferenced by the committed POT.
+- **Don't drop `--previous` from `msgmerge`.** It is what keeps the
+  `#| msgid` comment recording what a fuzzy entry used to say, which is how a
+  translator works out *why* something went fuzzy (`00ba34121`). A plain
+  `msgmerge` discards those comments wholesale and gives no hint it did --
+  212 entries' worth in `zh_CN.po` alone, found only by counting them before
+  and after.
 - **`po4a` must never be pointed at `locales/wxMaxima/<lang>.po` directly.**
   It looks like the obvious way to keep the manual's translations inside the
   combined file (`po4a.cfg`'s `$lang:` path *was* set to

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,17 @@
 # Current development version
 
+- About 7000 translations that had quietly disappeared from 21 languages are
+  back. The list of files the translation system reads was written in a way
+  that only found sources sitting directly in `src/`, so everything in a
+  subdirectory below it became invisible: menus, dialogs and above all the
+  wizards had been silently reverting to English since 2020, and the
+  sidebars and dialogs since 2024, without anything ever reporting a
+  problem. German, Russian, Ukrainian, Hungarian, Italian, Spanish and
+  Turkish each regain 500-660 strings; Catalan, Galician and Polish get
+  their first translated dialogs back at all. Every restored string is
+  exactly what a translator had written before it was lost. A new test now
+  fails the build if a source file can ever become invisible to the
+  translation system again.
 - Evaluating a folded section no longer unfolds it just because an error
   happened somewhere inside (GH #1952). Folding a time-consuming or
   no-longer-relevant calculation down to one line, so the worksheet stays

--- a/locales/wxMaxima/ca.po
+++ b/locales/wxMaxima/ca.po
@@ -63,11 +63,11 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1571
 msgid "      -X '--dynamic-space-size <int>'"
-msgstr ""
+msgstr "      -X '--dynamic-space-size <int>'"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1551
 msgid "      -l <name>"
-msgstr ""
+msgstr "      -l <name>"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1557
 msgid "      -u <versionnumber>"
@@ -165,7 +165,7 @@ msgstr ""
 #: ../../src/cells/ImgCell.cpp:212 ../../src/cells/ImgCell.cpp:214
 #: ../../src/cells/ImgCell.cpp:216
 msgid " (Graphics) "
-msgstr ""
+msgstr "(Gràfics)"
 
 #: ../../src/cells/EditorCell.cpp:3551 ../../src/cells/EditorCell.cpp:3820
 #: ../../src/cells/EditorCell.cpp:3945
@@ -213,7 +213,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1208
 msgid "\"Copy LaTeX\" adds equation markers"
-msgstr ""
+msgstr "«Copia LaTeX» afegeix els marcadors d'equacions"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:446
 msgid "\"MathML (rendered by the browser)\" is the recommended choice: every current browser renders MathML natively and instantly, and the exported page needs no JavaScript and makes no requests to any external server.\n"
@@ -227,7 +227,7 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:90
 msgid "\"implies\" symbol"
-msgstr ""
+msgstr "símbol «implica»"
 
 #: ../../src/dialogs/DiffFrame.cpp:306
 #, c-format
@@ -314,7 +314,7 @@ msgstr ""
 
 #: ../../src/wizards/IntegrateWiz.cpp:39
 msgid "&Definite integration"
-msgstr ""
+msgstr "Integració &definida"
 
 #: ../../src/wxMaximaFrame.cpp:1658
 msgid "&Demoivre"
@@ -430,11 +430,11 @@ msgstr ""
 
 #: ../../src/wizards/IntegrateWiz.cpp:52
 msgid "&Numerical integration"
-msgstr ""
+msgstr "Integració &numèrica"
 
 #: ../../src/wizards/SumWiz.cpp:44
 msgid "&Nusum"
-msgstr ""
+msgstr "&Nusum"
 
 #: ../../src/main.cpp:675
 msgid "&Open\tCtrl+O"
@@ -450,7 +450,7 @@ msgstr ""
 
 #: ../../src/wizards/SeriesWiz.cpp:45
 msgid "&Power series"
-msgstr ""
+msgstr "Sèrie de &potències"
 
 #: ../../src/wxMaximaFrame.cpp:655
 msgid "&Print...\tCtrl+P"
@@ -458,7 +458,7 @@ msgstr ""
 
 #: ../../src/wizards/SubstituteWiz.cpp:38
 msgid "&Rational"
-msgstr ""
+msgstr "&Racional"
 
 #: ../../src/wxMaximaFrame.cpp:1631
 msgid "&Reduce Trigonometric"
@@ -490,11 +490,11 @@ msgstr ""
 
 #: ../../src/wizards/Plot2dWiz.cpp:42
 msgid "&Special"
-msgstr ""
+msgstr "Especial"
 
 #: ../../src/wizards/LimitWiz.cpp:45
 msgid "&Taylor series"
-msgstr ""
+msgstr "Sèrie de Taylor"
 
 #: ../../src/wxMaximaFrame.cpp:1069
 msgid "&Time Display"
@@ -514,7 +514,7 @@ msgstr ""
 
 #: ../../src/wizards/Plot3dWiz.cpp:79
 msgid "&pm3d"
-msgstr ""
+msgstr "&pm3D"
 
 #: ../../src/cells/AnimationCell.cpp:475
 msgid "(Animation)"
@@ -550,7 +550,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:183
 msgid "(Use default language)"
-msgstr ""
+msgstr "(Fer servir l'idioma predeterminat)"
 
 #: ../../src/MaximaCommandMenus.cpp:440
 msgid "(f(x),x,a,b)), Epsilon algorithm"
@@ -592,7 +592,7 @@ msgstr ""
 #: ../../src/wizards/IntegrateWiz.cpp:217 ../../src/wizards/LimitWiz.cpp:132
 #: ../../src/wizards/LimitWiz.cpp:142
 msgid "- Infinity"
-msgstr ""
+msgstr "- Infinit"
 
 #: ../../src/MaximaOutputAppender.cpp:116
 msgid "... [suppressed additional lines as the output is longer than allowed in the wxMaxima configuration] "
@@ -608,7 +608,7 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:77
 msgid "1/2"
-msgstr ""
+msgstr "1/2"
 
 #: ../../src/sidebars/DrawSidebar.cpp:45
 msgid "2D"
@@ -649,7 +649,7 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:102
 msgid "A 'horizontal cursor' was introduced in wxMaxima 0.8.0. It looks like a horizontal line between cells. It indicates where a new cell will appear if you type or paste text or execute a menu command."
-msgstr ""
+msgstr "S'ha introduït en wxMaxima 0.8.0 un 'cursor horitzontal'. El seu aspecte és el d'una línia horitzontal entre cel·les, indicant on apareixerà una nova cel·la en escriure o copiar una nova instrucció."
 
 #: ../../src/MaximaCommandMenus.cpp:3039
 msgid "A Ctrl-F event"
@@ -767,7 +767,7 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:239
 msgid "A symbol from the configuration dialogue"
-msgstr ""
+msgstr "Un símbol des del diàleg de configuració"
 
 #: ../../src/cells/GroupCell.cpp:2181
 msgid "A text cell"
@@ -804,7 +804,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1618
 msgid "Abort evaluation on error"
-msgstr ""
+msgstr "Cancel·lar l'avaluació en cas d'error"
 
 #: ../../src/MaximaEvaluator.cpp:214
 #, c-format
@@ -881,7 +881,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1262
 msgid "Add the .wxmx file to the HTML export"
-msgstr ""
+msgstr "Afegir l'arxiu .wxmx a l'exportació a HTML"
 
 #: ../../src/wxMaximaFrame.cpp:1049
 msgid "Add to &Path..."
@@ -908,15 +908,15 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:393
 msgid "Additional commands to be added to the preamble of LaTeX output for pdftex."
-msgstr ""
+msgstr "Ordres addicionals que s'afegiran en el preàmbul en la sortida de LaTeX per a pdftex."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1187
 msgid "Additional lines for the TeX preamble:"
-msgstr ""
+msgstr "Línies addicionals per al preàmbul TeX:"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:389
 msgid "Additional parameters for Maxima (e.g. -l clisp)."
-msgstr ""
+msgstr "Paràmetres addicionals per a Maxima (p. ex. -l clisp)"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1543
 msgid "Additional parameters for Maxima (restart Maxima after changes)"
@@ -924,7 +924,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1318
 msgid "Additional symbols for the \"symbols\" sidebar:"
-msgstr ""
+msgstr "Símbols addicionals per la barra lateral «símbols»:"
 
 #: ../../src/wxMaximaFrame.cpp:1599
 msgid "Additionally: log(a*b)=log(a)+log(b)"
@@ -984,7 +984,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:750
 msgid "All variable names"
-msgstr ""
+msgstr "Tots els nombres de variables"
 
 #: ../../src/wxMaximaFrame.cpp:770
 msgid "All visible sidebars"
@@ -1012,7 +1012,7 @@ msgstr ""
 
 #: ../../src/dialogs/BinaryNameCtrl.cpp:69
 msgid "All|*"
-msgstr ""
+msgstr "Tots|*"
 
 #: ../../src/wxMaximaFrame.cpp:800
 msgid "Always after underscores"
@@ -1189,7 +1189,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1397
 msgid "Ask to save untitled documents"
-msgstr ""
+msgstr "Demanar per a desar documents sense títol"
 
 #: ../../src/dialogs/MaximaNotStartingDialog.cpp:36
 msgid "Asking the user for the location of a working maxima binary"
@@ -1213,7 +1213,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:897
 msgid "Auto-indent new lines"
-msgstr ""
+msgstr "Tabulació automàtica de noves línies"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:893
 msgid "Auto-insert closing parenthesis"
@@ -1291,7 +1291,7 @@ msgstr ""
 
 #: ../../src/wizards/BC2Wiz.cpp:59
 msgid "BC2"
-msgstr ""
+msgstr "BC2"
 
 #: ../../src/MaximaManual.cpp:559
 msgid "Background task that compiles the Manual anchors scheduled."
@@ -1299,7 +1299,7 @@ msgstr ""
 
 #: ../../src/sidebars/StatSidebar.cpp:91
 msgid "Barsplot..."
-msgstr ""
+msgstr "Diagrama de barres..."
 
 #: ../../src/wxMaximaFrame.cpp:1384
 msgid "Basic matrix operations"
@@ -1338,11 +1338,11 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:141
 msgid "Besides the global undo functionality that is active when the cursor is between cells, wxMaxima has a per-cell undo function that is active if the cursor is inside a cell. Pressing Ctrl+Z inside a cell can therefore been used for a fine-pitch undo that doesn't affect latter changes made in other cells."
-msgstr ""
+msgstr "A més a més de la funcionalitat de desfer global que està activada quan el cursor està entre cel·les, wxMaxima té una funció de desfer per cel·les que està activa si el cursor està dins una cel·la. En pressionar les tecles Ctrl+Z quan el cursor està dins una cel·la es pot fer servir un desfase d'ajust fi que no afecta als canvis realitzats en altres cel·les."
 
 #: ../../src/sidebars/GreekSidebar.cpp:179
 msgid "Beta"
-msgstr ""
+msgstr "Beta"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1898
 msgid "Bitmap"
@@ -1350,7 +1350,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1273
 msgid "Bitmap scale for export:"
-msgstr ""
+msgstr "Escala del mapa de bits per a l'exportació:"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1223
 msgid "Bitmaps"
@@ -1358,7 +1358,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2109
 msgid "Bold"
-msgstr ""
+msgstr "Negreta"
 
 #: ../../src/wxMaxima.cpp:2259
 msgid "Both horizontal and vertical cursor active at the same time"
@@ -1382,13 +1382,13 @@ msgstr ""
 
 #: ../../src/sidebars/StatSidebar.cpp:97
 msgid "Boxplot..."
-msgstr ""
+msgstr "Diagrama de caixes..."
 
 #: ../../src/dialogs/BinaryNameCtrl.cpp:42 ../../src/wizards/CsvWiz.cpp:57
 #: ../../src/wizards/CsvWiz.cpp:131 ../../src/wizards/Plot2dWiz.cpp:114
 #: ../../src/wizards/Plot3dWiz.cpp:109
 msgid "Browse"
-msgstr ""
+msgstr "Navegar"
 
 #: ../../src/wxMathml.cpp:101
 msgid "Bug: After removing the whitespace wxMathml.lisp is shorter than expected!"
@@ -1421,15 +1421,15 @@ msgstr ""
 
 #: ../../src/worksheet/Worksheet.cpp:2234
 msgid "Bug: Got a question but no cell to answer it in"
-msgstr ""
+msgstr "Error: hi ha una pregunta però no hi ha cap cel·la per contestar-la"
 
 #: ../../src/worksheet/Worksheet.cpp:4283
 msgid "Bug: Got a request to delete the cell above the beginning of the worksheet."
-msgstr ""
+msgstr "Error: hi ha una petició d'eliminar una cel·la situada abans de l'inici del full de càlcul."
 
 #: ../../src/worksheet/WorksheetDocument.cpp:239
 msgid "Bug: Got a request to first change the contents of a cell and to then undelete it."
-msgstr ""
+msgstr "Error: hi ha una petició de canviar el contingut d'una cel·la per a desprès recuperar-ho."
 
 #: ../../src/worksheet/WorksheetExport.cpp:1576
 msgid "Bug: HTML output is no valid XML"
@@ -1437,7 +1437,7 @@ msgstr ""
 
 #: ../../src/cells/Cell.cpp:289
 msgid "Bug: Math Cell that claims to have no group Cell it belongs to"
-msgstr ""
+msgstr "Error: hi ha una cel·la matemàtica que indica que no pertany a cap grup «Cell»"
 
 #: ../../src/Configuration.h:741
 msgid "Bug: Maximum number of digits that is to be displayed is too low!"
@@ -1480,7 +1480,7 @@ msgstr ""
 
 #: ../../src/cells/GroupCell.cpp:340
 msgid "Bug: Trying to append NULL to a group cell."
-msgstr ""
+msgstr "Error: s'està intentant assignar el valor NULL a una cel·la de grup."
 
 #: ../../src/worksheet/Worksheet.cpp:5939
 msgid "Bug: Trying to move a title out by one sectioning unit"
@@ -1488,7 +1488,7 @@ msgstr ""
 
 #: ../../src/worksheet/Worksheet.cpp:4915
 msgid "Bug: Trying to move the horizontally-drawn cursor to a place inside a GroupCell."
-msgstr ""
+msgstr "Error: intent de moure el cursor de dibuix en horitzontal a un lloc inclòs a un «GroupCell»."
 
 #: ../../src/TreeUndoAction.h:52 ../../src/TreeUndoAction.h:57
 msgid "Bug: Trying to record a cell contents change for undo without a cell."
@@ -1500,7 +1500,7 @@ msgstr ""
 
 #: ../../src/worksheet/WorksheetDocument.cpp:241
 msgid "Bug: Undo action with both cell contents change and cell addition."
-msgstr ""
+msgstr "Error: desfer acció amb canvi del contingut de la cel·la i addició de la cel·la."
 
 #: ../../src/cells/EditorCell.cpp:4541
 msgid "Bug: Unknown type of text"
@@ -1529,7 +1529,7 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:54
 msgid "By default, Shift-Enter is used to evaluate commands, while Enter is used for multiline input. This behaviour can be changed in 'Edit->Configure' dialog by checking 'Enter evaluates cells'. This switches the roles of these two key commands."
-msgstr ""
+msgstr "Per defecte, Shift+Enter es fa servir per avaluar instruccions, i Retorn per introduir línies múltiples. És possible canviar aquest comportament en «Editar->Configuració» seleccionant «Tecla retorn avalua cel·les». D'aquesta manera es canvia la funcionalitat de les tecles."
 
 #: ../../src/MaximaCommandMenus.cpp:4087
 msgid "Byte:"
@@ -1767,11 +1767,11 @@ msgstr ""
 
 #: ../../src/sidebars/MathSidebar.cpp:62
 msgid "Canonical (tr)"
-msgstr ""
+msgstr "Canònic (tr)"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:188
 msgid "Catalan"
-msgstr ""
+msgstr "Català"
 
 #: ../../src/MaximaCommandMenus.cpp:466
 msgid "Cauchy principal value of f(x)/(x-c), finite interval"
@@ -1917,7 +1917,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:199
 msgid "Chi"
-msgstr ""
+msgstr "Chi"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:189
 msgid "Chinese (Simplified)"
@@ -1941,7 +1941,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2100
 msgid "Choose font"
-msgstr ""
+msgstr "Seleccionar font"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:793
 msgid "Choose how mathematical output is formatted:\n"
@@ -1952,7 +1952,7 @@ msgstr ""
 
 #: ../../src/wizards/PlotFormatWiz.cpp:31
 msgid "Choose new plot format:"
-msgstr ""
+msgstr "Seleccionau un nuo format de gràfics:"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2432
 #, c-format
@@ -2126,7 +2126,7 @@ msgstr ""
 
 #: ../../src/wizards/MatWiz.cpp:155
 msgid "Columns:"
-msgstr ""
+msgstr "Columnes:"
 
 #: ../../src/wxMaximaFrame.cpp:1621
 msgid "Combine factorials in an expression"
@@ -2142,11 +2142,11 @@ msgstr ""
 
 #: ../../src/wizards/Plot2dWiz.cpp:626
 msgid "Comma separated x coordinates"
-msgstr ""
+msgstr "Coordenades x separades per comes."
 
 #: ../../src/wizards/Plot2dWiz.cpp:627
 msgid "Comma separated y coordinates"
-msgstr ""
+msgstr "Coordenades y separades per comes."
 
 #: ../../src/MaximaCommandMenus.cpp:4071
 msgid "Comma-separated arguments"
@@ -2240,7 +2240,7 @@ msgstr ""
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:465
 msgid "Comment Selection"
-msgstr ""
+msgstr "Comentar selecció"
 
 #: ../../src/wxMaximaFrame.cpp:718
 msgid "Comment out the currently selected text"
@@ -2372,7 +2372,7 @@ msgstr ""
 #: ../../src/dialogs/ConfigDialogue.cpp:2641
 #: ../../src/dialogs/ConfigDialogue.cpp:2647
 msgid "Config file (*.ini)|*.ini"
-msgstr ""
+msgstr "Arxius de configuració (*.ini)|*.ini"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2539
 #, c-format
@@ -2404,7 +2404,7 @@ msgstr ""
 #: ../../src/wizards/IntegrateWiz.cpp:208 ../../src/wizards/LimitWiz.cpp:133
 #: ../../src/wizards/SeriesWiz.cpp:105
 msgid "Constant"
-msgstr ""
+msgstr "Constant"
 
 #: ../../src/MaximaCommandMenus.cpp:1102
 msgid "Construct a fraction"
@@ -2650,7 +2650,7 @@ msgstr ""
 #: ../../src/worksheet/WorksheetContextMenu.cpp:133
 #: ../../src/worksheet/WorksheetContextMenu.cpp:279
 msgid "Copy as MathML (e.g. to word processor)"
-msgstr ""
+msgstr "Copiar com a MathML (per exemple al processador de textos)"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:148
 #: ../../src/worksheet/WorksheetContextMenu.cpp:295
@@ -2671,7 +2671,7 @@ msgstr ""
 #: ../../src/worksheet/WorksheetContextMenu.cpp:128
 #: ../../src/worksheet/WorksheetContextMenu.cpp:275
 msgid "Copy as plain text"
-msgstr ""
+msgstr "Copiar com text sense format"
 
 #: ../../src/MaximaCommandMenus.cpp:4388
 msgid "Copy file"
@@ -2878,7 +2878,7 @@ msgstr ""
 
 #: ../../src/worksheet/Worksheet.cpp:6115
 msgid "Cursor"
-msgstr ""
+msgstr "Cursor"
 
 #: ../../src/Styles.cpp:126
 msgid "Cursor color"
@@ -2900,11 +2900,11 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:193
 msgid "Czech"
-msgstr ""
+msgstr "Txec"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:194
 msgid "Danish"
-msgstr ""
+msgstr "Danès"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2069
 msgid "Dark"
@@ -2982,7 +2982,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1534
 msgid "Default port for communication with wxMaxima:"
-msgstr ""
+msgstr "Port predeterminat per a comunicació amb wxMaxima"
 
 #: ../../src/MaximaCommandMenus.cpp:3946
 msgid "Define a function"
@@ -3022,7 +3022,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:404
 msgid "Define the default speed (in frames per second) animations are played back with."
-msgstr ""
+msgstr "Defineix la velocitat predeterminada (en fotogrames per segon) de reproducció de les animacions."
 
 #: ../../src/wxMaximaFrame.cpp:1114
 msgid "Define variable..."
@@ -3043,7 +3043,7 @@ msgstr ""
 #: ../../src/worksheet/WorksheetContextMenu.cpp:157
 #: ../../src/worksheet/WorksheetContextMenu.cpp:298
 msgid "Delete Selection"
-msgstr ""
+msgstr "Suprimeix selecció"
 
 #: ../../src/wxMaximaFrame.cpp:1021
 msgid "Delete V&ariable..."
@@ -3095,7 +3095,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:181
 msgid "Delta"
-msgstr ""
+msgstr "Delta"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:110
 #: ../../src/worksheet/WorksheetContextMenu.cpp:558
@@ -3121,7 +3121,7 @@ msgstr ""
 
 #: ../../src/wizards/SeriesWiz.cpp:42
 msgid "Depth:"
-msgstr ""
+msgstr "Fondària:"
 
 #: ../../src/MaximaCommandMenus.cpp:994
 msgid "Derivate of y at that point:"
@@ -3156,7 +3156,7 @@ msgstr ""
 
 #: ../../src/sidebars/StatSidebar.cpp:61
 msgid "Deviation..."
-msgstr ""
+msgstr "Desviació..."
 
 #: ../../src/wxMaximaFrame.cpp:1534
 msgid "Di&vide Polynomials..."
@@ -3188,7 +3188,7 @@ msgstr ""
 
 #: ../../src/sidebars/MathSidebar.cpp:80
 msgid "Diff..."
-msgstr ""
+msgstr "Derivar"
 
 #: ../../src/dialogs/DiffFrame.cpp:308
 #, c-format
@@ -3205,7 +3205,7 @@ msgstr ""
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:363
 msgid "Differentiate..."
-msgstr ""
+msgstr "Derivar"
 
 #: ../../src/MaximaCommandMenus.cpp:264
 msgid "Differentiates an expression n times"
@@ -3217,7 +3217,7 @@ msgstr ""
 
 #: ../../src/wizards/LimitWiz.cpp:41
 msgid "Direction:"
-msgstr ""
+msgstr "Direcció:"
 
 #: ../../src/wxMaximaFrame.cpp:1246
 msgid "Directory operations"
@@ -3229,7 +3229,7 @@ msgstr ""
 
 #: ../../src/wizards/Plot2dWiz.cpp:418 ../../src/wizards/Plot2dWiz.cpp:619
 msgid "Discrete plot"
-msgstr ""
+msgstr "Gràfic discret"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:699
 msgid "Display"
@@ -3356,7 +3356,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1170
 msgid "Documentclass for TeX export:"
-msgstr ""
+msgstr "Ordre «documentclass» per l'exportació TeX:"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1178
 msgid "Documentclass options:"
@@ -3538,7 +3538,7 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:129
 msgid "End of proof"
-msgstr ""
+msgstr "Final de la demostració"
 
 #: ../../src/MaximaCommandMenus.cpp:1024
 msgid "End of t:"
@@ -3571,7 +3571,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:196
 msgid "English"
-msgstr ""
+msgstr "Anglès"
 
 #: ../../src/wizards/DrawWiz.cpp:552
 msgid "Enhanced 3D settings:"
@@ -3583,7 +3583,7 @@ msgstr ""
 
 #: ../../src/sidebars/StatSidebar.cpp:106
 msgid "Enter Matrix..."
-msgstr ""
+msgstr "Introduir matriu"
 
 #: ../../src/MaximaCommandMenus.cpp:2255
 msgid "Enter UUID to jump to:"
@@ -3603,7 +3603,7 @@ msgstr ""
 
 #: ../../src/wizards/SystemWiz.cpp:50
 msgid "Enter comma separated list of variables."
-msgstr ""
+msgstr "Introduir una llista de variables separades per comes."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:921
 msgid "Enter evaluates cells, Ctrl+Enter adds newlines"
@@ -3623,7 +3623,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:388
 msgid "Enter the path to the Maxima executable."
-msgstr ""
+msgstr "Introduir la ruta a l'executable Maxima."
 
 #: ../../src/MaximaCommandMenus.cpp:1103
 msgid "Enumerator:"
@@ -3639,7 +3639,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:182
 msgid "Epsilon"
-msgstr ""
+msgstr "Epsilon"
 
 #: ../../src/MaximaCommandMenus.cpp:299
 msgid "Epsilon:"
@@ -3732,7 +3732,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:184
 msgid "Eta"
-msgstr ""
+msgstr "Eta"
 
 #: ../../src/sidebars/TableOfContents.cpp:513
 msgid "Evaluate"
@@ -3793,24 +3793,24 @@ msgstr ""
 #: ../../src/worksheet/WorksheetContextMenu.cpp:196
 #: ../../src/worksheet/WorksheetContextMenu.cpp:509
 msgid "Evaluate Part\tShift+Ctrl+Enter"
-msgstr ""
+msgstr "Avaluar «Part»\tShift+Ctrl+Enter"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:202
 #: ../../src/worksheet/WorksheetContextMenu.cpp:514
 msgid "Evaluate Section\tShift+Ctrl+Enter"
-msgstr ""
+msgstr "Avaluar secció\tShift+Ctrl+Enter"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:216
 #: ../../src/worksheet/WorksheetContextMenu.cpp:524
 #: ../../src/worksheet/WorksheetContextMenu.cpp:651
 msgid "Evaluate Sub-Subsection\tShift+Ctrl+Enter"
-msgstr ""
+msgstr "Avaluar sub-subsecció\tShift+Ctrl+Enter"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:209
 #: ../../src/worksheet/WorksheetContextMenu.cpp:519
 #: ../../src/worksheet/WorksheetContextMenu.cpp:640
 msgid "Evaluate Subsection\tShift+Ctrl+Enter"
-msgstr ""
+msgstr "Avaluar sub-secció\tShift+Ctrl+Enter"
 
 #: ../../src/wxMaximaFrame.cpp:879
 msgid "Evaluate active or selected cell(s)"
@@ -3870,7 +3870,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2659
 msgid "Example text"
-msgstr ""
+msgstr "Text d'exemple"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1547
 msgid "Examples:"
@@ -3886,15 +3886,15 @@ msgstr ""
 
 #: ../../src/sidebars/MathSidebar.cpp:53
 msgid "Expand"
-msgstr ""
+msgstr "Expandir"
 
 #: ../../src/sidebars/MathSidebar.cpp:68
 msgid "Expand (tr)"
-msgstr ""
+msgstr "Expandir (tr)"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:356
 msgid "Expand Expression"
-msgstr ""
+msgstr "Expandir expressió"
 
 #: ../../src/wxMaximaFrame.cpp:1562
 msgid "Expand an expression"
@@ -4216,7 +4216,7 @@ msgstr ""
 
 #: ../../src/sidebars/MathSidebar.cpp:50
 msgid "Factor"
-msgstr ""
+msgstr "Factoritzar"
 
 #: ../../src/wxMaximaFrame.cpp:1558
 msgid "Factor Complex"
@@ -4224,7 +4224,7 @@ msgstr ""
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:354
 msgid "Factor Expression"
-msgstr ""
+msgstr "Factoritzar expresió"
 
 #: ../../src/wxMaximaFrame.cpp:1556
 msgid "Factor Expression including subexpressions"
@@ -4291,7 +4291,7 @@ msgstr ""
 #: ../../src/cells/GroupCell.cpp:2115
 #, c-format
 msgid "Figure %d:"
-msgstr ""
+msgstr "Figura %d:"
 
 #: ../../src/main.cpp:678
 msgid "File"
@@ -4363,7 +4363,7 @@ msgstr ""
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:349
 msgid "Find Root..."
-msgstr ""
+msgstr "Calcula arrel..."
 
 #: ../../src/wxMaximaFrame.cpp:1508
 msgid "Find a (unconstrained) minimum of an expression"
@@ -4472,7 +4472,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:197
 msgid "Finnish"
-msgstr ""
+msgstr "Finlandès"
 
 #: ../../src/wxMaximaFrame.cpp:1749
 msgid "First"
@@ -4485,11 +4485,11 @@ msgstr ""
 #: ../../src/dialogs/ConfigDialogue.cpp:1404
 #, c-format
 msgid "Fix reordered reference indices (of %i, %o) before saving"
-msgstr ""
+msgstr "Fitxar els índexs de referència reorganitzats (de %i, %o) abans de desar"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:873
 msgid "Fixed font in text controls"
-msgstr ""
+msgstr "Font proporcional en controls de text"
 
 #: ../../src/MaximaCommandMenus.cpp:4039
 msgid "Flush stream"
@@ -4533,7 +4533,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2047
 msgid "Fonts"
-msgstr ""
+msgstr "Fonts"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:442
 msgid "For each Text-, Sectioning or code cell wxMaxima can display a bracket showing the extend of the cell and allowing to fold it. This setting now tells if this bracket is to be printed, as well."
@@ -4561,7 +4561,7 @@ msgstr ""
 
 #: ../../src/wizards/Plot2dWiz.cpp:69 ../../src/wizards/Plot3dWiz.cpp:60
 msgid "Format:"
-msgstr ""
+msgstr "Format:"
 
 #: ../../src/worksheet/Worksheet.cpp:301 ../../src/wxMaxima.cpp:3521
 msgid "Forwarding the keyboard focus to a text control"
@@ -4626,7 +4626,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:198
 msgid "French"
-msgstr ""
+msgstr "Francès"
 
 #: ../../src/wxMaximaFrame.cpp:1447
 msgid "Frobenius Norm sqrt(sum((A(i,j))^2)) (complex)"
@@ -4709,11 +4709,11 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:199
 msgid "Galician"
-msgstr ""
+msgstr "Galleg"
 
 #: ../../src/sidebars/GreekSidebar.cpp:180
 msgid "Gamma"
-msgstr ""
+msgstr "Gamma"
 
 #: ../../src/wxMaximaFrame.cpp:316
 msgid "General Math"
@@ -4765,7 +4765,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:201
 msgid "German"
-msgstr ""
+msgstr "Alemany"
 
 #: ../../src/wxMaximaFrame.cpp:1656
 msgid "Get &Imaginary Part"
@@ -4837,7 +4837,7 @@ msgstr ""
 
 #: ../../src/worksheet/Worksheet.cpp:4296
 msgid "Got a request to undo an action that involves a delete which isn't possible at this moment."
-msgstr ""
+msgstr "Hi ha una petició de desfer una acció que implica una eliminació que no és possible realitzar en aquest moment."
 
 #: ../../src/wxMaximaFrame.cpp:1065
 msgid "Gradefs"
@@ -4853,7 +4853,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:202
 msgid "Greek"
-msgstr ""
+msgstr "Grec"
 
 #: ../../src/wxMaximaFrame.cpp:281
 msgid "Greek Letters"
@@ -4869,7 +4869,7 @@ msgstr ""
 
 #: ../../src/wizards/Plot3dWiz.cpp:52
 msgid "Grid:"
-msgstr ""
+msgstr "Quadrícula:"
 
 #: ../../src/wxMaximaFrame.cpp:1852
 msgid "Guess an exact number that could be meant by this float"
@@ -5046,7 +5046,7 @@ msgstr ""
 
 #: ../../src/sidebars/StatSidebar.cpp:85
 msgid "Histogram..."
-msgstr ""
+msgstr "Histograma..."
 
 #: ../../src/wxMaximaFrame.cpp:246
 msgid "History"
@@ -5058,7 +5058,7 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:105
 msgid "Horizontal cursor works like a normal cursor, but it operates on cells: press up or down arrow to move it, holding down Shift while moving will select cells, pressing backspace or delete twice will delete a cell next to it."
-msgstr ""
+msgstr "El cursor horitzontal funciona com un cursor normal, però opera amb cel·les: polsau la fletxa amunt o abaix per moure'l; si manteniu polsada la tecla 'Majúscula' durant el movimient es seleccionaran les cel·les, prement 'Retroces' o 'Espai' dues vegades es suprimirà la cel·la contigua."
 
 #: ../../src/wxMaximaFrame.cpp:1563
 msgid "Horner's rule"
@@ -5078,7 +5078,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:205
 msgid "Hungarian"
-msgstr ""
+msgstr "Hongarès"
 
 #: ../../src/wxMaximaFrame.cpp:1147
 msgid "I/O"
@@ -5086,7 +5086,7 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:121
 msgid "Identical to"
-msgstr ""
+msgstr "Idèntic a"
 
 #: ../../src/MaximaCommandMenus.cpp:3874
 msgid "If a program doesn't need local variables, Maxima allows putting the commands between parentheses. The result of the last operation is the return value of the program."
@@ -5118,19 +5118,19 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:375
 msgid "If multiple cells are evaluated in one go: Abort evaluation if wxMaxima detects that maxima has encountered any error."
-msgstr ""
+msgstr "Si vàries cel·les son avaluades simultàniament, aturar l'avaluació si wxMàxima detecta que Màxima ha trobat un error."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:727
 msgid "If not extremely long"
-msgstr ""
+msgstr "Si no és exageradament llarg"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:726
 msgid "If not very long"
-msgstr ""
+msgstr "Si no és massa llarg"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:418
 msgid "If numbers are getting longer than this number of digits they will be displayed abbreviated by an ellipsis."
-msgstr ""
+msgstr "Si els nombres superen aquest nombre de dígits es mostraran abreviats amb una el·lipse."
 
 #: ../../src/dialogs/TipOfTheDay.cpp:181
 msgid "If the \"Autosave\" functionality is enabled in the configuration dialogue wxMaxima acts like mobile apps that backup the file every few minutes and save it on closing."
@@ -5173,7 +5173,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:439
 msgid "If this option is set the .wxmx source of the current file is copied to a place a link to is put into the result of an export."
-msgstr ""
+msgstr "Si aquesta opció està seleccionada, la font .wxmx de l'arxiu actual serà copiat en un lloc al qual s'agregarà un enllaç cap el resultat de una exportació."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1873
 msgid "If unset, Maxima's output is announced to the screen reader as maths in a linear text form. Set this option if your screen reader can speak MathML properly."
@@ -5185,11 +5185,11 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:76
 msgid "If you type an operator (one of +*/^=,) as the first symbol in an input cell, % will be automatically inserted before the operator, as on a graphing calculator. You can disable this feature from the 'Edit->Configure' dialog."
-msgstr ""
+msgstr "Si escriu un operador (algun d'aquests +*/^=,) com a primer símbol en una cel·la d'entrada, el símbol % serà inserit abans de l'operador, com en una calculadora gràfica. Podeu desactivar aquesta funcionalitat en el formulari de 'Edició->Configuració'."
 
 #: ../../src/dialogs/TipOfTheDay.cpp:122
 msgid "If your calculation is taking too long to evaluate, you can try 'Maxima->Interrupt' or 'Maxima->Restart Maxima' menu commands."
-msgstr ""
+msgstr "Si es torba molt a realitzar-se un càlcul, és possible aturar-ho seleccionant 'Maxima->atura' o 'Maxima->Reinicia Maxima' en el menú."
 
 #: ../../src/MaximaManual.cpp:420
 msgid "Ignoring the cache version for the manual anchors."
@@ -5197,7 +5197,7 @@ msgstr ""
 
 #: ../../src/sidebars/FormatSidebar.cpp:66
 msgid "Image"
-msgstr ""
+msgstr "Imatge"
 
 #: ../../src/Image.cpp:110
 msgid "Image data had zero length!"
@@ -5265,7 +5265,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:421
 msgid "In the LaTeX output: Put exponents after an eventual subscript instead of above it. Might increase readability for some fonts and short subscripts."
-msgstr ""
+msgstr "A la sortida LaTeX: posar els exponents després de un subíndex enlloc de per sobre d'ell. Això poc millorar la llegibilitat d'algunes fonts o subíndex curts."
 
 #: ../../src/MaximaCommandMenus.cpp:1869
 msgid "Include columns:"
@@ -5326,7 +5326,7 @@ msgstr ""
 #: ../../src/wizards/IntegrateWiz.cpp:215 ../../src/wizards/LimitWiz.cpp:132
 #: ../../src/wizards/LimitWiz.cpp:140
 msgid "Infinity"
-msgstr ""
+msgstr "Infinit"
 
 #: ../../src/wxMaximaFrame.cpp:1986
 msgid "Info about Maxima build"
@@ -5384,7 +5384,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:889
 msgid "Insert % before an operator at the beginning of a cell"
-msgstr ""
+msgstr "Inserir % abans d'un operador a l'inici d'una cel·la"
 
 #: ../../src/wxMaximaFrame.cpp:939
 msgid "Insert &Section Cell\tCtrl+3"
@@ -5432,15 +5432,15 @@ msgstr ""
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:435
 msgid "Insert Section Cell"
-msgstr ""
+msgstr "Insereix cel·la de secció"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:437
 msgid "Insert Subsection Cell"
-msgstr ""
+msgstr "Insereix cel·la de subsecció"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:440
 msgid "Insert Subsubsection Cell"
-msgstr ""
+msgstr "Insereix cel·la de sub-subsecció"
 
 #: ../../src/wxMaximaFrame.cpp:937
 msgid "Insert T&itle Cell\tCtrl+2"
@@ -5448,11 +5448,11 @@ msgstr ""
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:431
 msgid "Insert Text Cell"
-msgstr ""
+msgstr "Insereix cel·la de text"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:433
 msgid "Insert Title Cell"
-msgstr ""
+msgstr "Insereix cel·la de títol"
 
 #: ../../src/wxMaximaFrame.cpp:947
 msgid "Insert a new heading5 cell"
@@ -5536,7 +5536,7 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:113
 msgid "Integral sign"
-msgstr ""
+msgstr "Símbol d'integral"
 
 #: ../../src/MaximaCommandMenus.cpp:149 ../../src/MaximaCommandMenus.cpp:170
 msgid "Integral/Sum:"
@@ -5566,7 +5566,7 @@ msgstr ""
 #: ../../src/sidebars/MathSidebar.cpp:83
 #: ../../src/worksheet/WorksheetContextMenu.cpp:361
 msgid "Integrate..."
-msgstr ""
+msgstr "Integra..."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:834
 msgid "Intelligently hide cell brackets"
@@ -5660,7 +5660,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:186
 msgid "Iota"
-msgstr ""
+msgstr "Iota"
 
 #: ../../src/MaximaCommandMenus.cpp:4150
 msgid "Is Char 1 greater than Char2, if case is ignored?"
@@ -5804,11 +5804,11 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:207
 msgid "Italian"
-msgstr ""
+msgstr "Italià"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2111
 msgid "Italic"
-msgstr ""
+msgstr "Itàlica"
 
 #: ../../src/MaximaCommandMenus.cpp:1617 ../../src/MaximaCommandMenus.cpp:1623
 msgid "Item"
@@ -5820,7 +5820,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:208
 msgid "Japanese"
-msgstr ""
+msgstr "Japonés"
 
 #: ../../src/MaximaCommandMenus.cpp:2255
 msgid "Jump to UUID"
@@ -5848,16 +5848,16 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:210
 msgid "Kabyle"
-msgstr ""
+msgstr "Kabyle"
 
 #: ../../src/sidebars/GreekSidebar.cpp:187
 msgid "Kappa"
-msgstr ""
+msgstr "Kappa"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:864
 #, c-format
 msgid "Keep percent sign with special symbols: %e, %i, etc."
-msgstr ""
+msgstr "Mantenir el signe de percentatge per a símbols especials: %e, %i, etc."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:212
 msgid "Korean"
@@ -5889,15 +5889,15 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1199
 msgid "LaTeX: Place exponents after, instead above subscripts"
-msgstr ""
+msgstr "LaTeX: situar els exponents després enlloc de dalt dels subíndexs"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1204
 msgid "LaTeX: Use the \"partial derivative\" symbol to represent diff()"
-msgstr ""
+msgstr "LaTeX: fer servir el símbol de «derivada parcial» per representar diff()"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:758
 msgid "Label width:"
-msgstr ""
+msgstr "Amplada de l'etiqueta:"
 
 #: ../../src/wxMaximaFrame.cpp:1059
 msgid "Labels"
@@ -5916,11 +5916,11 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:470
 msgid "Language used for wxMaxima GUI."
-msgstr ""
+msgstr "Idioma de la interfície d'usuari de wxMaxima."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1311
 msgid "Language:"
-msgstr ""
+msgstr "Idioma:"
 
 #: ../../src/MaximaCommandMenus.cpp:251
 msgid "Laplace"
@@ -5967,7 +5967,7 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:126
 msgid "Leads to"
-msgstr ""
+msgstr "tendeix a"
 
 #: ../../src/wxMaximaFrame.cpp:1530
 msgid "Least Common Multiple..."
@@ -5979,7 +5979,7 @@ msgstr ""
 
 #: ../../src/sidebars/StatSidebar.cpp:79
 msgid "Least Squares Fit..."
-msgstr ""
+msgstr "﻿Ajust per mínims quadrats..."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2007
 msgid "Left"
@@ -6037,7 +6037,7 @@ msgstr ""
 
 #: ../../src/sidebars/MathSidebar.cpp:86
 msgid "Limit..."
-msgstr ""
+msgstr "Límit..."
 
 #: ../../src/sidebars/DrawSidebar.cpp:88
 msgid "Line color"
@@ -6045,7 +6045,7 @@ msgstr ""
 
 #: ../../src/sidebars/StatSidebar.cpp:76
 msgid "Linear Regression..."
-msgstr ""
+msgstr "Regressió lineal..."
 
 #: ../../src/MaximaCommandMenus.cpp:4068
 msgid "Lisp format string:"
@@ -6178,7 +6178,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2162
 msgid "Load"
-msgstr ""
+msgstr "Carrega"
 
 #: ../../src/MaximaCommandMenus.cpp:2356
 msgid "Load Package"
@@ -6218,7 +6218,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2645
 msgid "Load style from file"
-msgstr ""
+msgstr "Llegir estil des d'un arxiu"
 
 #: ../../src/wxMaximaFrame.cpp:1232
 msgid "Load the file/dir operations (operatingsystem)"
@@ -6234,7 +6234,7 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:128
 msgid "Long Right arrow"
-msgstr ""
+msgstr "Fletxa dreta llarga"
 
 #: ../../src/MaximaCommandMenus.cpp:1409
 msgid "Loop variable"
@@ -6551,7 +6551,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1437
 msgid "Maxima program:"
-msgstr ""
+msgstr "Programa Maxima:"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:382
 msgid "Maxima provides no \"forget all\" command that flushes all settings a maxima session could make. wxMaxima therefore normally defaults to starting a fresh maxima process every time the worksheet is to be re-evaluated. As this needs a little bit of time this switch allows to disable this behavior."
@@ -6611,7 +6611,7 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:68
 msgid "Maxima supports three types of numbers: exact fractions (which can be generated for example by typing 1/10), IEEE floating-point numbers (0.2) and arbitrary precision big floats (1b-1). Note that, owing to their nature as binary (not decimal) numbers, there is for example no way to generate an IEEE floating-point number that exactly equals 0.1. If floating-point numbers are used instead of fractions, Maxima will therefore sometimes have to introduce a (very small) error and use things like 3602879701896397/36028797018963968 for 0.1."
-msgstr ""
+msgstr "Maxima gestiona tres tipus de nombres: fraccions exactes (per exemple les generades escrivint 1/10), nombres de coma flotant IEEE (0.2) i nombres decimals de precisió arbitrària (1b-1). Atès que es manegen en forma binaria, no com a nombres decimals, no hi ha manera de generar un nombre de coma flotant IEEE que sigui exactament 0,1. Si es fan servir nombres de coma flotant enlloc de fraccions, de vegades Maxima produirà petits errors com fer servir 3602879701896397/36028797018963968 per a 0,1."
 
 #: ../../src/wxMaximaFrame.cpp:1265
 msgid "Maxima to other language"
@@ -6786,15 +6786,15 @@ msgstr ""
 
 #: ../../src/sidebars/StatSidebar.cpp:70
 msgid "Mean Difference Test..."
-msgstr ""
+msgstr "Test diferència de mitjanes"
 
 #: ../../src/sidebars/StatSidebar.cpp:67
 msgid "Mean Test..."
-msgstr ""
+msgstr "Test mitjanes..."
 
 #: ../../src/sidebars/StatSidebar.cpp:52
 msgid "Mean..."
-msgstr ""
+msgstr "Aplicar..."
 
 #: ../../src/MaximaCommandMenus.cpp:1806
 msgid "Mean:"
@@ -6802,7 +6802,7 @@ msgstr ""
 
 #: ../../src/sidebars/StatSidebar.cpp:55
 msgid "Median..."
-msgstr ""
+msgstr "Mediana..."
 
 #: ../../src/wxMaximaFrame.cpp:1961
 msgid "Memoizing"
@@ -6823,7 +6823,7 @@ msgstr ""
 
 #: ../../src/wizards/IntegrateWiz.cpp:55
 msgid "Method:"
-msgstr ""
+msgstr "Mètode:"
 
 #: ../../src/wxMaximaFrame.cpp:1360
 msgid "Methods of generating a matrix"
@@ -6890,7 +6890,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:189
 msgid "Mu"
-msgstr ""
+msgstr "Mu"
 
 #: ../../src/wxMaximaFrame.cpp:1386
 msgid "Multiplication, exponent and similar"
@@ -6922,7 +6922,7 @@ msgstr ""
 
 #: ../../src/wizards/MatWiz.cpp:163
 msgid "Name:"
-msgstr ""
+msgstr "Nom:"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:216
 msgid "Nepali"
@@ -6985,7 +6985,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:901
 msgid "New lines: Jump to text"
-msgstr ""
+msgstr "Noves línies: anar al text"
 
 #: ../../src/MaximaResponseReader.cpp:1015
 #, c-format
@@ -6998,7 +6998,7 @@ msgstr ""
 
 #: ../../src/wizards/SubstituteWiz.cpp:35
 msgid "New value:"
-msgstr ""
+msgstr "Nuo valor:"
 
 #: ../../src/MaximaCommandMenus.cpp:151 ../../src/MaximaCommandMenus.cpp:171
 #: ../../src/MaximaCommandMenus.cpp:254 ../../src/MaximaCommandMenus.cpp:259
@@ -7101,7 +7101,7 @@ msgstr ""
 
 #: ../../src/sidebars/StatSidebar.cpp:73
 msgid "Normality Test..."
-msgstr ""
+msgstr "Test de normalitat..."
 
 #: ../../src/cells/TextCell.cpp:271
 msgid "Normally computers use floating-point numbers that can be handled incredibly fast while being accurate to dozens of digits. They will, though, introduce a small error into some common numbers. For example 0.1 is represented as 3602879701896397/36028797018963968.\n"
@@ -7112,11 +7112,11 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:431
 msgid "Normally html expects images to be rather low-res but space saving. These images tend to look rather blurry when viewed on modern screens. Therefore this setting was introduces that selects the factor by which the HTML export increases the resolution in respect to the default value."
-msgstr ""
+msgstr "Normalment, html espera que les imatges tenguin una resolució baixa per estalviar espai. És freqüent que aquestes imatges es vegin borroses en les pantalles modernes. Per això, s'ha introduït aquesta opció de configuració per permetre seleccionar el factor d'augment (respecte al valor predeterminat) de la resolució en fer l'exportació a HTML."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:217
 msgid "Norwegian"
-msgstr ""
+msgstr "Noruec"
 
 #: ../../src/MaximaCommandMenus.cpp:1351
 msgid "Not a valid matrix dimension!"
@@ -7152,7 +7152,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:190
 msgid "Nu"
-msgstr ""
+msgstr "Nu"
 
 #: ../../src/MaximaCommandMenus.cpp:177
 msgid "Num. deg:"
@@ -7303,7 +7303,7 @@ msgstr ""
 
 #: ../../src/wizards/SubstituteWiz.cpp:32
 msgid "Old value:"
-msgstr ""
+msgstr "Valor anterior:"
 
 #: ../../src/MaximaCommandMenus.cpp:151 ../../src/MaximaCommandMenus.cpp:172
 #: ../../src/MaximaCommandMenus.cpp:253 ../../src/MaximaCommandMenus.cpp:259
@@ -7312,11 +7312,11 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:201
 msgid "Omega"
-msgstr ""
+msgstr "Omega"
 
 #: ../../src/sidebars/GreekSidebar.cpp:192
 msgid "Omicron"
-msgstr ""
+msgstr "Omicron"
 
 #: ../../src/wxMaximaFrame.cpp:1089
 msgid "On all errors"
@@ -7349,7 +7349,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:905
 msgid "Open a cell when Maxima expects input"
-msgstr ""
+msgstr "Obrir una cel·la quan Maxima espera una entrada"
 
 #: ../../src/wxMaximaFrame.cpp:629
 msgid "Open a document"
@@ -7432,7 +7432,7 @@ msgstr ""
 
 #: ../../src/wizards/Plot2dWiz.cpp:75 ../../src/wizards/Plot3dWiz.cpp:66
 msgid "Options:"
-msgstr ""
+msgstr "Opcions:"
 
 #: ../../src/dialogs/FindReplacePane.cpp:109
 msgid "Output"
@@ -7505,7 +7505,7 @@ msgstr ""
 
 #: ../../src/sidebars/FormatSidebar.cpp:69
 msgid "Pagebreak"
-msgstr ""
+msgstr "﻿Salt de pàgina"
 
 #: ../../src/wxMaximaFrame.cpp:1674
 msgid "Parallel Substitute..."
@@ -7517,7 +7517,7 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:124
 msgid "Parallel to"
-msgstr ""
+msgstr "Paral·lel a"
 
 #: ../../src/MaximaCommandMenus.cpp:3991
 msgid "Parameter name:"
@@ -7533,7 +7533,7 @@ msgstr ""
 
 #: ../../src/wizards/Plot2dWiz.cpp:417 ../../src/wizards/Plot2dWiz.cpp:523
 msgid "Parametric plot"
-msgstr ""
+msgstr "Gràfic paramètric"
 
 #: ../../src/MaximaCommandMenus.cpp:4211
 msgid "Parse string"
@@ -7587,7 +7587,7 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:125
 msgid "Perpendicular to"
-msgstr ""
+msgstr "Perpendicular a"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:218
 msgid "Persian"
@@ -7595,15 +7595,15 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:198
 msgid "Phi"
-msgstr ""
+msgstr "Phi"
 
 #: ../../src/sidebars/GreekSidebar.cpp:193
 msgid "Pi"
-msgstr ""
+msgstr "Pi"
 
 #: ../../src/sidebars/StatSidebar.cpp:94
 msgid "Piechart..."
-msgstr ""
+msgstr "Diagrama de sectors..."
 
 #: ../../src/wxMaxima.cpp:1585
 msgid "Please configure wxMaxima with 'Edit->Configure'."
@@ -7611,7 +7611,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2606
 msgid "Please restart wxMaxima for changes to take effect!"
-msgstr ""
+msgstr "Reiniciau wxMaxima per aplicar els canvis"
 
 #: ../../src/MaximaCommandMenus.cpp:2250
 msgid "Please select exactly 2 or 3 files."
@@ -7638,7 +7638,7 @@ msgstr ""
 #: ../../src/sidebars/MathSidebar.cpp:89
 #: ../../src/worksheet/WorksheetContextMenu.cpp:366
 msgid "Plot 2D..."
-msgstr ""
+msgstr "Gràfics 2D..."
 
 #: ../../src/MaximaCommandMenus.cpp:85 ../../src/MaximaCommandMenus.cpp:3508
 #: ../../src/wizards/Plot3dWiz.cpp:103
@@ -7648,7 +7648,7 @@ msgstr ""
 #: ../../src/sidebars/MathSidebar.cpp:92
 #: ../../src/worksheet/WorksheetContextMenu.cpp:368
 msgid "Plot 3D..."
-msgstr ""
+msgstr "Gràfics 3D..."
 
 #: ../../src/wizards/DrawWiz.cpp:713
 msgid "Plot a parametric curve"
@@ -7689,7 +7689,7 @@ msgstr ""
 
 #: ../../src/wizards/Plot2dWiz.cpp:84 ../../src/wizards/Plot3dWiz.cpp:80
 msgid "Plot to file:"
-msgstr ""
+msgstr "Gràfic a l'arxiu:"
 
 #: ../../src/wxMaximaFrame.cpp:341 ../../src/wxMaximaFrame.cpp:749
 msgid "Plot using Draw"
@@ -7723,7 +7723,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:219
 msgid "Polish"
-msgstr ""
+msgstr "Polonès"
 
 #: ../../src/MaximaCommandMenus.cpp:215 ../../src/MaximaCommandMenus.cpp:220
 #: ../../src/MaximaCommandMenus.cpp:225
@@ -7759,7 +7759,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:221
 msgid "Portuguese (Brazilian)"
-msgstr ""
+msgstr "Portuguès (Brasil)"
 
 #: ../../src/wxMaximaFrame.cpp:1223
 msgid "Position of a match"
@@ -7775,7 +7775,7 @@ msgstr ""
 
 #: ../../src/wizards/Plot2dWiz.cpp:474 ../../src/wizards/Plot3dWiz.cpp:422
 msgid "Postscript file (*.eps)|*.eps|All|*"
-msgstr ""
+msgstr "Arxiu postscript (*.eps)|*.eps|Tots|*"
 
 #: ../../src/MaximaCommandMenus.cpp:190
 msgid "Power series"
@@ -7823,7 +7823,7 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:146
 msgid "Pressing Ctrl+Space or Ctrl+Tab starts an autocomplete function that can not only complete all functions that are integrated into the Maxima core and their parameters: It also knows about parameters from currently loaded packages and from functions that are defined in the current file."
-msgstr ""
+msgstr "Amb la combinació de tecles Crtl+Espai o Ctrl+Tabulador s'inicia la funció de auto-completar que no es limita a les funcions del nucli de Màxima i als seus paràmetres: també funciona amb els paràmetres del paquets carregats actualment i les funcions definides en l'arxiu actual."
 
 #: ../../src/wxMaximaFrame.cpp:961
 msgid "Previous Command\tAlt+Up"
@@ -7927,7 +7927,7 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:123
 msgid "Product sign"
-msgstr ""
+msgstr "Signe de producte"
 
 #: ../../src/wxMaximaFrame.cpp:1129
 msgid "Program"
@@ -7951,7 +7951,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:200
 msgid "Psi"
-msgstr ""
+msgstr "Psi"
 
 #: ../../src/wxMaximaFrame.cpp:1788
 msgid "Push"
@@ -8037,7 +8037,7 @@ msgstr ""
 
 #: ../../src/sidebars/StatSidebar.cpp:103
 msgid "Read Matrix..."
-msgstr ""
+msgstr "Llegir matri"
 
 #: ../../src/MaximaCommandMenus.cpp:4008
 msgid "Read a structure field"
@@ -8174,7 +8174,7 @@ msgstr ""
 
 #: ../../src/sidebars/MathSidebar.cpp:56
 msgid "Rectform"
-msgstr ""
+msgstr "Forma cartesiana"
 
 #: ../../src/wxMaximaFrame.cpp:1677
 msgid "Recursive Substitute..."
@@ -8198,7 +8198,7 @@ msgstr ""
 
 #: ../../src/sidebars/MathSidebar.cpp:71
 msgid "Reduce (tr)"
-msgstr ""
+msgstr "Reduir (tr)"
 
 #: ../../src/wxMaximaFrame.cpp:1632
 msgid "Reduce trigonometric expression"
@@ -8533,7 +8533,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:194
 msgid "Rho"
-msgstr ""
+msgstr "Rho"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2015
 msgid "Right"
@@ -8546,7 +8546,7 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:127
 msgid "Right arrow"
-msgstr ""
+msgstr "Fletxa esquerra"
 
 #: ../../src/MaximaCommandMenus.cpp:1380
 msgid "Right end"
@@ -8586,7 +8586,7 @@ msgstr ""
 
 #: ../../src/wizards/MatWiz.cpp:152
 msgid "Rows:"
-msgstr ""
+msgstr "Files:"
 
 #: ../../src/MaximaCommandMenus.cpp:1391
 msgid "Rule"
@@ -8656,7 +8656,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:223
 msgid "Russian"
-msgstr ""
+msgstr "Russ"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1578
 msgid "SBCL: use <int>Mbytes of heap"
@@ -8709,7 +8709,7 @@ msgstr ""
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:55
 msgid "Save Animation..."
-msgstr ""
+msgstr "Desa animació"
 
 #: ../../src/MaximaFileIO.cpp:779
 msgid "Save As"
@@ -8721,7 +8721,7 @@ msgstr ""
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:50
 msgid "Save Image..."
-msgstr ""
+msgstr "Desa imatge..."
 
 #: ../../src/MaximaCommandMenus.cpp:2866
 msgid "Save Selection to Image"
@@ -8758,7 +8758,7 @@ msgstr ""
 
 #: ../../src/wizards/Plot2dWiz.cpp:473 ../../src/wizards/Plot3dWiz.cpp:421
 msgid "Save plot to file"
-msgstr ""
+msgstr "Desa gràfic en un arxiu"
 
 #: ../../src/wxMaximaFrame.cpp:713
 msgid "Save selection from document to an image file"
@@ -8770,7 +8770,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2640
 msgid "Save style to file"
-msgstr ""
+msgstr "Desa estil en un arxiu"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1384
 msgid "Save the worksheet automatically"
@@ -8802,7 +8802,7 @@ msgstr ""
 
 #: ../../src/sidebars/StatSidebar.cpp:88
 msgid "Scatterplot..."
-msgstr ""
+msgstr "Diagrama dispersió..."
 
 #: ../../src/Autocomplete.cpp:157
 msgid "Scheduling a background task that compiles a new list of autocompletable maxima commands."
@@ -8875,7 +8875,7 @@ msgstr ""
 #: ../../src/worksheet/WorksheetContextMenu.cpp:428
 #: ../../src/worksheet/WorksheetContextMenu.cpp:460
 msgid "Select All"
-msgstr ""
+msgstr "Selecciona tot"
 
 #: ../../src/wxMaximaFrame.cpp:710
 msgid "Select All\tCtrl+A"
@@ -8893,7 +8893,7 @@ msgstr ""
 #: ../../src/wizards/IntegrateWiz.cpp:208 ../../src/wizards/LimitWiz.cpp:133
 #: ../../src/wizards/SeriesWiz.cpp:105
 msgid "Select a constant"
-msgstr ""
+msgstr "Selecciona una constant"
 
 #: ../../src/ToolBar.cpp:390 ../../src/ToolBar.cpp:392
 #: ../../src/wxMaximaFrame.cpp:710
@@ -8914,7 +8914,7 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:109
 msgid "Selecting a part of an output and right-clicking on the selection will bring up a menu with convenient functions that will operate on the selection."
-msgstr ""
+msgstr "Seleccionant una part del resultat i polsant el botó dret emergirà un menú amb funcions aplicables sobre la selecció."
 
 #: ../../src/Styles.cpp:127
 msgid "Selection color"
@@ -9002,7 +9002,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:479
 msgid "Set fixed font in text controls."
-msgstr ""
+msgstr "Establir la font fitxa en els controls de text."
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:68
 #: ../../src/worksheet/WorksheetContextMenu.cpp:250
@@ -9229,11 +9229,11 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:465
 msgid "Show long expressions in wxMaxima document."
-msgstr ""
+msgstr "Mostra expressions llargues en el document de wxMaxima."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:722
 msgid "Show long expressions:"
-msgstr ""
+msgstr "Mostra expressions llargues:"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:377
 msgid "Show max. 100 digits"
@@ -9322,7 +9322,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:195
 msgid "Sigma"
-msgstr ""
+msgstr "Sigma"
 
 #: ../../src/dialogs/FindReplacePane.cpp:88
 msgid "Simple"
@@ -9334,7 +9334,7 @@ msgstr ""
 
 #: ../../src/sidebars/MathSidebar.cpp:44
 msgid "Simplify"
-msgstr ""
+msgstr "Simplifica"
 
 #: ../../src/wxMaximaFrame.cpp:1550
 msgid "Simplify &Radicals..."
@@ -9342,15 +9342,15 @@ msgstr ""
 
 #: ../../src/sidebars/MathSidebar.cpp:47
 msgid "Simplify (r)"
-msgstr ""
+msgstr "Simplifica (r)"
 
 #: ../../src/sidebars/MathSidebar.cpp:65
 msgid "Simplify (tr)"
-msgstr ""
+msgstr "Simplifica (tr)"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:352
 msgid "Simplify Expression"
-msgstr ""
+msgstr "Simplifica expressió"
 
 #: ../../src/wxMaximaFrame.cpp:1605
 msgid "Simplify Logarithms"
@@ -9386,7 +9386,7 @@ msgstr ""
 
 #: ../../src/wizards/SumWiz.cpp:68
 msgid "Simplify the sum"
-msgstr ""
+msgstr "Simplifica la suma"
 
 #: ../../src/wxMaximaFrame.cpp:1629
 msgid "Simplify trigonometric expression"
@@ -9451,7 +9451,7 @@ msgstr ""
 
 #: ../../src/wizards/BC2Wiz.cpp:30
 msgid "Solution:"
-msgstr ""
+msgstr "Solució:"
 
 #: ../../src/MaximaCommandMenus.cpp:3446
 msgid "Solve"
@@ -9491,7 +9491,7 @@ msgstr ""
 
 #: ../../src/sidebars/MathSidebar.cpp:77
 msgid "Solve ODE..."
-msgstr ""
+msgstr "Resoldre EDO..."
 
 #: ../../src/wxMaximaFrame.cpp:1432
 msgid "Solve a linear equation system using dgesv"
@@ -9576,7 +9576,7 @@ msgstr ""
 #: ../../src/sidebars/MathSidebar.cpp:74
 #: ../../src/worksheet/WorksheetContextMenu.cpp:347
 msgid "Solve..."
-msgstr ""
+msgstr "Resoldre"
 
 #: ../../src/wxMaximaFrame.cpp:1953
 msgid "Solving differential equations"
@@ -9618,12 +9618,12 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:227
 msgid "Spanish"
-msgstr ""
+msgstr "Castellà"
 
 #: ../../src/wizards/IntegrateWiz.cpp:44 ../../src/wizards/IntegrateWiz.cpp:50
 #: ../../src/wizards/LimitWiz.cpp:38 ../../src/wizards/SeriesWiz.cpp:39
 msgid "Special"
-msgstr ""
+msgstr "Especial"
 
 #: ../../src/wizards/DrawWiz.cpp:918
 msgid "Speed versus accuracy"
@@ -9663,7 +9663,7 @@ msgstr ""
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:60
 msgid "Start Animation"
-msgstr ""
+msgstr "Inicia animació"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1622
 msgid "Start a new maxima for each re-evaluation"
@@ -9834,15 +9834,15 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:282
 msgid "Style"
-msgstr ""
+msgstr "Estil"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2082
 msgid "Styles"
-msgstr ""
+msgstr "Estils"
 
 #: ../../src/sidebars/StatSidebar.cpp:112
 msgid "Subsample..."
-msgstr ""
+msgstr "Sub-mostra"
 
 #: ../../src/ToolBar.cpp:484 ../../src/sidebars/FormatSidebar.cpp:54
 msgid "Subsection"
@@ -9862,7 +9862,7 @@ msgstr ""
 
 #: ../../src/sidebars/MathSidebar.cpp:59
 msgid "Subst..."
-msgstr ""
+msgstr "S&ubstitueix"
 
 #: ../../src/MaximaCommandMenus.cpp:715 ../../src/MaximaCommandMenus.cpp:3490
 #: ../../src/MaximaCommandMenus.cpp:4500 ../../src/wizards/SubstituteWiz.cpp:53
@@ -9938,7 +9938,7 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:122
 msgid "Sum sign"
-msgstr ""
+msgstr "Signe de suma"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:228
 msgid "Swedish"
@@ -10003,7 +10003,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:196
 msgid "Tau"
-msgstr ""
+msgstr "Tau"
 
 #: ../../src/MaximaCommandMenus.cpp:181
 msgid "Taylor series"
@@ -10134,15 +10134,15 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:415
 msgid "The default height for embedded plots. Can be read out or overridden by the maxima variable wxplot_size."
-msgstr ""
+msgstr "L'alçada predeterminada dels gràfics incrustats. Es pot llegir o modificar amb la variable «wxplot_size» de Maxima."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:492
 msgid "The default port used for communication between Maxima and wxMaxima."
-msgstr ""
+msgstr "Port predeterminat per a comunicació entre Maxima i wxMaxima"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:412
 msgid "The default width for embedded plots. Can be read out or overridden by the maxima variable wxplot_size"
-msgstr ""
+msgstr "L'amplada predeterminada dels gràfics incrustats. Es pot llegir o modificar amb la variable «wxplot_size» de Maxima."
 
 #: ../../src/sidebars/DrawSidebar.cpp:74
 msgid "The diagram title"
@@ -10175,7 +10175,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:475
 msgid "The document class LaTeX is instructed to use for our documents."
-msgstr ""
+msgstr "Es farà servir l'ordre «documentclass» de LaTex en els seus documents."
 
 #: ../../src/MaximaCommandMenus.cpp:1832
 msgid "The equation to fit the data to"
@@ -10460,7 +10460,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:185
 msgid "Theta"
-msgstr ""
+msgstr "Theta"
 
 #: ../../src/dialogs/LicenseDialog.cpp:85
 msgid "Third-party notices"
@@ -10520,7 +10520,7 @@ msgstr ""
 
 #: ../../src/wizards/Plot2dWiz.cpp:65 ../../src/wizards/Plot2dWiz.cpp:505
 msgid "Ticks:"
-msgstr ""
+msgstr "Graduacions:"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1359
 msgid "Time [in Minutes] between autosaves"
@@ -10548,7 +10548,7 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:89
 msgid "Title, section and subsection cells can be folded to hide their contents. To fold or unfold, click in the square next to the cell. If you shift-click, all sublevels of that cell will also fold/unfold."
-msgstr ""
+msgstr "Les cel·les de títol, secció i sub-secció són plegables per a ocultar el contingut. Tant per plegar-les com per a des-plegarles feu clic en el quadre contigu a la cel·la. Si al mateix temps polsau 'Majúscules', tots els sub-nivells es plegaran/des-plegaran."
 
 #: ../../src/wxMaximaFrame.cpp:1831
 msgid "To &Bigfloat"
@@ -10560,7 +10560,7 @@ msgstr ""
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:344
 msgid "To Float"
-msgstr ""
+msgstr "A real"
 
 #: ../../src/wxMaximaFrame.cpp:1834
 msgid "To Numeri&c\tCtrl+Shift+N"
@@ -10576,15 +10576,15 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:124
 msgid "To plot in polar coordinates, select 'set polar' in the Options entry for Plot2d dialog. You can also plot in spherical and cylindrical coordinates in 3D."
-msgstr ""
+msgstr "Per a representar en coordenades polars, seleccioneu 'set polar' a l'entrada d'Opcions del quadre de diàleg de Gràfic 2D. Podeu ferla representació en coordenades esfèriques i cilíndriques en 3D."
 
 #: ../../src/dialogs/TipOfTheDay.cpp:131
 msgid "To put parentheses around an expression, select it, and press '(' or ')' depending on where you want the cursor to appear afterwards."
-msgstr ""
+msgstr "Per a col·locar entre parèntesi una expressió, seleccioneu-la i premeu «(» o «)», segons on voleu que es col·loqui el cursor a continuació."
 
 #: ../../src/dialogs/TipOfTheDay.cpp:137
 msgid "To save the size and position of wxMaxima windows between session, use 'Edit->Configure' dialog."
-msgstr ""
+msgstr "Per a desar la mida i posició de la finestra de wxMaxima entre sessions, feu servir 'Edita->Configura'."
 
 #: ../../src/dialogs/TipOfTheDay.cpp:51
 msgid "To start using wxMaxima right away, start typing your command. An input cell should appear. Then press Shift-Enter to evaluate your command."
@@ -10768,7 +10768,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:230
 msgid "Turkish"
-msgstr ""
+msgstr "Turc"
 
 #: ../../src/wxMaximaFrame.cpp:1965
 msgid "Tutorials"
@@ -10804,7 +10804,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:231
 msgid "Ukrainian"
-msgstr ""
+msgstr "Ucraïnés"
 
 #: ../../src/wxMaxima.cpp:3164
 msgid "Un-closed parenthesis"
@@ -10835,11 +10835,11 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2115
 msgid "Underlined"
-msgstr ""
+msgstr "Subrallat"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:745
 msgid "Underscore converts to subscripts:"
-msgstr ""
+msgstr "El subratllat es converteix en subíndexs:"
 
 #: ../../src/ToolBar.cpp:354 ../../src/ToolBar.cpp:357
 msgid "Undo"
@@ -10971,7 +10971,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:197
 msgid "Upsilon"
-msgstr ""
+msgstr "Ípsilon:"
 
 #: ../../src/wxMaximaFrame.cpp:829
 msgid "Use \"<\" and \">\" as parenthesis for matrices"
@@ -10983,7 +10983,7 @@ msgstr ""
 
 #: ../../src/wizards/SumWiz.cpp:69
 msgid "Use Gosper algorithm"
-msgstr ""
+msgstr "Usar algoritme Gosper"
 
 #: ../../src/sidebars/RegexCtrl.cpp:133
 msgid "Use RegEx filtering"
@@ -11011,7 +11011,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:849
 msgid "Use centered dot character for multiplication"
-msgstr ""
+msgstr "Usar punt centrat com a operador de multiplicació"
 
 #: ../../src/wxMaximaFrame.cpp:1745
 msgid "Use list"
@@ -11035,7 +11035,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:425
 msgid "Use the \"partial derivative\" symbol to represent the fraction that represents a diff() when exporting LaTeX"
-msgstr ""
+msgstr "Feu servir el símbol de «derivada parcial» per a representar la fracció que representa diff() en exportar a LaTeX"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2052
 msgid "Use unicode Math Symbols, if available"
@@ -11196,7 +11196,7 @@ msgstr ""
 
 #: ../../src/sidebars/StatSidebar.cpp:58
 msgid "Variance..."
-msgstr ""
+msgstr "Variància..."
 
 #: ../../src/WXMXformat.cpp:339
 msgid "Verified that we are able to read the whole .zip archive we produced."
@@ -11268,7 +11268,7 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:134
 msgid "When applying functions with one argument from menus, the default argument is '%'. To apply the function to some other value, select it in the document before executing a menu command."
-msgstr ""
+msgstr "En aplicar funcions amb un argument del menú, l'argument pre-determinat és '%'. Per aplicar la funció a un altre valor, seleccioneu-lo en el document abans d'executar la instrucció del menú."
 
 #: ../../src/wxMaximaFrame.cpp:1092
 msgid "When to invoke the lisp compiler's debugger"
@@ -11296,7 +11296,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:280
 msgid "Worksheet"
-msgstr ""
+msgstr "Full de càlcul"
 
 #: ../../src/MaximaResponseReader.cpp:117
 #, c-format
@@ -11317,11 +11317,11 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:428
 msgid "Wrap equations exported by the \"copy as LaTeX\" feature between \\[ and \\] as equation markers"
-msgstr ""
+msgstr "Emboliqui les equacions exportades per la funció «copia a LaTeX» amb \\[ i \\] com a marcadors d'equació"
 
 #: ../../src/worksheet/Worksheet.cpp:5190
 msgid "Wrapped search"
-msgstr ""
+msgstr "Cerca embolicada"
 
 #: ../../src/WXMXformat.cpp:284
 msgid "Wrote all image and gnuplot files to the zip archive"
@@ -11347,19 +11347,19 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:191
 msgid "Xi"
-msgstr ""
+msgstr "Xi"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:728
 msgid "Yes"
-msgstr ""
+msgstr "Sí"
 
 #: ../../src/dialogs/TipOfTheDay.cpp:64
 msgid "You can access the last output using the variable '%'. You can access the output of previous commands using variables '%on' where n is the number of output."
-msgstr ""
+msgstr "Podeu veure la darrera sortida fent servir la variable '%' . És possible veure la sortida de les ordres anteriors fent servir les variables '%on' on n és el número de la sortida."
 
 #: ../../src/dialogs/TipOfTheDay.cpp:118
 msgid "You can evaluate your whole document by using 'Cell->Evaluate All Cells' menu command or the appropriate key shortcut. The cells will be evaluated in the order they appear in the document."
-msgstr ""
+msgstr "Podeu avaluar el document complet seleccionant 'Cel·la->Avaluar totes les cel·les' en el menú o amb les tecles ràpides. Les cel·les s'avaluaran en l'ordre en què apareixen en el document."
 
 #: ../../src/dialogs/TipOfTheDay.cpp:98
 msgid "You can get help on a Maxima function by selecting or clicking on the function name and pressing F1. wxMaxima will search the help index for the selection or the word under the cursor."
@@ -11367,15 +11367,15 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:92
 msgid "You can hide output part of cells by clicking in the triangle on the left side of cells. This works on text cells also."
-msgstr ""
+msgstr "Podeu amagar la part del resultat d'una cel·la fent clic sobre el triangle a la seva esquerra. Això mateix podeu fer-ho a cel·les de text."
 
 #: ../../src/dialogs/TipOfTheDay.cpp:81
 msgid "You can insert different types of 'cells' in wxMaxima documents using the 'Cell' menu. Note that only 'input cells' can be evaluated, while others are used for commenting and structuring your calculations."
-msgstr ""
+msgstr "Podeu afegir diferents tipus de cel·les en un document de wxMaxima seleccionant el menú 'Cel·la'. Cal tenir present que només és possible avaluar «cel·les d'entrada», els altres tipus de cel·les es fan servir per a comentaris i estructuració dels vostres càlculs."
 
 #: ../../src/dialogs/TipOfTheDay.cpp:112
 msgid "You can select multiple cells either with a mouse - click'n'drag from between cells or from a cell bracket on the left - or with a keyboard - hold down Shift while moving the horizontal cursor - and then operate on selection. This comes in handy when you want to delete or evaluate multiple cells."
-msgstr ""
+msgstr "Podeu seleccionar més d'una cel·la, amb el ratolí, fent clic i arrossegant entre cel·les o claudàtor de cel·les, amb el teclat, mantenint polsada la tecla de Majúscules a la vegada que es mou el cursor horitzontal, per a  operar sobre la selecció. Això serà d'utilitat en haver de suprimir o avaluar vàries cel·les simultàniament."
 
 #: ../../src/dialogs/TipOfTheDay.cpp:232
 msgid "You found a bug in wxMaxima? Please report it at https://github.com/wxMaxima-developers/wxmaxima/issues\n"
@@ -11403,7 +11403,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:183
 msgid "Zeta"
-msgstr ""
+msgstr "Zeta"
 
 #: ../../src/wxMaximaFrame.cpp:842
 msgid "Zoom &In\tCtrl++"
@@ -11443,15 +11443,15 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:151
 msgid "alpha"
-msgstr ""
+msgstr "alpha"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:95
 msgid "and"
-msgstr ""
+msgstr "i"
 
 #: ../../src/wizards/MatWiz.cpp:160
 msgid "antisymmetric"
-msgstr ""
+msgstr "anti-simètrica"
 
 #: ../../src/wxMaximaFrame.cpp:1727
 msgid "apply function to each element"
@@ -11475,11 +11475,11 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:152
 msgid "beta"
-msgstr ""
+msgstr "beta"
 
 #: ../../src/wizards/LimitWiz.cpp:42
 msgid "both sides"
-msgstr ""
+msgstr "ambdós costats"
 
 #: ../../src/wxMaximaFrame.cpp:1173
 msgid "char to Ascii code..."
@@ -11487,7 +11487,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:172
 msgid "chi"
-msgstr ""
+msgstr "chi"
 
 #: ../../src/MaximaFileIO.cpp:318
 #, c-format
@@ -11497,15 +11497,15 @@ msgstr ""
 #: ../../src/wizards/Plot2dWiz.cpp:70 ../../src/wizards/Plot2dWiz.cpp:372
 #: ../../src/wizards/Plot3dWiz.cpp:61 ../../src/wizards/Plot3dWiz.cpp:358
 msgid "default"
-msgstr ""
+msgstr "pre-determinat"
 
 #: ../../src/sidebars/GreekSidebar.cpp:154
 msgid "delta"
-msgstr ""
+msgstr "delta"
 
 #: ../../src/wizards/MatWiz.cpp:159
 msgid "diagonal"
-msgstr ""
+msgstr "diagonal"
 
 #: ../../src/cells/FracCell.cpp:73
 msgid "diff(): Cannot find the multiplication sign I should hide"
@@ -11521,19 +11521,19 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:92
 msgid "empty"
-msgstr ""
+msgstr "buit"
 
 #: ../../src/sidebars/GreekSidebar.cpp:155
 msgid "epsilon"
-msgstr ""
+msgstr "epsilon"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:100
 msgid "equivalent"
-msgstr ""
+msgstr "equivalent"
 
 #: ../../src/sidebars/GreekSidebar.cpp:157
 msgid "eta"
-msgstr ""
+msgstr "eta"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:799
 msgid "ev() shall evaluate this automatically"
@@ -11541,7 +11541,7 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:88
 msgid "exists"
-msgstr ""
+msgstr "existeix"
 
 #: ../../src/MaximaCommandMenus.cpp:3942
 msgid "expression:"
@@ -11583,11 +11583,11 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:153
 msgid "gamma"
-msgstr ""
+msgstr "gamma"
 
 #: ../../src/wizards/MatWiz.cpp:159
 msgid "general"
-msgstr ""
+msgstr "general"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1630
 msgid "gnuplot: Without command console"
@@ -11595,11 +11595,11 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:118
 msgid "greater than or equal"
-msgstr ""
+msgstr "més gran o igual que"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:87
 msgid "in"
-msgstr ""
+msgstr "pertany"
 
 #: ../../src/wxMaximaFrame.cpp:784
 msgid "in 2D"
@@ -11610,31 +11610,31 @@ msgstr ""
 #: ../../src/wizards/Plot3dWiz.cpp:61 ../../src/wizards/Plot3dWiz.cpp:194
 #: ../../src/wizards/Plot3dWiz.cpp:358 ../../src/wizards/Plot3dWiz.cpp:386
 msgid "inline"
-msgstr ""
+msgstr "en línia"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:104
 msgid "intersection"
-msgstr ""
+msgstr "intersecció"
 
 #: ../../src/sidebars/GreekSidebar.cpp:159
 msgid "iota"
-msgstr ""
+msgstr "iota"
 
 #: ../../src/sidebars/GreekSidebar.cpp:160
 msgid "kappa"
-msgstr ""
+msgstr "kappa"
 
 #: ../../src/sidebars/GreekSidebar.cpp:161
 msgid "lambda"
-msgstr ""
+msgstr "lambda"
 
 #: ../../src/wizards/LimitWiz.cpp:42
 msgid "left"
-msgstr ""
+msgstr "esquerra"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:117
 msgid "less or equal"
-msgstr ""
+msgstr "menor o igual"
 
 #: ../../src/MaximaCommandMenus.cpp:1567
 msgid "list"
@@ -11642,7 +11642,7 @@ msgstr ""
 
 #: ../../src/wizards/Plot2dWiz.cpp:54 ../../src/wizards/Plot2dWiz.cpp:64
 msgid "logscale"
-msgstr ""
+msgstr "escala logarítmica"
 
 #: ../../src/wizards/DrawWiz.cpp:822
 msgid "matrix([x_1,x_2,...],[y_1,y_2,...])"
@@ -11658,15 +11658,15 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:162
 msgid "mu"
-msgstr ""
+msgstr "mu"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:120
 msgid "much greater than"
-msgstr ""
+msgstr "Molt major que"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:119
 msgid "much less than"
-msgstr ""
+msgstr "molt menor que"
 
 #: ../../src/MaximaCommandMenus.cpp:1232
 msgid "m×n Matrix A:"
@@ -11683,7 +11683,7 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:98
 msgid "nand"
-msgstr ""
+msgstr "nand"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:772
 msgid "nary: f(x, f(y,z)) = foo(x,y,z)"
@@ -11691,23 +11691,23 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:99
 msgid "nor"
-msgstr ""
+msgstr "nor"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:102
 msgid "not"
-msgstr ""
+msgstr "not"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:116
 msgid "not bytewise identical"
-msgstr ""
+msgstr "no idèntics en el mode de bit"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:108
 msgid "not subset"
-msgstr ""
+msgstr "no és subconjunt"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:107
 msgid "not subset or equal"
-msgstr ""
+msgstr "no és subconjunt o igual"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:796
 msgid "noun: Not evaluated by default"
@@ -11719,7 +11719,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:163
 msgid "nu"
-msgstr ""
+msgstr "nu"
 
 #: ../../src/MaximaCommandMenus.cpp:1233
 msgid "n×1 Matrix b:"
@@ -11727,15 +11727,15 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:174
 msgid "omega"
-msgstr ""
+msgstr "omega"
 
 #: ../../src/sidebars/GreekSidebar.cpp:165
 msgid "omicron"
-msgstr ""
+msgstr "omicron"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:96
 msgid "or"
-msgstr ""
+msgstr "or"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:793
 msgid "outative: f(2*x) = 2*f(x)"
@@ -11752,19 +11752,19 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:111
 msgid "partial sign"
-msgstr ""
+msgstr "símbol parcial"
 
 #: ../../src/sidebars/GreekSidebar.cpp:171
 msgid "phi"
-msgstr ""
+msgstr "phi"
 
 #: ../../src/sidebars/GreekSidebar.cpp:166
 msgid "pi"
-msgstr ""
+msgstr "pi"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:101
 msgid "plus or minus"
-msgstr ""
+msgstr "més o menys"
 
 #: ../../src/MaximaCommandMenus.cpp:196
 msgid "point:"
@@ -11789,11 +11789,11 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:115
 msgid "proportional to"
-msgstr ""
+msgstr "proporcional a "
 
 #: ../../src/sidebars/GreekSidebar.cpp:173
 msgid "psi"
-msgstr ""
+msgstr "psi"
 
 #: ../../src/MaximaCommandMenus.cpp:642
 msgid "radcan() is a powerful tools for simplification trigonometric functions but needs to be taken with care: If a function has more than one branch radcan uses the one that looks like it would fit best, not necessarily the one that makes sense for the problem that resulted in the Expression that is to be simplified."
@@ -11821,11 +11821,11 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:167
 msgid "rho"
-msgstr ""
+msgstr "rho"
 
 #: ../../src/wizards/LimitWiz.cpp:42
 msgid "right"
-msgstr ""
+msgstr "dreta"
 
 #: ../../src/wizards/DrawWiz.cpp:310
 msgid "secondary x axis label"
@@ -11845,7 +11845,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:168
 msgid "sigma"
-msgstr ""
+msgstr "sigma"
 
 #: ../../src/MaximaCommandMenus.cpp:3447
 msgid "solve() will solve a list of equations only if for n independent equations there are n variables to solve to.\n"
@@ -11869,15 +11869,15 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:106
 msgid "subset"
-msgstr ""
+msgstr "Sub-conjunt"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:105
 msgid "subset or equal"
-msgstr ""
+msgstr "Subconjunt o igual"
 
 #: ../../src/wizards/MatWiz.cpp:160
 msgid "symmetric"
-msgstr ""
+msgstr "simètrica"
 
 #: ../../src/MaximaCommandMenus.cpp:970
 msgid "t:"
@@ -11885,7 +11885,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:169
 msgid "tau"
-msgstr ""
+msgstr "tau"
 
 #: ../../src/cells/TextCell.cpp:340
 msgid "the [] operator tried to extract an element of a list, a matrix, an equation or an array. But instead of an integer number something was used whose numerical value is unknown or not an integer.\n"
@@ -11902,23 +11902,23 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:89
 msgid "there is no"
-msgstr ""
+msgstr "no hi ha"
 
 #: ../../src/sidebars/GreekSidebar.cpp:158
 msgid "theta"
-msgstr ""
+msgstr "theta"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:78
 msgid "to the power of 2"
-msgstr ""
+msgstr "a la potència de 2"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:79
 msgid "to the power of 3"
-msgstr ""
+msgstr "a la potència de 3"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:103
 msgid "union"
-msgstr ""
+msgstr "unió"
 
 #: ../../src/wxMaximaFrame.cpp:1109
 msgid "unnamed function (lambda)..."
@@ -11935,7 +11935,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:170
 msgid "upsilon"
-msgstr ""
+msgstr "upsilon"
 
 #: ../../src/wxMaximaFrame.cpp:1737
 msgid "use as function arguments"
@@ -11982,7 +11982,7 @@ msgstr ""
 #: ../../src/dialogs/ConfigDialogue.cpp:142
 #: ../../src/dialogs/ConfigDialogue.cpp:311
 msgid "wxMaxima configuration"
-msgstr ""
+msgstr "Configuració de wxMaxima"
 
 #: ../../src/MaximaProcessManager.cpp:209
 msgid "wxMaxima could not start a server.\n\n"
@@ -11992,7 +11992,7 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:127
 msgid "wxMaxima dialogs set default values for inputs entries, one of which is '%'. If you have made a selection in your document, the selection will be used instead of '%'."
-msgstr ""
+msgstr "En los quadres de diàleg de wxMaxima apareixen entrades pre-determinades, una de las quals és '%'. Si heu fet una selecció en el document, es farà servir enlloc de '%'."
 
 #: ../../src/MaximaCommandMenus.cpp:4544
 msgid "wxMaxima document"
@@ -12118,7 +12118,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:709
 msgid "x"
-msgstr ""
+msgstr "x"
 
 #: ../../src/wizards/DrawWiz.cpp:266
 msgid "x axis label"
@@ -12134,7 +12134,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:164
 msgid "xi"
-msgstr ""
+msgstr "xi"
 
 #: ../../src/MaximaFileIO.cpp:408 ../../src/MaximaFileIO.cpp:566
 msgid "xml contained in the file claims not to be a wxMaxima worksheet. "
@@ -12142,7 +12142,7 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:97
 msgid "xor"
-msgstr ""
+msgstr "xor"
 
 #: ../../src/wizards/DrawWiz.cpp:279
 msgid "y axis label"
@@ -12170,7 +12170,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:156
 msgid "zeta"
-msgstr ""
+msgstr "zeta"
 
 #. type: Title #
 #: ../../info/wxmaxima.md:1

--- a/locales/wxMaxima/cs.po
+++ b/locales/wxMaxima/cs.po
@@ -63,11 +63,11 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1571
 msgid "      -X '--dynamic-space-size <int>'"
-msgstr ""
+msgstr "      -X '--dynamic-space-size <int>'"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1551
 msgid "      -l <name>"
-msgstr ""
+msgstr "      -l <name>"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1557
 msgid "      -u <versionnumber>"
@@ -165,7 +165,7 @@ msgstr ""
 #: ../../src/cells/ImgCell.cpp:212 ../../src/cells/ImgCell.cpp:214
 #: ../../src/cells/ImgCell.cpp:216
 msgid " (Graphics) "
-msgstr ""
+msgstr " (Gràfics) "
 
 #: ../../src/cells/EditorCell.cpp:3551 ../../src/cells/EditorCell.cpp:3820
 #: ../../src/cells/EditorCell.cpp:3945
@@ -213,7 +213,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1208
 msgid "\"Copy LaTeX\" adds equation markers"
-msgstr ""
+msgstr "«Copia LaTeX» afegeix els marcadors d'equacions"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:446
 msgid "\"MathML (rendered by the browser)\" is the recommended choice: every current browser renders MathML natively and instantly, and the exported page needs no JavaScript and makes no requests to any external server.\n"
@@ -227,7 +227,7 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:90
 msgid "\"implies\" symbol"
-msgstr ""
+msgstr "símbol «implica»"
 
 #: ../../src/dialogs/DiffFrame.cpp:306
 #, c-format
@@ -314,7 +314,7 @@ msgstr "&Kopírovat\tCtrl+C"
 
 #: ../../src/wizards/IntegrateWiz.cpp:39
 msgid "&Definite integration"
-msgstr ""
+msgstr "&Určitý integrál"
 
 #: ../../src/wxMaximaFrame.cpp:1658
 msgid "&Demoivre"
@@ -430,11 +430,11 @@ msgstr ""
 
 #: ../../src/wizards/IntegrateWiz.cpp:52
 msgid "&Numerical integration"
-msgstr ""
+msgstr "&Numerické integrování"
 
 #: ../../src/wizards/SumWiz.cpp:44
 msgid "&Nusum"
-msgstr ""
+msgstr "&Numerické sčítání (nusum)"
 
 #: ../../src/main.cpp:675
 msgid "&Open\tCtrl+O"
@@ -450,7 +450,7 @@ msgstr "&Grafy"
 
 #: ../../src/wizards/SeriesWiz.cpp:45
 msgid "&Power series"
-msgstr ""
+msgstr "&Mocninná řada"
 
 #: ../../src/wxMaximaFrame.cpp:655
 msgid "&Print...\tCtrl+P"
@@ -458,7 +458,7 @@ msgstr "&Tisk...\tCtrl+P"
 
 #: ../../src/wizards/SubstituteWiz.cpp:38
 msgid "&Rational"
-msgstr ""
+msgstr "&Racionální výraz"
 
 #: ../../src/wxMaximaFrame.cpp:1631
 msgid "&Reduce Trigonometric"
@@ -490,11 +490,11 @@ msgstr "&Řešit..."
 
 #: ../../src/wizards/Plot2dWiz.cpp:42
 msgid "&Special"
-msgstr ""
+msgstr "&Special"
 
 #: ../../src/wizards/LimitWiz.cpp:45
 msgid "&Taylor series"
-msgstr ""
+msgstr "&Taylorova řada"
 
 #: ../../src/wxMaximaFrame.cpp:1069
 msgid "&Time Display"
@@ -514,7 +514,7 @@ msgstr ""
 
 #: ../../src/wizards/Plot3dWiz.cpp:79
 msgid "&pm3d"
-msgstr ""
+msgstr "&pm3d"
 
 #: ../../src/cells/AnimationCell.cpp:475
 msgid "(Animation)"
@@ -550,7 +550,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:183
 msgid "(Use default language)"
-msgstr ""
+msgstr "(Původní jazykové nastavení)"
 
 #: ../../src/MaximaCommandMenus.cpp:440
 msgid "(f(x),x,a,b)), Epsilon algorithm"
@@ -592,7 +592,7 @@ msgstr ""
 #: ../../src/wizards/IntegrateWiz.cpp:217 ../../src/wizards/LimitWiz.cpp:132
 #: ../../src/wizards/LimitWiz.cpp:142
 msgid "- Infinity"
-msgstr ""
+msgstr "- Nekonečno"
 
 #: ../../src/MaximaOutputAppender.cpp:116
 msgid "... [suppressed additional lines as the output is longer than allowed in the wxMaxima configuration] "
@@ -608,7 +608,7 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:77
 msgid "1/2"
-msgstr ""
+msgstr "1/2"
 
 #: ../../src/sidebars/DrawSidebar.cpp:45
 msgid "2D"
@@ -649,7 +649,7 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:102
 msgid "A 'horizontal cursor' was introduced in wxMaxima 0.8.0. It looks like a horizontal line between cells. It indicates where a new cell will appear if you type or paste text or execute a menu command."
-msgstr ""
+msgstr "'Horizontální kurzor' se poprvé objevil ve wxMaxima 0.8.0. Vypadá jako vodorovná čára mezi kolonkami. Indikuje novou buňku při psaní nebo vkládání textu nebo provedení příkazu menu."
 
 #: ../../src/MaximaCommandMenus.cpp:3039
 msgid "A Ctrl-F event"
@@ -767,7 +767,7 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:239
 msgid "A symbol from the configuration dialogue"
-msgstr ""
+msgstr "Un símbol del formulari de configuració"
 
 #: ../../src/cells/GroupCell.cpp:2181
 msgid "A text cell"
@@ -804,7 +804,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1618
 msgid "Abort evaluation on error"
-msgstr ""
+msgstr "Aturar l'avaluació en cas d'error"
 
 #: ../../src/MaximaEvaluator.cpp:214
 #, c-format
@@ -881,7 +881,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1262
 msgid "Add the .wxmx file to the HTML export"
-msgstr ""
+msgstr "Afegir l'arxiu .wxmx a l'exportació a HTML"
 
 #: ../../src/wxMaximaFrame.cpp:1049
 msgid "Add to &Path..."
@@ -908,15 +908,15 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:393
 msgid "Additional commands to be added to the preamble of LaTeX output for pdftex."
-msgstr ""
+msgstr "Les ordres addicionals s'afegiran en el preàmbul de la sortida de LaTeX per a pdftex."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1187
 msgid "Additional lines for the TeX preamble:"
-msgstr ""
+msgstr "Línies addicionals per al preàmbul TeX"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:389
 msgid "Additional parameters for Maxima (e.g. -l clisp)."
-msgstr ""
+msgstr "Doplňkové parametry pro program Maxima (např., -l clisp)."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1543
 msgid "Additional parameters for Maxima (restart Maxima after changes)"
@@ -924,7 +924,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1318
 msgid "Additional symbols for the \"symbols\" sidebar:"
-msgstr ""
+msgstr "Símbols addicionals per a la barra lateral «símbols»"
 
 #: ../../src/wxMaximaFrame.cpp:1599
 msgid "Additionally: log(a*b)=log(a)+log(b)"
@@ -1012,7 +1012,7 @@ msgstr ""
 
 #: ../../src/dialogs/BinaryNameCtrl.cpp:69
 msgid "All|*"
-msgstr ""
+msgstr "Vše|* "
 
 #: ../../src/wxMaximaFrame.cpp:800
 msgid "Always after underscores"
@@ -1189,7 +1189,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1397
 msgid "Ask to save untitled documents"
-msgstr ""
+msgstr "Preguntar si desar els documents sense títol"
 
 #: ../../src/dialogs/MaximaNotStartingDialog.cpp:36
 msgid "Asking the user for the location of a working maxima binary"
@@ -1213,7 +1213,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:897
 msgid "Auto-indent new lines"
-msgstr ""
+msgstr "Tabulació automàtica de noves línies"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:893
 msgid "Auto-insert closing parenthesis"
@@ -1291,7 +1291,7 @@ msgstr ""
 
 #: ../../src/wizards/BC2Wiz.cpp:59
 msgid "BC2"
-msgstr ""
+msgstr "BC2"
 
 #: ../../src/MaximaManual.cpp:559
 msgid "Background task that compiles the Manual anchors scheduled."
@@ -1299,7 +1299,7 @@ msgstr ""
 
 #: ../../src/sidebars/StatSidebar.cpp:91
 msgid "Barsplot..."
-msgstr ""
+msgstr "Gràfic de barres..."
 
 #: ../../src/wxMaximaFrame.cpp:1384
 msgid "Basic matrix operations"
@@ -1358,7 +1358,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2109
 msgid "Bold"
-msgstr ""
+msgstr "Tučný"
 
 #: ../../src/wxMaxima.cpp:2259
 msgid "Both horizontal and vertical cursor active at the same time"
@@ -1388,7 +1388,7 @@ msgstr ""
 #: ../../src/wizards/CsvWiz.cpp:131 ../../src/wizards/Plot2dWiz.cpp:114
 #: ../../src/wizards/Plot3dWiz.cpp:109
 msgid "Browse"
-msgstr ""
+msgstr "Prohlížení"
 
 #: ../../src/wxMathml.cpp:101
 msgid "Bug: After removing the whitespace wxMathml.lisp is shorter than expected!"
@@ -1941,7 +1941,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2100
 msgid "Choose font"
-msgstr ""
+msgstr "Výběr fontu"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:793
 msgid "Choose how mathematical output is formatted:\n"
@@ -2126,7 +2126,7 @@ msgstr ""
 
 #: ../../src/wizards/MatWiz.cpp:155
 msgid "Columns:"
-msgstr ""
+msgstr "Sloupce:"
 
 #: ../../src/wxMaximaFrame.cpp:1621
 msgid "Combine factorials in an expression"
@@ -2142,11 +2142,11 @@ msgstr ""
 
 #: ../../src/wizards/Plot2dWiz.cpp:626
 msgid "Comma separated x coordinates"
-msgstr ""
+msgstr "Zadejte x-ové souřadnice oddělené čárkou"
 
 #: ../../src/wizards/Plot2dWiz.cpp:627
 msgid "Comma separated y coordinates"
-msgstr ""
+msgstr "Zadejte y-ové souřadnice oddělené čárkou"
 
 #: ../../src/MaximaCommandMenus.cpp:4071
 msgid "Comma-separated arguments"
@@ -2372,7 +2372,7 @@ msgstr "Podmínka:"
 #: ../../src/dialogs/ConfigDialogue.cpp:2641
 #: ../../src/dialogs/ConfigDialogue.cpp:2647
 msgid "Config file (*.ini)|*.ini"
-msgstr ""
+msgstr "Konfigurační soubor (*.ini)|*.ini"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2539
 #, c-format
@@ -2404,7 +2404,7 @@ msgstr ""
 #: ../../src/wizards/IntegrateWiz.cpp:208 ../../src/wizards/LimitWiz.cpp:133
 #: ../../src/wizards/SeriesWiz.cpp:105
 msgid "Constant"
-msgstr ""
+msgstr "Konstanta"
 
 #: ../../src/MaximaCommandMenus.cpp:1102
 msgid "Construct a fraction"
@@ -2878,7 +2878,7 @@ msgstr ""
 
 #: ../../src/worksheet/Worksheet.cpp:6115
 msgid "Cursor"
-msgstr ""
+msgstr "Kurzor"
 
 #: ../../src/Styles.cpp:126
 msgid "Cursor color"
@@ -2900,11 +2900,11 @@ msgstr "Vystřihnout výběr"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:193
 msgid "Czech"
-msgstr ""
+msgstr "Česky"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:194
 msgid "Danish"
-msgstr ""
+msgstr "Dánsky"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2069
 msgid "Dark"
@@ -3121,7 +3121,7 @@ msgstr ""
 
 #: ../../src/wizards/SeriesWiz.cpp:42
 msgid "Depth:"
-msgstr ""
+msgstr "Hloubka:"
 
 #: ../../src/MaximaCommandMenus.cpp:994
 msgid "Derivate of y at that point:"
@@ -3188,7 +3188,7 @@ msgstr ""
 
 #: ../../src/sidebars/MathSidebar.cpp:80
 msgid "Diff..."
-msgstr ""
+msgstr "Derivovat..."
 
 #: ../../src/dialogs/DiffFrame.cpp:308
 #, c-format
@@ -3217,7 +3217,7 @@ msgstr ""
 
 #: ../../src/wizards/LimitWiz.cpp:41
 msgid "Direction:"
-msgstr ""
+msgstr "Směr:"
 
 #: ../../src/wxMaximaFrame.cpp:1246
 msgid "Directory operations"
@@ -3229,7 +3229,7 @@ msgstr ""
 
 #: ../../src/wizards/Plot2dWiz.cpp:418 ../../src/wizards/Plot2dWiz.cpp:619
 msgid "Discrete plot"
-msgstr ""
+msgstr "Diskrétní graf"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:699
 msgid "Display"
@@ -3571,7 +3571,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:196
 msgid "English"
-msgstr ""
+msgstr "Anglický"
 
 #: ../../src/wizards/DrawWiz.cpp:552
 msgid "Enhanced 3D settings:"
@@ -3583,7 +3583,7 @@ msgstr ""
 
 #: ../../src/sidebars/StatSidebar.cpp:106
 msgid "Enter Matrix..."
-msgstr ""
+msgstr "Vložte matici..."
 
 #: ../../src/MaximaCommandMenus.cpp:2255
 msgid "Enter UUID to jump to:"
@@ -3603,7 +3603,7 @@ msgstr "Zadejte rovnici pro racionální zjednodušení"
 
 #: ../../src/wizards/SystemWiz.cpp:50
 msgid "Enter comma separated list of variables."
-msgstr ""
+msgstr "Zadejte seznam proměnných oddělených čárkami."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:921
 msgid "Enter evaluates cells, Ctrl+Enter adds newlines"
@@ -3623,7 +3623,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:388
 msgid "Enter the path to the Maxima executable."
-msgstr ""
+msgstr "Zadejte cestu ke spustitelnému souboru programu Maxima."
 
 #: ../../src/MaximaCommandMenus.cpp:1103
 msgid "Enumerator:"
@@ -3870,7 +3870,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2659
 msgid "Example text"
-msgstr ""
+msgstr "Text příkladu"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1547
 msgid "Examples:"
@@ -3886,11 +3886,11 @@ msgstr ""
 
 #: ../../src/sidebars/MathSidebar.cpp:53
 msgid "Expand"
-msgstr ""
+msgstr "Rozložit"
 
 #: ../../src/sidebars/MathSidebar.cpp:68
 msgid "Expand (tr)"
-msgstr ""
+msgstr "Rozložit (trig.)"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:356
 msgid "Expand Expression"
@@ -4216,7 +4216,7 @@ msgstr ""
 
 #: ../../src/sidebars/MathSidebar.cpp:50
 msgid "Factor"
-msgstr ""
+msgstr "Na součin"
 
 #: ../../src/wxMaximaFrame.cpp:1558
 msgid "Factor Complex"
@@ -4489,7 +4489,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:873
 msgid "Fixed font in text controls"
-msgstr ""
+msgstr "Fixní font v textových vstupech"
 
 #: ../../src/MaximaCommandMenus.cpp:4039
 msgid "Flush stream"
@@ -4533,7 +4533,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2047
 msgid "Fonts"
-msgstr ""
+msgstr "Fonty"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:442
 msgid "For each Text-, Sectioning or code cell wxMaxima can display a bracket showing the extend of the cell and allowing to fold it. This setting now tells if this bracket is to be printed, as well."
@@ -4561,7 +4561,7 @@ msgstr ""
 
 #: ../../src/wizards/Plot2dWiz.cpp:69 ../../src/wizards/Plot3dWiz.cpp:60
 msgid "Format:"
-msgstr ""
+msgstr "Formát:"
 
 #: ../../src/worksheet/Worksheet.cpp:301 ../../src/wxMaxima.cpp:3521
 msgid "Forwarding the keyboard focus to a text control"
@@ -4626,7 +4626,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:198
 msgid "French"
-msgstr ""
+msgstr "Francouzský"
 
 #: ../../src/wxMaximaFrame.cpp:1447
 msgid "Frobenius Norm sqrt(sum((A(i,j))^2)) (complex)"
@@ -4765,7 +4765,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:201
 msgid "German"
-msgstr ""
+msgstr "Německý"
 
 #: ../../src/wxMaximaFrame.cpp:1656
 msgid "Get &Imaginary Part"
@@ -4869,7 +4869,7 @@ msgstr ""
 
 #: ../../src/wizards/Plot3dWiz.cpp:52
 msgid "Grid:"
-msgstr ""
+msgstr "Mřížka:"
 
 #: ../../src/wxMaximaFrame.cpp:1852
 msgid "Guess an exact number that could be meant by this float"
@@ -5046,7 +5046,7 @@ msgstr ""
 
 #: ../../src/sidebars/StatSidebar.cpp:85
 msgid "Histogram..."
-msgstr ""
+msgstr "Histogram..."
 
 #: ../../src/wxMaximaFrame.cpp:246
 msgid "History"
@@ -5058,7 +5058,7 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:105
 msgid "Horizontal cursor works like a normal cursor, but it operates on cells: press up or down arrow to move it, holding down Shift while moving will select cells, pressing backspace or delete twice will delete a cell next to it."
-msgstr ""
+msgstr "Vodorovný kurzor se chová stejně jako kurzor klasický, ale je použit u polí: stiskněte šipku nahoru nebo dolů pro posun, pro označování stiskněte navíc shift. Stisk klávesy Backspace nebo dvojí stisk klávesy Delete vymaže sousední pole."
 
 #: ../../src/wxMaximaFrame.cpp:1563
 msgid "Horner's rule"
@@ -5078,7 +5078,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:205
 msgid "Hungarian"
-msgstr ""
+msgstr "Maďarský"
 
 #: ../../src/wxMaximaFrame.cpp:1147
 msgid "I/O"
@@ -5189,7 +5189,7 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:122
 msgid "If your calculation is taking too long to evaluate, you can try 'Maxima->Interrupt' or 'Maxima->Restart Maxima' menu commands."
-msgstr ""
+msgstr "Jestliže výpočet trvá příliš dlouho, můžete zkusit volby 'Maxima->Interrupt' nebo 'Maxima->Restart Maxima'."
 
 #: ../../src/MaximaManual.cpp:420
 msgid "Ignoring the cache version for the manual anchors."
@@ -5197,7 +5197,7 @@ msgstr ""
 
 #: ../../src/sidebars/FormatSidebar.cpp:66
 msgid "Image"
-msgstr ""
+msgstr "Obraz"
 
 #: ../../src/Image.cpp:110
 msgid "Image data had zero length!"
@@ -5326,7 +5326,7 @@ msgstr ""
 #: ../../src/wizards/IntegrateWiz.cpp:215 ../../src/wizards/LimitWiz.cpp:132
 #: ../../src/wizards/LimitWiz.cpp:140
 msgid "Infinity"
-msgstr ""
+msgstr "Nekonečno"
 
 #: ../../src/wxMaximaFrame.cpp:1986
 msgid "Info about Maxima build"
@@ -5804,11 +5804,11 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:207
 msgid "Italian"
-msgstr ""
+msgstr "Italský"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2111
 msgid "Italic"
-msgstr ""
+msgstr "Kurzíva"
 
 #: ../../src/MaximaCommandMenus.cpp:1617 ../../src/MaximaCommandMenus.cpp:1623
 msgid "Item"
@@ -5916,11 +5916,11 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:470
 msgid "Language used for wxMaxima GUI."
-msgstr ""
+msgstr "Jazyk používaný GUI programu wxMaxima."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1311
 msgid "Language:"
-msgstr ""
+msgstr "Jazyk:"
 
 #: ../../src/MaximaCommandMenus.cpp:251
 msgid "Laplace"
@@ -5979,7 +5979,7 @@ msgstr "Metoda nejmenších čtverců"
 
 #: ../../src/sidebars/StatSidebar.cpp:79
 msgid "Least Squares Fit..."
-msgstr ""
+msgstr "Metoda nejmenších čtverců..."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2007
 msgid "Left"
@@ -6037,7 +6037,7 @@ msgstr "Limita"
 
 #: ../../src/sidebars/MathSidebar.cpp:86
 msgid "Limit..."
-msgstr ""
+msgstr "Limita..."
 
 #: ../../src/sidebars/DrawSidebar.cpp:88
 msgid "Line color"
@@ -6178,7 +6178,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2162
 msgid "Load"
-msgstr ""
+msgstr "Načíst"
 
 #: ../../src/MaximaCommandMenus.cpp:2356
 msgid "Load Package"
@@ -6218,7 +6218,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2645
 msgid "Load style from file"
-msgstr ""
+msgstr "Načíst styl ze souboru"
 
 #: ../../src/wxMaximaFrame.cpp:1232
 msgid "Load the file/dir operations (operatingsystem)"
@@ -6551,7 +6551,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1437
 msgid "Maxima program:"
-msgstr ""
+msgstr "Program Maxima:"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:382
 msgid "Maxima provides no \"forget all\" command that flushes all settings a maxima session could make. wxMaxima therefore normally defaults to starting a fresh maxima process every time the worksheet is to be re-evaluated. As this needs a little bit of time this switch allows to disable this behavior."
@@ -6823,7 +6823,7 @@ msgstr ""
 
 #: ../../src/wizards/IntegrateWiz.cpp:55
 msgid "Method:"
-msgstr ""
+msgstr "Metoda:"
 
 #: ../../src/wxMaximaFrame.cpp:1360
 msgid "Methods of generating a matrix"
@@ -6922,7 +6922,7 @@ msgstr ""
 
 #: ../../src/wizards/MatWiz.cpp:163
 msgid "Name:"
-msgstr ""
+msgstr "Jméno:"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:216
 msgid "Nepali"
@@ -6998,7 +6998,7 @@ msgstr ""
 
 #: ../../src/wizards/SubstituteWiz.cpp:35
 msgid "New value:"
-msgstr ""
+msgstr "Nová hodnota:"
 
 #: ../../src/MaximaCommandMenus.cpp:151 ../../src/MaximaCommandMenus.cpp:171
 #: ../../src/MaximaCommandMenus.cpp:254 ../../src/MaximaCommandMenus.cpp:259
@@ -7303,7 +7303,7 @@ msgstr ""
 
 #: ../../src/wizards/SubstituteWiz.cpp:32
 msgid "Old value:"
-msgstr ""
+msgstr "Původní hodnota:"
 
 #: ../../src/MaximaCommandMenus.cpp:151 ../../src/MaximaCommandMenus.cpp:172
 #: ../../src/MaximaCommandMenus.cpp:253 ../../src/MaximaCommandMenus.cpp:259
@@ -7432,7 +7432,7 @@ msgstr "Volby"
 
 #: ../../src/wizards/Plot2dWiz.cpp:75 ../../src/wizards/Plot3dWiz.cpp:66
 msgid "Options:"
-msgstr ""
+msgstr "Volby:"
 
 #: ../../src/dialogs/FindReplacePane.cpp:109
 msgid "Output"
@@ -7505,7 +7505,7 @@ msgstr "Padého aproximace Taylorovy řady"
 
 #: ../../src/sidebars/FormatSidebar.cpp:69
 msgid "Pagebreak"
-msgstr ""
+msgstr "Zlom stránky"
 
 #: ../../src/wxMaximaFrame.cpp:1674
 msgid "Parallel Substitute..."
@@ -7533,7 +7533,7 @@ msgstr ""
 
 #: ../../src/wizards/Plot2dWiz.cpp:417 ../../src/wizards/Plot2dWiz.cpp:523
 msgid "Parametric plot"
-msgstr ""
+msgstr "Graf zadaný parametricky"
 
 #: ../../src/MaximaCommandMenus.cpp:4211
 msgid "Parse string"
@@ -7611,7 +7611,7 @@ msgstr "Konfigurujte program wxMaxima pomocí 'Edit->Configure'."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2606
 msgid "Please restart wxMaxima for changes to take effect!"
-msgstr ""
+msgstr "Aby změny byly provedeny, je nutné program wxMaxima restartovat!"
 
 #: ../../src/MaximaCommandMenus.cpp:2250
 msgid "Please select exactly 2 or 3 files."
@@ -7689,7 +7689,7 @@ msgstr ""
 
 #: ../../src/wizards/Plot2dWiz.cpp:84 ../../src/wizards/Plot3dWiz.cpp:80
 msgid "Plot to file:"
-msgstr ""
+msgstr "Graf do souboru:"
 
 #: ../../src/wxMaximaFrame.cpp:341 ../../src/wxMaximaFrame.cpp:749
 msgid "Plot using Draw"
@@ -7723,7 +7723,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:219
 msgid "Polish"
-msgstr ""
+msgstr "Polský"
 
 #: ../../src/MaximaCommandMenus.cpp:215 ../../src/MaximaCommandMenus.cpp:220
 #: ../../src/MaximaCommandMenus.cpp:225
@@ -7759,7 +7759,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:221
 msgid "Portuguese (Brazilian)"
-msgstr ""
+msgstr "Portugalský (Brazilský)"
 
 #: ../../src/wxMaximaFrame.cpp:1223
 msgid "Position of a match"
@@ -7775,7 +7775,7 @@ msgstr ""
 
 #: ../../src/wizards/Plot2dWiz.cpp:474 ../../src/wizards/Plot3dWiz.cpp:422
 msgid "Postscript file (*.eps)|*.eps|All|*"
-msgstr ""
+msgstr "Postscriptový soubor (*.eps)|*.eps|Vše|*"
 
 #: ../../src/MaximaCommandMenus.cpp:190
 msgid "Power series"
@@ -8174,7 +8174,7 @@ msgstr ""
 
 #: ../../src/sidebars/MathSidebar.cpp:56
 msgid "Rectform"
-msgstr ""
+msgstr "Algebraický tvar"
 
 #: ../../src/wxMaximaFrame.cpp:1677
 msgid "Recursive Substitute..."
@@ -8198,7 +8198,7 @@ msgstr ""
 
 #: ../../src/sidebars/MathSidebar.cpp:71
 msgid "Reduce (tr)"
-msgstr ""
+msgstr "Zjednodušit (trig.)"
 
 #: ../../src/wxMaximaFrame.cpp:1632
 msgid "Reduce trigonometric expression"
@@ -8586,7 +8586,7 @@ msgstr ""
 
 #: ../../src/wizards/MatWiz.cpp:152
 msgid "Rows:"
-msgstr ""
+msgstr "Řádky:"
 
 #: ../../src/MaximaCommandMenus.cpp:1391
 msgid "Rule"
@@ -8656,7 +8656,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:223
 msgid "Russian"
-msgstr ""
+msgstr "Ruský"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1578
 msgid "SBCL: use <int>Mbytes of heap"
@@ -8758,7 +8758,7 @@ msgstr "Uložit dokument jako"
 
 #: ../../src/wizards/Plot2dWiz.cpp:473 ../../src/wizards/Plot3dWiz.cpp:421
 msgid "Save plot to file"
-msgstr ""
+msgstr "Uložit graf do souboru"
 
 #: ../../src/wxMaximaFrame.cpp:713
 msgid "Save selection from document to an image file"
@@ -8770,7 +8770,7 @@ msgstr "Uložit označené do souboru"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2640
 msgid "Save style to file"
-msgstr ""
+msgstr "Uložit styl do souboru"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1384
 msgid "Save the worksheet automatically"
@@ -8893,7 +8893,7 @@ msgstr ""
 #: ../../src/wizards/IntegrateWiz.cpp:208 ../../src/wizards/LimitWiz.cpp:133
 #: ../../src/wizards/SeriesWiz.cpp:105
 msgid "Select a constant"
-msgstr ""
+msgstr "Vybrat konstantu"
 
 #: ../../src/ToolBar.cpp:390 ../../src/ToolBar.cpp:392
 #: ../../src/wxMaximaFrame.cpp:710
@@ -9002,7 +9002,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:479
 msgid "Set fixed font in text controls."
-msgstr ""
+msgstr "Nastavit fixní font pro textové příkazy."
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:68
 #: ../../src/worksheet/WorksheetContextMenu.cpp:250
@@ -9229,7 +9229,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:465
 msgid "Show long expressions in wxMaxima document."
-msgstr ""
+msgstr "Zobrazovat dlouhé výrazy v dokumentu wxMaxima."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:722
 msgid "Show long expressions:"
@@ -9334,7 +9334,7 @@ msgstr ""
 
 #: ../../src/sidebars/MathSidebar.cpp:44
 msgid "Simplify"
-msgstr ""
+msgstr "Zjednodušit"
 
 #: ../../src/wxMaximaFrame.cpp:1550
 msgid "Simplify &Radicals..."
@@ -9342,11 +9342,11 @@ msgstr ""
 
 #: ../../src/sidebars/MathSidebar.cpp:47
 msgid "Simplify (r)"
-msgstr ""
+msgstr "Zjednodušit (rac.)"
 
 #: ../../src/sidebars/MathSidebar.cpp:65
 msgid "Simplify (tr)"
-msgstr ""
+msgstr "Zjednodušit (trig.)"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:352
 msgid "Simplify Expression"
@@ -9386,7 +9386,7 @@ msgstr ""
 
 #: ../../src/wizards/SumWiz.cpp:68
 msgid "Simplify the sum"
-msgstr ""
+msgstr "Zjednodušit sumu"
 
 #: ../../src/wxMaximaFrame.cpp:1629
 msgid "Simplify trigonometric expression"
@@ -9451,7 +9451,7 @@ msgstr ""
 
 #: ../../src/wizards/BC2Wiz.cpp:30
 msgid "Solution:"
-msgstr ""
+msgstr "Řešení:"
 
 #: ../../src/MaximaCommandMenus.cpp:3446
 msgid "Solve"
@@ -9491,7 +9491,7 @@ msgstr "Řešit ODR pomocí LTR..."
 
 #: ../../src/sidebars/MathSidebar.cpp:77
 msgid "Solve ODE..."
-msgstr ""
+msgstr "Řešit ODR..."
 
 #: ../../src/wxMaximaFrame.cpp:1432
 msgid "Solve a linear equation system using dgesv"
@@ -9618,12 +9618,12 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:227
 msgid "Spanish"
-msgstr ""
+msgstr "Španělský"
 
 #: ../../src/wizards/IntegrateWiz.cpp:44 ../../src/wizards/IntegrateWiz.cpp:50
 #: ../../src/wizards/LimitWiz.cpp:38 ../../src/wizards/SeriesWiz.cpp:39
 msgid "Special"
-msgstr ""
+msgstr "Speciální"
 
 #: ../../src/wizards/DrawWiz.cpp:918
 msgid "Speed versus accuracy"
@@ -9834,11 +9834,11 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:282
 msgid "Style"
-msgstr ""
+msgstr "Styl"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2082
 msgid "Styles"
-msgstr ""
+msgstr "Styly"
 
 #: ../../src/sidebars/StatSidebar.cpp:112
 msgid "Subsample..."
@@ -9862,7 +9862,7 @@ msgstr ""
 
 #: ../../src/sidebars/MathSidebar.cpp:59
 msgid "Subst..."
-msgstr ""
+msgstr "Subst..."
 
 #: ../../src/MaximaCommandMenus.cpp:715 ../../src/MaximaCommandMenus.cpp:3490
 #: ../../src/MaximaCommandMenus.cpp:4500 ../../src/wizards/SubstituteWiz.cpp:53
@@ -10138,7 +10138,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:492
 msgid "The default port used for communication between Maxima and wxMaxima."
-msgstr ""
+msgstr "Standardní port pro komunikaci mezi programy Maxima a wxMaxima."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:412
 msgid "The default width for embedded plots. Can be read out or overridden by the maxima variable wxplot_size"
@@ -10520,7 +10520,7 @@ msgstr ""
 
 #: ../../src/wizards/Plot2dWiz.cpp:65 ../../src/wizards/Plot2dWiz.cpp:505
 msgid "Ticks:"
-msgstr ""
+msgstr "Počet dělicích bodů:"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1359
 msgid "Time [in Minutes] between autosaves"
@@ -10548,7 +10548,7 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:89
 msgid "Title, section and subsection cells can be folded to hide their contents. To fold or unfold, click in the square next to the cell. If you shift-click, all sublevels of that cell will also fold/unfold."
-msgstr ""
+msgstr "Pole s názvem, kapitolou a podkapitolou mohou být sbalena. Pro jejich sbalení nebo rozbalení klikněte na čtvereček vedle pole. Kliknutí s tlačítkem Shift sbalí/rozbalí také všechny podčásti."
 
 #: ../../src/wxMaximaFrame.cpp:1831
 msgid "To &Bigfloat"
@@ -10576,7 +10576,7 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:124
 msgid "To plot in polar coordinates, select 'set polar' in the Options entry for Plot2d dialog. You can also plot in spherical and cylindrical coordinates in 3D."
-msgstr ""
+msgstr "Pro graf v polárních souřadnicích zvolte 'set polar' v Nastavení Plot2D. Můžete též zvolit 3D graf ve sférických nebo cylindrických souřadnicích."
 
 #: ../../src/dialogs/TipOfTheDay.cpp:131
 msgid "To put parentheses around an expression, select it, and press '(' or ')' depending on where you want the cursor to appear afterwards."
@@ -10584,7 +10584,7 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:137
 msgid "To save the size and position of wxMaxima windows between session, use 'Edit->Configure' dialog."
-msgstr ""
+msgstr "Použijte dialog 'Edit->Configure' pro uložení velikosti a pozice okna programu wxMaxima mezi sezeními."
 
 #: ../../src/dialogs/TipOfTheDay.cpp:51
 msgid "To start using wxMaxima right away, start typing your command. An input cell should appear. Then press Shift-Enter to evaluate your command."
@@ -10804,7 +10804,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:231
 msgid "Ukrainian"
-msgstr ""
+msgstr "Ukrajinský"
 
 #: ../../src/wxMaxima.cpp:3164
 msgid "Un-closed parenthesis"
@@ -10835,7 +10835,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2115
 msgid "Underlined"
-msgstr ""
+msgstr "Podtržení"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:745
 msgid "Underscore converts to subscripts:"
@@ -10983,7 +10983,7 @@ msgstr ""
 
 #: ../../src/wizards/SumWiz.cpp:69
 msgid "Use Gosper algorithm"
-msgstr ""
+msgstr "Použít Gosperův algoritmus"
 
 #: ../../src/sidebars/RegexCtrl.cpp:133
 msgid "Use RegEx filtering"
@@ -11011,7 +11011,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:849
 msgid "Use centered dot character for multiplication"
-msgstr ""
+msgstr "Použít centrovanou tečku jako symbol násobení"
 
 #: ../../src/wxMaximaFrame.cpp:1745
 msgid "Use list"
@@ -11268,7 +11268,7 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:134
 msgid "When applying functions with one argument from menus, the default argument is '%'. To apply the function to some other value, select it in the document before executing a menu command."
-msgstr ""
+msgstr "Při aplikaci funkcejedné proměnné pomocí menu je výchozí přednastavený argument '%'. Pro aplikaci funkce na jiný argument musíte tento před volbou v menu označit."
 
 #: ../../src/wxMaximaFrame.cpp:1092
 msgid "When to invoke the lisp compiler's debugger"
@@ -11355,7 +11355,7 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:64
 msgid "You can access the last output using the variable '%'. You can access the output of previous commands using variables '%on' where n is the number of output."
-msgstr ""
+msgstr "Poslední výsledek se označuje '%'. Výsledek libovolného jiného výpočtu se označuje '%on', kde n je pořadové číslo výpočtu."
 
 #: ../../src/dialogs/TipOfTheDay.cpp:118
 msgid "You can evaluate your whole document by using 'Cell->Evaluate All Cells' menu command or the appropriate key shortcut. The cells will be evaluated in the order they appear in the document."
@@ -11367,7 +11367,7 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:92
 msgid "You can hide output part of cells by clicking in the triangle on the left side of cells. This works on text cells also."
-msgstr ""
+msgstr "Výstup můžete skrýt kliknutím na trojúhelníček nalevo od pole. Tuto operaci můžete použít i u textových polí."
 
 #: ../../src/dialogs/TipOfTheDay.cpp:81
 msgid "You can insert different types of 'cells' in wxMaxima documents using the 'Cell' menu. Note that only 'input cells' can be evaluated, while others are used for commenting and structuring your calculations."
@@ -11375,7 +11375,7 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:112
 msgid "You can select multiple cells either with a mouse - click'n'drag from between cells or from a cell bracket on the left - or with a keyboard - hold down Shift while moving the horizontal cursor - and then operate on selection. This comes in handy when you want to delete or evaluate multiple cells."
-msgstr ""
+msgstr "Pomocí myši (tažením a pohybem) nebo pohybem vodorovného kurzoru (s klávesou Shift) můžete vybratvíce polí a pracovat s nimi. Toto je vhodné, pokud chcete vymazat nebo vyhodnotit více polí."
 
 #: ../../src/dialogs/TipOfTheDay.cpp:232
 msgid "You found a bug in wxMaxima? Please report it at https://github.com/wxMaxima-developers/wxmaxima/issues\n"
@@ -11451,7 +11451,7 @@ msgstr ""
 
 #: ../../src/wizards/MatWiz.cpp:160
 msgid "antisymmetric"
-msgstr ""
+msgstr "antisymetrická"
 
 #: ../../src/wxMaximaFrame.cpp:1727
 msgid "apply function to each element"
@@ -11479,7 +11479,7 @@ msgstr ""
 
 #: ../../src/wizards/LimitWiz.cpp:42
 msgid "both sides"
-msgstr ""
+msgstr "oboustranný"
 
 #: ../../src/wxMaximaFrame.cpp:1173
 msgid "char to Ascii code..."
@@ -11497,7 +11497,7 @@ msgstr ""
 #: ../../src/wizards/Plot2dWiz.cpp:70 ../../src/wizards/Plot2dWiz.cpp:372
 #: ../../src/wizards/Plot3dWiz.cpp:61 ../../src/wizards/Plot3dWiz.cpp:358
 msgid "default"
-msgstr ""
+msgstr "standardní nastavení"
 
 #: ../../src/sidebars/GreekSidebar.cpp:154
 msgid "delta"
@@ -11505,7 +11505,7 @@ msgstr ""
 
 #: ../../src/wizards/MatWiz.cpp:159
 msgid "diagonal"
-msgstr ""
+msgstr "diagonální"
 
 #: ../../src/cells/FracCell.cpp:73
 msgid "diff(): Cannot find the multiplication sign I should hide"
@@ -11587,7 +11587,7 @@ msgstr ""
 
 #: ../../src/wizards/MatWiz.cpp:159
 msgid "general"
-msgstr ""
+msgstr "obecná"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1630
 msgid "gnuplot: Without command console"
@@ -11610,7 +11610,7 @@ msgstr ""
 #: ../../src/wizards/Plot3dWiz.cpp:61 ../../src/wizards/Plot3dWiz.cpp:194
 #: ../../src/wizards/Plot3dWiz.cpp:358 ../../src/wizards/Plot3dWiz.cpp:386
 msgid "inline"
-msgstr ""
+msgstr "vestavěný"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:104
 msgid "intersection"
@@ -11630,7 +11630,7 @@ msgstr ""
 
 #: ../../src/wizards/LimitWiz.cpp:42
 msgid "left"
-msgstr ""
+msgstr "zleva"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:117
 msgid "less or equal"
@@ -11642,7 +11642,7 @@ msgstr ""
 
 #: ../../src/wizards/Plot2dWiz.cpp:54 ../../src/wizards/Plot2dWiz.cpp:64
 msgid "logscale"
-msgstr ""
+msgstr "logaritmické měřítko"
 
 #: ../../src/wizards/DrawWiz.cpp:822
 msgid "matrix([x_1,x_2,...],[y_1,y_2,...])"
@@ -11825,7 +11825,7 @@ msgstr ""
 
 #: ../../src/wizards/LimitWiz.cpp:42
 msgid "right"
-msgstr ""
+msgstr "zprava"
 
 #: ../../src/wizards/DrawWiz.cpp:310
 msgid "secondary x axis label"
@@ -11877,7 +11877,7 @@ msgstr ""
 
 #: ../../src/wizards/MatWiz.cpp:160
 msgid "symmetric"
-msgstr ""
+msgstr "symetrická"
 
 #: ../../src/MaximaCommandMenus.cpp:970
 msgid "t:"
@@ -11982,7 +11982,7 @@ msgstr ""
 #: ../../src/dialogs/ConfigDialogue.cpp:142
 #: ../../src/dialogs/ConfigDialogue.cpp:311
 msgid "wxMaxima configuration"
-msgstr ""
+msgstr "Konfigurace programu wxMaxima"
 
 #: ../../src/MaximaProcessManager.cpp:209
 msgid "wxMaxima could not start a server.\n\n"
@@ -11992,7 +11992,7 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:127
 msgid "wxMaxima dialogs set default values for inputs entries, one of which is '%'. If you have made a selection in your document, the selection will be used instead of '%'."
-msgstr ""
+msgstr "Dialog programu wxMaxima nastaví vstupní hodnoty, z nichž jedna je '%'. Pokud v dokumentu vyberete část textu, je místo toho použit tento výběr."
 
 #: ../../src/MaximaCommandMenus.cpp:4544
 msgid "wxMaxima document"

--- a/locales/wxMaxima/da.po
+++ b/locales/wxMaxima/da.po
@@ -314,7 +314,7 @@ msgstr "K&opier\tCtrl+C"
 
 #: ../../src/wizards/IntegrateWiz.cpp:39
 msgid "&Definite integration"
-msgstr ""
+msgstr "&Bestemt integration"
 
 #: ../../src/wxMaximaFrame.cpp:1658
 msgid "&Demoivre"
@@ -430,11 +430,11 @@ msgstr ""
 
 #: ../../src/wizards/IntegrateWiz.cpp:52
 msgid "&Numerical integration"
-msgstr ""
+msgstr "&Numerisk integration"
 
 #: ../../src/wizards/SumWiz.cpp:44
 msgid "&Nusum"
-msgstr ""
+msgstr "Anvend &nusum"
 
 #: ../../src/main.cpp:675
 msgid "&Open\tCtrl+O"
@@ -450,7 +450,7 @@ msgstr ""
 
 #: ../../src/wizards/SeriesWiz.cpp:45
 msgid "&Power series"
-msgstr ""
+msgstr "&Potensrækker"
 
 #: ../../src/wxMaximaFrame.cpp:655
 msgid "&Print...\tCtrl+P"
@@ -458,7 +458,7 @@ msgstr "&Udskriv...\tCtrl+P"
 
 #: ../../src/wizards/SubstituteWiz.cpp:38
 msgid "&Rational"
-msgstr ""
+msgstr "Anvend &ratsubst"
 
 #: ../../src/wxMaximaFrame.cpp:1631
 msgid "&Reduce Trigonometric"
@@ -490,11 +490,11 @@ msgstr "&Løs..."
 
 #: ../../src/wizards/Plot2dWiz.cpp:42
 msgid "&Special"
-msgstr ""
+msgstr "&Plottype"
 
 #: ../../src/wizards/LimitWiz.cpp:45
 msgid "&Taylor series"
-msgstr ""
+msgstr "&Taylorrækker"
 
 #: ../../src/wxMaximaFrame.cpp:1069
 msgid "&Time Display"
@@ -514,7 +514,7 @@ msgstr ""
 
 #: ../../src/wizards/Plot3dWiz.cpp:79
 msgid "&pm3d"
-msgstr ""
+msgstr "&pm3d"
 
 #: ../../src/cells/AnimationCell.cpp:475
 msgid "(Animation)"
@@ -550,7 +550,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:183
 msgid "(Use default language)"
-msgstr ""
+msgstr "(Anvend standard sprog)"
 
 #: ../../src/MaximaCommandMenus.cpp:440
 msgid "(f(x),x,a,b)), Epsilon algorithm"
@@ -649,7 +649,7 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:102
 msgid "A 'horizontal cursor' was introduced in wxMaxima 0.8.0. It looks like a horizontal line between cells. It indicates where a new cell will appear if you type or paste text or execute a menu command."
-msgstr ""
+msgstr "En 'vandret markør' blev introduceret i wxMaxima 0.8.0. Det ser ud som en vandret linje mellem celler. Den indikerer hvor en ny celle vil blive indsat, hvis du begynder at skrive, indsætter tekst eller udføre en kommando."
 
 #: ../../src/MaximaCommandMenus.cpp:3039
 msgid "A Ctrl-F event"
@@ -916,7 +916,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:389
 msgid "Additional parameters for Maxima (e.g. -l clisp)."
-msgstr ""
+msgstr "Yderligere Maxima-parametre (f.eks. -l clisp)."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1543
 msgid "Additional parameters for Maxima (restart Maxima after changes)"
@@ -1012,7 +1012,7 @@ msgstr ""
 
 #: ../../src/dialogs/BinaryNameCtrl.cpp:69
 msgid "All|*"
-msgstr ""
+msgstr "Alle|*"
 
 #: ../../src/wxMaximaFrame.cpp:800
 msgid "Always after underscores"
@@ -1291,7 +1291,7 @@ msgstr ""
 
 #: ../../src/wizards/BC2Wiz.cpp:59
 msgid "BC2"
-msgstr ""
+msgstr "BC2"
 
 #: ../../src/MaximaManual.cpp:559
 msgid "Background task that compiles the Manual anchors scheduled."
@@ -1358,7 +1358,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2109
 msgid "Bold"
-msgstr ""
+msgstr "Fed"
 
 #: ../../src/wxMaxima.cpp:2259
 msgid "Both horizontal and vertical cursor active at the same time"
@@ -1388,7 +1388,7 @@ msgstr ""
 #: ../../src/wizards/CsvWiz.cpp:131 ../../src/wizards/Plot2dWiz.cpp:114
 #: ../../src/wizards/Plot3dWiz.cpp:109
 msgid "Browse"
-msgstr ""
+msgstr "Gennemse"
 
 #: ../../src/wxMathml.cpp:101
 msgid "Bug: After removing the whitespace wxMathml.lisp is shorter than expected!"
@@ -1941,7 +1941,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2100
 msgid "Choose font"
-msgstr ""
+msgstr "Vælg skrifttype"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:793
 msgid "Choose how mathematical output is formatted:\n"
@@ -2126,7 +2126,7 @@ msgstr ""
 
 #: ../../src/wizards/MatWiz.cpp:155
 msgid "Columns:"
-msgstr ""
+msgstr "Søjler:"
 
 #: ../../src/wxMaximaFrame.cpp:1621
 msgid "Combine factorials in an expression"
@@ -2142,11 +2142,11 @@ msgstr ""
 
 #: ../../src/wizards/Plot2dWiz.cpp:626
 msgid "Comma separated x coordinates"
-msgstr ""
+msgstr "Kommaseparerede y-koordinater"
 
 #: ../../src/wizards/Plot2dWiz.cpp:627
 msgid "Comma separated y coordinates"
-msgstr ""
+msgstr "Kommaseparerede x-koordinater"
 
 #: ../../src/MaximaCommandMenus.cpp:4071
 msgid "Comma-separated arguments"
@@ -2372,7 +2372,7 @@ msgstr ""
 #: ../../src/dialogs/ConfigDialogue.cpp:2641
 #: ../../src/dialogs/ConfigDialogue.cpp:2647
 msgid "Config file (*.ini)|*.ini"
-msgstr ""
+msgstr "Konfigurationsfil (*.ini)|*.ini"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2539
 #, c-format
@@ -2404,7 +2404,7 @@ msgstr ""
 #: ../../src/wizards/IntegrateWiz.cpp:208 ../../src/wizards/LimitWiz.cpp:133
 #: ../../src/wizards/SeriesWiz.cpp:105
 msgid "Constant"
-msgstr ""
+msgstr "Konstant"
 
 #: ../../src/MaximaCommandMenus.cpp:1102
 msgid "Construct a fraction"
@@ -2878,7 +2878,7 @@ msgstr ""
 
 #: ../../src/worksheet/Worksheet.cpp:6115
 msgid "Cursor"
-msgstr ""
+msgstr "Markør"
 
 #: ../../src/Styles.cpp:126
 msgid "Cursor color"
@@ -3121,7 +3121,7 @@ msgstr ""
 
 #: ../../src/wizards/SeriesWiz.cpp:42
 msgid "Depth:"
-msgstr ""
+msgstr "Orden:"
 
 #: ../../src/MaximaCommandMenus.cpp:994
 msgid "Derivate of y at that point:"
@@ -3188,7 +3188,7 @@ msgstr ""
 
 #: ../../src/sidebars/MathSidebar.cpp:80
 msgid "Diff..."
-msgstr ""
+msgstr "Differentier..."
 
 #: ../../src/dialogs/DiffFrame.cpp:308
 #, c-format
@@ -3217,7 +3217,7 @@ msgstr ""
 
 #: ../../src/wizards/LimitWiz.cpp:41
 msgid "Direction:"
-msgstr ""
+msgstr "Fra:"
 
 #: ../../src/wxMaximaFrame.cpp:1246
 msgid "Directory operations"
@@ -3229,7 +3229,7 @@ msgstr ""
 
 #: ../../src/wizards/Plot2dWiz.cpp:418 ../../src/wizards/Plot2dWiz.cpp:619
 msgid "Discrete plot"
-msgstr ""
+msgstr "Diskret plot"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:699
 msgid "Display"
@@ -3571,7 +3571,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:196
 msgid "English"
-msgstr ""
+msgstr "Engelsk"
 
 #: ../../src/wizards/DrawWiz.cpp:552
 msgid "Enhanced 3D settings:"
@@ -3603,7 +3603,7 @@ msgstr "Indtast udtryk:"
 
 #: ../../src/wizards/SystemWiz.cpp:50
 msgid "Enter comma separated list of variables."
-msgstr ""
+msgstr "Indtast kommasepareret liste med variable."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:921
 msgid "Enter evaluates cells, Ctrl+Enter adds newlines"
@@ -3623,7 +3623,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:388
 msgid "Enter the path to the Maxima executable."
-msgstr ""
+msgstr "Indtast stien til Maxima-programmet."
 
 #: ../../src/MaximaCommandMenus.cpp:1103
 msgid "Enumerator:"
@@ -3870,7 +3870,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2659
 msgid "Example text"
-msgstr ""
+msgstr "Teksteksempel"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1547
 msgid "Examples:"
@@ -3886,11 +3886,11 @@ msgstr ""
 
 #: ../../src/sidebars/MathSidebar.cpp:53
 msgid "Expand"
-msgstr ""
+msgstr "Udvid til ledform"
 
 #: ../../src/sidebars/MathSidebar.cpp:68
 msgid "Expand (tr)"
-msgstr ""
+msgstr "Udvid trig."
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:356
 msgid "Expand Expression"
@@ -4216,7 +4216,7 @@ msgstr ""
 
 #: ../../src/sidebars/MathSidebar.cpp:50
 msgid "Factor"
-msgstr ""
+msgstr "Faktoriser"
 
 #: ../../src/wxMaximaFrame.cpp:1558
 msgid "Factor Complex"
@@ -4489,7 +4489,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:873
 msgid "Fixed font in text controls"
-msgstr ""
+msgstr "Fast tegnbredde i indtastningsfelter"
 
 #: ../../src/MaximaCommandMenus.cpp:4039
 msgid "Flush stream"
@@ -4533,7 +4533,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2047
 msgid "Fonts"
-msgstr ""
+msgstr "Skrifttyper"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:442
 msgid "For each Text-, Sectioning or code cell wxMaxima can display a bracket showing the extend of the cell and allowing to fold it. This setting now tells if this bracket is to be printed, as well."
@@ -4561,7 +4561,7 @@ msgstr ""
 
 #: ../../src/wizards/Plot2dWiz.cpp:69 ../../src/wizards/Plot3dWiz.cpp:60
 msgid "Format:"
-msgstr ""
+msgstr "Format:"
 
 #: ../../src/worksheet/Worksheet.cpp:301 ../../src/wxMaxima.cpp:3521
 msgid "Forwarding the keyboard focus to a text control"
@@ -4626,7 +4626,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:198
 msgid "French"
-msgstr ""
+msgstr "Fransk"
 
 #: ../../src/wxMaximaFrame.cpp:1447
 msgid "Frobenius Norm sqrt(sum((A(i,j))^2)) (complex)"
@@ -4765,7 +4765,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:201
 msgid "German"
-msgstr ""
+msgstr "Tysk"
 
 #: ../../src/wxMaximaFrame.cpp:1656
 msgid "Get &Imaginary Part"
@@ -4869,7 +4869,7 @@ msgstr ""
 
 #: ../../src/wizards/Plot3dWiz.cpp:52
 msgid "Grid:"
-msgstr ""
+msgstr "Gitter:"
 
 #: ../../src/wxMaximaFrame.cpp:1852
 msgid "Guess an exact number that could be meant by this float"
@@ -5058,7 +5058,7 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:105
 msgid "Horizontal cursor works like a normal cursor, but it operates on cells: press up or down arrow to move it, holding down Shift while moving will select cells, pressing backspace or delete twice will delete a cell next to it."
-msgstr ""
+msgstr "En vandret markør fungerer som en normal markør, men opererer på celler: tryk på op eller ned piletast for at flytte markørstregen. Holdes Shift nede mens pile tasterne benyttes markeres celle(r), ved tryk på backspace eller delete  slettes de(n) markerede celle(r)."
 
 #: ../../src/wxMaximaFrame.cpp:1563
 msgid "Horner's rule"
@@ -5078,7 +5078,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:205
 msgid "Hungarian"
-msgstr ""
+msgstr "Ungarsk"
 
 #: ../../src/wxMaximaFrame.cpp:1147
 msgid "I/O"
@@ -5189,7 +5189,7 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:122
 msgid "If your calculation is taking too long to evaluate, you can try 'Maxima->Interrupt' or 'Maxima->Restart Maxima' menu commands."
-msgstr ""
+msgstr "Hvis din beregning tager for lang tid, kan du benytte 'Maxima->Afbryd' eller 'Maxima->Genstart Maxima'"
 
 #: ../../src/MaximaManual.cpp:420
 msgid "Ignoring the cache version for the manual anchors."
@@ -5804,11 +5804,11 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:207
 msgid "Italian"
-msgstr ""
+msgstr "Italiensk"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2111
 msgid "Italic"
-msgstr ""
+msgstr "Kursiv"
 
 #: ../../src/MaximaCommandMenus.cpp:1617 ../../src/MaximaCommandMenus.cpp:1623
 msgid "Item"
@@ -5916,11 +5916,11 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:470
 msgid "Language used for wxMaxima GUI."
-msgstr ""
+msgstr "Sprog for wxMaxima-brugerfladen."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1311
 msgid "Language:"
-msgstr ""
+msgstr "Sprog:"
 
 #: ../../src/MaximaCommandMenus.cpp:251
 msgid "Laplace"
@@ -6037,7 +6037,7 @@ msgstr "Grænseværdi"
 
 #: ../../src/sidebars/MathSidebar.cpp:86
 msgid "Limit..."
-msgstr ""
+msgstr "Grænseværdi..."
 
 #: ../../src/sidebars/DrawSidebar.cpp:88
 msgid "Line color"
@@ -6178,7 +6178,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2162
 msgid "Load"
-msgstr ""
+msgstr "Indlæs"
 
 #: ../../src/MaximaCommandMenus.cpp:2356
 msgid "Load Package"
@@ -6218,7 +6218,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2645
 msgid "Load style from file"
-msgstr ""
+msgstr "Indlæs typografi fra fil"
 
 #: ../../src/wxMaximaFrame.cpp:1232
 msgid "Load the file/dir operations (operatingsystem)"
@@ -6551,7 +6551,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1437
 msgid "Maxima program:"
-msgstr ""
+msgstr "Sti til Maxima-program:"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:382
 msgid "Maxima provides no \"forget all\" command that flushes all settings a maxima session could make. wxMaxima therefore normally defaults to starting a fresh maxima process every time the worksheet is to be re-evaluated. As this needs a little bit of time this switch allows to disable this behavior."
@@ -6823,7 +6823,7 @@ msgstr ""
 
 #: ../../src/wizards/IntegrateWiz.cpp:55
 msgid "Method:"
-msgstr ""
+msgstr "Metode:"
 
 #: ../../src/wxMaximaFrame.cpp:1360
 msgid "Methods of generating a matrix"
@@ -6922,7 +6922,7 @@ msgstr ""
 
 #: ../../src/wizards/MatWiz.cpp:163
 msgid "Name:"
-msgstr ""
+msgstr "Navn:"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:216
 msgid "Nepali"
@@ -6998,7 +6998,7 @@ msgstr ""
 
 #: ../../src/wizards/SubstituteWiz.cpp:35
 msgid "New value:"
-msgstr ""
+msgstr "Ny værdi:"
 
 #: ../../src/MaximaCommandMenus.cpp:151 ../../src/MaximaCommandMenus.cpp:171
 #: ../../src/MaximaCommandMenus.cpp:254 ../../src/MaximaCommandMenus.cpp:259
@@ -7303,7 +7303,7 @@ msgstr ""
 
 #: ../../src/wizards/SubstituteWiz.cpp:32
 msgid "Old value:"
-msgstr ""
+msgstr "Tidligere værdi:"
 
 #: ../../src/MaximaCommandMenus.cpp:151 ../../src/MaximaCommandMenus.cpp:172
 #: ../../src/MaximaCommandMenus.cpp:253 ../../src/MaximaCommandMenus.cpp:259
@@ -7432,7 +7432,7 @@ msgstr "Indstillinger"
 
 #: ../../src/wizards/Plot2dWiz.cpp:75 ../../src/wizards/Plot3dWiz.cpp:66
 msgid "Options:"
-msgstr ""
+msgstr "Egenskaber:"
 
 #: ../../src/dialogs/FindReplacePane.cpp:109
 msgid "Output"
@@ -7533,7 +7533,7 @@ msgstr ""
 
 #: ../../src/wizards/Plot2dWiz.cpp:417 ../../src/wizards/Plot2dWiz.cpp:523
 msgid "Parametric plot"
-msgstr ""
+msgstr "Parameterplot"
 
 #: ../../src/MaximaCommandMenus.cpp:4211
 msgid "Parse string"
@@ -7611,7 +7611,7 @@ msgstr "Ændrer indstillinger for wxMaxima i 'Rediger->Indstillinger'"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2606
 msgid "Please restart wxMaxima for changes to take effect!"
-msgstr ""
+msgstr "Genstart wxMaxima for at ændringer træder i kraft!"
 
 #: ../../src/MaximaCommandMenus.cpp:2250
 msgid "Please select exactly 2 or 3 files."
@@ -7689,7 +7689,7 @@ msgstr ""
 
 #: ../../src/wizards/Plot2dWiz.cpp:84 ../../src/wizards/Plot3dWiz.cpp:80
 msgid "Plot to file:"
-msgstr ""
+msgstr "Plot til fil:"
 
 #: ../../src/wxMaximaFrame.cpp:341 ../../src/wxMaximaFrame.cpp:749
 msgid "Plot using Draw"
@@ -7723,7 +7723,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:219
 msgid "Polish"
-msgstr ""
+msgstr "Polsk"
 
 #: ../../src/MaximaCommandMenus.cpp:215 ../../src/MaximaCommandMenus.cpp:220
 #: ../../src/MaximaCommandMenus.cpp:225
@@ -7759,7 +7759,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:221
 msgid "Portuguese (Brazilian)"
-msgstr ""
+msgstr "Portugisisk (brasiliansk)"
 
 #: ../../src/wxMaximaFrame.cpp:1223
 msgid "Position of a match"
@@ -7775,7 +7775,7 @@ msgstr ""
 
 #: ../../src/wizards/Plot2dWiz.cpp:474 ../../src/wizards/Plot3dWiz.cpp:422
 msgid "Postscript file (*.eps)|*.eps|All|*"
-msgstr ""
+msgstr "Postscript-fil (*.eps)|*.eps|Alle|*"
 
 #: ../../src/MaximaCommandMenus.cpp:190
 msgid "Power series"
@@ -8174,7 +8174,7 @@ msgstr ""
 
 #: ../../src/sidebars/MathSidebar.cpp:56
 msgid "Rectform"
-msgstr ""
+msgstr "Rektangulær form"
 
 #: ../../src/wxMaximaFrame.cpp:1677
 msgid "Recursive Substitute..."
@@ -8198,7 +8198,7 @@ msgstr ""
 
 #: ../../src/sidebars/MathSidebar.cpp:71
 msgid "Reduce (tr)"
-msgstr ""
+msgstr "Sammentræk trig."
 
 #: ../../src/wxMaximaFrame.cpp:1632
 msgid "Reduce trigonometric expression"
@@ -8586,7 +8586,7 @@ msgstr ""
 
 #: ../../src/wizards/MatWiz.cpp:152
 msgid "Rows:"
-msgstr ""
+msgstr "Rækker:"
 
 #: ../../src/MaximaCommandMenus.cpp:1391
 msgid "Rule"
@@ -8656,7 +8656,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:223
 msgid "Russian"
-msgstr ""
+msgstr "Russisk"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1578
 msgid "SBCL: use <int>Mbytes of heap"
@@ -8758,7 +8758,7 @@ msgstr ""
 
 #: ../../src/wizards/Plot2dWiz.cpp:473 ../../src/wizards/Plot3dWiz.cpp:421
 msgid "Save plot to file"
-msgstr ""
+msgstr "Gem plot som fil"
 
 #: ../../src/wxMaximaFrame.cpp:713
 msgid "Save selection from document to an image file"
@@ -8770,7 +8770,7 @@ msgstr "Gem markering i fil"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2640
 msgid "Save style to file"
-msgstr ""
+msgstr "Gem typografi i fil"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1384
 msgid "Save the worksheet automatically"
@@ -8893,7 +8893,7 @@ msgstr ""
 #: ../../src/wizards/IntegrateWiz.cpp:208 ../../src/wizards/LimitWiz.cpp:133
 #: ../../src/wizards/SeriesWiz.cpp:105
 msgid "Select a constant"
-msgstr ""
+msgstr "Vælg en konstant"
 
 #: ../../src/ToolBar.cpp:390 ../../src/ToolBar.cpp:392
 #: ../../src/wxMaximaFrame.cpp:710
@@ -9002,7 +9002,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:479
 msgid "Set fixed font in text controls."
-msgstr ""
+msgstr "Brug fast tegnbredde i indtastningsfelter"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:68
 #: ../../src/worksheet/WorksheetContextMenu.cpp:250
@@ -9229,7 +9229,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:465
 msgid "Show long expressions in wxMaxima document."
-msgstr ""
+msgstr "Vis lange udtryk i wxMaxima-dokument."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:722
 msgid "Show long expressions:"
@@ -9334,7 +9334,7 @@ msgstr ""
 
 #: ../../src/sidebars/MathSidebar.cpp:44
 msgid "Simplify"
-msgstr ""
+msgstr "Reducer (ratsimp)"
 
 #: ../../src/wxMaximaFrame.cpp:1550
 msgid "Simplify &Radicals..."
@@ -9342,11 +9342,11 @@ msgstr ""
 
 #: ../../src/sidebars/MathSidebar.cpp:47
 msgid "Simplify (r)"
-msgstr ""
+msgstr "Reducer (radcan)"
 
 #: ../../src/sidebars/MathSidebar.cpp:65
 msgid "Simplify (tr)"
-msgstr ""
+msgstr "Reducer trig."
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:352
 msgid "Simplify Expression"
@@ -9386,7 +9386,7 @@ msgstr ""
 
 #: ../../src/wizards/SumWiz.cpp:68
 msgid "Simplify the sum"
-msgstr ""
+msgstr "Reducer sum"
 
 #: ../../src/wxMaximaFrame.cpp:1629
 msgid "Simplify trigonometric expression"
@@ -9451,7 +9451,7 @@ msgstr ""
 
 #: ../../src/wizards/BC2Wiz.cpp:30
 msgid "Solution:"
-msgstr ""
+msgstr "Løsning:"
 
 #: ../../src/MaximaCommandMenus.cpp:3446
 msgid "Solve"
@@ -9491,7 +9491,7 @@ msgstr "Løs O&DL med Laplace..."
 
 #: ../../src/sidebars/MathSidebar.cpp:77
 msgid "Solve ODE..."
-msgstr ""
+msgstr "Løs ODL..."
 
 #: ../../src/wxMaximaFrame.cpp:1432
 msgid "Solve a linear equation system using dgesv"
@@ -9618,12 +9618,12 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:227
 msgid "Spanish"
-msgstr ""
+msgstr "Spansk"
 
 #: ../../src/wizards/IntegrateWiz.cpp:44 ../../src/wizards/IntegrateWiz.cpp:50
 #: ../../src/wizards/LimitWiz.cpp:38 ../../src/wizards/SeriesWiz.cpp:39
 msgid "Special"
-msgstr ""
+msgstr "Specialtegn"
 
 #: ../../src/wizards/DrawWiz.cpp:918
 msgid "Speed versus accuracy"
@@ -9834,11 +9834,11 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:282
 msgid "Style"
-msgstr ""
+msgstr "Typografi"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2082
 msgid "Styles"
-msgstr ""
+msgstr "Typografier"
 
 #: ../../src/sidebars/StatSidebar.cpp:112
 msgid "Subsample..."
@@ -9862,7 +9862,7 @@ msgstr ""
 
 #: ../../src/sidebars/MathSidebar.cpp:59
 msgid "Subst..."
-msgstr ""
+msgstr "Substituer..."
 
 #: ../../src/MaximaCommandMenus.cpp:715 ../../src/MaximaCommandMenus.cpp:3490
 #: ../../src/MaximaCommandMenus.cpp:4500 ../../src/wizards/SubstituteWiz.cpp:53
@@ -10138,7 +10138,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:492
 msgid "The default port used for communication between Maxima and wxMaxima."
-msgstr ""
+msgstr "Standardport for kommunikation mellem Maxima og wxMaxima."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:412
 msgid "The default width for embedded plots. Can be read out or overridden by the maxima variable wxplot_size"
@@ -10520,7 +10520,7 @@ msgstr ""
 
 #: ../../src/wizards/Plot2dWiz.cpp:65 ../../src/wizards/Plot2dWiz.cpp:505
 msgid "Ticks:"
-msgstr ""
+msgstr "Inddeling:"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1359
 msgid "Time [in Minutes] between autosaves"
@@ -10576,7 +10576,7 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:124
 msgid "To plot in polar coordinates, select 'set polar' in the Options entry for Plot2d dialog. You can also plot in spherical and cylindrical coordinates in 3D."
-msgstr ""
+msgstr "For at lave et polærplot, vælg 'set polar; set zeroaxis;' under 'Egenskaber' i 2D-plot-menuen. Du kan også lave sfæriske og cylindriske plot i 3D."
 
 #: ../../src/dialogs/TipOfTheDay.cpp:131
 msgid "To put parentheses around an expression, select it, and press '(' or ')' depending on where you want the cursor to appear afterwards."
@@ -10584,7 +10584,7 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:137
 msgid "To save the size and position of wxMaxima windows between session, use 'Edit->Configure' dialog."
-msgstr ""
+msgstr "For at gemme størrelse og position af wxMaxima vinduer fra gang til gang, benyt 'Rediger->Indstillinger' og marker ved 'Gem wxMaxima vindue størrelse/position' "
 
 #: ../../src/dialogs/TipOfTheDay.cpp:51
 msgid "To start using wxMaxima right away, start typing your command. An input cell should appear. Then press Shift-Enter to evaluate your command."
@@ -10804,7 +10804,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:231
 msgid "Ukrainian"
-msgstr ""
+msgstr "Ukrainsk"
 
 #: ../../src/wxMaxima.cpp:3164
 msgid "Un-closed parenthesis"
@@ -10835,7 +10835,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2115
 msgid "Underlined"
-msgstr ""
+msgstr "Understreget"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:745
 msgid "Underscore converts to subscripts:"
@@ -10983,7 +10983,7 @@ msgstr ""
 
 #: ../../src/wizards/SumWiz.cpp:69
 msgid "Use Gosper algorithm"
-msgstr ""
+msgstr "Anvend Gosper-algortime"
 
 #: ../../src/sidebars/RegexCtrl.cpp:133
 msgid "Use RegEx filtering"
@@ -11011,7 +11011,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:849
 msgid "Use centered dot character for multiplication"
-msgstr ""
+msgstr "Anvend prik som multiplikationssymbol"
 
 #: ../../src/wxMaximaFrame.cpp:1745
 msgid "Use list"
@@ -11268,7 +11268,7 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:134
 msgid "When applying functions with one argument from menus, the default argument is '%'. To apply the function to some other value, select it in the document before executing a menu command."
-msgstr ""
+msgstr "Når der vælges en funktion med et enkelt input-argument fra en menu, er input-argument automatisk '%'. For at få funktionen til at virke på en anden værdi, skal input-argumentet vælges inden funktionen vælges fra menuen."
 
 #: ../../src/wxMaximaFrame.cpp:1092
 msgid "When to invoke the lisp compiler's debugger"
@@ -11355,7 +11355,7 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:64
 msgid "You can access the last output using the variable '%'. You can access the output of previous commands using variables '%on' where n is the number of output."
-msgstr ""
+msgstr "Det seneste output kan tilgås gennem variablen '%'. Output fra tidligere kommandoer kan tilgås ved at anvende variable '%on', hvor n er output-nummeret."
 
 #: ../../src/dialogs/TipOfTheDay.cpp:118
 msgid "You can evaluate your whole document by using 'Cell->Evaluate All Cells' menu command or the appropriate key shortcut. The cells will be evaluated in the order they appear in the document."
@@ -11367,7 +11367,7 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:92
 msgid "You can hide output part of cells by clicking in the triangle on the left side of cells. This works on text cells also."
-msgstr ""
+msgstr "Output fra en celle kan skjules ved at klikke i trekanten i cellens venstre side. Indholdet i tekstceller kan skjules på samme måde."
 
 #: ../../src/dialogs/TipOfTheDay.cpp:81
 msgid "You can insert different types of 'cells' in wxMaxima documents using the 'Cell' menu. Note that only 'input cells' can be evaluated, while others are used for commenting and structuring your calculations."
@@ -11375,7 +11375,7 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:112
 msgid "You can select multiple cells either with a mouse - click'n'drag from between cells or from a cell bracket on the left - or with a keyboard - hold down Shift while moving the horizontal cursor - and then operate on selection. This comes in handy when you want to delete or evaluate multiple cells."
-msgstr ""
+msgstr "Du kan markere og vælge flere celler af gangen enten ved at bruge musen - klik og træk mellem celler eller marker en enkelt celle ved at trække fra venstre mod højre - eller ved at bruge keyboardet - hold Shift nede og brug piletastern og den horisontale markør. Herefter kan du udføre beregning på de markerede celler på én gang."
 
 #: ../../src/dialogs/TipOfTheDay.cpp:232
 msgid "You found a bug in wxMaxima? Please report it at https://github.com/wxMaxima-developers/wxmaxima/issues\n"
@@ -11451,7 +11451,7 @@ msgstr ""
 
 #: ../../src/wizards/MatWiz.cpp:160
 msgid "antisymmetric"
-msgstr ""
+msgstr "antisymmetrisk"
 
 #: ../../src/wxMaximaFrame.cpp:1727
 msgid "apply function to each element"
@@ -11479,7 +11479,7 @@ msgstr ""
 
 #: ../../src/wizards/LimitWiz.cpp:42
 msgid "both sides"
-msgstr ""
+msgstr "begge sider"
 
 #: ../../src/wxMaximaFrame.cpp:1173
 msgid "char to Ascii code..."
@@ -11497,7 +11497,7 @@ msgstr ""
 #: ../../src/wizards/Plot2dWiz.cpp:70 ../../src/wizards/Plot2dWiz.cpp:372
 #: ../../src/wizards/Plot3dWiz.cpp:61 ../../src/wizards/Plot3dWiz.cpp:358
 msgid "default"
-msgstr ""
+msgstr "standard"
 
 #: ../../src/sidebars/GreekSidebar.cpp:154
 msgid "delta"
@@ -11505,7 +11505,7 @@ msgstr ""
 
 #: ../../src/wizards/MatWiz.cpp:159
 msgid "diagonal"
-msgstr ""
+msgstr "diagonal"
 
 #: ../../src/cells/FracCell.cpp:73
 msgid "diff(): Cannot find the multiplication sign I should hide"
@@ -11587,7 +11587,7 @@ msgstr ""
 
 #: ../../src/wizards/MatWiz.cpp:159
 msgid "general"
-msgstr ""
+msgstr "generel"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1630
 msgid "gnuplot: Without command console"
@@ -11610,7 +11610,7 @@ msgstr ""
 #: ../../src/wizards/Plot3dWiz.cpp:61 ../../src/wizards/Plot3dWiz.cpp:194
 #: ../../src/wizards/Plot3dWiz.cpp:358 ../../src/wizards/Plot3dWiz.cpp:386
 msgid "inline"
-msgstr ""
+msgstr "på linje med tekst"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:104
 msgid "intersection"
@@ -11630,7 +11630,7 @@ msgstr ""
 
 #: ../../src/wizards/LimitWiz.cpp:42
 msgid "left"
-msgstr ""
+msgstr "venstre"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:117
 msgid "less or equal"
@@ -11825,7 +11825,7 @@ msgstr ""
 
 #: ../../src/wizards/LimitWiz.cpp:42
 msgid "right"
-msgstr ""
+msgstr "højre"
 
 #: ../../src/wizards/DrawWiz.cpp:310
 msgid "secondary x axis label"
@@ -11877,7 +11877,7 @@ msgstr ""
 
 #: ../../src/wizards/MatWiz.cpp:160
 msgid "symmetric"
-msgstr ""
+msgstr "symmetrisk"
 
 #: ../../src/MaximaCommandMenus.cpp:970
 msgid "t:"
@@ -11982,7 +11982,7 @@ msgstr ""
 #: ../../src/dialogs/ConfigDialogue.cpp:142
 #: ../../src/dialogs/ConfigDialogue.cpp:311
 msgid "wxMaxima configuration"
-msgstr ""
+msgstr "Indstillinger for wxMaxima"
 
 #: ../../src/MaximaProcessManager.cpp:209
 msgid "wxMaxima could not start a server.\n\n"
@@ -11992,7 +11992,7 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:127
 msgid "wxMaxima dialogs set default values for inputs entries, one of which is '%'. If you have made a selection in your document, the selection will be used instead of '%'."
-msgstr ""
+msgstr "I wxMaxima-dialogboksenes felter er indsat standardværdier, hvoraf en er '%'. Hvis der er foretaget markering i dokumentet, anvendes denne markering i stedet for '%'."
 
 #: ../../src/MaximaCommandMenus.cpp:4544
 msgid "wxMaxima document"

--- a/locales/wxMaxima/de.po
+++ b/locales/wxMaxima/de.po
@@ -53,23 +53,23 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1569
 msgid "      -X \"--control-stack-size <int>\""
-msgstr ""
+msgstr "      -X \"--control-stack-size <int>\""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1568
 msgid "      -X \"--dynamic-space-size <int>\""
-msgstr ""
+msgstr "      -X \"--dynamic-space-size <int>\""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1572
 msgid "      -X '--control-stack-size <int>'"
-msgstr ""
+msgstr "      -X '--control-stack-size <int>'"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1571
 msgid "      -X '--dynamic-space-size <int>'"
-msgstr ""
+msgstr "      -X '--dynamic-space-size <int>'"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1551
 msgid "      -l <name>"
-msgstr ""
+msgstr "      -l <name>"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1557
 msgid "      -u <versionnumber>"
@@ -167,7 +167,7 @@ msgstr "(Dateiformat (WXM Version 1, erste Zeile der Datei) nicht erkannt)"
 #: ../../src/cells/ImgCell.cpp:212 ../../src/cells/ImgCell.cpp:214
 #: ../../src/cells/ImgCell.cpp:216
 msgid " (Graphics) "
-msgstr ""
+msgstr " (Bild) "
 
 #: ../../src/cells/EditorCell.cpp:3551 ../../src/cells/EditorCell.cpp:3820
 #: ../../src/cells/EditorCell.cpp:3945
@@ -177,7 +177,7 @@ msgstr ""
 
 #: ../../src/cells/EditorCell.cpp:3553
 msgid " ... + 1 hidden line"
-msgstr ""
+msgstr "... + 1 versteckte Zeile"
 
 #: ../../src/dialogs/TipOfTheDay.cpp:273
 msgid " Did you know? "
@@ -193,15 +193,15 @@ msgstr " Falsch, wenn es eine komplexe"
 
 #: ../../src/wizards/DrawWiz.cpp:964 ../../src/wizards/DrawWiz.cpp:980
 msgid " samples"
-msgstr ""
+msgstr " Stützstellen"
 
 #: ../../src/wizards/DrawWiz.cpp:929 ../../src/wizards/DrawWiz.cpp:945
 msgid " samples, on demand split "
-msgstr ""
+msgstr " Stützstellen, bei Bedarf "
 
 #: ../../src/wizards/DrawWiz.cpp:933 ../../src/wizards/DrawWiz.cpp:952
 msgid " times"
-msgstr ""
+msgstr "-mal verdoppelt."
 
 #: ../../src/MaximaCommandMenus.cpp:4413
 msgid "\".\" = \"The current directory\"\n"
@@ -216,7 +216,7 @@ msgstr "\"..\" bedeutet::\"Ein Verzeichnis nach oben\"."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1208
 msgid "\"Copy LaTeX\" adds equation markers"
-msgstr ""
+msgstr "\"LaTeX Kopieren\" fügt Mathe-Markierung hinzu"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:446
 msgid "\"MathML (rendered by the browser)\" is the recommended choice: every current browser renders MathML natively and instantly, and the exported page needs no JavaScript and makes no requests to any external server.\n"
@@ -226,11 +226,11 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:930
 msgid "\"Numpad Enter\" always evaluates cells"
-msgstr ""
+msgstr "\"Eingabe\" (am numerischen Tastenfeld) wertet Zellen immer aus"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:90
 msgid "\"implies\" symbol"
-msgstr ""
+msgstr "Das \"daraus folgt\"-Symbol"
 
 #: ../../src/dialogs/DiffFrame.cpp:306
 #, c-format
@@ -317,7 +317,7 @@ msgstr "&Kopieren\tCtrl+C"
 
 #: ../../src/wizards/IntegrateWiz.cpp:39
 msgid "&Definite integration"
-msgstr ""
+msgstr "&Bestimmtes Integral"
 
 #: ../../src/wxMaximaFrame.cpp:1658
 msgid "&Demoivre"
@@ -433,11 +433,11 @@ msgstr "&Numerische Ausgabe"
 
 #: ../../src/wizards/IntegrateWiz.cpp:52
 msgid "&Numerical integration"
-msgstr ""
+msgstr "&Numerische Integration"
 
 #: ../../src/wizards/SumWiz.cpp:44
 msgid "&Nusum"
-msgstr ""
+msgstr "&Gosper"
 
 #: ../../src/main.cpp:675
 msgid "&Open\tCtrl+O"
@@ -453,7 +453,7 @@ msgstr "&Plotten"
 
 #: ../../src/wizards/SeriesWiz.cpp:45
 msgid "&Power series"
-msgstr ""
+msgstr "&Potenzreihe"
 
 #: ../../src/wxMaximaFrame.cpp:655
 msgid "&Print...\tCtrl+P"
@@ -461,7 +461,7 @@ msgstr "Drucken ...\tCtrl+P"
 
 #: ../../src/wizards/SubstituteWiz.cpp:38
 msgid "&Rational"
-msgstr ""
+msgstr "&rational"
 
 #: ../../src/wxMaximaFrame.cpp:1631
 msgid "&Reduce Trigonometric"
@@ -493,11 +493,11 @@ msgstr "Gleichung lö&sen ..."
 
 #: ../../src/wizards/Plot2dWiz.cpp:42
 msgid "&Special"
-msgstr ""
+msgstr "Be&sondere Werte"
 
 #: ../../src/wizards/LimitWiz.cpp:45
 msgid "&Taylor series"
-msgstr ""
+msgstr "Taylorreihe"
 
 #: ../../src/wxMaximaFrame.cpp:1069
 msgid "&Time Display"
@@ -517,7 +517,7 @@ msgstr "&Variablen"
 
 #: ../../src/wizards/Plot3dWiz.cpp:79
 msgid "&pm3d"
-msgstr ""
+msgstr "&Farbe nach Höhe"
 
 #: ../../src/cells/AnimationCell.cpp:475
 msgid "(Animation)"
@@ -549,11 +549,11 @@ msgstr ""
 
 #: ../../src/sidebars/VariablesPane.cpp:254
 msgid "(Not a valid variable name)"
-msgstr ""
+msgstr "(Kein gültiger Variablenname)"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:183
 msgid "(Use default language)"
-msgstr ""
+msgstr "(Standardsprache verwenden)"
 
 #: ../../src/MaximaCommandMenus.cpp:440
 msgid "(f(x),x,a,b)), Epsilon algorithm"
@@ -587,7 +587,7 @@ msgstr "(f(x),x,y) mit Singularitäten und Unstetigkeiten"
 #: ../../src/wizards/DrawWiz.cpp:303 ../../src/wizards/DrawWiz.cpp:320
 #: ../../src/wizards/DrawWiz.cpp:335
 msgid "-"
-msgstr ""
+msgstr "-"
 
 #: ../../src/wizards/IntegrateWiz.cpp:192
 #: ../../src/wizards/IntegrateWiz.cpp:202
@@ -595,7 +595,7 @@ msgstr ""
 #: ../../src/wizards/IntegrateWiz.cpp:217 ../../src/wizards/LimitWiz.cpp:132
 #: ../../src/wizards/LimitWiz.cpp:142
 msgid "- Infinity"
-msgstr ""
+msgstr "- Infinity"
 
 #: ../../src/MaximaOutputAppender.cpp:116
 msgid "... [suppressed additional lines as the output is longer than allowed in the wxMaxima configuration] "
@@ -611,11 +611,11 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:77
 msgid "1/2"
-msgstr ""
+msgstr "1/2"
 
 #: ../../src/sidebars/DrawSidebar.cpp:45
 msgid "2D"
-msgstr ""
+msgstr "2D"
 
 #: ../../src/wxMaximaFrame.cpp:1346
 msgid "2D Array to Matrix..."
@@ -639,7 +639,7 @@ msgstr ""
 
 #: ../../src/sidebars/DrawSidebar.cpp:49
 msgid "3D"
-msgstr ""
+msgstr "3D"
 
 #: ../../src/wxMaxima.cpp:1833
 #, c-format
@@ -652,7 +652,7 @@ msgstr "Ein \":lisp\" als erster Befehl meldet evtl. nicht, wenn er fertig ist."
 
 #: ../../src/dialogs/TipOfTheDay.cpp:102
 msgid "A 'horizontal cursor' was introduced in wxMaxima 0.8.0. It looks like a horizontal line between cells. It indicates where a new cell will appear if you type or paste text or execute a menu command."
-msgstr ""
+msgstr "Seit wxMaxima 0.8.0 steht ein horizontaler Cursor zur Verfügung, der zwischen den Zellen als eine horizontale Linie erscheint. Der horizontale Cursor zeigt an, wo z. B. die nächste neue Zelle eingefügt wird."
 
 #: ../../src/MaximaCommandMenus.cpp:3039
 msgid "A Ctrl-F event"
@@ -678,7 +678,7 @@ msgstr ""
 
 #: ../../src/wizards/ListSortWiz.cpp:63
 msgid "A function f(a,b), named"
-msgstr ""
+msgstr "Eine Funktion f(a,b) des Namens"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:784
 msgid "A function returning integers"
@@ -690,7 +690,7 @@ msgstr "Eine Funktion, die positive ganze Zahlen retourniert"
 
 #: ../../src/wizards/DrawWiz.cpp:164
 msgid "A good example equation would be x^2+y^2=1"
-msgstr ""
+msgstr "Eine gute Beispielgleichung wäre x^2+y^2=1"
 
 #: ../../src/cells/GroupCell.cpp:2193 ../../src/cells/GroupCell.cpp:2196
 msgid "A heading"
@@ -714,15 +714,15 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:84
 msgid "A new document format has been introduced in wxMaxima 0.8.2 that saves not only your input and text commentaries, but also the outputs of your calculations. When saving your document, select 'Whole document (*.wxmx)' format."
-msgstr ""
+msgstr "Mit wxMaxima 0.8.2 wurde ein neues Format für Dokumente eingeführt. Dieses sichert nicht nur die Eingaben, sondern auch die Ergebnisse der Berechnungen. Wenn Sie Ihr Dokument speichern, können Sie dazu das Format 'Gesamtes Dokument (*.wxmx)' auswählen."
 
 #: ../../src/cells/GroupCell.cpp:2175
 msgid "A page break"
-msgstr ""
+msgstr "Ein Seitenumbruch"
 
 #: ../../src/dialogs/TipOfTheDay.cpp:168
 msgid "A plot to be embedded into the work sheet by preceding its name with a \"wx\". \"draw\" can be replaced by \"wxdraw\", plot by \"wxplot\" etc."
-msgstr ""
+msgstr "Diagramme können eingebettet werden, indem an den Beginn des Namens des Zeichenbefehls ein \"wx\" vorangestellt wird.\n\"draw\" wird so zu \"wxdraw\", plot zu \"wxplot\" etc."
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:735
 msgid "A rational variable"
@@ -734,7 +734,7 @@ msgstr "Eine rechts-assoziative Funktion"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:436
 msgid "A scale factor for the printout. Helpful for printing big equations on small pdf pages."
-msgstr ""
+msgstr "Ein Skalierungsfaktor für den Druck. Erlaubt es, große Gleichungen auf Papiergröße zu bringen."
 
 #: ../../src/wxMaximaFrame.cpp:1671
 msgid "A search-and-replace for equations"
@@ -742,27 +742,27 @@ msgstr "Suchen und Ersetzen für Gleichungen"
 
 #: ../../src/cells/EditorCell.cpp:4522 ../../src/cells/GroupCell.cpp:2184
 msgid "A section heading"
-msgstr ""
+msgstr "Ein Kapiteltitel"
 
 #: ../../src/wizards/DrawWiz.cpp:479
 msgid "A static plot"
-msgstr ""
+msgstr "Ein statisches Bild"
 
 #: ../../src/cells/EditorCell.cpp:4534
 msgid "A sub-sub-sub-subsection heading"
-msgstr ""
+msgstr "Ein Unterparagraph"
 
 #: ../../src/cells/EditorCell.cpp:4531
 msgid "A sub-sub-subsection heading"
-msgstr ""
+msgstr "Ein Paragraph"
 
 #: ../../src/cells/EditorCell.cpp:4528 ../../src/cells/GroupCell.cpp:2190
 msgid "A sub-subsection heading"
-msgstr ""
+msgstr "Unter-Unterkapitelzelle"
 
 #: ../../src/cells/EditorCell.cpp:4525 ../../src/cells/GroupCell.cpp:2187
 msgid "A subsection heading"
-msgstr ""
+msgstr "Unter-Unterkapitelzelle"
 
 #: ../../src/wxMaximaFrame.cpp:1673
 msgid "A subst with basic maths knowledge"
@@ -770,7 +770,7 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:239
 msgid "A symbol from the configuration dialogue"
-msgstr ""
+msgstr "Ein Symbol aus dem Konfigurationsdialog"
 
 #: ../../src/cells/GroupCell.cpp:2181
 msgid "A text cell"
@@ -807,7 +807,7 @@ msgstr "ASCII-Art"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1618
 msgid "Abort evaluation on error"
-msgstr ""
+msgstr "Fehler beenden das Evaluieren"
 
 #: ../../src/MaximaEvaluator.cpp:214
 #, c-format
@@ -840,7 +840,7 @@ msgstr ""
 
 #: ../../src/sidebars/DrawSidebar.cpp:103
 msgid "Accuracy"
-msgstr ""
+msgstr "Genauigkeit"
 
 #: ../../src/wxMaximaFrame.cpp:1405
 msgid "Ad&joint Matrix"
@@ -860,7 +860,7 @@ msgstr "Füge ein neues Element zum Anfang der Liste hinzu. Praktisch zur Generi
 
 #: ../../src/sidebars/VariablesPane.cpp:228
 msgid "Add all"
-msgstr ""
+msgstr "Alle hinzufügen"
 
 #: ../../src/MaximaCommandMenus.cpp:1621
 msgid "Add an element to the end of a list"
@@ -880,11 +880,11 @@ msgstr "Gebe Vereinfacher für rationale Ausdrücke eine Gleichung"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:204
 msgid "Add more symbols"
-msgstr ""
+msgstr "Mehr Symbole"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1262
 msgid "Add the .wxmx file to the HTML export"
-msgstr ""
+msgstr "Füge die .wxmx-Quellen zum HTML-Export hinzu"
 
 #: ../../src/wxMaximaFrame.cpp:1049
 msgid "Add to &Path..."
@@ -892,7 +892,7 @@ msgstr "Zum &Pfad hinzufügen ..."
 
 #: ../../src/sidebars/UnicodeSidebar.cpp:105
 msgid "Add to symbols Sidebar"
-msgstr ""
+msgstr "In die \"Symbole\"-Seitenleiste"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:304
 #: ../../src/worksheet/WorksheetContextMenu.cpp:337
@@ -903,23 +903,23 @@ msgstr "Zur Beobachtungsliste"
 #: ../../src/sidebars/XmlInspector.cpp:147
 #, c-format
 msgid "Added much text (%li chars) to the XML inspector."
-msgstr ""
+msgstr "Stelle viel Text (%li Zeichen) im XML-Inspektor dar."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1896
 msgid "Additional clipboard formats to put on the clipboard on ordinary copy"
-msgstr ""
+msgstr "Zusätzliche Standard-Formate für \"Kopieren\":"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:393
 msgid "Additional commands to be added to the preamble of LaTeX output for pdftex."
-msgstr ""
+msgstr "Zusätzliche Zeilen, die zu der Präambel jedes generierten LaTeX-Dokuments hinzugefügt werden sollen."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1187
 msgid "Additional lines for the TeX preamble:"
-msgstr ""
+msgstr "Zusätzliche Zeilen für die LaTeX-Präambel:"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:389
 msgid "Additional parameters for Maxima (e.g. -l clisp)."
-msgstr ""
+msgstr "Zusätzliche Parameter für Maxima (z. B. -l clisp)."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1543
 msgid "Additional parameters for Maxima (restart Maxima after changes)"
@@ -927,7 +927,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1318
 msgid "Additional symbols for the \"symbols\" sidebar:"
-msgstr ""
+msgstr "Zusätzliche Symbole für die \"Symbole\"-Seitenleiste:"
 
 #: ../../src/wxMaximaFrame.cpp:1599
 msgid "Additionally: log(a*b)=log(a)+log(b)"
@@ -989,7 +989,7 @@ msgstr "\"Alle unterstützten Dateien (*.wxm, *.wxmx, *.mac, *.out, *.xml)|*.wxm
 
 #: ../../src/dialogs/ConfigDialogue.cpp:750
 msgid "All variable names"
-msgstr ""
+msgstr "Alle Variablennamen"
 
 #: ../../src/wxMaximaFrame.cpp:770
 msgid "All visible sidebars"
@@ -1017,7 +1017,7 @@ msgstr ""
 
 #: ../../src/dialogs/BinaryNameCtrl.cpp:69
 msgid "All|*"
-msgstr ""
+msgstr "Alle|*"
 
 #: ../../src/wxMaximaFrame.cpp:800
 msgid "Always after underscores"
@@ -1037,7 +1037,7 @@ msgstr "Zeige immer alle Ziffern"
 
 #: ../../src/wizards/DrawWiz.cpp:484
 msgid "An animation with multiple frames"
-msgstr ""
+msgstr "Eine Animation mit mehreren Einzelbildern"
 
 #: ../../src/cells/GroupCell.cpp:2202
 msgid "An image cell"
@@ -1194,7 +1194,7 @@ msgstr "Ascii-code in Zeichen konvertieren..."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1397
 msgid "Ask to save untitled documents"
-msgstr ""
+msgstr "Frage nach, wenn Dokumente nicht gespeichert sind"
 
 #: ../../src/dialogs/MaximaNotStartingDialog.cpp:36
 msgid "Asking the user for the location of a working maxima binary"
@@ -1218,21 +1218,21 @@ msgstr "Achtung: Ein zufälliges Listenelement extrahieren, ist nicht effizient 
 
 #: ../../src/dialogs/ConfigDialogue.cpp:897
 msgid "Auto-indent new lines"
-msgstr ""
+msgstr "Automatisches Einrücken neuer Zeilen"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:893
 msgid "Auto-insert closing parenthesis"
-msgstr ""
+msgstr "Schließende Klammer automatisch einfügen"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1441
 #: ../../src/dialogs/ConfigDialogue.cpp:1472
 #: ../../src/dialogs/MaximaNotStartingDialog.cpp:43
 msgid "Autodetect"
-msgstr ""
+msgstr "Automatisch"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1236
 msgid "Automatic"
-msgstr ""
+msgstr "Automatisch"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:391
 msgid "Automatic labels"
@@ -1241,7 +1241,7 @@ msgstr "Automatische Marken"
 #: ../../src/dialogs/ConfigDialogue.cpp:769
 #, c-format
 msgid "Automatic labels (%i1, %o1,...)"
-msgstr ""
+msgstr "Automatische Marken (%i1, %o2)"
 
 #: ../../src/wxMaximaFrame.cpp:986
 msgid "Automatically answer questions"
@@ -1253,7 +1253,7 @@ msgstr "Automatisches Beantworten von Fragen, deren Antwort das letzte Mal gegeb
 
 #: ../../src/dialogs/ConfigDialogue.cpp:460
 msgid "Automatically insert a closing parenthesis the moment the user enters an opening one."
-msgstr ""
+msgstr "Automatisch eine schließende Klammer einfügen, wenn eine öffnende eingetippt wurde."
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:235
 #: ../../src/worksheet/WorksheetContextMenu.cpp:610
@@ -1288,15 +1288,15 @@ msgstr "Diese Variable automatisch mit Subscript ausstatten"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:734
 msgid "Autowrap long lines:"
-msgstr ""
+msgstr "Automatischer Zeilenumbruch:"
 
 #: ../../src/sidebars/DrawSidebar.cpp:75
 msgid "Axis"
-msgstr ""
+msgstr "Achsen"
 
 #: ../../src/wizards/BC2Wiz.cpp:59
 msgid "BC2"
-msgstr ""
+msgstr "Randwertproblem"
 
 #: ../../src/MaximaManual.cpp:559
 msgid "Background task that compiles the Manual anchors scheduled."
@@ -1304,7 +1304,7 @@ msgstr ""
 
 #: ../../src/sidebars/StatSidebar.cpp:91
 msgid "Barsplot..."
-msgstr ""
+msgstr "Balkendiagramm"
 
 #: ../../src/wxMaximaFrame.cpp:1384
 msgid "Basic matrix operations"
@@ -1343,27 +1343,27 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:141
 msgid "Besides the global undo functionality that is active when the cursor is between cells, wxMaxima has a per-cell undo function that is active if the cursor is inside a cell. Pressing Ctrl+Z inside a cell can therefore been used for a fine-pitch undo that doesn't affect latter changes made in other cells."
-msgstr ""
+msgstr "wxMaxima bietet zwei Funktionen, die Änderungen rückgängig machen können:\nSteht der Cursor zwischen zwei Zellen, macht die Tastenkombination Ctrl+Z Änderungen am Arbeitsblatt rückgängig. Steht er innerhalb einer Zelle, ist Ctrl+Z mit einer sehr feinkörnigen Rückgängigmach-Funktion verbunden, die sich nur um Änderungen innerhalb der aktuellen Zelle kümmert und den Rest des Arbeitsblattes ignoriert."
 
 #: ../../src/sidebars/GreekSidebar.cpp:179
 msgid "Beta"
-msgstr ""
+msgstr "Beta"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1898
 msgid "Bitmap"
-msgstr ""
+msgstr "Bitmap"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1273
 msgid "Bitmap scale for export:"
-msgstr ""
+msgstr "Skalierung der Bitmaps für den Export"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1223
 msgid "Bitmaps"
-msgstr ""
+msgstr "Bild"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2109
 msgid "Bold"
-msgstr ""
+msgstr "Fett"
 
 #: ../../src/wxMaxima.cpp:2259
 msgid "Both horizontal and vertical cursor active at the same time"
@@ -1387,13 +1387,13 @@ msgstr ""
 
 #: ../../src/sidebars/StatSidebar.cpp:97
 msgid "Boxplot..."
-msgstr ""
+msgstr "Kastengraphik..."
 
 #: ../../src/dialogs/BinaryNameCtrl.cpp:42 ../../src/wizards/CsvWiz.cpp:57
 #: ../../src/wizards/CsvWiz.cpp:131 ../../src/wizards/Plot2dWiz.cpp:114
 #: ../../src/wizards/Plot3dWiz.cpp:109
 msgid "Browse"
-msgstr ""
+msgstr "Ordner Anzeigen"
 
 #: ../../src/wxMathml.cpp:101
 msgid "Bug: After removing the whitespace wxMathml.lisp is shorter than expected!"
@@ -1442,7 +1442,7 @@ msgstr "Interner Fehler: Die HTML-Ausgabe ist kein gültiges XML."
 
 #: ../../src/cells/Cell.cpp:289
 msgid "Bug: Math Cell that claims to have no group Cell it belongs to"
-msgstr ""
+msgstr "Interner Fehler: Eine MathCell behauptet, keine GroupCell zu besitzen."
 
 #: ../../src/Configuration.h:741
 msgid "Bug: Maximum number of digits that is to be displayed is too low!"
@@ -1454,7 +1454,7 @@ msgstr "Interner Fehler: Fehlender Inhalt"
 
 #: ../../src/cells/GroupCell.cpp:1498
 msgid "Bug: No image counter to write to!"
-msgstr ""
+msgstr "Interner Fehler: Habe keinen Bildzähler, den ich beschreiben könnte."
 
 #: ../../src/cells/AnimationCell.cpp:543 ../../src/cells/EditorCell.cpp:2968
 #: ../../src/cells/ImgCell.cpp:353 ../../src/graphical_io/BitmapOut.cpp:161
@@ -1473,7 +1473,7 @@ msgstr "Interner Fehler: Die Zwischenablage ist bereits geöffnet"
 
 #: ../../src/cells/EditorCell.cpp:3051
 msgid "Bug: The clipboard isn't open on pasting into an editor cell"
-msgstr ""
+msgstr "Interner Fehler: Die Zwischenablage ist noch nicht geöffnet, obwohl in eine Textcelle eingefügt werden soll."
 
 #: ../../src/cells/GroupCell.cpp:2288
 msgid "Bug: The predecessor to a GroupCell is not a GroupCell."
@@ -1485,7 +1485,7 @@ msgstr ""
 
 #: ../../src/cells/GroupCell.cpp:340
 msgid "Bug: Trying to append NULL to a group cell."
-msgstr ""
+msgstr "Interner Fehler: Versuche, eine nichtexistierende Zelle an eine Gruppenzelle anzuhängen."
 
 #: ../../src/worksheet/Worksheet.cpp:5939
 msgid "Bug: Trying to move a title out by one sectioning unit"
@@ -1509,7 +1509,7 @@ msgstr "Interner Fehler: Rückgängig will Zellen ändern und gleichzeitig Zelle
 
 #: ../../src/cells/EditorCell.cpp:4541
 msgid "Bug: Unknown type of text"
-msgstr ""
+msgstr "Interner Fehler: Unbekannte Art von Text"
 
 #: ../../src/cells/EditorCell.cpp:3981 ../../src/cells/TextCell.cpp:479
 msgid "Bug: dc == NULL"
@@ -1517,11 +1517,11 @@ msgstr ""
 
 #: ../../src/cells/EditorCell.cpp:2637
 msgid "Bug: x position of cell is unknown!"
-msgstr ""
+msgstr "Interner Fehler: Die x-Position der Zelle ist unbekannt!"
 
 #: ../../src/cells/EditorCell.cpp:2638
 msgid "Bug: y position of cell is unknown!"
-msgstr ""
+msgstr "Interner Fehler: Die y-Position der Zelle ist unbekannt!"
 
 #: ../../src/wxMaximaFrame.cpp:1985
 msgid "Build &Info"
@@ -1534,7 +1534,7 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:54
 msgid "By default, Shift-Enter is used to evaluate commands, while Enter is used for multiline input. This behaviour can be changed in 'Edit->Configure' dialog by checking 'Enter evaluates cells'. This switches the roles of these two key commands."
-msgstr ""
+msgstr "Standardmäßig wird mit 'Umschalt-Eingabe' eine Zelle ausgewertet, wogegen 'Eingabe' die Eingabe mehrer Zeilen in einer Zelle erlaubt. Dieses Verhalten kann im Dialog 'Bearbeiten->Einstellungen' durch Markierung der Auswahl 'Eingabe wertet die Zelle aus' geändert werden. Die Funktion der beiden Befehle 'Umschalt-Eingabe' und 'Eingabe' wird ausgetauscht."
 
 #: ../../src/MaximaCommandMenus.cpp:4087
 msgid "Byte:"
@@ -1728,20 +1728,20 @@ msgstr "Kann die Versionsnummer %s nicht interpretieren"
 
 #: ../../src/cells/EditorCell.cpp:2991
 msgid "Cannot put the copied text on the clipboard"
-msgstr ""
+msgstr "Kann den kopierten Text nicht in der Zwischenablage platzieren"
 
 #: ../../src/cells/EditorCell.cpp:2984
 msgid "Cannot put the copied text on the clipboard (1st try)"
-msgstr ""
+msgstr "Text kann nicht in der Zwischenablage platziert werden (1. Versuch)"
 
 #: ../../src/cells/EditorCell.cpp:2988
 msgid "Cannot put the copied text on the clipboard (2nd try)"
-msgstr ""
+msgstr "Text kann nicht in der Zwischenablage platziert werden (2. Versuch)"
 
 #: ../../src/graphical_io/OutCommon.cpp:98
 #, c-format
 msgid "Cannot remove the file %s"
-msgstr ""
+msgstr "Kann die Datei %s nicht löschen"
 
 #: ../../src/sidebars/History.cpp:258
 #, c-format
@@ -1772,11 +1772,11 @@ msgstr "Kann Maxima nicht starten"
 
 #: ../../src/sidebars/MathSidebar.cpp:62
 msgid "Canonical (tr)"
-msgstr ""
+msgstr "Trigrat"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:188
 msgid "Catalan"
-msgstr ""
+msgstr "Katalanisch"
 
 #: ../../src/MaximaCommandMenus.cpp:466
 msgid "Cauchy principal value of f(x)/(x-c), finite interval"
@@ -1833,7 +1833,7 @@ msgstr "Verzeichnis wechseln..."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:859
 msgid "Change names of greek letters to greek letters"
-msgstr ""
+msgstr "Zeige Namen griechischer Buchstaben als griechischen Buchstaben an"
 
 #: ../../src/wxMaximaFrame.cpp:1073
 msgid "Change the 2d display algorithm used to display math output"
@@ -1841,7 +1841,7 @@ msgstr "Wähle ein Format für die 2D Anzeige"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:489
 msgid "Change the text \"alpha\" and \"beta\" to the corresponding greek letter?"
-msgstr ""
+msgstr "Variablennamen wie \"alpha\" oder \"beta\" durch den entsprechenden griechischen Buchstaben austauschen?"
 
 #: ../../src/MaximaCommandMenus.cpp:136
 msgid "Change variable"
@@ -1922,15 +1922,15 @@ msgstr "Prüft, ob Sie eine aktuelle Version von wxMaxima erhältlich ist."
 
 #: ../../src/sidebars/GreekSidebar.cpp:199
 msgid "Chi"
-msgstr ""
+msgstr "Chi"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:189
 msgid "Chinese (Simplified)"
-msgstr ""
+msgstr "Chinesisch (Vereinfacht)"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:190
 msgid "Chinese (traditional)"
-msgstr ""
+msgstr "Chinesisch (traditionell)"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1554
 msgid "Choose a Lisp Maxima was compiled with"
@@ -1946,7 +1946,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2100
 msgid "Choose font"
-msgstr ""
+msgstr "Schriftart wählen"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:793
 msgid "Choose how mathematical output is formatted:\n"
@@ -1957,12 +1957,12 @@ msgstr ""
 
 #: ../../src/wizards/PlotFormatWiz.cpp:31
 msgid "Choose new plot format:"
-msgstr ""
+msgstr "Neues Plot-Format eingeben:"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2432
 #, c-format
 msgid "Choose the %s Font"
-msgstr ""
+msgstr "Schriftart %s wählen"
 
 #: ../../src/wxMaximaFrame.cpp:837
 msgid "Choose the parenthesis type for Matrices"
@@ -1998,7 +1998,7 @@ msgstr ""
 
 #: ../../src/sidebars/History.cpp:116
 msgid "Clear all history"
-msgstr ""
+msgstr "&Speicher löschen"
 
 #: ../../src/wxMaximaFrame.cpp:1034
 msgid "Clear all labels"
@@ -2030,7 +2030,7 @@ msgstr "Alle Variablen löschen"
 
 #: ../../src/sidebars/History.cpp:115
 msgid "Clear the selection"
-msgstr ""
+msgstr "Auswahl löschen"
 
 #: ../../src/cells/FontVariantCache.cpp:44
 #, c-format
@@ -2039,7 +2039,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1926
 msgid "Clipboard format parameters"
-msgstr ""
+msgstr "Formatierungs-Parameter für die Zwischenablage"
 
 #: ../../src/wxMaximaFrame.cpp:637
 msgid "Close\tCtrl+W"
@@ -2131,7 +2131,7 @@ msgstr "Spalten"
 
 #: ../../src/wizards/MatWiz.cpp:155
 msgid "Columns:"
-msgstr ""
+msgstr "Spalten:"
 
 #: ../../src/wxMaximaFrame.cpp:1621
 msgid "Combine factorials in an expression"
@@ -2147,11 +2147,11 @@ msgstr "Komma wird von einer schließenden Klammer gefolgt"
 
 #: ../../src/wizards/Plot2dWiz.cpp:626
 msgid "Comma separated x coordinates"
-msgstr ""
+msgstr "x-Koordinaten durch Kommata getrennt"
 
 #: ../../src/wizards/Plot2dWiz.cpp:627
 msgid "Comma separated y coordinates"
-msgstr ""
+msgstr "y-Koordinaten durch Kommata getrennt"
 
 #: ../../src/MaximaCommandMenus.cpp:4071
 msgid "Comma-separated arguments"
@@ -2237,11 +2237,11 @@ msgstr "Befehl:"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1145
 msgid "Commands that are executed at every start of maxima."
-msgstr ""
+msgstr "Maxima-Befehle, die bei jedem Start von Maxima ausgeführt werden."
 
 #: ../../src/cells/EditorCell.cpp:4538
 msgid "Comment (ordinary worksheet text that isn't fed to maxima)"
-msgstr ""
+msgstr "Kommentar (Text, der nicht an Maxima gesendet wird)"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:465
 msgid "Comment Selection"
@@ -2377,16 +2377,16 @@ msgstr "Bedingung:"
 #: ../../src/dialogs/ConfigDialogue.cpp:2641
 #: ../../src/dialogs/ConfigDialogue.cpp:2647
 msgid "Config file (*.ini)|*.ini"
-msgstr ""
+msgstr "Konfigurationsdatei (*.ini)|*.ini"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2539
 #, c-format
 msgid "Config item \"%s\" was of an unknown type"
-msgstr ""
+msgstr "Konfigurations-Element \"%s\" hatte einen unbekannten typ"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2607
 msgid "Configuration warning"
-msgstr ""
+msgstr "Konfigurationswarnung"
 
 #: ../../src/ToolBar.cpp:367 ../../src/ToolBar.cpp:369
 #: ../../src/wxMaximaFrame.cpp:722 ../../src/wxMaximaFrame.cpp:724
@@ -2395,7 +2395,7 @@ msgstr "wxMaxima konfigurieren"
 
 #: ../../src/wizards/DrawWiz.cpp:829
 msgid "Connect the dots"
-msgstr ""
+msgstr "Verbinde die Punkte"
 
 #: ../../src/MaximaProcessManager.cpp:163
 msgid "Connection attempt, but connection failed."
@@ -2409,7 +2409,7 @@ msgstr "Verbindung mit Maxima verloren."
 #: ../../src/wizards/IntegrateWiz.cpp:208 ../../src/wizards/LimitWiz.cpp:133
 #: ../../src/wizards/SeriesWiz.cpp:105
 msgid "Constant"
-msgstr ""
+msgstr "Konstante"
 
 #: ../../src/MaximaCommandMenus.cpp:1102
 msgid "Construct a fraction"
@@ -2421,7 +2421,7 @@ msgstr "Bruch eingeben..."
 
 #: ../../src/sidebars/VariablesPane.cpp:58
 msgid "Contents"
-msgstr ""
+msgstr "Inhalt"
 
 #: ../../src/MaximaCommandMenus.cpp:3970
 msgid "Contents:"
@@ -2437,27 +2437,27 @@ msgstr "Kontextsensitive &Hilfe\tF1"
 
 #: ../../src/sidebars/DrawSidebar.cpp:80
 msgid "Contour"
-msgstr ""
+msgstr "Höhenlinien"
 
 #: ../../src/sidebars/DrawSidebar.cpp:101
 msgid "Contour lines for 3d plots"
-msgstr ""
+msgstr "Höhenlinien für 3D-Diagramme"
 
 #: ../../src/wizards/DrawWiz.cpp:648
 msgid "Contour lines on surface and Bottom"
-msgstr ""
+msgstr "Höhenlinien auf der Oberfläche und dem Boden"
 
 #: ../../src/wizards/DrawWiz.cpp:644
 msgid "Contour lines on the Bottom"
-msgstr ""
+msgstr "Höhenlinien auf dem Boden"
 
 #: ../../src/wizards/DrawWiz.cpp:641
 msgid "Contour lines on the Surface"
-msgstr ""
+msgstr "Höhenlinien auf der Oberfläche"
 
 #: ../../src/wizards/DrawWiz.cpp:629
 msgid "Contour lines settings for the following 3d plots"
-msgstr ""
+msgstr "Höhenlinien für die nun folgenden 3D-Objekte"
 
 #: ../../src/wxMaximaFrame.cpp:1579
 msgid "Contract Logarithms"
@@ -2542,30 +2542,30 @@ msgstr "&Standarddarstellung"
 #: ../../src/sidebars/TableOfContents.cpp:522
 #: ../../src/sidebars/TableOfContents.cpp:543
 msgid "Convert to Heading 5"
-msgstr ""
+msgstr "Konvertiere zu Paragraph"
 
 #: ../../src/sidebars/TableOfContents.cpp:519
 msgid "Convert to Heading 6"
-msgstr ""
+msgstr "Konvertiere zu Unterparagraph"
 
 #: ../../src/sidebars/TableOfContents.cpp:531
 #: ../../src/sidebars/TableOfContents.cpp:552
 msgid "Convert to Section"
-msgstr ""
+msgstr "Konvertiere zu Kapitel"
 
 #: ../../src/sidebars/TableOfContents.cpp:525
 #: ../../src/sidebars/TableOfContents.cpp:546
 msgid "Convert to Sub-Subsection"
-msgstr ""
+msgstr "Konvertiere zu Unter-Unterkapitel"
 
 #: ../../src/sidebars/TableOfContents.cpp:528
 #: ../../src/sidebars/TableOfContents.cpp:549
 msgid "Convert to Subsection"
-msgstr ""
+msgstr "Konvertiere zu Unterkapitel"
 
 #: ../../src/sidebars/TableOfContents.cpp:555
 msgid "Convert to Title"
-msgstr ""
+msgstr "Konvertiere zu Titel"
 
 #: ../../src/wxMaximaFrame.cpp:1200
 msgid "Convert to downcase..."
@@ -2751,22 +2751,22 @@ msgstr "Knöpfe für Kopieren, Ausschneiden und Einfügen"
 #: ../../src/dialogs/ConfigDialogue.cpp:2523
 #, c-format
 msgid "Copying config bool \"%s\""
-msgstr ""
+msgstr "Kopiere boolsche Konfigurations-Variable \"%s\""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2533
 #, c-format
 msgid "Copying config float \"%s\""
-msgstr ""
+msgstr "Kopiere die Konfigurations-Fließkommazahl %s"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2528
 #, c-format
 msgid "Copying config int \"%s\""
-msgstr ""
+msgstr "Kopiere Konfigurations-Integer \"%s\""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2518
 #, c-format
 msgid "Copying config string \"%s\""
-msgstr ""
+msgstr "Kopiere die Konfigurations-Zeichenkette \"%s\""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:191
 msgid "Corsican"
@@ -2859,7 +2859,7 @@ msgstr "Erzeuge eine Liste aus komma-getrennten Elementen"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1389
 msgid "Create scalable plots."
-msgstr ""
+msgstr "Erzeuge skalierbare Diagramme."
 
 #: ../../src/wxMaximaFrame.cpp:1116
 msgid "Create struct..."
@@ -2883,7 +2883,7 @@ msgstr ""
 
 #: ../../src/worksheet/Worksheet.cpp:6115
 msgid "Cursor"
-msgstr ""
+msgstr "Cursor"
 
 #: ../../src/Styles.cpp:126
 msgid "Cursor color"
@@ -2905,11 +2905,11 @@ msgstr "Auswahl ausschneiden"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:193
 msgid "Czech"
-msgstr ""
+msgstr "Tschechisch"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:194
 msgid "Danish"
-msgstr ""
+msgstr "Dänisch"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2069
 msgid "Dark"
@@ -2925,7 +2925,7 @@ msgstr "Datendatei (*.csv, *.tab, *.txt)|*.csv;*.tab;*.txt"
 
 #: ../../src/wizards/DrawWiz.cpp:810
 msgid "Data format"
-msgstr ""
+msgstr "Datenformat"
 
 #: ../../src/MaximaCommandMenus.cpp:1767 ../../src/MaximaCommandMenus.cpp:1772
 #: ../../src/MaximaCommandMenus.cpp:1777 ../../src/MaximaCommandMenus.cpp:1781
@@ -2979,15 +2979,15 @@ msgstr "Fallende Funktionen f(x)<x"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1336
 msgid "Default animation framerate:"
-msgstr ""
+msgstr "Die Standard-Wiederholrate für Animationen:"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:717
 msgid "Default plot size for new maxima sessions:"
-msgstr ""
+msgstr "Die Standard-Größe von Diagrammen:"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1534
 msgid "Default port for communication with wxMaxima:"
-msgstr ""
+msgstr "Standard-Port für die Kommunikation zwischen Maxima und wxMaxima."
 
 #: ../../src/MaximaCommandMenus.cpp:3946
 msgid "Define a function"
@@ -3027,7 +3027,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:404
 msgid "Define the default speed (in frames per second) animations are played back with."
-msgstr ""
+msgstr "Definiert die Geschwindigkeit (in Bilder pro Sekunde), mit der Animationen standardmäßig abgespielt werden."
 
 #: ../../src/wxMaximaFrame.cpp:1114
 msgid "Define variable..."
@@ -3100,7 +3100,7 @@ msgstr "Trennzeichen:"
 
 #: ../../src/sidebars/GreekSidebar.cpp:181
 msgid "Delta"
-msgstr ""
+msgstr "Delta"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:110
 #: ../../src/worksheet/WorksheetContextMenu.cpp:558
@@ -3126,7 +3126,7 @@ msgstr "Abhängigkeiten"
 
 #: ../../src/wizards/SeriesWiz.cpp:42
 msgid "Depth:"
-msgstr ""
+msgstr "Ordnung:"
 
 #: ../../src/MaximaCommandMenus.cpp:994
 msgid "Derivate of y at that point:"
@@ -3161,7 +3161,7 @@ msgstr ""
 
 #: ../../src/sidebars/StatSidebar.cpp:61
 msgid "Deviation..."
-msgstr ""
+msgstr "Standardabw."
 
 #: ../../src/wxMaximaFrame.cpp:1534
 msgid "Di&vide Polynomials..."
@@ -3173,11 +3173,11 @@ msgstr ""
 
 #: ../../src/sidebars/DrawSidebar.cpp:71
 msgid "Diagram title"
-msgstr ""
+msgstr "Diagrammtitel"
 
 #: ../../src/sidebars/HelpBrowser.cpp:51
 msgid "Didn't find an installed offline manual."
-msgstr ""
+msgstr "Konnte das installierte Offline-Handbuch nicht finden."
 
 #: ../../src/MaximaManual.cpp:534
 msgid "Didn't find the maxima HTML manual."
@@ -3193,7 +3193,7 @@ msgstr ""
 
 #: ../../src/sidebars/MathSidebar.cpp:80
 msgid "Diff..."
-msgstr ""
+msgstr "Differenzieren ..."
 
 #: ../../src/dialogs/DiffFrame.cpp:308
 #, c-format
@@ -3222,7 +3222,7 @@ msgstr "Den Ausdruck n mal differenzieren"
 
 #: ../../src/wizards/LimitWiz.cpp:41
 msgid "Direction:"
-msgstr ""
+msgstr "Richtung:"
 
 #: ../../src/wxMaximaFrame.cpp:1246
 msgid "Directory operations"
@@ -3234,11 +3234,11 @@ msgstr ""
 
 #: ../../src/wizards/Plot2dWiz.cpp:418 ../../src/wizards/Plot2dWiz.cpp:619
 msgid "Discrete plot"
-msgstr ""
+msgstr "Diskreter Plot"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:699
 msgid "Display"
-msgstr ""
+msgstr "Anzeige"
 
 #: ../../src/wxMaximaFrame.cpp:1075
 msgid "Display Te&X Form"
@@ -3250,11 +3250,11 @@ msgstr "Darstellungmethode"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:827
 msgid "Display all and allow linebreaks in long numbers"
-msgstr ""
+msgstr "Zeige alle Ziffern und erlaube Zeilenumbrüche bei langen Zahlen"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:820
 msgid "Display all digits"
-msgstr ""
+msgstr "Anzeige aller Ziffern"
 
 #: ../../src/wxMaximaFrame.cpp:788
 msgid "Display an expression as maxima's internal lisp representation"
@@ -3282,7 +3282,7 @@ msgstr "Zeige letztes Ergebnis in TeX Format"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:804
 msgid "Display of long numbers"
-msgstr ""
+msgstr "Anzeige von großen Zahlen"
 
 #: ../../src/ToolBar.cpp:580
 #, c-format
@@ -3361,11 +3361,11 @@ msgstr "Das Dokument wurde mit einer aktuelleren wxMaxima Version gespeichert. B
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1170
 msgid "Documentclass for TeX export:"
-msgstr ""
+msgstr "Dokumentklasse für TeX-Export:"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1178
 msgid "Documentclass options:"
-msgstr ""
+msgstr "Optionen für die Dokumentenklasse:"
 
 #: ../../src/wxMaximaFrame.cpp:807
 msgid "Don't autosubscript after an underscore"
@@ -3411,19 +3411,19 @@ msgstr "Keine Klammern für Matrizen"
 
 #: ../../src/dialogs/DiffFrame.cpp:428 ../../src/dialogs/FindReplacePane.cpp:83
 msgid "Down"
-msgstr ""
+msgstr "Nach unten"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:185
 msgid "Drag-and-drop unicode symbols here"
-msgstr ""
+msgstr "Hierher können Unicode-Symbole kopiert werden"
 
 #: ../../src/wizards/DrawWiz.cpp:155
 msgid "Draw all points where an equation is true."
-msgstr ""
+msgstr "Zeichne alle Punkte, an denen eine Gleichung gilt"
 
 #: ../../src/wizards/DrawWiz.cpp:802
 msgid "Draw points"
-msgstr ""
+msgstr "Zeichne Punkte"
 
 #: ../../src/MaximaCommandMenus.cpp:1536
 msgid "Drop the first n list elements"
@@ -3543,7 +3543,7 @@ msgstr "Unbekanntes Netzwerk-Ereignis."
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:129
 msgid "End of proof"
-msgstr ""
+msgstr "q.e.d. (Beweisende)"
 
 #: ../../src/MaximaCommandMenus.cpp:1024
 msgid "End of t:"
@@ -3551,19 +3551,19 @@ msgstr "Ende von t:"
 
 #: ../../src/wizards/DrawWiz.cpp:71 ../../src/wizards/DrawWiz.cpp:176
 msgid "End of the x value"
-msgstr ""
+msgstr "Ende des x-Bereichs"
 
 #: ../../src/wizards/DrawWiz.cpp:88 ../../src/wizards/DrawWiz.cpp:191
 msgid "End of the y value"
-msgstr ""
+msgstr "Ende des y-Bereichs"
 
 #: ../../src/wizards/DrawWiz.cpp:208
 msgid "End of the z value"
-msgstr ""
+msgstr "Ende des z-Bereichs"
 
 #: ../../src/wizards/DrawWiz.cpp:760
 msgid "End value of the parameter"
-msgstr ""
+msgstr "Endwert des Parameters"
 
 #: ../../src/MaximaResponseReader.cpp:432
 #: ../../src/MaximaResponseReader.cpp:586
@@ -3576,19 +3576,19 @@ msgstr "Zahlenformat für Ingenieure (12.1e6 etc.)"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:196
 msgid "English"
-msgstr ""
+msgstr "Englisch"
 
 #: ../../src/wizards/DrawWiz.cpp:552
 msgid "Enhanced 3D settings:"
-msgstr ""
+msgstr "Erweiterte 3D-Einstellungen:"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1919
 msgid "Enhanced meta file (emf)"
-msgstr ""
+msgstr "Erweiterte Metadatei (emf)"
 
 #: ../../src/sidebars/StatSidebar.cpp:106
 msgid "Enter Matrix..."
-msgstr ""
+msgstr "Matrix &eingeben ..."
 
 #: ../../src/MaximaCommandMenus.cpp:2255
 msgid "Enter UUID to jump to:"
@@ -3600,7 +3600,7 @@ msgstr "Eine Matrix eingeben"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:925
 msgid "Enter adds newlines, Ctrl+Enter evaluates cells"
-msgstr ""
+msgstr "'Strg+Eingabe' wertet die Zelle aus, Enter beginnt neue Zeile"
 
 #: ../../src/MaximaCommandMenus.cpp:873
 msgid "Enter an equation for rational simplification:"
@@ -3608,11 +3608,11 @@ msgstr "Geben Sie eine Gleichung zum Vereinfachen rationaler Ausdrücke an:"
 
 #: ../../src/wizards/SystemWiz.cpp:50
 msgid "Enter comma separated list of variables."
-msgstr ""
+msgstr "Geben Sie die Variablen durch Beistriche getrennt ein."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:921
 msgid "Enter evaluates cells, Ctrl+Enter adds newlines"
-msgstr ""
+msgstr "'Eingabe' wertet die Zelle aus, Strg+Enter beginnt neue Zeile"
 
 #: ../../src/MaximaCommandMenus.cpp:1357
 msgid "Enter matrix"
@@ -3628,7 +3628,7 @@ msgstr "Neue Genauigkeit für als Bigfloat deklarierte Zahlen eingeben:"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:388
 msgid "Enter the path to the Maxima executable."
-msgstr ""
+msgstr "Geben Sie den Pfad zum Maxima Programm an."
 
 #: ../../src/MaximaCommandMenus.cpp:1103
 msgid "Enumerator:"
@@ -3640,11 +3640,11 @@ msgstr "Umgebungsvariablen"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1605
 msgid "Environment variables for maxima"
-msgstr ""
+msgstr "Umgebungsvariablen für Maxima:"
 
 #: ../../src/sidebars/GreekSidebar.cpp:182
 msgid "Epsilon"
-msgstr ""
+msgstr "Epsilon"
 
 #: ../../src/MaximaCommandMenus.cpp:299
 msgid "Epsilon:"
@@ -3683,7 +3683,7 @@ msgstr "Gleichung:"
 
 #: ../../src/dialogs/TipOfTheDay.cpp:196
 msgid "Equations have several advantages over functions. For example they can be manipulated with factor(), expand() and similar functions. They can easily be introduced one into another. Also they are always printed out as 2D maths."
-msgstr ""
+msgstr "Gleichungen haben gleich mehrere Vorteile gegenüber Funktionen. So können sie mit factor(), expand() und ähnlichen Funktionen umgeformt werden. Sie können ineinander eingesetzt werden und sie werden stets in einer menschenlesbaren 2D-Form ausgegeben."
 
 #: ../../src/MaximaFileIO.cpp:64 ../../src/MaximaFileIO.cpp:121
 #: ../../src/MaximaFileIO.cpp:130 ../../src/MaximaFileIO.cpp:399
@@ -3739,11 +3739,11 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:184
 msgid "Eta"
-msgstr ""
+msgstr "Eta"
 
 #: ../../src/sidebars/TableOfContents.cpp:513
 msgid "Evaluate"
-msgstr ""
+msgstr "Auswerten"
 
 #: ../../src/wxMaximaFrame.cpp:1689
 msgid "Evaluate &Noun Forms..."
@@ -3877,11 +3877,11 @@ msgstr "Gerade Zahl"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2659
 msgid "Example text"
-msgstr ""
+msgstr "Mustertext"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1547
 msgid "Examples:"
-msgstr ""
+msgstr "Beispiele:"
 
 #: ../../src/wxMaximaFrame.cpp:1740
 msgid "Execute a command for each element of the list"
@@ -3893,11 +3893,11 @@ msgstr "Beenden"
 
 #: ../../src/sidebars/MathSidebar.cpp:53
 msgid "Expand"
-msgstr ""
+msgstr "Expandieren"
 
 #: ../../src/sidebars/MathSidebar.cpp:68
 msgid "Expand (tr)"
-msgstr ""
+msgstr "Trigexpand"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:356
 msgid "Expand Expression"
@@ -3942,7 +3942,7 @@ msgstr "Exportieren"
 
 #: ../../src/sidebars/History.cpp:152
 msgid "Export As"
-msgstr ""
+msgstr "Exportiere als"
 
 #: ../../src/wxMaximaFrame.cpp:1742
 msgid "Export List to csv file..."
@@ -3958,15 +3958,15 @@ msgstr "Matrix in csv-Datei exportieren"
 
 #: ../../src/sidebars/History.cpp:102
 msgid "Export all history to a .mac file"
-msgstr ""
+msgstr "Exportiere die Historie als .mac Datei"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1016
 msgid "Export all settings"
-msgstr ""
+msgstr "Exportiere alle Einstellungen"
 
 #: ../../src/sidebars/History.cpp:105
 msgid "Export commands from the current maxima session to a .mac file"
-msgstr ""
+msgstr "Exportiere die Befehle der aktuellen Maxima-Session als .mac Datei"
 
 #: ../../src/wxMaximaFrame.cpp:652
 msgid "Export document to a HTML or LaTeX file"
@@ -3974,7 +3974,7 @@ msgstr "Exportiere Dokument als HTML oder LaTeX-Datei"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1218
 msgid "Export equations to HTML as:"
-msgstr ""
+msgstr "Export von Gleichungen nach HTML als:"
 
 #: ../../src/wxMaximaFrame.cpp:600
 msgid "Export failed."
@@ -3990,7 +3990,7 @@ msgstr ""
 
 #: ../../src/sidebars/History.cpp:108
 msgid "Export selected commands to a .mac file"
-msgstr ""
+msgstr "Exportiere ausgewählte Befehle in eine .mac Datei"
 
 #: ../../src/wxMaximaFrame.cpp:588
 msgid "Export successful."
@@ -4002,11 +4002,11 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1022
 msgid "Export the style settings"
-msgstr ""
+msgstr "Exportieren aller Stil-Einstellungen"
 
 #: ../../src/sidebars/History.cpp:111
 msgid "Export visible commands to a .mac file"
-msgstr ""
+msgstr "Exportiere sichtbare Befehle in eine .mac Datei"
 
 #: ../../src/MaximaCommandMenus.cpp:3417
 #, c-format
@@ -4020,7 +4020,7 @@ msgstr ""
 
 #: ../../src/sidebars/History.cpp:228
 msgid "Exporting to .mac file failed!"
-msgstr ""
+msgstr "Export als .mac-Datei ist fehlgeschlagen!"
 
 #: ../../src/MaximaCommandMenus.cpp:2343
 msgid "Exporting to HTML failed!"
@@ -4056,19 +4056,19 @@ msgstr "Erzeuge eine Liste von Komma-separierten Ausdrücken"
 
 #: ../../src/wizards/DrawWiz.cpp:733
 msgid "Expression that calculates the x value"
-msgstr ""
+msgstr "Ausdruck, der den x-Wert ermittelt"
 
 #: ../../src/wizards/DrawWiz.cpp:738
 msgid "Expression that calculates the y value"
-msgstr ""
+msgstr "Ausdruck, der den y-Wert ermittelt"
 
 #: ../../src/wizards/DrawWiz.cpp:744
 msgid "Expression that calculates the z value"
-msgstr ""
+msgstr "Ausdruck, der den z-Wert ermittelt"
 
 #: ../../src/wizards/DrawWiz.cpp:56
 msgid "Expression to plot"
-msgstr ""
+msgstr "Darzustellender Ausdruck"
 
 #: ../../src/wxMaximaFrame.cpp:1122
 msgid "Expression to string..."
@@ -4223,7 +4223,7 @@ msgstr "Extrahiert ein Rechteck aus einem 2D-Array und konvertiert es in eine Ma
 
 #: ../../src/sidebars/MathSidebar.cpp:50
 msgid "Factor"
-msgstr ""
+msgstr "Faktorisieren"
 
 #: ../../src/wxMaximaFrame.cpp:1558
 msgid "Factor Complex"
@@ -4298,7 +4298,7 @@ msgstr "Felder:"
 #: ../../src/cells/GroupCell.cpp:2115
 #, c-format
 msgid "Figure %d:"
-msgstr ""
+msgstr "Abbildung %d:"
 
 #: ../../src/main.cpp:678
 msgid "File"
@@ -4350,7 +4350,7 @@ msgstr "Dateiname oder Liste von Komma-separierten Dateinamen"
 
 #: ../../src/sidebars/DrawSidebar.cpp:93
 msgid "Fill color"
-msgstr ""
+msgstr "Füllfarbe"
 
 #: ../../src/ToolBar.cpp:401 ../../src/ToolBar.cpp:403
 msgid "Find"
@@ -4471,7 +4471,7 @@ msgstr "Berechne die maximale Summe der Absolutbeträge einer Matrixzeile"
 
 #: ../../src/dialogs/FindReplacePane.cpp:46
 msgid "Find:"
-msgstr ""
+msgstr "Suchen:"
 
 #: ../../src/wxMaximaFrame.cpp:1869
 msgid "Fine-tune the display of engineering-format numbers"
@@ -4479,7 +4479,7 @@ msgstr "Feineinstellung des Zahlenformats für Ingenieure"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:197
 msgid "Finnish"
-msgstr ""
+msgstr "Finnisch"
 
 #: ../../src/wxMaximaFrame.cpp:1749
 msgid "First"
@@ -4492,11 +4492,11 @@ msgstr "Kurven an Messdaten anlegen"
 #: ../../src/dialogs/ConfigDialogue.cpp:1404
 #, c-format
 msgid "Fix reordered reference indices (of %i, %o) before saving"
-msgstr ""
+msgstr "Neunummerierung der Ein- und Ausgabemarken (%ixxx und %oxxx) beim Speichern"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:873
 msgid "Fixed font in text controls"
-msgstr ""
+msgstr "Schriftart mit fester Breite in Texteingabefeldern"
 
 #: ../../src/MaximaCommandMenus.cpp:4039
 msgid "Flush stream"
@@ -4524,11 +4524,11 @@ msgstr ""
 
 #: ../../src/wizards/DrawWiz.cpp:341
 msgid "Following plots use secondary x axis"
-msgstr ""
+msgstr "Die folgenden Kurven verwenden die 2. x-Achse"
 
 #: ../../src/wizards/DrawWiz.cpp:347
 msgid "Following plots use secondary y axis"
-msgstr ""
+msgstr "Die folgenden Kurven verwenden die 2. y-Achse"
 
 #: ../../src/sidebars/PerformanceSidebar.cpp:37
 msgid "Font cache hits:"
@@ -4540,11 +4540,11 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2047
 msgid "Fonts"
-msgstr ""
+msgstr "Schriftarten"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:442
 msgid "For each Text-, Sectioning or code cell wxMaxima can display a bracket showing the extend of the cell and allowing to fold it. This setting now tells if this bracket is to be printed, as well."
-msgstr ""
+msgstr "wxMaxima kann die Höhe jeder Text- Kapitel- oder Codezelle durch eine Art Klammer darstellen, die an deren linkem Rand gezeichnet ist, und erlaubt, die Zelle und ihren Inhalt zu verstecken. Dieses Häkchen sagt nun, ob diese Klammer auch mit ausgedruckt werden soll."
 
 #: ../../src/ToolBar.cpp:495
 msgid "For faster creation of cells the following shortcuts exist:\n\n"
@@ -4576,7 +4576,7 @@ msgstr "For Schleife..."
 
 #: ../../src/wizards/Plot2dWiz.cpp:69 ../../src/wizards/Plot3dWiz.cpp:60
 msgid "Format:"
-msgstr ""
+msgstr "Format:"
 
 #: ../../src/worksheet/Worksheet.cpp:301 ../../src/wxMaxima.cpp:3521
 msgid "Forwarding the keyboard focus to a text control"
@@ -4621,15 +4621,15 @@ msgstr "Bild %li von %li"
 
 #: ../../src/wizards/DrawWiz.cpp:488
 msgid "Frame counter"
-msgstr ""
+msgstr "Zähler für die Bilder"
 
 #: ../../src/wizards/DrawWiz.cpp:499
 msgid "Frame counter end"
-msgstr ""
+msgstr "Zahl des letzten Bildes"
 
 #: ../../src/wizards/DrawWiz.cpp:494
 msgid "Frame counter start"
-msgstr ""
+msgstr "Zahl des ersten Bildes"
 
 #: ../../src/MaximaCommandMenus.cpp:102
 msgid "Frame rate"
@@ -4641,7 +4641,7 @@ msgstr "Alle unbenutzten Objekte jetzt freigeben"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:198
 msgid "French"
-msgstr ""
+msgstr "Französisch"
 
 #: ../../src/wxMaximaFrame.cpp:1447
 msgid "Frobenius Norm sqrt(sum((A(i,j))^2)) (complex)"
@@ -4724,11 +4724,11 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:199
 msgid "Galician"
-msgstr ""
+msgstr "Galicisch"
 
 #: ../../src/sidebars/GreekSidebar.cpp:180
 msgid "Gamma"
-msgstr ""
+msgstr "Gamma"
 
 #: ../../src/wxMaximaFrame.cpp:316
 msgid "General Math"
@@ -4780,7 +4780,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:201
 msgid "German"
-msgstr ""
+msgstr "Deutsch"
 
 #: ../../src/wxMaximaFrame.cpp:1656
 msgid "Get &Imaginary Part"
@@ -4868,7 +4868,7 @@ msgstr "Größer, Groß/Kleinschreibung ignorieren?..."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:202
 msgid "Greek"
-msgstr ""
+msgstr "Griechisch"
 
 #: ../../src/wxMaximaFrame.cpp:281
 msgid "Greek Letters"
@@ -4880,11 +4880,11 @@ msgstr "Griechische Buchstaben\tAlt+Shift+G"
 
 #: ../../src/sidebars/DrawSidebar.cpp:97
 msgid "Grid"
-msgstr ""
+msgstr "Gitter"
 
 #: ../../src/wizards/Plot3dWiz.cpp:52
 msgid "Grid:"
-msgstr ""
+msgstr "Gitter:"
 
 #: ../../src/wxMaximaFrame.cpp:1852
 msgid "Guess an exact number that could be meant by this float"
@@ -4892,7 +4892,7 @@ msgstr "Eine exakte Zahl schätzen, die diese Gleitkommazahl sein könnte"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1215
 msgid "HTML"
-msgstr ""
+msgstr "HTML"
 
 #: ../../src/MaximaCommandMenus.cpp:2279
 msgid "HTML file (*.html)|*.html|maxima batch file (*.mac)|*.mac|LaTeX file (*.tex)|*.tex"
@@ -4940,7 +4940,7 @@ msgstr "Hilfe"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1461
 msgid "Help browser:"
-msgstr ""
+msgstr "Hilfe Browser:"
 
 #: ../../src/ToolBar.cpp:835
 msgid "Help button"
@@ -4959,7 +4959,7 @@ msgstr ""
 
 #: ../../src/sidebars/TableOfContents.cpp:510
 msgid "Hide"
-msgstr ""
+msgstr "Verstecken"
 
 #: ../../src/ToolBar.cpp:471 ../../src/ToolBar.cpp:473
 msgid "Hide Code"
@@ -4999,7 +4999,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:487
 msgid "Hide all multiplication signs that aren't really necessary for understanding the equation"
-msgstr ""
+msgstr "Verstecke jene Malzeichen, die nicht für das Verständnis der Gleichung notwendig sind."
 
 #: ../../src/wxMaximaFrame.cpp:767
 msgid "Hide all panes"
@@ -5019,15 +5019,15 @@ msgstr "Verstecke Multiplikationszeichen"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:854
 msgid "Hide multiplication signs, if possible"
-msgstr ""
+msgstr "Verstecke unnötige Multiplikationszeichen"
 
 #: ../../src/wizards/DrawWiz.cpp:555
 msgid "Hide objects behind the surface"
-msgstr ""
+msgstr "Verstecke Objekte hinter der Oberfläche"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:502
 msgid "Hide the brackets that mark the extend of the worksheet cells at the worksheet's right side and that contain the \"hide\" button of the cell if the cells aren't active."
-msgstr ""
+msgstr "Verstecke die Klammer, die zeigt, was zum Inhalt einer Zelle des Arbeitsblatts gehört und die das Verstecken eines Abschnitts/Kapitels/Zellinhalts erlaubt."
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:702
 #: ../../src/worksheet/WorksheetContextMenu.cpp:835
@@ -5045,11 +5045,11 @@ msgstr "Hervorgehoben (box)"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:869
 msgid "Highlight the matching parenthesis"
-msgstr ""
+msgstr "Zusammengehörige Klammern hervorheben"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:463
 msgid "Highlight the opening or closing parenthesis for the parenthesis the cursor is at."
-msgstr ""
+msgstr "Markiere die öffnende oder schließende Klammer, die zu der Klammer unter dem Cursor gehört."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:204
 msgid "Hindi"
@@ -5061,7 +5061,7 @@ msgstr "Histogramm"
 
 #: ../../src/sidebars/StatSidebar.cpp:85
 msgid "Histogram..."
-msgstr ""
+msgstr "Histogramm ..."
 
 #: ../../src/wxMaximaFrame.cpp:246
 msgid "History"
@@ -5073,7 +5073,7 @@ msgstr "Historie\tAlt+Shift+H"
 
 #: ../../src/dialogs/TipOfTheDay.cpp:105
 msgid "Horizontal cursor works like a normal cursor, but it operates on cells: press up or down arrow to move it, holding down Shift while moving will select cells, pressing backspace or delete twice will delete a cell next to it."
-msgstr ""
+msgstr "Der horizontale Cursor arbeitet wie ein normaler Cursor, der jedoch auf Zellen wirkt. Mit den Pfeilen abwärts und aufwärts wird der horizontale Cursor zwischen den Zellen bewegt. Wird dabei die Umschalt-Taste gehalten, werden die Zellen markiert. Mit der Entf-Taste oder Rücktaste wird die nächste oder vorhergehende Zelle gelöscht."
 
 #: ../../src/wxMaximaFrame.cpp:1563
 msgid "Horner's rule"
@@ -5081,7 +5081,7 @@ msgstr "Horner-Schema"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:918
 msgid "Hotkeys for sending commands to maxima"
-msgstr ""
+msgstr "Tastenkürzel zum Senden von Befehlen an Maxima"
 
 #: ../../src/MaximaCommandMenus.cpp:398
 msgid "How many digits to show:"
@@ -5093,7 +5093,7 @@ msgstr "Wie sollen neue Gleichungen angezeigt werden?"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:205
 msgid "Hungarian"
-msgstr ""
+msgstr "Ungarisch"
 
 #: ../../src/wxMaximaFrame.cpp:1147
 msgid "I/O"
@@ -5101,7 +5101,7 @@ msgstr "Eingabe/Ausgabe"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:121
 msgid "Identical to"
-msgstr ""
+msgstr "Identisch zu"
 
 #: ../../src/MaximaCommandMenus.cpp:3874
 msgid "If a program doesn't need local variables, Maxima allows putting the commands between parentheses. The result of the last operation is the return value of the program."
@@ -5109,51 +5109,51 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:145
 msgid "If maxima versions compiled with different lisps are installed: The name of the lisp to use by default"
-msgstr ""
+msgstr "Wenn Maxima-Versionen, die mit unterschiedlichen Lisps compiliert wurden, installiert sind: Der Name des Lisps, das standardmäßig verwendet wird"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:174
 msgid "If maxima was compiled by GCL: Garbage Collect at minimum allocation past this heapsize"
-msgstr ""
+msgstr "Falls Maxima von GCL compiliert wurde: Aufräumen des Heaps nicht unter dieser Heapgröße."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:171
 msgid "If maxima was compiled by GCL: Minimum allocation fraction between Garbage Collects"
-msgstr ""
+msgstr "Falls Maxima von GCL compiliert wurde: Minimaler Anteil an malloc()s vor Aufräumen des Heaps"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:168
 msgid "If maxima was compiled by GCL: Only garbage collect past this heapsize fraction of working mem"
-msgstr ""
+msgstr "Falls Maxima von GCL compiliert wurde: Minimaler Anteil der malloc()s an der Arbeitsspeichergröße vor Aufräumen des Heaps"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:180
 msgid "If maxima was compiled by GCL: Share the allocated memory between gcl processes. Allows more than one gcl-compiled maxima to run at the same time, but might provoke crashes."
-msgstr ""
+msgstr "Falls Maxima von GCL compiliert wurde: Teile den Heap zwischen den GCL-Prozessen. Ermöglicht es, mehrere maxima-Prozesse gleichzeitig auf demselben Rechner laufen zu lassen, aber führt manchmal zu Abstürzen."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:177
 msgid "If maxima was compiled by GCL: The fraction of the total installed RAM to reserve for maxima"
-msgstr ""
+msgstr "Falls Maxima von GCL compiliert wurde: Welcher Anteil des gesamten RAMs der Maschine soll für Maxima reserviert sein?"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:375
 msgid "If multiple cells are evaluated in one go: Abort evaluation if wxMaxima detects that maxima has encountered any error."
-msgstr ""
+msgstr "Wenn mehrere Zellen auf einmal evaluiert werden sollen und ein Fehler auftritt: Soll Maxima bei der Fehlermeldung anhalten?"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:727
 msgid "If not extremely long"
-msgstr ""
+msgstr "Wenn sie nicht extrem lang sind"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:726
 msgid "If not very long"
-msgstr ""
+msgstr "Wenn sie nicht sehr lang sind"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:418
 msgid "If numbers are getting longer than this number of digits they will be displayed abbreviated by an ellipsis."
-msgstr ""
+msgstr "Zahlen mit mehr als dieser Zahl an Stellen werden verkürzt dargestellt."
 
 #: ../../src/dialogs/TipOfTheDay.cpp:181
 msgid "If the \"Autosave\" functionality is enabled in the configuration dialogue wxMaxima acts like mobile apps that backup the file every few minutes and save it on closing."
-msgstr ""
+msgstr "Wenn im Konfigurationsdialog die \"Automatisches Speichern\"-Funktion aktiviert wird, verhält sich wxMaxima wie die meisten Apps auf mobilen Geräten, indem es die Datei beim Schließen und davor alle paar Minuten speichert."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:396
 msgid "If the font provides big parenthesis symbols: Use them when big parenthesis are needed for maths display."
-msgstr ""
+msgstr "Falls der Zeichensatz große Klammern enthält: Nutze diese, wo eine Formel eine große Klammer erfordert."
 
 #: ../../src/cells/TextCell.cpp:327
 msgid "If the thing maxima complains about actually looks like a polynomial you can try running it through ratdisrep() in order to fix that problem."
@@ -5167,15 +5167,15 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:399
 msgid "If this checkbox is checked wxMaxima automatically saves the file closing and every few minutes giving wxMaxima a more cellphone-app-like feel as the file is virtually always saved. If this checkbox is unchecked from time to time a backup is made in the temp folder instead."
-msgstr ""
+msgstr "Wenn dieses Häkchen gesetzt ist, speichert wxMaxima alle Dateien automatisch beim Schließen und alle paar Minuten, so dass es sich wie eine Handy-App verhält, bei der alles eigentlich immer gespeichert ist. Ist das Häkchen nicht gesetzt, werden stattdessen Sicherheitskopien im Temp-Ordner gemacht."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:378
 msgid "If this checkbox is set a new code cell is opened as soon as maxima requests data. If it isn't set a new code cell is opened in this case as soon as the user starts typing in code."
-msgstr ""
+msgstr "Wenn dieses Häkchen gesetzt ist, wird eine neue Codezelle erzeugt, sobald Maxima Daten anfordert. Andererweise wird die neue Zelle erst erstellt, wenn der Benutzer Text eingibt."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:372
 msgid "If this checkbox isn't checked the current command is sent to maxima only on pressing Ctrl+Enter"
-msgstr ""
+msgstr "Wenn diese Checkbox nicht angekreuzt ist, wird das aktuelle Kommando an Maxima gesendet, wenn Ctrl+Enter gedrückt wird"
 
 #: ../../src/MathParser.cpp:945
 msgid "If this isn't a function returning a lambda() expression a multiplication sign (*) between closing and opening parenthesis is missing here."
@@ -5188,7 +5188,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:439
 msgid "If this option is set the .wxmx source of the current file is copied to a place a link to is put into the result of an export."
-msgstr ""
+msgstr "Wenn diese Option aktiv wird, wird die aktuelle Datei im .wxmx-Format an einem Ort abgelegt, auf den ein Link vom HTML-Export zeigt."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1873
 msgid "If unset, Maxima's output is announced to the screen reader as maths in a linear text form. Set this option if your screen reader can speak MathML properly."
@@ -5196,15 +5196,15 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:247
 msgid "If you have ideas, how to improve the design or functionality of wxMaxima, please share your ideas at the issue list or discussion forum at https://github.com/wxMaxima-developers/wxmaxima/."
-msgstr ""
+msgstr "Sie haben eine Idee für eine Verbesserung von wxMaxima? Super! Bitte tragen Sie ihre Idee auf https://github.com/wxMaxima-developers/wxmaxima/ als Verbesserungsvorschlag (Issue) ein oder nutzen Sie das Diskussionsforum."
 
 #: ../../src/dialogs/TipOfTheDay.cpp:76
 msgid "If you type an operator (one of +*/^=,) as the first symbol in an input cell, % will be automatically inserted before the operator, as on a graphing calculator. You can disable this feature from the 'Edit->Configure' dialog."
-msgstr ""
+msgstr "Bei Eingabe eines Operators (+, *, /, ^ oder =) als erstes Symbol einer Zelle\nwird automatisch ein % eingefügt, so dass sich das Programm wie ein\ngraphischer Taschenrechner verhält. Diese Funktion kann über die Konfiguration\n(erreichbar über 'Bearbeiten->Einstellungen') abgeschaltet werden."
 
 #: ../../src/dialogs/TipOfTheDay.cpp:122
 msgid "If your calculation is taking too long to evaluate, you can try 'Maxima->Interrupt' or 'Maxima->Restart Maxima' menu commands."
-msgstr ""
+msgstr "Wenn Ihre Berechnung zu lange braucht, ohne dass Sie ein Ergebnis erhalten, können Sie mit dem Menübefehl 'Maxima->Unterbrechen' oder 'Maxima->Maxima neustarten' die Berechnung abbrechen."
 
 #: ../../src/MaximaManual.cpp:420
 msgid "Ignoring the cache version for the manual anchors."
@@ -5212,7 +5212,7 @@ msgstr "Ignoriere den Zwischenspeicher für Handbucheinträge."
 
 #: ../../src/sidebars/FormatSidebar.cpp:66
 msgid "Image"
-msgstr ""
+msgstr "Bild"
 
 #: ../../src/Image.cpp:110
 msgid "Image data had zero length!"
@@ -5234,15 +5234,15 @@ msgstr "Bild-Zelle ohne Bild."
 
 #: ../../src/sidebars/DrawSidebar.cpp:60
 msgid "Implicit Plot"
-msgstr ""
+msgstr "Implizit"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1028
 msgid "Import settings"
-msgstr ""
+msgstr "Importiere die Einstellungen von einer Datei"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1013
 msgid "Import+Export"
-msgstr ""
+msgstr "Importieren+Exportieren"
 
 #: ../../src/MathParser.cpp:395
 msgid "Importing compressed gnuplot sources for an animation"
@@ -5276,11 +5276,11 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:214
 msgid "In text cells bullet lists can be created by beginning a line with \" * \". The number of spaces in front of the \"*\" determines the indentation level; Indentation can be continued in the next line by indenting the line using spaces."
-msgstr ""
+msgstr "In Textzellen können Aufzählungen dargestellt werden, indem Zeilen mit der Zeichenkombination \" * \" begonnen werden. Die Anzahl der Leerzeichen vor dem \"*\" bestimmt dabei, wie weit die Zeile eingerückt wird. Absätze in Aufzählungen werden dadurch realisiert, dass eine Zeile mit Leerzeichen eingerückt wird."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:421
 msgid "In the LaTeX output: Put exponents after an eventual subscript instead of above it. Might increase readability for some fonts and short subscripts."
-msgstr ""
+msgstr "In der LaTeX-Ausgabe ist es je nach Zeichensatz bei kurzen Indizes manchmal lesbarer, wenn Exponenten hinter, nicht direkt über tiefgestelltem Text dargestellt werden. Diese Option wählt, was von beidem erwünscht ist."
 
 #: ../../src/MaximaCommandMenus.cpp:1869
 msgid "Include columns:"
@@ -5292,15 +5292,15 @@ msgstr "Steigende Funktion f(x)>x"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:884
 msgid "Incremental Search"
-msgstr ""
+msgstr "Suche während des Tippens"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:844
 msgid "Indent equations by the label width"
-msgstr ""
+msgstr "Einrücken von Gleichungen"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:512
 msgid "Indent maths so all lines are in par with the first line that starts after the label."
-msgstr ""
+msgstr "Rückt alle Zeilen von Gleichungen so ein, dass deren zweite Zeile hinter der Gleichungsnummer steht, nicht darunter."
 
 #: ../../src/sidebars/TableOfContents.cpp:583
 msgid "Indentation"
@@ -5341,7 +5341,7 @@ msgstr ""
 #: ../../src/wizards/IntegrateWiz.cpp:215 ../../src/wizards/LimitWiz.cpp:132
 #: ../../src/wizards/LimitWiz.cpp:140
 msgid "Infinity"
-msgstr ""
+msgstr "Infinity"
 
 #: ../../src/wxMaximaFrame.cpp:1986
 msgid "Info about Maxima build"
@@ -5399,7 +5399,7 @@ msgstr "Zellen Einfügen"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:889
 msgid "Insert % before an operator at the beginning of a cell"
-msgstr ""
+msgstr "Ein % Zeichen vor einem Operator am Anfang einer Zelle einfügen"
 
 #: ../../src/wxMaximaFrame.cpp:939
 msgid "Insert &Section Cell\tCtrl+3"
@@ -5547,11 +5547,11 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:749
 msgid "Integers and single letters"
-msgstr ""
+msgstr "Ganze Zahlen und Einzelbuchstaben"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:113
 msgid "Integral sign"
-msgstr ""
+msgstr "Integralzeichen"
 
 #: ../../src/MaximaCommandMenus.cpp:149 ../../src/MaximaCommandMenus.cpp:170
 msgid "Integral/Sum:"
@@ -5585,15 +5585,15 @@ msgstr "Integrieren ..."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:834
 msgid "Intelligently hide cell brackets"
-msgstr ""
+msgstr "Intelligentes Verstecken der Zellklammer"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:881
 msgid "Interaction"
-msgstr ""
+msgstr "Interaktion"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1349
 msgid "Interactive popup memory limit [MB/plot]:"
-msgstr ""
+msgstr "Max. Megabytes für interaktives Öffnen:"
 
 #: ../../src/wxMaximaFrame.cpp:1774
 msgid "Interleave"
@@ -5658,7 +5658,7 @@ msgstr ""
 
 #: ../../src/sidebars/RegexCtrl.cpp:40
 msgid "Invalid RegEx!"
-msgstr ""
+msgstr "Fehlerhafte RegEx!"
 
 #: ../../src/MathParser.cpp:1338
 #, c-format
@@ -5675,7 +5675,7 @@ msgstr "Inverse Laplacet&ransformation ..."
 
 #: ../../src/sidebars/GreekSidebar.cpp:186
 msgid "Iota"
-msgstr ""
+msgstr "Iota"
 
 #: ../../src/MaximaCommandMenus.cpp:4150
 msgid "Is Char 1 greater than Char2, if case is ignored?"
@@ -5791,7 +5791,7 @@ msgstr "Ist es ein Großbuchstabe?..."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:498
 msgid "Issue a notification if maxima finishes calculating while the wxMaxima window isn't in focus."
-msgstr ""
+msgstr "Informiere den Benutzer, wenn Maxima mit dem Rechnen fertig wird, während das Fenster gerade nicht aktiv ist."
 
 #: ../../src/worksheet/Worksheet.cpp:4237
 msgid "Issuing the active cell's undo function"
@@ -5803,27 +5803,27 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:185
 msgid "It is possible to add custom symbols to the \"symbols\" sidebar by copying them into the respective field in the configuration dialogue."
-msgstr ""
+msgstr "Es ist möglich, eigene Symbole in die \"Symbole\"-Seitenleiste einzutragen, indem sie in das entsprechende Feld des Konfigurationsdialogs kopiert werden."
 
 #: ../../src/dialogs/TipOfTheDay.cpp:152
 msgid "It is possible to define reusable Maxima libraries with wxMaxima that can be later loaded by using the load() function. All that has to be done is to export a file in the .mac or to save it in the .wxm format. Note, though, that a few special characters like the \"not equal\" symbol for \"#\" are handled by wxMaxima, not by Maxima and therefore cannot be recognized on load()."
-msgstr ""
+msgstr "Es ist möglich, mit wxMaxima wiederverwendbare Bibliotheken zu schreiben, die über die load()-Funktion in Maxima eingelesen werden können. Das einzige, was hierfür zu tun ist, ist, das Arbeitsblatt als .mac-Datei zu exportieren oder als .wxm-Datei zu schreiben. Es ist allerdings zu beachten, dass Sonderzeichen wie das \"ungleich\"-Symbol, anstelle dessen Maxima ein \"#\" will, vom load()-Befehl nicht automatisch in Maxima-Befehle konvertiert werden und daher beim load() nicht erkannt werden.."
 
 #: ../../src/wizards/DrawWiz.cpp:476
 msgid "It needs to be filled with objects to draw afterwards."
-msgstr ""
+msgstr "Muss mit Objekten gefüllt werden, die dargestellt werden sollen."
 
 #: ../../src/wizards/ActualValuesStorageWiz.cpp:38
 msgid "It therefore makes sense to apply the known values for variables as late as possible."
-msgstr ""
+msgstr "Es macht daher Sinn, den Variablen erst so spät wie möglich konkrete Zahlenwerte zuzuweisen."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:207
 msgid "Italian"
-msgstr ""
+msgstr "Italienisch"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2111
 msgid "Italic"
-msgstr ""
+msgstr "Kursiv"
 
 #: ../../src/MaximaCommandMenus.cpp:1617 ../../src/MaximaCommandMenus.cpp:1623
 msgid "Item"
@@ -5835,7 +5835,7 @@ msgstr "Laufvariable:"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:208
 msgid "Japanese"
-msgstr ""
+msgstr "Japanisch"
 
 #: ../../src/MaximaCommandMenus.cpp:2255
 msgid "Jump to UUID"
@@ -5863,16 +5863,16 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:210
 msgid "Kabyle"
-msgstr ""
+msgstr "Kabylisch"
 
 #: ../../src/sidebars/GreekSidebar.cpp:187
 msgid "Kappa"
-msgstr ""
+msgstr "Kappa"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:864
 #, c-format
 msgid "Keep percent sign with special symbols: %e, %i, etc."
-msgstr ""
+msgstr "Zeige Prozentzeichen für spezielle Symbole: %e, %i, usw."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:212
 msgid "Korean"
@@ -5900,19 +5900,19 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1166
 msgid "LaTeX"
-msgstr ""
+msgstr "LaTeX"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1199
 msgid "LaTeX: Place exponents after, instead above subscripts"
-msgstr ""
+msgstr "LaTeX: Platziere Exponenten hinter, nicht direkt über Indizes."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1204
 msgid "LaTeX: Use the \"partial derivative\" symbol to represent diff()"
-msgstr ""
+msgstr "LaTeX: Verwende das \"partielle Ableitung\"-Symbol, um diff() darzustellen"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:758
 msgid "Label width:"
-msgstr ""
+msgstr "Breite der Ein- und Ausgabemarken:"
 
 #: ../../src/wxMaximaFrame.cpp:1059
 msgid "Labels"
@@ -5931,11 +5931,11 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:470
 msgid "Language used for wxMaxima GUI."
-msgstr ""
+msgstr "Von wxMaxima verwendete Sprache."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1311
 msgid "Language:"
-msgstr ""
+msgstr "Sprache:"
 
 #: ../../src/MaximaCommandMenus.cpp:251
 msgid "Laplace"
@@ -5982,7 +5982,7 @@ msgstr "Konnte den Hilfe-Browser des Systems nicht starten."
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:126
 msgid "Leads to"
-msgstr ""
+msgstr "Führt zu"
 
 #: ../../src/wxMaximaFrame.cpp:1530
 msgid "Least Common Multiple..."
@@ -5994,7 +5994,7 @@ msgstr "Least-Squares-Fit"
 
 #: ../../src/sidebars/StatSidebar.cpp:79
 msgid "Least Squares Fit..."
-msgstr ""
+msgstr "Least-Squares-Fit ..."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2007
 msgid "Left"
@@ -6031,12 +6031,12 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:163
 msgid "Libraries can be accessed by any wxMaxima process regardless of which directory it runs in, if they are placed in the user directory. This directory can be found by typing maxima_userdir;"
-msgstr ""
+msgstr "Auf Bibliotheken, die im Benutzerverzeichnis von Maxima abgelegt sind, kann man von jedem Verzeichnis aus zugreifen. Wo das Benutzerverzeichnis liegt, zeigt Maxima, wenn man den Befehl maxima_userdir; eingibt. "
 
 #: ../../src/dialogs/LicenseDialog.cpp:63
 #: ../../src/dialogs/LicenseDialog.cpp:77
 msgid "License"
-msgstr ""
+msgstr "Lizenz"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2068
 msgid "Light"
@@ -6052,15 +6052,15 @@ msgstr "Grenzwert"
 
 #: ../../src/sidebars/MathSidebar.cpp:86
 msgid "Limit..."
-msgstr ""
+msgstr "Grenzwert ..."
 
 #: ../../src/sidebars/DrawSidebar.cpp:88
 msgid "Line color"
-msgstr ""
+msgstr "Linienfarbe"
 
 #: ../../src/sidebars/StatSidebar.cpp:76
 msgid "Linear Regression..."
-msgstr ""
+msgstr "Lineare Regression..."
 
 #: ../../src/MaximaCommandMenus.cpp:4068
 msgid "Lisp format string:"
@@ -6108,15 +6108,15 @@ msgstr "Verzeichnis anzeigen..."
 
 #: ../../src/wizards/ListSortWiz.cpp:34
 msgid "List name:"
-msgstr ""
+msgstr "Name der Liste:"
 
 #: ../../src/sidebars/VariablesPane.cpp:188
 msgid "List of arrays"
-msgstr ""
+msgstr "Liste der Arrays"
 
 #: ../../src/sidebars/VariablesPane.cpp:191
 msgid "List of changed options"
-msgstr ""
+msgstr "Liste der geänderten Optionen"
 
 #: ../../src/MaximaCommandMenus.cpp:4197
 msgid "List of char to String"
@@ -6136,43 +6136,43 @@ msgstr ""
 
 #: ../../src/sidebars/VariablesPane.cpp:203
 msgid "List of labels"
-msgstr ""
+msgstr "Liste der Markierungen"
 
 #: ../../src/sidebars/VariablesPane.cpp:200
 msgid "List of structs"
-msgstr ""
+msgstr "Liste der Strukturen"
 
 #: ../../src/sidebars/VariablesPane.cpp:197
 msgid "List of user aliases"
-msgstr ""
+msgstr "Liste der aliases"
 
 #: ../../src/sidebars/VariablesPane.cpp:185
 msgid "List of user functions"
-msgstr ""
+msgstr "Liste der selbstdefinierten Funktionen"
 
 #: ../../src/sidebars/VariablesPane.cpp:194
 msgid "List of user rules"
-msgstr ""
+msgstr "Liste der selbstdefinierten Regeln"
 
 #: ../../src/sidebars/VariablesPane.cpp:182
 msgid "List of user variables"
-msgstr ""
+msgstr "Liste der selbstdefinierten Variablen"
 
 #: ../../src/sidebars/VariablesPane.cpp:206
 msgid "List of user-defined derivatives"
-msgstr ""
+msgstr "Liste der gradefs"
 
 #: ../../src/sidebars/VariablesPane.cpp:216
 msgid "List of user-defined let rule packages"
-msgstr ""
+msgstr "Liste der let-Regeln"
 
 #: ../../src/sidebars/VariablesPane.cpp:212
 msgid "List of user-defined macros"
-msgstr ""
+msgstr "Liste der benutzerdefinierten Makros"
 
 #: ../../src/sidebars/VariablesPane.cpp:209
 msgid "List of user-defined properties"
-msgstr ""
+msgstr "Liste der benutzerdefinierten Eigenschaften"
 
 #: ../../src/MaximaCommandMenus.cpp:1575
 msgid "List with values"
@@ -6193,7 +6193,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2162
 msgid "Load"
-msgstr ""
+msgstr "Laden"
 
 #: ../../src/MaximaCommandMenus.cpp:2356
 msgid "Load Package"
@@ -6233,7 +6233,7 @@ msgstr "Lade Lisp..."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2645
 msgid "Load style from file"
-msgstr ""
+msgstr "Lade Layout aus einer Datei"
 
 #: ../../src/wxMaximaFrame.cpp:1232
 msgid "Load the file/dir operations (operatingsystem)"
@@ -6249,7 +6249,7 @@ msgstr "Lade das Paket für andere Programmiersprachen (gentran)"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:128
 msgid "Long Right arrow"
-msgstr ""
+msgstr "Langer Pfeil nach rechts"
 
 #: ../../src/MaximaCommandMenus.cpp:1409
 msgid "Loop variable"
@@ -6269,7 +6269,7 @@ msgstr ""
 
 #: ../../src/sidebars/XmlInspector.cpp:104
 msgid "MAXIMA RESPONSE:"
-msgstr ""
+msgstr "ANTWORT VON MAXIMA:"
 
 #: ../../src/MaximaCommandMenus.cpp:3965
 msgid "Macro contents:"
@@ -6333,7 +6333,7 @@ msgstr "Eine Funktion auf Elemente einer Matrix (inklusive Klone) anwenden"
 
 #: ../../src/dialogs/FindReplacePane.cpp:71
 msgid "Match Case"
-msgstr ""
+msgstr "Groß-/Kleinschreibung beachten"
 
 #: ../../src/Styles.cpp:139
 msgid "Math Default"
@@ -6345,7 +6345,7 @@ msgstr ""
 
 #: ../../src/cells/Cell.cpp:1490
 msgid "Math output"
-msgstr ""
+msgstr "Mathematische Ausgabe"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1221
 msgid "MathML (rendered by the browser)"
@@ -6357,11 +6357,11 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1906
 msgid "MathML as HTML"
-msgstr ""
+msgstr "MathML als HTML"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1902
 msgid "MathML description"
-msgstr ""
+msgstr "MathML Beschreibung"
 
 #: ../../src/wxMaximaFrame.cpp:307
 msgid "Mathematical Symbols"
@@ -6441,11 +6441,11 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:281
 msgid "Maxima"
-msgstr ""
+msgstr "Maxima"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1433
 msgid "Maxima Location"
-msgstr ""
+msgstr "Maxima-Binary"
 
 #: ../../src/MaximaCommandMenus.cpp:619
 msgid "Maxima allows making functions \"nouns\", which means that they aren't automatically evaluated as soon as Maxima encounters them.\n"
@@ -6478,19 +6478,19 @@ msgstr ""
 
 #: ../../src/cells/EditorCell.cpp:4516
 msgid "Maxima code"
-msgstr ""
+msgstr "Maxima-Code"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1110
 msgid "Maxima commands to be executed at every start of Maxima"
-msgstr ""
+msgstr "Maxima-Befehle, die beim jedem Start von Maxima ausgeführt werden sollen: "
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1063
 msgid "Maxima commands to be executed every time wxMaxima starts Maxima"
-msgstr ""
+msgstr "Maxima-Befehle, die wxMaxima jeden neuen Maxima-Prozess ausführen lassen soll: "
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1507
 msgid "Maxima configuration"
-msgstr ""
+msgstr "Maxima Konfiguration"
 
 #: ../../src/MaximaResponseReader.cpp:346
 msgid "Maxima didn't attempt to authenticate!"
@@ -6566,11 +6566,11 @@ msgstr "Maxima wurde unerwartet beendet."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1437
 msgid "Maxima program:"
-msgstr ""
+msgstr "Maxima-Programm:"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:382
 msgid "Maxima provides no \"forget all\" command that flushes all settings a maxima session could make. wxMaxima therefore normally defaults to starting a fresh maxima process every time the worksheet is to be re-evaluated. As this needs a little bit of time this switch allows to disable this behavior."
-msgstr ""
+msgstr "Maxima besitzt kein Kommando, das wirklich alles, was vom Benutzer geändert werden kann, wieder ungeschehen macht. wxMaxima startet daher standardmäßig jedes Mal, wenn das Arbeitsblatt neu ausgewertet werden soll, einen neuen Maxima-Prozess. Dies benötigt jedoch Zeit, weswegen diese Option eingeführt wurde, die es erlaubt, dieses Verhalten wieder auszuschalten."
 
 #: ../../src/Styles.cpp:108
 msgid "Maxima question labels"
@@ -6590,7 +6590,7 @@ msgstr "Maxima sendet einen neuen Satz an Variablen für die Beobachtungsliste"
 
 #: ../../src/sidebars/History.cpp:153
 msgid "Maxima session (*.mac)|*.mac"
-msgstr ""
+msgstr "Maxima Paket (*.mac)|*.mac"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1518 ../../src/wxMaximaFrame.cpp:1981
 msgid "Maxima shows help in a browser"
@@ -6622,11 +6622,11 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1143
 msgid "Maxima startup file location: "
-msgstr ""
+msgstr "Ort, an dem diese Datei liegt: "
 
 #: ../../src/dialogs/TipOfTheDay.cpp:68
 msgid "Maxima supports three types of numbers: exact fractions (which can be generated for example by typing 1/10), IEEE floating-point numbers (0.2) and arbitrary precision big floats (1b-1). Note that, owing to their nature as binary (not decimal) numbers, there is for example no way to generate an IEEE floating-point number that exactly equals 0.1. If floating-point numbers are used instead of fractions, Maxima will therefore sometimes have to introduce a (very small) error and use things like 3602879701896397/36028797018963968 for 0.1."
-msgstr ""
+msgstr "Maxima kann mit drei Typen von Zahlen umgehen: exakten Brüchen (diese können beispielsweise als 1/10 eingegeben werden), IEEE-Fließkommazahlen (0.2 und ähnliche) und Fließkommazahlen einer frei wählbaren Länge (1b-1). Da diese Fließkommazahlen als Binärzahlen abgebildet werden, ist dabei zu beachten, dass es bei einigen Zahlen (ein Beispiel wäre 0,1) keine Möglichkeit gibt, sie exakt in einer Fließkommazahl abzubilden. Falls Maxima Fließkommazahlen verwenden soll, muss es daher in diesem Fall stattdessen etwas wie 3602879701896397/36028797018963968 statt 0.1 verwenden, was einen (allerdings sehr kleinen) Fehler in die Rechnung einführt."
 
 #: ../../src/wxMaximaFrame.cpp:1265
 msgid "Maxima to other language"
@@ -6642,7 +6642,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1615
 msgid "Maxima usage"
-msgstr ""
+msgstr "Verwendung von Maxima"
 
 #: ../../src/MaximaResponseReader.cpp:776
 #, c-format
@@ -6738,7 +6738,7 @@ msgstr "Maxima's Handbuch liegt im Ordner %s"
 
 #: ../../src/wizards/ActualValuesStorageWiz.cpp:34
 msgid "Maxima's power lies in symbolic operations."
-msgstr ""
+msgstr "Die Stärke von Maxima liegt im symbolischen Rechnen."
 
 #: ../../src/StatusBar.cpp:365
 msgid "Maxima's reader is in Lisp mode (after to_lisp()).\n"
@@ -6785,7 +6785,7 @@ msgstr "Betrag der höchsten Zahl, die ohne Exponent dargestellt werden soll"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1931
 msgid "Maximum bitmap size on clipboard [Mb]:"
-msgstr ""
+msgstr "Maximale Bitmap-Größe in der Zwischenablage [MB]:"
 
 #: ../../src/MaximaCommandMenus.cpp:488 ../../src/MaximaCommandMenus.cpp:501
 #: ../../src/MaximaCommandMenus.cpp:516 ../../src/MaximaCommandMenus.cpp:530
@@ -6798,19 +6798,19 @@ msgstr "Maximale Anzahl an anzuzeigenden Ziffern:"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:811
 msgid "Maximum number of displayed digits:"
-msgstr ""
+msgstr "Maximale Anzahl an anzuzeigenden Ziffern:"
 
 #: ../../src/sidebars/StatSidebar.cpp:70
 msgid "Mean Difference Test..."
-msgstr ""
+msgstr "Zweistichprobentest ..."
 
 #: ../../src/sidebars/StatSidebar.cpp:67
 msgid "Mean Test..."
-msgstr ""
+msgstr "Mittelwerttest ..."
 
 #: ../../src/sidebars/StatSidebar.cpp:52
 msgid "Mean..."
-msgstr ""
+msgstr "Mittelwert..."
 
 #: ../../src/MaximaCommandMenus.cpp:1806
 msgid "Mean:"
@@ -6818,7 +6818,7 @@ msgstr "Mittelwert:"
 
 #: ../../src/sidebars/StatSidebar.cpp:55
 msgid "Median..."
-msgstr ""
+msgstr "Median..."
 
 #: ../../src/wxMaximaFrame.cpp:1961
 msgid "Memoizing"
@@ -6839,7 +6839,7 @@ msgstr "Nachricht vom stdout von Maxima: "
 
 #: ../../src/wizards/IntegrateWiz.cpp:55
 msgid "Method:"
-msgstr ""
+msgstr "Methode:"
 
 #: ../../src/wxMaximaFrame.cpp:1360
 msgid "Methods of generating a matrix"
@@ -6865,7 +6865,7 @@ msgstr "Betrag der kleinsten Zahl, die ohne Exponent dargestellt werden soll:"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1270
 msgid "Misc"
-msgstr ""
+msgstr "Verschiedenes"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1963
 msgid "Misc settings"
@@ -6906,7 +6906,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:189
 msgid "Mu"
-msgstr ""
+msgstr "My"
 
 #: ../../src/wxMaximaFrame.cpp:1386
 msgid "Multiplication, exponent and similar"
@@ -6930,7 +6930,7 @@ msgstr "Name von t:"
 
 #: ../../src/wizards/DrawWiz.cpp:750
 msgid "Name of the parameter"
-msgstr ""
+msgstr "Name des Parameters"
 
 #: ../../src/MaximaCommandMenus.cpp:1019
 msgid "Name of x:"
@@ -6938,7 +6938,7 @@ msgstr "Name von x:"
 
 #: ../../src/wizards/MatWiz.cpp:163
 msgid "Name:"
-msgstr ""
+msgstr "Name:"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:216
 msgid "Nepali"
@@ -7001,7 +7001,7 @@ msgstr "Neues Dokument"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:901
 msgid "New lines: Jump to text"
-msgstr ""
+msgstr "Neue Zeilen: Springe zum Text"
 
 #: ../../src/MaximaResponseReader.cpp:1015
 #, c-format
@@ -7014,7 +7014,7 @@ msgstr "Neuer Abschnitt:"
 
 #: ../../src/wizards/SubstituteWiz.cpp:35
 msgid "New value:"
-msgstr ""
+msgstr "Neuer Wert:"
 
 #: ../../src/MaximaCommandMenus.cpp:151 ../../src/MaximaCommandMenus.cpp:171
 #: ../../src/MaximaCommandMenus.cpp:254 ../../src/MaximaCommandMenus.cpp:259
@@ -7052,7 +7052,7 @@ msgstr ""
 
 #: ../../src/wizards/DrawWiz.cpp:636
 msgid "No contour lines"
-msgstr ""
+msgstr "Keine Höhenlinien"
 
 #: ../../src/dialogs/DiffFrame.cpp:304
 msgid "No differences"
@@ -7089,11 +7089,11 @@ msgstr "Keine Übereinstimmung gefunden!"
 
 #: ../../src/wizards/DrawWiz.cpp:651
 msgid "No plot, only contour lines"
-msgstr ""
+msgstr "Kein Diagramm, nur Höhenlinien"
 
 #: ../../src/wizards/DrawWiz.cpp:837
 msgid "No points"
-msgstr ""
+msgstr "Keine Punkte"
 
 #: ../../src/MaximaResponseReader.cpp:145
 msgid "No topics found in topic flag"
@@ -7109,7 +7109,7 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:179
 msgid "Non-builtin symbols"
-msgstr ""
+msgstr "Nicht-eingebaute Symbole"
 
 #: ../../src/wxMaximaFrame.cpp:834
 msgid "None"
@@ -7117,7 +7117,7 @@ msgstr "Keine"
 
 #: ../../src/sidebars/StatSidebar.cpp:73
 msgid "Normality Test..."
-msgstr ""
+msgstr "Test Normalverteilung..."
 
 #: ../../src/cells/TextCell.cpp:271
 msgid "Normally computers use floating-point numbers that can be handled incredibly fast while being accurate to dozens of digits. They will, though, introduce a small error into some common numbers. For example 0.1 is represented as 3602879701896397/36028797018963968.\n"
@@ -7128,11 +7128,11 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:431
 msgid "Normally html expects images to be rather low-res but space saving. These images tend to look rather blurry when viewed on modern screens. Therefore this setting was introduces that selects the factor by which the HTML export increases the resolution in respect to the default value."
-msgstr ""
+msgstr "HTML besteht normalerweise auf Bildern mit einer niedrigen Graphikauflösung, die im Gegenzug wenig Speicherplatz benötigen. Dafür werden diese jedoch auf hochauflösenden oder großen Bildschirmen verschwommen dargestellt. Diese Einstellung erlaubt es, die Auflösung der Bilder zu vervielfachen. "
 
 #: ../../src/dialogs/ConfigDialogue.cpp:217
 msgid "Norwegian"
-msgstr ""
+msgstr "Norwegisch"
 
 #: ../../src/MaximaCommandMenus.cpp:1351
 msgid "Not a valid matrix dimension!"
@@ -7168,7 +7168,7 @@ msgstr "Keine Evaluierung auslösen, es gibt keinen laufenden Maxima Prozess"
 
 #: ../../src/sidebars/GreekSidebar.cpp:190
 msgid "Nu"
-msgstr ""
+msgstr "Ny"
 
 #: ../../src/MaximaCommandMenus.cpp:177
 msgid "Num. deg:"
@@ -7311,7 +7311,7 @@ msgstr "Ungerade Zahl"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:910
 msgid "Offer answers for questions known from previous runs"
-msgstr ""
+msgstr "Biete von früheren Durchläufen bekannte Antworten an"
 
 #: ../../src/cells/TextCell.cpp:332
 msgid "Often caused by recursive function calls. Some lisps allow increasing the control stack size using command-line arguments."
@@ -7319,7 +7319,7 @@ msgstr ""
 
 #: ../../src/wizards/SubstituteWiz.cpp:32
 msgid "Old value:"
-msgstr ""
+msgstr "Alter Wert:"
 
 #: ../../src/MaximaCommandMenus.cpp:151 ../../src/MaximaCommandMenus.cpp:172
 #: ../../src/MaximaCommandMenus.cpp:253 ../../src/MaximaCommandMenus.cpp:259
@@ -7328,11 +7328,11 @@ msgstr "Alte Variable:"
 
 #: ../../src/sidebars/GreekSidebar.cpp:201
 msgid "Omega"
-msgstr ""
+msgstr "Omega"
 
 #: ../../src/sidebars/GreekSidebar.cpp:192
 msgid "Omicron"
-msgstr ""
+msgstr "Omikron"
 
 #: ../../src/wxMaximaFrame.cpp:1089
 msgid "On all errors"
@@ -7356,7 +7356,7 @@ msgstr "Nur ganze Zahlen und einzelne Buchstaben"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:771
 msgid "Only user-defined labels"
-msgstr ""
+msgstr "Nur benutzerdefinierte Marken"
 
 #: ../../src/MaximaCommandMenus.cpp:2197 ../../src/ToolBar.cpp:330
 #: ../../src/ToolBar.cpp:333 ../../src/main.cpp:882
@@ -7365,7 +7365,7 @@ msgstr "Öffnen"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:905
 msgid "Open a cell when Maxima expects input"
-msgstr ""
+msgstr "Öffne eine Zelle, wenn Maxima eine Eingabe erwartet"
 
 #: ../../src/wxMaximaFrame.cpp:629
 msgid "Open a document"
@@ -7439,7 +7439,7 @@ msgstr "Optimiere den Speicherbedarf"
 
 #: ../../src/wizards/DrawWiz.cpp:97
 msgid "Optional: A 2nd expression that defines a region to fill"
-msgstr ""
+msgstr "Optional: Ein 2. Ausdruck, der einen zu füllenden Bereich begrenzt"
 
 #: ../../src/ToolBar.cpp:367 ../../src/ToolBar.cpp:369
 #: ../../src/dialogs/ConfigDialogue.cpp:284
@@ -7448,7 +7448,7 @@ msgstr "Optionen"
 
 #: ../../src/wizards/Plot2dWiz.cpp:75 ../../src/wizards/Plot3dWiz.cpp:66
 msgid "Options:"
-msgstr ""
+msgstr "Optionen:"
 
 #: ../../src/dialogs/FindReplacePane.cpp:109
 msgid "Output"
@@ -7509,7 +7509,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:458
 msgid "PNG images can be read by old wxMaxima versions - but aren't really scalable."
-msgstr ""
+msgstr "PNG-Bilder können auch von alten wxMaxima-Versionen gelesen werden, sind aber nur begrenzt skalierbar."
 
 #: ../../src/MaximaCommandMenus.cpp:175
 msgid "Pade approximation"
@@ -7521,7 +7521,7 @@ msgstr "Pade-Approximation einer Taylorreihe"
 
 #: ../../src/sidebars/FormatSidebar.cpp:69
 msgid "Pagebreak"
-msgstr ""
+msgstr "Seitenumbruch"
 
 #: ../../src/wxMaximaFrame.cpp:1674
 msgid "Parallel Substitute..."
@@ -7533,7 +7533,7 @@ msgstr "Parallel Substituieren"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:124
 msgid "Parallel to"
-msgstr ""
+msgstr "Parallel"
 
 #: ../../src/MaximaCommandMenus.cpp:3991
 msgid "Parameter name:"
@@ -7545,11 +7545,11 @@ msgstr "Parameter:"
 
 #: ../../src/sidebars/DrawSidebar.cpp:64
 msgid "Parametric Plot"
-msgstr ""
+msgstr "Parametrischer Plot"
 
 #: ../../src/wizards/Plot2dWiz.cpp:417 ../../src/wizards/Plot2dWiz.cpp:523
 msgid "Parametric plot"
-msgstr ""
+msgstr "Parametrischer Plot"
 
 #: ../../src/MaximaCommandMenus.cpp:4211
 msgid "Parse string"
@@ -7603,7 +7603,7 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:125
 msgid "Perpendicular to"
-msgstr ""
+msgstr "Senkrecht"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:218
 msgid "Persian"
@@ -7611,15 +7611,15 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:198
 msgid "Phi"
-msgstr ""
+msgstr "Phi"
 
 #: ../../src/sidebars/GreekSidebar.cpp:193
 msgid "Pi"
-msgstr ""
+msgstr "Pi"
 
 #: ../../src/sidebars/StatSidebar.cpp:94
 msgid "Piechart..."
-msgstr ""
+msgstr "Kreisdiagramm..."
 
 #: ../../src/wxMaxima.cpp:1585
 msgid "Please configure wxMaxima with 'Edit->Configure'."
@@ -7627,7 +7627,7 @@ msgstr "Bitte konfigurieren Sie wxMaxima mit 'Bearbeiten->Einstellungen'."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2606
 msgid "Please restart wxMaxima for changes to take effect!"
-msgstr ""
+msgstr "Bitte starten Sie wxMaxima neu, um die Änderungen zu aktivieren!"
 
 #: ../../src/MaximaCommandMenus.cpp:2250
 msgid "Please select exactly 2 or 3 files."
@@ -7668,16 +7668,16 @@ msgstr "3D Plotten ..."
 
 #: ../../src/wizards/DrawWiz.cpp:713
 msgid "Plot a parametric curve"
-msgstr ""
+msgstr "Zeichne eine parametrische Kurve"
 
 #: ../../src/wizards/DrawWiz.cpp:45 ../../src/wizards/DrawWiz.cpp:148
 #: ../../src/wizards/DrawWiz.cpp:255
 msgid "Plot an explicit expression"
-msgstr ""
+msgstr "Darstellung eines explizit angegebenen Ausdrucks"
 
 #: ../../src/wizards/DrawWiz.cpp:53
 msgid "Plot an expression, for example sin(x) or (x+1)^2."
-msgstr ""
+msgstr "Zeichnet einen Ausdruck, wie sin(x) oder (x+1)^2."
 
 #: ../../src/MaximaCommandMenus.cpp:1776
 msgid "Plot as bars"
@@ -7701,11 +7701,11 @@ msgstr "In drei Dimensionen plotten"
 
 #: ../../src/sidebars/DrawSidebar.cpp:83
 msgid "Plot name"
-msgstr ""
+msgstr "Name der Kurve"
 
 #: ../../src/wizards/Plot2dWiz.cpp:84 ../../src/wizards/Plot3dWiz.cpp:80
 msgid "Plot to file:"
-msgstr ""
+msgstr "Plot in Datei:"
 
 #: ../../src/wxMaximaFrame.cpp:341 ../../src/wxMaximaFrame.cpp:749
 msgid "Plot using Draw"
@@ -7725,7 +7725,7 @@ msgstr ""
 
 #: ../../src/wizards/DrawWiz.cpp:842
 msgid "Point type:"
-msgstr ""
+msgstr "Punkttyp:"
 
 #: ../../src/MaximaCommandMenus.cpp:186 ../../src/MaximaCommandMenus.cpp:1090
 #: ../../src/wizards/BC2Wiz.cpp:33 ../../src/wizards/BC2Wiz.cpp:39
@@ -7735,11 +7735,11 @@ msgstr "Punkt:"
 
 #: ../../src/sidebars/DrawSidebar.cpp:67
 msgid "Points"
-msgstr ""
+msgstr "Punkte"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:219
 msgid "Polish"
-msgstr ""
+msgstr "Polnisch"
 
 #: ../../src/MaximaCommandMenus.cpp:215 ../../src/MaximaCommandMenus.cpp:220
 #: ../../src/MaximaCommandMenus.cpp:225
@@ -7775,7 +7775,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:221
 msgid "Portuguese (Brazilian)"
-msgstr ""
+msgstr "Portugiesisch (Brasilien)"
 
 #: ../../src/wxMaximaFrame.cpp:1223
 msgid "Position of a match"
@@ -7791,7 +7791,7 @@ msgstr ""
 
 #: ../../src/wizards/Plot2dWiz.cpp:474 ../../src/wizards/Plot3dWiz.cpp:422
 msgid "Postscript file (*.eps)|*.eps|All|*"
-msgstr ""
+msgstr "Postscript-Datei (*.eps)|*.eps|Alle|*"
 
 #: ../../src/MaximaCommandMenus.cpp:190
 msgid "Power series"
@@ -7811,7 +7811,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1492
 msgid "Prefer the all-in-one-file >1000 page manual"
-msgstr ""
+msgstr "Bevorzuge das Handbuch in einer Datei (>1000 Seiten)"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:389
 msgid "Prefer user labels"
@@ -7839,7 +7839,7 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:146
 msgid "Pressing Ctrl+Space or Ctrl+Tab starts an autocomplete function that can not only complete all functions that are integrated into the Maxima core and their parameters: It also knows about parameters from currently loaded packages and from functions that are defined in the current file."
-msgstr ""
+msgstr "Ctrl+Leertaste oder Ctrl+Tabulator startet eine Auto-Vervollständigungs-Funktion, die nicht nur über in Maxima eingebaute Funktionen und Variablen informiert ist, sondern auch die von externen Paketen nachgeladenen Befehle in Erfahrung bringt sowie die im aktuellen Arbeitsblatt definierten Funktionen."
 
 #: ../../src/wxMaximaFrame.cpp:961
 msgid "Previous Command\tAlt+Up"
@@ -7876,11 +7876,11 @@ msgstr "Gebe Fließkommazahlen mit durch 3 teilbaren Exponenten aus"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1968
 msgid "Print scale:"
-msgstr ""
+msgstr "Skalierung für den Druck:"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1981
 msgid "Print the cell brackets [drawn to their left]"
-msgstr ""
+msgstr "Drucke die Zellenklammer auf der linken Seite mit aus"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:287
 msgid "Printout settings"
@@ -7930,7 +7930,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:936
 msgid "Privacy settings"
-msgstr ""
+msgstr "Privatspähreneinstellungen"
 
 #: ../../src/WXMXformat.cpp:256
 msgid "Produced invalid XML. The erroneous XML data has therefore not been saved but has been put on the clipboard in order to allow debugging it.\n"
@@ -7943,7 +7943,7 @@ msgstr "Produkt"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:123
 msgid "Product sign"
-msgstr ""
+msgstr "Produktzeichen"
 
 #: ../../src/wxMaximaFrame.cpp:1129
 msgid "Program"
@@ -7967,7 +7967,7 @@ msgstr "Programmblock ohne lokale Variablen..."
 
 #: ../../src/sidebars/GreekSidebar.cpp:200
 msgid "Psi"
-msgstr ""
+msgstr "Psi"
 
 #: ../../src/wxMaximaFrame.cpp:1788
 msgid "Push"
@@ -7991,7 +7991,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1910
 msgid "RTF with OMML maths"
-msgstr ""
+msgstr "RTF mit OMML-Formeln"
 
 #: ../../src/MaximaCommandMenus.cpp:207
 msgid "Range radius:"
@@ -8053,7 +8053,7 @@ msgstr "Verzeichnis einlesen"
 
 #: ../../src/sidebars/StatSidebar.cpp:103
 msgid "Read Matrix..."
-msgstr ""
+msgstr "Matrix laden ..."
 
 #: ../../src/MaximaCommandMenus.cpp:4008
 msgid "Read a structure field"
@@ -8069,7 +8069,7 @@ msgstr "Lese ein Zeichen"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2488
 msgid "Read config to file"
-msgstr ""
+msgstr "Konfiguration in eine Datei speichern"
 
 #: ../../src/MaximaCommandMenus.cpp:4405
 msgid "Read environment variable"
@@ -8182,7 +8182,7 @@ msgstr "Empfang der Startmeldung von Maxima: %s"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1327
 msgid "Recent files list length:"
-msgstr ""
+msgstr "Länge der Liste zuletzt geöffneter Dateien"
 
 #: ../../src/wxMaximaFrame.cpp:634
 msgid "Recover unsaved"
@@ -8190,7 +8190,7 @@ msgstr "Nicht gespeicherte Dateien wiederherstellen"
 
 #: ../../src/sidebars/MathSidebar.cpp:56
 msgid "Rectform"
-msgstr ""
+msgstr "Rectform"
 
 #: ../../src/wxMaximaFrame.cpp:1677
 msgid "Recursive Substitute..."
@@ -8214,7 +8214,7 @@ msgstr "Letzte Änderung erneut durchführen"
 
 #: ../../src/sidebars/MathSidebar.cpp:71
 msgid "Reduce (tr)"
-msgstr ""
+msgstr "Trigreduce"
 
 #: ../../src/wxMaximaFrame.cpp:1632
 msgid "Reduce trigonometric expression"
@@ -8264,11 +8264,11 @@ msgstr "Bild \"%s\" neu laden"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:997
 msgid "Reload all GUI settings from disc"
-msgstr ""
+msgstr "Neuladen aller GUI-Einstellungen"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1004
 msgid "Reload the style settings from disc"
-msgstr ""
+msgstr "Neuladen aller Stil-Einstellungen"
 
 #: ../../src/MaximaCommandMenus.cpp:3212
 #, c-format
@@ -8277,15 +8277,15 @@ msgstr "Bilddatei %s neu laden."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2573
 msgid "Reloading the configuration from disc"
-msgstr ""
+msgstr "Lade die Konfiguration von der Festplatte."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2581
 msgid "Reloading the styles from disc"
-msgstr ""
+msgstr "Lade die Stil-Einstellungen von der Festplatte."
 
 #: ../../src/sidebars/VariablesPane.cpp:220
 msgid "Remove"
-msgstr ""
+msgstr "Entfernen"
 
 #: ../../src/wxMaximaFrame.cpp:917
 msgid "Remove All Output"
@@ -8301,7 +8301,7 @@ msgstr ""
 
 #: ../../src/sidebars/VariablesPane.cpp:225
 msgid "Remove all"
-msgstr ""
+msgstr "Entferne alle"
 
 #: ../../src/wxMaximaFrame.cpp:1785
 msgid "Remove all list elements that appear twice in a row. Normally used in conjunction with sort."
@@ -8381,7 +8381,7 @@ msgstr "Wiederholte Element-für-Element-Multiplikation"
 
 #: ../../src/dialogs/FindReplacePane.cpp:117
 msgid "Replace All"
-msgstr ""
+msgstr "Alles ersetzen"
 
 #: ../../src/MaximaCommandMenus.cpp:4350
 msgid "Replace all regex matches"
@@ -8410,7 +8410,7 @@ msgstr "%li Ersetzungen ausgeführt."
 
 #: ../../src/dialogs/FindReplacePane.cpp:62
 msgid "Replacement:"
-msgstr ""
+msgstr "Ersatz:"
 
 #: ../../src/MaximaCommandMenus.cpp:768
 msgid "Replaces the subexpression that part(expr, n_1, n_2, ...) would select by a new value. The part numbers form a path: n_1 selects a part of the expression, n_2 a part of that, and so on."
@@ -8422,7 +8422,7 @@ msgstr "Einen Fehler berichten"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:983
 msgid "Reset all GUI settings"
-msgstr ""
+msgstr "Rücksetzen aller GUI-Einstellungen"
 
 #: ../../src/wxMaximaFrame.cpp:1030
 msgid "Reset option variables"
@@ -8430,12 +8430,12 @@ msgstr "Optionsvariablen zurücksetzen"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:990
 msgid "Reset the Style settings"
-msgstr ""
+msgstr "Rücksetzen aller Stil-Einstellungen"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2557
 #: ../../src/dialogs/ConfigDialogue.cpp:2565
 msgid "Resetting all configuration settings"
-msgstr ""
+msgstr "Setze alle Konfigurations-Einstellungen zurück"
 
 #: ../../src/ToolBar.cpp:411 ../../src/ToolBar.cpp:417
 #: ../../src/wxMaximaFrame.cpp:1008
@@ -8525,7 +8525,7 @@ msgstr ""
 
 #: ../../src/wizards/DrawWiz.cpp:836
 msgid "Reuse last"
-msgstr ""
+msgstr "Keine Änderung"
 
 #: ../../src/wxMaximaFrame.cpp:1780
 msgid "Reverse"
@@ -8541,15 +8541,15 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:295
 msgid "Revert all to defaults"
-msgstr ""
+msgstr "Setze alles zurück"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:980
 msgid "Revert changes"
-msgstr ""
+msgstr "Änderungen rückgängig machen"
 
 #: ../../src/sidebars/GreekSidebar.cpp:194
 msgid "Rho"
-msgstr ""
+msgstr "Rho"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2015
 msgid "Right"
@@ -8562,7 +8562,7 @@ msgstr "Rechte Matrix:"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:127
 msgid "Right arrow"
-msgstr ""
+msgstr "Pfeil nach rechts"
 
 #: ../../src/MaximaCommandMenus.cpp:1380
 msgid "Right end"
@@ -8602,7 +8602,7 @@ msgstr "Zeilen"
 
 #: ../../src/wizards/MatWiz.cpp:152
 msgid "Rows:"
-msgstr ""
+msgstr "Zeilen:"
 
 #: ../../src/MaximaCommandMenus.cpp:1391
 msgid "Rule"
@@ -8672,7 +8672,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:223
 msgid "Russian"
-msgstr ""
+msgstr "Russisch"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1578
 msgid "SBCL: use <int>Mbytes of heap"
@@ -8684,11 +8684,11 @@ msgstr ""
 
 #: ../../src/sidebars/XmlInspector.cpp:78
 msgid "SENT TO MAXIMA:"
-msgstr ""
+msgstr "AN MAXIMA GESENDET:"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1224
 msgid "SVG graphics"
-msgstr ""
+msgstr "SVG-Grafik"
 
 #: ../../src/MaximaCommandMenus.cpp:1810
 msgid "Sample 1:"
@@ -8704,19 +8704,19 @@ msgstr "Probe:"
 
 #: ../../src/wizards/DrawWiz.cpp:956
 msgid "Samples for explicit and parametric plots:"
-msgstr ""
+msgstr "Stützstellen für explizite und parametrische Kurven."
 
 #: ../../src/wizards/DrawWiz.cpp:969
 msgid "Samples for implicit plots and regions:"
-msgstr ""
+msgstr "Stützstellen für implizite Kurven und Regionen:"
 
 #: ../../src/wizards/DrawWiz.cpp:937
 msgid "Samples for implicit plots:"
-msgstr ""
+msgstr "Stützstellen für implizite Kurven:"
 
 #: ../../src/wizards/DrawWiz.cpp:924
 msgid "Samples on a line:"
-msgstr ""
+msgstr "Stützstellen auf einer Linie:"
 
 #: ../../src/ToolBar.cpp:331 ../../src/ToolBar.cpp:334
 #: ../../src/dialogs/ConfigDialogue.cpp:2163 ../../src/wxMaxima.cpp:3507
@@ -8761,7 +8761,7 @@ msgstr "Als Lisp-Datei speichern..."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2478
 msgid "Save config to file"
-msgstr ""
+msgstr "Konfiguration in eine Datei speichern"
 
 #: ../../src/ToolBar.cpp:331 ../../src/ToolBar.cpp:334
 #: ../../src/wxMaximaFrame.cpp:639
@@ -8774,7 +8774,7 @@ msgstr "Dokument speichern als"
 
 #: ../../src/wizards/Plot2dWiz.cpp:473 ../../src/wizards/Plot3dWiz.cpp:421
 msgid "Save plot to file"
-msgstr ""
+msgstr "Plot in Datei speichern"
 
 #: ../../src/wxMaximaFrame.cpp:713
 msgid "Save selection from document to an image file"
@@ -8786,11 +8786,11 @@ msgstr "Auswahl in eine Datei speichern"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2640
 msgid "Save style to file"
-msgstr ""
+msgstr "Speichere Layout in eine Datei"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1384
 msgid "Save the worksheet automatically"
-msgstr ""
+msgstr "Speichere das Arbeitsblatt automatisch"
 
 #: ../../src/MaximaFileIO.cpp:873
 msgid "Saving failed!"
@@ -8806,7 +8806,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1914
 msgid "Scalable Vector Graphics (svg)"
-msgstr ""
+msgstr "Skalierbare Vektorgraphiken (svg)"
 
 #: ../../src/MaximaCommandMenus.cpp:3536
 msgid "Scalable Vector image (*.svg)|*.svg|Compressed Scalable Vector Image (*.svgz)|*.svgz|PNG image (*.png)|*.png|JPEG image (*.jpg)|*.jpg|GIF image (*.gif)|*.gif|Windows bitmap (*.bmp)|*.bmp|"
@@ -8818,7 +8818,7 @@ msgstr "Streudiagramm"
 
 #: ../../src/sidebars/StatSidebar.cpp:88
 msgid "Scatterplot..."
-msgstr ""
+msgstr "Streudiagramm ..."
 
 #: ../../src/Autocomplete.cpp:157
 msgid "Scheduling a background task that compiles a new list of autocompletable maxima commands."
@@ -8866,7 +8866,7 @@ msgstr ""
 
 #: ../../src/wizards/DrawWiz.cpp:158
 msgid "See also the speed <-> accuracy button."
-msgstr ""
+msgstr "Siehe auch den Geschwindigkeit <-> Genauigkeit-Knopf."
 
 #: ../../src/MaximaCommandMenus.cpp:4030
 msgid "Seek to position"
@@ -8882,7 +8882,7 @@ msgstr "Das Paket mit den Share-Dateien von Maxima scheint nicht installiert zu 
 
 #: ../../src/sidebars/TableOfContents.cpp:511
 msgid "Select"
-msgstr ""
+msgstr "Auswählen"
 
 #: ../../src/MaximaCommandMenus.cpp:2239
 msgid "Select 2 or 3 files to compare"
@@ -8909,7 +8909,7 @@ msgstr "Wähle Teilstichprobe"
 #: ../../src/wizards/IntegrateWiz.cpp:208 ../../src/wizards/LimitWiz.cpp:133
 #: ../../src/wizards/SeriesWiz.cpp:105
 msgid "Select a constant"
-msgstr ""
+msgstr "Eine Konstante auswählen:"
 
 #: ../../src/ToolBar.cpp:390 ../../src/ToolBar.cpp:392
 #: ../../src/wxMaximaFrame.cpp:710
@@ -8930,7 +8930,7 @@ msgstr "Algorithmus zum Anzeigen von Formeln auswählen"
 
 #: ../../src/dialogs/TipOfTheDay.cpp:109
 msgid "Selecting a part of an output and right-clicking on the selection will bring up a menu with convenient functions that will operate on the selection."
-msgstr ""
+msgstr "Markieren Sie im Ausgabebereich der Zelle einen Bereich, dann erhalten mit einem Rechtsklick ein Kontextmenü, das Funktionen zeigt, die auf die Auswahl angewendet werden können."
 
 #: ../../src/Styles.cpp:127
 msgid "Selection color"
@@ -9018,7 +9018,7 @@ msgstr "Genauigkeit für als bigfloat deklarierte Fließkommazahlen setzen ..."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:479
 msgid "Set fixed font in text controls."
-msgstr ""
+msgstr "In Eingabefeldern eine Schrift mit fester Breite verwenden."
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:68
 #: ../../src/worksheet/WorksheetContextMenu.cpp:250
@@ -9027,7 +9027,7 @@ msgstr "Bildauflösung einstellen"
 
 #: ../../src/dialogs/ResolutionChooser.cpp:29
 msgid "Set image resolution [in ppi]"
-msgstr ""
+msgstr "Bildauflösung [in ppi]"
 
 #: ../../src/wxMaximaFrame.cpp:1547
 msgid "Set main variable..."
@@ -9035,7 +9035,7 @@ msgstr "Hauptvariable definieren..."
 
 #: ../../src/dialogs/MaxSizeChooser.cpp:29
 msgid "Set maximum image size [in mm]"
-msgstr ""
+msgstr "Setze die maximale Größe eines Bildes [in mm]"
 
 #: ../../src/wxMaximaFrame.cpp:1810
 msgid "Set plot format"
@@ -9097,7 +9097,7 @@ msgstr "Setze Vergrößerung auf 80%"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:163
 msgid "Sets the language, line ending type and charset encoding programs will use"
-msgstr ""
+msgstr "Wählt die Sprache, Zeilenenden und den Zeichensatz, den Programme verwenden"
 
 #: ../../src/MaximaEvaluator.cpp:574
 #, c-format
@@ -9110,24 +9110,24 @@ msgstr "Prompt- und Hilfe-Format einstellen"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:165
 msgid "Setting this to \"cat\" causes gnuplot not to halt if there is much output"
-msgstr ""
+msgstr "\"cat\" bedeutet, dass gnuplot nicht anhält, wenn zu viel Text auszugeben ist"
 
 #: ../../src/wizards/DrawWiz.cpp:546
 msgid "Settings for the following 3d plots"
-msgstr ""
+msgstr "Einstellungen für die nun folgenden 3d-Graphiken"
 
 #: ../../src/wizards/DrawWiz.cpp:462
 #, c-format
 msgid "Setup a %iD scene"
-msgstr ""
+msgstr "Einstellungen für %iD-Diagramme"
 
 #: ../../src/sidebars/DrawSidebar.cpp:48
 msgid "Setup a 2D plot"
-msgstr ""
+msgstr "Einstellungen für 2D-Diagramme"
 
 #: ../../src/sidebars/DrawSidebar.cpp:52
 msgid "Setup a 3D plot"
-msgstr ""
+msgstr "Einstellungen für 3D-Diagramme"
 
 #: ../../src/wxMaximaFrame.cpp:1326
 msgid "Setup atvalues for solving ODE with Laplace transformation"
@@ -9139,11 +9139,11 @@ msgstr "Die aktuelle Restklasse angeben"
 
 #: ../../src/sidebars/DrawSidebar.cpp:78
 msgid "Setup the axis"
-msgstr ""
+msgstr "Einstellungen für die Achsen"
 
 #: ../../src/wizards/DrawWiz.cpp:263
 msgid "Setup the axis for the current plot."
-msgstr ""
+msgstr "Einstellungen für die Axen für das aktuelle Diagramm."
 
 #: ../../src/MaximaCommandMenus.cpp:411
 msgid "Setup the engineering format"
@@ -9191,7 +9191,7 @@ msgstr "Zeige alle Befehle, die ähnlich sind zu:"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:206
 msgid "Show all unicode symbols"
-msgstr ""
+msgstr "Alle Unicode-Symbole anzeigen"
 
 #: ../../src/MaximaCommandMenus.cpp:2111
 msgid "Show an example for the command:"
@@ -9203,7 +9203,7 @@ msgstr "Zeige ein Anwendungsbeispiel"
 
 #: ../../src/sidebars/History.cpp:121
 msgid "Show commands from current session only"
-msgstr ""
+msgstr "Zeige nur Befehle aus dem aktuellen Durchlauf"
 
 #: ../../src/wxMaximaFrame.cpp:1921
 msgid "Show commands similar to"
@@ -9239,7 +9239,7 @@ msgstr "Eingabemarken anzeigen"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:766
 msgid "Show labels:"
-msgstr ""
+msgstr "Zeige Marken:"
 
 #: ../../src/wxMaximaFrame.cpp:787
 msgid "Show lisp representation"
@@ -9247,11 +9247,11 @@ msgstr "Lisp Darstellung anzeigen"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:465
 msgid "Show long expressions in wxMaxima document."
-msgstr ""
+msgstr "Zeige lange Ausdrücke im wxMaxima Dokument."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:722
 msgid "Show long expressions:"
-msgstr ""
+msgstr "Auch sehr lange Ausdrücke anzeigen:"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:377
 msgid "Show max. 100 digits"
@@ -9315,7 +9315,7 @@ msgstr "Zeige die Knöpfe für Rückgängigmachen und Wiederholen?"
 
 #: ../../src/dialogs/TipOfTheDay.cpp:288
 msgid "Show tips at Startup"
-msgstr ""
+msgstr "Zeige Tips beim Start des Programms"
 
 #: ../../src/wxMaximaFrame.cpp:1040 ../../src/wxMaximaFrame.cpp:1045
 msgid "Show used + to-be-freed memory"
@@ -9340,7 +9340,7 @@ msgstr "Seitenleisten"
 
 #: ../../src/sidebars/GreekSidebar.cpp:195
 msgid "Sigma"
-msgstr ""
+msgstr "Sigma"
 
 #: ../../src/dialogs/FindReplacePane.cpp:88
 msgid "Simple"
@@ -9352,7 +9352,7 @@ msgstr ""
 
 #: ../../src/sidebars/MathSidebar.cpp:44
 msgid "Simplify"
-msgstr ""
+msgstr "Vereinfachen"
 
 #: ../../src/wxMaximaFrame.cpp:1550
 msgid "Simplify &Radicals..."
@@ -9360,11 +9360,11 @@ msgstr "&Wurzeln vereinfachen..."
 
 #: ../../src/sidebars/MathSidebar.cpp:47
 msgid "Simplify (r)"
-msgstr ""
+msgstr "Wurzelvereinf."
 
 #: ../../src/sidebars/MathSidebar.cpp:65
 msgid "Simplify (tr)"
-msgstr ""
+msgstr "Trigsimp"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:352
 msgid "Simplify Expression"
@@ -9404,7 +9404,7 @@ msgstr "Vereinfache Summen"
 
 #: ../../src/wizards/SumWiz.cpp:68
 msgid "Simplify the sum"
-msgstr ""
+msgstr "Vereinfache die Summe"
 
 #: ../../src/wxMaximaFrame.cpp:1629
 msgid "Simplify trigonometric expression"
@@ -9412,7 +9412,7 @@ msgstr "Ausdruck mit Winkelfunktionen vereinfachen"
 
 #: ../../src/dialogs/TipOfTheDay.cpp:139
 msgid "Since wxMaxima 0.8.2 you can also insert images into your documents. Use 'Cell->Insert Image...' menu command."
-msgstr ""
+msgstr "Seit wxMaxima 0.8.2 können Sie auch Bilder in ein Dokument einfügen. Nutzen Sie dazu den Menübefehl 'Zellen->Bild einfügen'."
 
 #: ../../src/wxMaximaFrame.cpp:1433
 msgid "Singular Values"
@@ -9469,7 +9469,7 @@ msgstr "Lösung der gewöhnlichen Differantialgleichung:"
 
 #: ../../src/wizards/BC2Wiz.cpp:30
 msgid "Solution:"
-msgstr ""
+msgstr "Lösung:"
 
 #: ../../src/MaximaCommandMenus.cpp:3446
 msgid "Solve"
@@ -9509,7 +9509,7 @@ msgstr "GDG mit Lapla&cetransformation lösen ..."
 
 #: ../../src/sidebars/MathSidebar.cpp:77
 msgid "Solve ODE..."
-msgstr ""
+msgstr "Löse GDG ..."
 
 #: ../../src/wxMaximaFrame.cpp:1432
 msgid "Solve a linear equation system using dgesv"
@@ -9616,7 +9616,7 @@ msgstr "Sortiere"
 
 #: ../../src/wizards/ListSortWiz.cpp:41
 msgid "Sort Criterion:"
-msgstr ""
+msgstr "Sortierkriterium"
 
 #: ../../src/MaximaCommandMenus.cpp:1500
 msgid "Sort a list"
@@ -9636,16 +9636,16 @@ msgstr "Quellliste:"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:227
 msgid "Spanish"
-msgstr ""
+msgstr "Spanisch"
 
 #: ../../src/wizards/IntegrateWiz.cpp:44 ../../src/wizards/IntegrateWiz.cpp:50
 #: ../../src/wizards/LimitWiz.cpp:38 ../../src/wizards/SeriesWiz.cpp:39
 msgid "Special"
-msgstr ""
+msgstr "Andere arten von Kurven"
 
 #: ../../src/wizards/DrawWiz.cpp:918
 msgid "Speed versus accuracy"
-msgstr ""
+msgstr "Geschwindigkeit versus Genauigkeit"
 
 #: ../../src/MaximaCommandMenus.cpp:4241
 msgid "Split"
@@ -9673,7 +9673,7 @@ msgstr "Rechteckig"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1300
 msgid "Standard Options"
-msgstr ""
+msgstr "Standard Optionen"
 
 #: ../../src/Styles.cpp:115
 msgid "Standard Text"
@@ -9685,7 +9685,7 @@ msgstr "Starte Animation"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1622
 msgid "Start a new maxima for each re-evaluation"
-msgstr ""
+msgstr "Erneute Auswertung startet ein neues Maxima"
 
 #: ../../src/MaximaCommandMenus.cpp:1023
 msgid "Start of t:"
@@ -9693,15 +9693,15 @@ msgstr "Beginn des t-Werts"
 
 #: ../../src/wizards/DrawWiz.cpp:66 ../../src/wizards/DrawWiz.cpp:171
 msgid "Start of the x value"
-msgstr ""
+msgstr "Beginn des x-Werts"
 
 #: ../../src/wizards/DrawWiz.cpp:83 ../../src/wizards/DrawWiz.cpp:186
 msgid "Start of the y value"
-msgstr ""
+msgstr "Beginn des y-Werts"
 
 #: ../../src/wizards/DrawWiz.cpp:203
 msgid "Start of the z value"
-msgstr ""
+msgstr "Beginn des z-Werts"
 
 #: ../../src/ToolBar.cpp:507 ../../src/ToolBar.cpp:519
 msgid "Start or Stop animation"
@@ -9713,11 +9713,11 @@ msgstr "Startet oder stoppt die aktuell ausgewählte Animation, die mit einem de
 
 #: ../../src/dialogs/ConfigDialogue.cpp:496
 msgid "Start searching while the phrase to search for is still being typed."
-msgstr ""
+msgstr "Beginne die Suche bereits, während das Suchwort eingegeben wird."
 
 #: ../../src/wizards/DrawWiz.cpp:755
 msgid "Start value of the parameter"
-msgstr ""
+msgstr "Startwert des x-Parameters"
 
 #: ../../src/wxMaxima.cpp:403
 msgid "Starting Maxima process failed"
@@ -9742,7 +9742,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:286
 msgid "Startup commands"
-msgstr ""
+msgstr "Startbefehle"
 
 #: ../../src/wxMaximaFrame.cpp:266
 msgid "Statistics"
@@ -9758,7 +9758,7 @@ msgstr "Schrittweite:"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:939
 msgid "Store filenames in image cells to enable image reloading after re-opening the worksheet"
-msgstr ""
+msgstr "Speichere die Dateinamen in Bild-Zellen, um das Laden des Bildes nach dem erneuten Öffnen des Arbeitsblattes zu ermöglichen."
 
 #: ../../src/wxMaximaFrame.cpp:831
 msgid "Straight lines"
@@ -9852,15 +9852,15 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:282
 msgid "Style"
-msgstr ""
+msgstr "Stil"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2082
 msgid "Styles"
-msgstr ""
+msgstr "Schriftstile"
 
 #: ../../src/sidebars/StatSidebar.cpp:112
 msgid "Subsample..."
-msgstr ""
+msgstr "Teilstichprobe ..."
 
 #: ../../src/ToolBar.cpp:484 ../../src/sidebars/FormatSidebar.cpp:54
 msgid "Subsection"
@@ -9880,7 +9880,7 @@ msgstr ""
 
 #: ../../src/sidebars/MathSidebar.cpp:59
 msgid "Subst..."
-msgstr ""
+msgstr "Substituieren ..."
 
 #: ../../src/MaximaCommandMenus.cpp:715 ../../src/MaximaCommandMenus.cpp:3490
 #: ../../src/MaximaCommandMenus.cpp:4500 ../../src/wizards/SubstituteWiz.cpp:53
@@ -9956,7 +9956,7 @@ msgstr "Summieren"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:122
 msgid "Sum sign"
-msgstr ""
+msgstr "Summenzeichen"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:228
 msgid "Swedish"
@@ -9985,7 +9985,7 @@ msgstr "Symbole\tAlt+Shift+Y"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:472
 msgid "Symbols that are entered or copied here will appear in the symbols sidebar so they can be entered into the worksheet easily."
-msgstr ""
+msgstr "Symbole, die hier eingegeben oder hierhin kopiert werden, erscheinen in der \"Symbole\"-Seitenleiste, was es leicht macht, sie ins Arbeitsblatt mit einzufügen."
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:778
 msgid "Symmetric function: f(x)=f(-x)"
@@ -10013,7 +10013,7 @@ msgstr "Inhaltsverzeichnis\tAlt+Shift+T"
 
 #: ../../src/wizards/DrawWiz.cpp:561
 msgid "Take surface color from steepness"
-msgstr ""
+msgstr "Errechnung der Farbe aus der Steilheit"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:229
 msgid "Tamil"
@@ -10021,7 +10021,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:196
 msgid "Tau"
-msgstr ""
+msgstr "Tau"
 
 #: ../../src/MaximaCommandMenus.cpp:181
 msgid "Taylor series"
@@ -10057,7 +10057,7 @@ msgstr "Sagt Maxima, dass die Hilfe für ?, ?? und describe() in der Konsole ang
 
 #: ../../src/dialogs/ConfigDialogue.cpp:148
 msgid "Tells maxima where to store the result of compiling libraries"
-msgstr ""
+msgstr "Wo soll Maxima Bibliotheken nach dem Compilieren ablegen?"
 
 #: ../../src/ToolBar.cpp:481 ../../src/sidebars/FormatSidebar.cpp:45
 msgid "Text"
@@ -10069,7 +10069,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:738
 msgid "Text Only"
-msgstr ""
+msgstr "Nur Text"
 
 #: ../../src/Styles.cpp:122
 msgid "Text cell background"
@@ -10077,7 +10077,7 @@ msgstr "Hintergrundfarbe Textzelle"
 
 #: ../../src/dialogs/TipOfTheDay.cpp:219
 msgid "Text cells can hold citations that as marked as such by beginning a line with \" > \". The number of spaces in front of the \">\" determines the indentation level, as it does with bullet lists."
-msgstr ""
+msgstr "Zitate können in Textzellen dadurch markiert werden, dass sie mit \" > \" begonnen werden. Wie auch bei Aufzählungen können sie durch zusätzliche Leerzeichen eingerückt werden. "
 
 #: ../../src/MaximaCommandMenus.cpp:3001
 msgid "Text snippet"
@@ -10100,7 +10100,7 @@ msgstr "Maxima bietet keinen geteilten Speicher an, in dem ein \"Unterbrechen\"-
 
 #: ../../src/dialogs/ConfigDialogue.cpp:392
 msgid "The URL MathJaX.js should be downloaded from by our HTML export."
-msgstr ""
+msgstr "Die URL, von der MathJaX.js für den HTML-Export heruntergeladen werden soll."
 
 #: ../../src/cells/TextCell.cpp:336
 msgid "The [] or the part() command tried to access a list or matrix element that doesn't exist."
@@ -10108,7 +10108,7 @@ msgstr ""
 
 #: ../../src/sidebars/DrawSidebar.cpp:106
 msgid "The accuracy versus speed tradeoff"
-msgstr ""
+msgstr "Abwägung der Genauigkeit gegenüber der Geschwindigkeit"
 
 #: ../../src/cells/TextCell.cpp:357
 msgid "The argument of a function was of the wrong type. Most probably an equation was expected but was lacking an \"=\"."
@@ -10132,7 +10132,7 @@ msgstr ""
 
 #: ../../src/sidebars/DrawSidebar.cpp:91
 msgid "The color of the next line to draw"
-msgstr ""
+msgstr "Die Farbe der nächsten Kurve"
 
 #: ../../src/MaximaCommandMenus.cpp:4005
 msgid "The comma-separated contents of the struct fields"
@@ -10152,48 +10152,48 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:415
 msgid "The default height for embedded plots. Can be read out or overridden by the maxima variable wxplot_size."
-msgstr ""
+msgstr "Die Standardgröße für eingebettete Graphen. Kann von Maxima aus über die Variable wxplot_size ausgelesen oder geändert werden."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:492
 msgid "The default port used for communication between Maxima and wxMaxima."
-msgstr ""
+msgstr "Standardport für die Kommunikation zwischen Maxima und wxMaxima."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:412
 msgid "The default width for embedded plots. Can be read out or overridden by the maxima variable wxplot_size"
-msgstr ""
+msgstr "Die Standardgröße für eingebettete Graphen. Kann von Maxima aus über die Variable wxplot_size ausgelesen oder geändert werden."
 
 #: ../../src/sidebars/DrawSidebar.cpp:74
 msgid "The diagram title"
-msgstr ""
+msgstr "Der Titel des Diagramms"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2401
 #, c-format
 msgid "The directory %s with maxima's startup file doesn't exist. Trying to create it..."
-msgstr ""
+msgstr "Das Verzeichnis %s mit den Kommandos, die Maxima beim Hochfahren ausführt, existiert nicht. Versuche, es zu erstellen."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:150
 msgid "The directory containing the startup files, any user libraries and, if MAXIMA_OBJDIR isn't set the subdirectory with the results from compiling maxima libraries."
-msgstr ""
+msgstr "Das Verzeichnis, das die Startup-Dateien, vom User geschriebene Bibliotheken und, wenn MAXIMA_OBJDIR nicht gesetzt ist, das Ergebnis vom Versuch, maxima's Bibliotheken zu compilieren enthält."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:154
 msgid "The directory maxima places temporary files in, for example plots that are to be included in the worksheet."
-msgstr ""
+msgstr "Das Verzeichnis, in dem Maxima temporäre Dateien ablegt, zum Beispiel alles, was für das Zeichnen und Darstellen von Diagrammen benötigt wird."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:157
 msgid "The directory the compiled versions of maxima are placed in"
-msgstr ""
+msgstr "Das Verzeichnis, in dem die compilierten Versionen von Maxima liegen"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:159
 msgid "The directory the maxima manual can be found in"
-msgstr ""
+msgstr "Das Verzeichnis mit dem Handbuch von Maxima"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:160
 msgid "The directory the user's home directory is in"
-msgstr ""
+msgstr "Das \"Eigene Dateien\"-Verzeichnis des Benutzers"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:475
 msgid "The document class LaTeX is instructed to use for our documents."
-msgstr ""
+msgstr "Die Dokumentklasse für den Export von LaTeX-Dokumenten "
 
 #: ../../src/MaximaCommandMenus.cpp:1832
 msgid "The equation to fit the data to"
@@ -10210,7 +10210,7 @@ msgstr ""
 
 #: ../../src/sidebars/DrawSidebar.cpp:96
 msgid "The fill color for the next objects"
-msgstr ""
+msgstr "Die Füllfarbe für die nächsten Objekte"
 
 #: ../../src/cells/TextCell.cpp:354
 msgid "The first argument of subst() isn't an equation or a list of equations. Most probably it was lacking an \"=\"."
@@ -10222,7 +10222,7 @@ msgstr "Die Funktion, deren Argumente extrahiert werden sollen"
 
 #: ../../src/sidebars/DrawSidebar.cpp:100
 msgid "The grid in the background of the diagram"
-msgstr ""
+msgstr "Das Gitter im Hintergrund der Zeichnung"
 
 #: ../../src/wxMaximaFrame.cpp:1332
 msgid "The half of the equation that is to the left of the \"=\""
@@ -10257,11 +10257,11 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:223
 msgid "The key combination Shift+Space results in a non-breakable space."
-msgstr ""
+msgstr "Die Tastenkombination Shift+Leertaste erzeugt ein nicht-trennbares Leerzeichen."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:162
 msgid "The list of directories the operating system looks for programs in"
-msgstr ""
+msgstr "In welchen Verzeichnissen das Betriebssystem nach Programmen suchen soll"
 
 #: ../../src/cells/TextCell.cpp:293
 msgid "The list of time-dependent variables to solve to doesn't match the time-dependent variables the list of dgls contains."
@@ -10273,7 +10273,7 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:166
 msgid "The load() command of Maxima versions >5.38 is able to load .wxm files as library of Maxima's commands."
-msgstr ""
+msgstr "Seit Maxima >5.38 akzeptiert die load()-Funktion .wxm-Dateien als Bibliotheken mit Maxima-Befehlen."
 
 #: ../../src/wxMaximaFrame.cpp:228
 msgid "The main toolbar"
@@ -10289,7 +10289,7 @@ msgstr "Das Handbuch von wxMaxima"
 
 #: ../../src/dialogs/MaxSizeChooser.cpp:59
 msgid "The maximum size for this image. Values <= 0 mean: Unspecified."
-msgstr ""
+msgstr "Die maximale Größe für dieses Bild. Werte <= 0 bedeuten: Unspezifiziert."
 
 #: ../../src/MaximaCommandMenus.cpp:3937
 msgid "The name of a function we don't want to be evaluated here"
@@ -10321,11 +10321,11 @@ msgstr ""
 
 #: ../../src/sidebars/DrawSidebar.cpp:86
 msgid "The next plot's title"
-msgstr ""
+msgstr "Der Titel der nächsten Kurve"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:494
 msgid "The number of recently opened files that is to be remembered."
-msgstr ""
+msgstr "Die Anzahl der zuletzt geöffneten Dateien, die sich das Programm merken soll."
 
 #: ../../src/MaximaCommandMenus.cpp:1471
 msgid "The number of the item which is stepped from \"Index Start\" to \"Index End\"."
@@ -10333,16 +10333,16 @@ msgstr "Die Zahl des Elements wird von Startindex bis Endeindex durchgezählt."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:477
 msgid "The options the document class LaTeX is instructed to use for our documents gets."
-msgstr ""
+msgstr "Die Optionen, die der Dokumentenklasse für LaTeX mitgegeben werden."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1065
 #: ../../src/dialogs/ConfigDialogue.cpp:1112
 msgid "The part of the output of these commands that isn't declared as \"math\" might be suppressed by wxMaxima. As always maxima commands are required to end in a \";\" or a \"$\""
-msgstr ""
+msgstr "Jener Teil der Ausgabe dieser Kommandos, der nicht als \"Mathematik\" deklariert ist, kann unterdrückt werden; Befehle für Maxima müssen stets in \";\" oder \"$\" enden."
 
 #: ../../src/dialogs/ResolutionChooser.cpp:51
 msgid "The resolution for this image."
-msgstr ""
+msgstr "Die Auflösung für dieses Bild."
 
 #: ../../src/cells/TextCell.cpp:182
 msgid "The result was indefinite, which might be infinity, both plus or minus infinity or something additionally potentially involving a complex infinity."
@@ -10401,7 +10401,7 @@ msgstr ""
 
 #: ../../src/sidebars/DrawSidebar.cpp:58
 msgid "The standard plot command: Plot an equation as a curve"
-msgstr ""
+msgstr "Zeichne eine Kurve"
 
 #: ../../src/cells/TextCell.cpp:267
 msgid "The value of few special variables is assigned by Maxima and cannot be changed by the user. Also a few constructs aren't variable names and therefore cannot be written to."
@@ -10437,7 +10437,7 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:95
 msgid "There are many resources about Maxima and wxMaxima on the internet. Visit https://wxMaxima-developers.github.io/wxmaxima/help.html for more information and to find tutorials on using wxMaxima and Maxima."
-msgstr ""
+msgstr "Es gibt viele Informationen über Maxima and wxMaxima im Internet. https://wxMaxima-developers.github.io/wxmaxima/help.html enthält Links auf Dokumentation und Schritt-für-Schritt-Anleitungen.\""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:251
 msgid "There is a discussion forum for wxMaxima at https://github.com/wxMaxima-developers/wxmaxima/discussions.\n"
@@ -10482,7 +10482,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:185
 msgid "Theta"
-msgstr ""
+msgstr "Theta"
 
 #: ../../src/dialogs/LicenseDialog.cpp:85
 msgid "Third-party notices"
@@ -10504,7 +10504,7 @@ msgstr "Diese Datei wird von wxMaxima generiert.\n"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1097
 msgid "This file won't be read by maxima if maxima is used without wxMaxima. In order to add startup commands that are executed in this case, too, please add them to maxima-init.mac, instead."
-msgstr ""
+msgstr "Diese Datei wird nur von Maxima gelesen, wenn Maxima von wxMaxima geladen wird."
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:764
 msgid "This function will return even integers"
@@ -10537,7 +10537,7 @@ msgstr ""
 #: ../../src/wizards/DrawWiz.cpp:471
 #, c-format
 msgid "This wizard setups a %iD scene."
-msgstr ""
+msgstr "Einstellungen für %iD-Diagramme"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:752
 msgid "Throw an error if this symbol is used before assigning it any contents"
@@ -10545,11 +10545,11 @@ msgstr "Fehler ausgeben, falls das Symbol verwendet wird, bevor ein Wert zugewie
 
 #: ../../src/wizards/Plot2dWiz.cpp:65 ../../src/wizards/Plot2dWiz.cpp:505
 msgid "Ticks:"
-msgstr ""
+msgstr "Startpunkte:"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1359
 msgid "Time [in Minutes] between autosaves"
-msgstr ""
+msgstr "Zeit [in Minuten] zwischen automatischen Speicherungen"
 
 #: ../../src/MaximaCommandMenus.cpp:267 ../../src/MaximaCommandMenus.cpp:3487
 msgid "Times:"
@@ -10557,7 +10557,7 @@ msgstr "Wie oft:"
 
 #: ../../src/dialogs/TipOfTheDay.cpp:49 ../../src/dialogs/TipOfTheDay.cpp:267
 msgid "Tip of the day"
-msgstr ""
+msgstr "Tipp des Tages"
 
 #: ../../src/ToolBar.cpp:482 ../../src/sidebars/FormatSidebar.cpp:48
 msgid "Title"
@@ -10573,7 +10573,7 @@ msgstr "Titel (1. Gliederungsebene)"
 
 #: ../../src/dialogs/TipOfTheDay.cpp:89
 msgid "Title, section and subsection cells can be folded to hide their contents. To fold or unfold, click in the square next to the cell. If you shift-click, all sublevels of that cell will also fold/unfold."
-msgstr ""
+msgstr "Titel-, Kapitel- and Unterkapitelzellen können zugeklappt werden, um den Inhalt zu verbergen. Mit einen Klick in das linke obere Quadrat der Zelle wird die Zelle auf- oder zugeklappt. Wird beim Klicken die Umschalt-Taste gehalten, werden alle Ebenen unterhalb der Zelle ebenfalls auf- oder zugeklappt."
 
 #: ../../src/wxMaximaFrame.cpp:1831
 msgid "To &Bigfloat"
@@ -10601,19 +10601,19 @@ msgstr "Als exakte Zahl"
 
 #: ../../src/dialogs/TipOfTheDay.cpp:124
 msgid "To plot in polar coordinates, select 'set polar' in the Options entry for Plot2d dialog. You can also plot in spherical and cylindrical coordinates in 3D."
-msgstr ""
+msgstr "Um in Polarkoordinaten zu plotten, können Sie im Eingabefeld 'Optionen' des Dialogs '2D Plotten' die Option 'set polar' auswählen. Entsprechend können Sie im Dialog '3D Plotten' zylindrische und sphärische Koordinaten für den Plot auswählen."
 
 #: ../../src/dialogs/TipOfTheDay.cpp:131
 msgid "To put parentheses around an expression, select it, and press '(' or ')' depending on where you want the cursor to appear afterwards."
-msgstr ""
+msgstr "Sie können Klammern um einen Ausdruck einfügen, indem Sie diesen markieren und dann entweder '(' oder ')' drücken, je nachdem, wo der Cursor nach der Eingabe stehen soll."
 
 #: ../../src/dialogs/TipOfTheDay.cpp:137
 msgid "To save the size and position of wxMaxima windows between session, use 'Edit->Configure' dialog."
-msgstr ""
+msgstr "Im Dialog 'Bearbeiten->Einstellungen' können Sie angeben, ob Ort und Größe des wxMaxima-Fensters gespeichert werden sollen."
 
 #: ../../src/dialogs/TipOfTheDay.cpp:51
 msgid "To start using wxMaxima right away, start typing your command. An input cell should appear. Then press Shift-Enter to evaluate your command."
-msgstr ""
+msgstr "Beginnen Sie die Arbeit mit wxMaxima einfach mit einer ersten Eingabe. Es erscheint dann automatisch die erste Eingabezelle. Mit dem Tastenbefehl 'Umschalt-Eingabe' wird Ihre Eingabe von Maxima ausgewertet."
 
 #: ../../src/MaximaCommandMenus.cpp:318 ../../src/wizards/IntegrateWiz.cpp:47
 #: ../../src/wizards/Plot2dWiz.cpp:51 ../../src/wizards/Plot2dWiz.cpp:61
@@ -10624,7 +10624,7 @@ msgstr "bis:"
 
 #: ../../src/sidebars/TableOfContents.cpp:579
 msgid "Toc levels shown here"
-msgstr ""
+msgstr "Inhaltsverzeichnis-Ebenen, die hier angezeigt werden."
 
 #: ../../src/wxMaximaFrame.cpp:862 ../../src/wxMaximaFrame.cpp:865
 msgid "Toggle full screen editing"
@@ -10793,7 +10793,7 @@ msgstr "Versuche, den Netzwerksocket des lokalen Rechners, zu dem sich Maxima ve
 
 #: ../../src/dialogs/ConfigDialogue.cpp:230
 msgid "Turkish"
-msgstr ""
+msgstr "Türkisch"
 
 #: ../../src/wxMaximaFrame.cpp:1965
 msgid "Tutorials"
@@ -10809,7 +10809,7 @@ msgstr "Art"
 
 #: ../../src/cells/EditorCell.cpp:4550
 msgid "Type in text"
-msgstr ""
+msgstr "Text eingeben"
 
 #: ../../src/MaximaCommandMenus.cpp:3992 ../../src/wizards/MatWiz.cpp:158
 msgid "Type:"
@@ -10829,7 +10829,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:231
 msgid "Ukrainian"
-msgstr ""
+msgstr "Ukrainisch"
 
 #: ../../src/wxMaxima.cpp:3164
 msgid "Un-closed parenthesis"
@@ -10856,15 +10856,15 @@ msgstr ""
 #: ../../src/sidebars/VariablesPane.cpp:303
 #: ../../src/sidebars/VariablesPane.cpp:386
 msgid "Undefined"
-msgstr ""
+msgstr "Undefiniert"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2115
 msgid "Underlined"
-msgstr ""
+msgstr "Unterstrichen"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:745
 msgid "Underscore converts to subscripts:"
-msgstr ""
+msgstr "Unterstrich macht tiefgestellt:"
 
 #: ../../src/ToolBar.cpp:354 ../../src/ToolBar.cpp:357
 msgid "Undo"
@@ -10897,7 +10897,7 @@ msgstr "Alle zugeklappten Sektionen aufklappen"
 
 #: ../../src/sidebars/TableOfContents.cpp:507
 msgid "Unhide"
-msgstr ""
+msgstr "Verstecken aufheben"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:665
 msgid "Unhide Heading 5"
@@ -10953,7 +10953,7 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:180
 msgid "Unicode symbols:"
-msgstr ""
+msgstr "Unicode-Symbole:"
 
 #: ../../src/MaximaCommandMenus.cpp:3890
 msgid "Unlike in other programming language return() only exits from the current loop or block(), not from the whole function."
@@ -10969,11 +10969,11 @@ msgstr "Fehlendes schließendes Anführungszeichen"
 
 #: ../../src/wizards/ActualValuesStorageWiz.cpp:43
 msgid "Until then the actual values for all variables can be kept in a list."
-msgstr ""
+msgstr "Bis dahin können die konkreten Variablenwerte in einer Liste gespeichert werden."
 
 #: ../../src/dialogs/DiffFrame.cpp:429 ../../src/dialogs/FindReplacePane.cpp:80
 msgid "Up"
-msgstr ""
+msgstr "Nach oben"
 
 #: ../../src/MaximaEvaluator.cpp:629
 msgid "Updating maxima's configuration"
@@ -10996,7 +10996,7 @@ msgstr "Obere Schranke:"
 
 #: ../../src/sidebars/GreekSidebar.cpp:197
 msgid "Upsilon"
-msgstr ""
+msgstr "Ypsilon"
 
 #: ../../src/wxMaximaFrame.cpp:829
 msgid "Use \"<\" and \">\" as parenthesis for matrices"
@@ -11008,7 +11008,7 @@ msgstr ""
 
 #: ../../src/wizards/SumWiz.cpp:69
 msgid "Use Gosper algorithm"
-msgstr ""
+msgstr "Verwende Gosper-Algorithmus"
 
 #: ../../src/sidebars/RegexCtrl.cpp:133
 msgid "Use RegEx filtering"
@@ -11032,11 +11032,11 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:485
 msgid "Use centered dot and Minus, not Star and Hyphen"
-msgstr ""
+msgstr "Mal und Minus statt Stern und Bindestrich"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:849
 msgid "Use centered dot character for multiplication"
-msgstr ""
+msgstr "Zentrierter Punkt als Zeichen für Multiplikation"
 
 #: ../../src/wxMaximaFrame.cpp:1745
 msgid "Use list"
@@ -11060,11 +11060,11 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:425
 msgid "Use the \"partial derivative\" symbol to represent the fraction that represents a diff() when exporting LaTeX"
-msgstr ""
+msgstr "Verwende das \"Partielle Ableitung\"-Symbol, um den Bruch, der ein diff() darstellt, beim LaTeX-Export auszudrücken."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2052
 msgid "Use unicode Math Symbols, if available"
-msgstr ""
+msgstr "Verwende Unicode-Mathematik-Symbole, falls verfügbar"
 
 #: ../../src/wxMaximaFrame.cpp:832
 msgid "Use vertical lines instead of parenthesis for matrices"
@@ -11079,7 +11079,7 @@ msgstr "Nur benutzerdefinierte Marken"
 #: ../../src/dialogs/ConfigDialogue.cpp:1480
 #: ../../src/dialogs/MaximaNotStartingDialog.cpp:54
 msgid "User specified"
-msgstr ""
+msgstr "Benutzerdefiniert"
 
 #: ../../src/Styles.cpp:110
 msgid "User-defined labels"
@@ -11087,7 +11087,7 @@ msgstr "Benutzerdefinierte Marken"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:770
 msgid "User-defined labels if available"
-msgstr ""
+msgstr "Benutzerdefinierte Marken, falls vorhanden"
 
 #: ../../src/MaximaManual.cpp:500
 msgid "Using Maxima help file from wxMaxima configuration file (helpFile=...))"
@@ -11125,7 +11125,7 @@ msgstr "Überprüft, daß die XML-Darstellung des Dokuments gültiges XML ist"
 #: ../../src/dialogs/ConfigDialogue.cpp:542
 #: ../../src/wizards/ActualValuesStorageWiz.cpp:49
 msgid "Value"
-msgstr ""
+msgstr "Wert"
 
 #: ../../src/MaximaCommandMenus.cpp:756
 msgid "Value at a given point"
@@ -11165,15 +11165,15 @@ msgstr ""
 
 #: ../../src/wizards/DrawWiz.cpp:61 ../../src/wizards/DrawWiz.cpp:166
 msgid "Variable for the x value"
-msgstr ""
+msgstr "Variable für den x-Wert"
 
 #: ../../src/wizards/DrawWiz.cpp:78 ../../src/wizards/DrawWiz.cpp:181
 msgid "Variable for the y value"
-msgstr ""
+msgstr "Variable für den y-Wert"
 
 #: ../../src/wizards/DrawWiz.cpp:198
 msgid "Variable for the z value"
-msgstr ""
+msgstr "Variable für den z-Wert"
 
 #: ../../src/MaximaCommandMenus.cpp:1586 ../../src/MaximaCommandMenus.cpp:2990
 #: ../../src/MaximaCommandMenus.cpp:2996
@@ -11221,7 +11221,7 @@ msgstr "Variablen:"
 
 #: ../../src/sidebars/StatSidebar.cpp:58
 msgid "Variance..."
-msgstr ""
+msgstr "Varianz..."
 
 #: ../../src/WXMXformat.cpp:339
 msgid "Verified that we are able to read the whole .zip archive we produced."
@@ -11249,7 +11249,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1410
 msgid "Warn if an inactive window is idle"
-msgstr ""
+msgstr "Information über Rechnungsende in inaktivem Fenster"
 
 #: ../../src/MathParser.cpp:1343 ../../src/MaximaFileIO.cpp:536
 #: ../../src/MaximaResponseReader.cpp:361 ../../src/wxMaxima.cpp:1583
@@ -11268,7 +11268,7 @@ msgstr "%s, das Verzeichnis, in denen Maxima den Cache, Pakete des Benutzers und
 
 #: ../../src/cells/GroupCell.cpp:400 ../../src/cells/GroupCell.cpp:406
 msgid "Warning: Lookalike chars: "
-msgstr ""
+msgstr "Warnung: Schwer unterscheidbare Zeichen: "
 
 #: ../../src/wxMaximaFrame.cpp:1583
 msgid "Warning: No test if the argument of the log is complex, positive or negative"
@@ -11293,7 +11293,7 @@ msgstr "Was ist zu tun:"
 
 #: ../../src/dialogs/TipOfTheDay.cpp:134
 msgid "When applying functions with one argument from menus, the default argument is '%'. To apply the function to some other value, select it in the document before executing a menu command."
-msgstr ""
+msgstr "Werden Funktionen mit einem Argument von einem Menü ausgewählt, ist das Standardargument '%'. Wollen Sie die Funktion auf einen anderen Wert anwenden, können Sie diesen im Dokument markieren und dann den Menübefehl ausführen."
 
 #: ../../src/wxMaximaFrame.cpp:1092
 msgid "When to invoke the lisp compiler's debugger"
@@ -11309,7 +11309,7 @@ msgstr "While Schleife..."
 
 #: ../../src/dialogs/TipOfTheDay.cpp:243
 msgid "While wxMaxima is programmed mostly in C++, it also uses some Lisp code. You can help to improve wxMaxima, if you have knowledge of Common Lisp."
-msgstr ""
+msgstr "wxMaxima ist hauptsächlich in C++ programmiert, verwendet aber auch die Programmiersprache Lisp. Sie können mithelfen, wxMaxima zu verbessern, wenn Sie Common Lisp beherrschen."
 
 #: ../../src/MaximaFileIO.cpp:780
 msgid "Whole document (*.wxmx)|*.wxmx|The input, readable by load() (maxima > 5.38) (*.wxm)|*.wxm|All Files (*.*)|*"
@@ -11321,7 +11321,7 @@ msgstr "Versuche einen Stack-Backtrace zu generieren, falls das Programm abstür
 
 #: ../../src/dialogs/ConfigDialogue.cpp:280
 msgid "Worksheet"
-msgstr ""
+msgstr "Arbeitsblatt"
 
 #: ../../src/MaximaResponseReader.cpp:117
 #, c-format
@@ -11342,7 +11342,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:428
 msgid "Wrap equations exported by the \"copy as LaTeX\" feature between \\[ and \\] as equation markers"
-msgstr ""
+msgstr "Platziere Formeln, die durch \"LaTeX Kopieren\" in der Zwischenablage abgelegt wurden, zwischen \\[ und \\], um TeX in den Mathematik-Modus zu versetzen."
 
 #: ../../src/worksheet/Worksheet.cpp:5190
 msgid "Wrapped search"
@@ -11364,7 +11364,7 @@ msgstr "Mimetype Information geschrieben"
 #: ../../src/wizards/DrawWiz.cpp:961 ../../src/wizards/DrawWiz.cpp:974
 #: ../../src/wizards/DrawWiz.cpp:977
 msgid "X"
-msgstr ""
+msgstr "X"
 
 #: ../../src/MathParser.cpp:1279
 msgid "XML nesting limit exceeded"
@@ -11372,35 +11372,35 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:191
 msgid "Xi"
-msgstr ""
+msgstr "Xi"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:728
 msgid "Yes"
-msgstr ""
+msgstr "Ja"
 
 #: ../../src/dialogs/TipOfTheDay.cpp:64
 msgid "You can access the last output using the variable '%'. You can access the output of previous commands using variables '%on' where n is the number of output."
-msgstr ""
+msgstr "Maxima speichert die Ergebnisse aller Auswertungen ab. Das letzte Ergebnis wird mit der Variable '%' abgerufen. Auf vorhergehende Ergebnisse kann mit den Marken '%on' zurückgegriffen werden, wobei n die Nummer des Ergebnisses ist."
 
 #: ../../src/dialogs/TipOfTheDay.cpp:118
 msgid "You can evaluate your whole document by using 'Cell->Evaluate All Cells' menu command or the appropriate key shortcut. The cells will be evaluated in the order they appear in the document."
-msgstr ""
+msgstr "Mit dem Menübefehl 'Bearbeiten->Zelle->Alle Zellen neu auswerten' oder dem entsprechenden Tastenkürzel können Sie das ganze Dokument neu berechnen. Die Zellen werden nacheinander in der Reihenfolge berechnet, wie sie im Dokument erscheinen."
 
 #: ../../src/dialogs/TipOfTheDay.cpp:98
 msgid "You can get help on a Maxima function by selecting or clicking on the function name and pressing F1. wxMaxima will search the help index for the selection or the word under the cursor."
-msgstr ""
+msgstr "Sie erhalten Hilfe zu einer Maxima-Funktion, indem Sie die Funktion im Dokument markieren oder auf den Funktionsnamen klicken und F1 drücken. wxMaxima öffnet das Maxima-Manual und sucht im Index den markierten Begriff."
 
 #: ../../src/dialogs/TipOfTheDay.cpp:92
 msgid "You can hide output part of cells by clicking in the triangle on the left side of cells. This works on text cells also."
-msgstr ""
+msgstr "Durch einen Klick in das linke obere Dreieck einer Zelle können Sie den Ausgabebereich der Zelle ausblenden. Das funktioniert auch für Textzellen."
 
 #: ../../src/dialogs/TipOfTheDay.cpp:81
 msgid "You can insert different types of 'cells' in wxMaxima documents using the 'Cell' menu. Note that only 'input cells' can be evaluated, while others are used for commenting and structuring your calculations."
-msgstr ""
+msgstr "Sie können verschiedene Zelltypen in ein wxMaxima-Dokument einfügen. Diese Typen finden Sie im Menü unter 'Bearbeiten->Zelle'. Beachten Sie, daß nur Eingabezellen von Maxima ausgewertet werden. Die anderen Zelltypen dienen dazu, das wxMaxima-Dokument zu strukturieren und mit Kommentaren zu versehen."
 
 #: ../../src/dialogs/TipOfTheDay.cpp:112
 msgid "You can select multiple cells either with a mouse - click'n'drag from between cells or from a cell bracket on the left - or with a keyboard - hold down Shift while moving the horizontal cursor - and then operate on selection. This comes in handy when you want to delete or evaluate multiple cells."
-msgstr ""
+msgstr "Sie können mehrere Zellen mit der Maus oder der Tastatur auswählen. Ziehen Sie dazu mit gedrückter linker Maustaste über die linken Zellklammern oder halten Sie 'Umschalt-Taste' fest und bewegen sich mit dem Cursor über die auszuwählenden Zellen. Dies ist nützlich, wenn Sie mehrere Zellen auf einmal löschen oder auswerten wollen."
 
 #: ../../src/dialogs/TipOfTheDay.cpp:232
 msgid "You found a bug in wxMaxima? Please report it at https://github.com/wxMaxima-developers/wxmaxima/issues\n"
@@ -11410,7 +11410,7 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:238
 msgid "You got an idea for an improvement of wxMaxima? Great! Please submit your idea at https://github.com/wxMaxima-developers/wxmaxima/issues. "
-msgstr ""
+msgstr "Sie haben eine Idee für eine Verbesserung von wxMaxima? Super! Bitte geben Sie ihre Idee auf https://github.com/wxMaxima-developers/wxmaxima/issues ein."
 
 #: ../../src/wxMaxima.cpp:3402 ../../src/wxMaxima.cpp:3456
 #, c-format
@@ -11428,7 +11428,7 @@ msgstr "Ihre wxMaxima Version ist aktuell."
 
 #: ../../src/sidebars/GreekSidebar.cpp:183
 msgid "Zeta"
-msgstr ""
+msgstr "Zeta"
 
 #: ../../src/wxMaximaFrame.cpp:842
 msgid "Zoom &In\tCtrl++"
@@ -11456,11 +11456,11 @@ msgstr "[ nicht gespeichert* ]"
 
 #: ../../src/wizards/DrawWiz.cpp:819 ../../src/wizards/DrawWiz.cpp:825
 msgid "[[x_1,x_2,...],[y_1,y_2,...]]"
-msgstr ""
+msgstr "[[x_1,x_2,...],[y_1,y_2,...]]"
 
 #: ../../src/wizards/DrawWiz.cpp:814
 msgid "[x_1, x_2,...] or [x_1, x_2,...],[y_1, y_2,...] or matrix([x_1,y_1],[x_2,y_2],...)"
-msgstr ""
+msgstr "[x_1, x_2,...] oder [x_1, x_2,...],[y_1, y_2,...] oder matrix([x_1,y_1],[x_2,\"\n\"y_2],...)"
 
 #: ../../src/wizards/ListSortWiz.cpp:46
 msgid "a<b (Maxima default)"
@@ -11468,15 +11468,15 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:151
 msgid "alpha"
-msgstr ""
+msgstr "alpha"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:95
 msgid "and"
-msgstr ""
+msgstr "Und"
 
 #: ../../src/wizards/MatWiz.cpp:160
 msgid "antisymmetric"
-msgstr ""
+msgstr "schiefsymmetrisch"
 
 #: ../../src/wxMaximaFrame.cpp:1727
 msgid "apply function to each element"
@@ -11500,11 +11500,11 @@ msgstr "als Speicher für die konkreten Inhalte von Variablen"
 
 #: ../../src/sidebars/GreekSidebar.cpp:152
 msgid "beta"
-msgstr ""
+msgstr "beta"
 
 #: ../../src/wizards/LimitWiz.cpp:42
 msgid "both sides"
-msgstr ""
+msgstr "beide Seiten"
 
 #: ../../src/wxMaximaFrame.cpp:1173
 msgid "char to Ascii code..."
@@ -11512,7 +11512,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:172
 msgid "chi"
-msgstr ""
+msgstr "chi"
 
 #: ../../src/MaximaFileIO.cpp:318
 #, c-format
@@ -11522,15 +11522,15 @@ msgstr ""
 #: ../../src/wizards/Plot2dWiz.cpp:70 ../../src/wizards/Plot2dWiz.cpp:372
 #: ../../src/wizards/Plot3dWiz.cpp:61 ../../src/wizards/Plot3dWiz.cpp:358
 msgid "default"
-msgstr ""
+msgstr "Standard"
 
 #: ../../src/sidebars/GreekSidebar.cpp:154
 msgid "delta"
-msgstr ""
+msgstr "delta"
 
 #: ../../src/wizards/MatWiz.cpp:159
 msgid "diagonal"
-msgstr ""
+msgstr "diagonal"
 
 #: ../../src/cells/FracCell.cpp:73
 msgid "diff(): Cannot find the multiplication sign I should hide"
@@ -11546,19 +11546,19 @@ msgstr "Tue das folgende für jedes Element:"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:92
 msgid "empty"
-msgstr ""
+msgstr "Leere Menge"
 
 #: ../../src/sidebars/GreekSidebar.cpp:155
 msgid "epsilon"
-msgstr ""
+msgstr "epsilon"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:100
 msgid "equivalent"
-msgstr ""
+msgstr "Äquivalent"
 
 #: ../../src/sidebars/GreekSidebar.cpp:157
 msgid "eta"
-msgstr ""
+msgstr "eta"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:799
 msgid "ev() shall evaluate this automatically"
@@ -11566,7 +11566,7 @@ msgstr "ev() soll das automatisch evaluieren"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:88
 msgid "exists"
-msgstr ""
+msgstr "Existiert"
 
 #: ../../src/MaximaCommandMenus.cpp:3942
 msgid "expression:"
@@ -11608,11 +11608,11 @@ msgstr "Funktion"
 
 #: ../../src/sidebars/GreekSidebar.cpp:153
 msgid "gamma"
-msgstr ""
+msgstr "gamma"
 
 #: ../../src/wizards/MatWiz.cpp:159
 msgid "general"
-msgstr ""
+msgstr "allgemein"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1630
 msgid "gnuplot: Without command console"
@@ -11620,11 +11620,11 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:118
 msgid "greater than or equal"
-msgstr ""
+msgstr "Größer oder gleich"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:87
 msgid "in"
-msgstr ""
+msgstr "Element von"
 
 #: ../../src/wxMaximaFrame.cpp:784
 msgid "in 2D"
@@ -11635,31 +11635,31 @@ msgstr ""
 #: ../../src/wizards/Plot3dWiz.cpp:61 ../../src/wizards/Plot3dWiz.cpp:194
 #: ../../src/wizards/Plot3dWiz.cpp:358 ../../src/wizards/Plot3dWiz.cpp:386
 msgid "inline"
-msgstr ""
+msgstr "eingebettet"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:104
 msgid "intersection"
-msgstr ""
+msgstr "Schnittmenge"
 
 #: ../../src/sidebars/GreekSidebar.cpp:159
 msgid "iota"
-msgstr ""
+msgstr "iota"
 
 #: ../../src/sidebars/GreekSidebar.cpp:160
 msgid "kappa"
-msgstr ""
+msgstr "kappa"
 
 #: ../../src/sidebars/GreekSidebar.cpp:161
 msgid "lambda"
-msgstr ""
+msgstr "lambda"
 
 #: ../../src/wizards/LimitWiz.cpp:42
 msgid "left"
-msgstr ""
+msgstr "links"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:117
 msgid "less or equal"
-msgstr ""
+msgstr "Kleiner oder gleich"
 
 #: ../../src/MaximaCommandMenus.cpp:1567
 msgid "list"
@@ -11667,11 +11667,11 @@ msgstr ""
 
 #: ../../src/wizards/Plot2dWiz.cpp:54 ../../src/wizards/Plot2dWiz.cpp:64
 msgid "logscale"
-msgstr ""
+msgstr "Logarithmische Skala"
 
 #: ../../src/wizards/DrawWiz.cpp:822
 msgid "matrix([x_1,x_2,...],[y_1,y_2,...])"
-msgstr ""
+msgstr "matrix([x_1,x_2,...],[y_1,y_2,...])"
 
 #: ../../src/wxMaximaFrame.cpp:1439
 msgid "max(abs(A(i,j))) (complex)"
@@ -11683,15 +11683,15 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:162
 msgid "mu"
-msgstr ""
+msgstr "my"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:120
 msgid "much greater than"
-msgstr ""
+msgstr "Viel größer als"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:119
 msgid "much less than"
-msgstr ""
+msgstr "Viel kleiner als"
 
 #: ../../src/MaximaCommandMenus.cpp:1232
 msgid "m×n Matrix A:"
@@ -11704,11 +11704,11 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:112
 msgid "nabla sign"
-msgstr ""
+msgstr "Nabla-Zeichen"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:98
 msgid "nand"
-msgstr ""
+msgstr "Nicht und"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:772
 msgid "nary: f(x, f(y,z)) = foo(x,y,z)"
@@ -11716,23 +11716,23 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:99
 msgid "nor"
-msgstr ""
+msgstr "Nicht oder"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:102
 msgid "not"
-msgstr ""
+msgstr "nicht"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:116
 msgid "not bytewise identical"
-msgstr ""
+msgstr "Nicht Zeichen für Zeichen identisch"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:108
 msgid "not subset"
-msgstr ""
+msgstr "Nicht Untermenge von"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:107
 msgid "not subset or equal"
-msgstr ""
+msgstr "Nicht Untermenge von oder gleich zu"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:796
 msgid "noun: Not evaluated by default"
@@ -11744,7 +11744,7 @@ msgstr "n-tes Element"
 
 #: ../../src/sidebars/GreekSidebar.cpp:163
 msgid "nu"
-msgstr ""
+msgstr "ny"
 
 #: ../../src/MaximaCommandMenus.cpp:1233
 msgid "n×1 Matrix b:"
@@ -11752,15 +11752,15 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:174
 msgid "omega"
-msgstr ""
+msgstr "omega"
 
 #: ../../src/sidebars/GreekSidebar.cpp:165
 msgid "omicron"
-msgstr ""
+msgstr "omikron"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:96
 msgid "or"
-msgstr ""
+msgstr "Oder"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:793
 msgid "outative: f(2*x) = 2*f(x)"
@@ -11777,19 +11777,19 @@ msgstr "Teil:"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:111
 msgid "partial sign"
-msgstr ""
+msgstr "Symbol für partielle Ableitung"
 
 #: ../../src/sidebars/GreekSidebar.cpp:171
 msgid "phi"
-msgstr ""
+msgstr "phi"
 
 #: ../../src/sidebars/GreekSidebar.cpp:166
 msgid "pi"
-msgstr ""
+msgstr "pi"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:101
 msgid "plus or minus"
-msgstr ""
+msgstr "Plus oder Minus"
 
 #: ../../src/MaximaCommandMenus.cpp:196
 msgid "point:"
@@ -11814,11 +11814,11 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:115
 msgid "proportional to"
-msgstr ""
+msgstr "Proportional zu"
 
 #: ../../src/sidebars/GreekSidebar.cpp:173
 msgid "psi"
-msgstr ""
+msgstr "psi"
 
 #: ../../src/MaximaCommandMenus.cpp:642
 msgid "radcan() is a powerful tools for simplification trigonometric functions but needs to be taken with care: If a function has more than one branch radcan uses the one that looks like it would fit best, not necessarily the one that makes sense for the problem that resulted in the Expression that is to be simplified."
@@ -11846,31 +11846,31 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:167
 msgid "rho"
-msgstr ""
+msgstr "rho"
 
 #: ../../src/wizards/LimitWiz.cpp:42
 msgid "right"
-msgstr ""
+msgstr "rechts"
 
 #: ../../src/wizards/DrawWiz.cpp:310
 msgid "secondary x axis label"
-msgstr ""
+msgstr "Der Titel der 2. x-Achse"
 
 #: ../../src/wizards/DrawWiz.cpp:315
 msgid "secondary x range (automatic if incomplete)"
-msgstr ""
+msgstr "Der Bereich für die 2. x-Achse (automatisch, wenn leer)"
 
 #: ../../src/wizards/DrawWiz.cpp:325
 msgid "secondary y axis label"
-msgstr ""
+msgstr "Der Titel der 2. y-Achse"
 
 #: ../../src/wizards/DrawWiz.cpp:330
 msgid "secondary y range (automatic if incomplete)"
-msgstr ""
+msgstr "Der Bereich für die 2. y-Achse (automatisch, wenn leer)"
 
 #: ../../src/sidebars/GreekSidebar.cpp:168
 msgid "sigma"
-msgstr ""
+msgstr "sigma"
 
 #: ../../src/MaximaCommandMenus.cpp:3447
 msgid "solve() will solve a list of equations only if for n independent equations there are n variables to solve to.\n"
@@ -11892,19 +11892,19 @@ msgstr "Löst eine Gleichung der Form\n"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:81
 msgid "sqrt (needs parenthesis for its argument to work as a Maxima command)"
-msgstr ""
+msgstr "sqrt (Erfordert, um als Maxima-Befehl zu funktionieren, Klammern um das Argument)"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:106
 msgid "subset"
-msgstr ""
+msgstr "Untermenge"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:105
 msgid "subset or equal"
-msgstr ""
+msgstr "Untermenge oder gleich"
 
 #: ../../src/wizards/MatWiz.cpp:160
 msgid "symmetric"
-msgstr ""
+msgstr "symmetrisch"
 
 #: ../../src/MaximaCommandMenus.cpp:970
 msgid "t:"
@@ -11912,7 +11912,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:169
 msgid "tau"
-msgstr ""
+msgstr "tau"
 
 #: ../../src/cells/TextCell.cpp:340
 msgid "the [] operator tried to extract an element of a list, a matrix, an equation or an array. But instead of an integer number something was used whose numerical value is unknown or not an integer.\n"
@@ -11921,31 +11921,31 @@ msgstr ""
 
 #: ../../src/wizards/DrawWiz.cpp:725
 msgid "the x and the y coordinate."
-msgstr ""
+msgstr "die x- und die y-Koordinate zu berechnen."
 
 #: ../../src/wizards/DrawWiz.cpp:729
 msgid "the x, the y and the z coordinate."
-msgstr ""
+msgstr "die x-, y- und z-Koordinate zu berechnen."
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:89
 msgid "there is no"
-msgstr ""
+msgstr "Es existiert kein"
 
 #: ../../src/sidebars/GreekSidebar.cpp:158
 msgid "theta"
-msgstr ""
+msgstr "theta"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:78
 msgid "to the power of 2"
-msgstr ""
+msgstr "Hoch 2"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:79
 msgid "to the power of 3"
-msgstr ""
+msgstr "Hoch 3"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:103
 msgid "union"
-msgstr ""
+msgstr "Vereinigung"
 
 #: ../../src/wxMaximaFrame.cpp:1109
 msgid "unnamed function (lambda)..."
@@ -11962,7 +11962,7 @@ msgstr "unbenannt"
 
 #: ../../src/sidebars/GreekSidebar.cpp:170
 msgid "upsilon"
-msgstr ""
+msgstr "ypsilon"
 
 #: ../../src/wxMaximaFrame.cpp:1737
 msgid "use as function arguments"
@@ -12000,7 +12000,7 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:159
 msgid "wxMaxima can be made to execute commands at every start-up by placing them in a text file with the name wxmaxima.rc in the user directory. This directory can be found by typing maxima_userdir;"
-msgstr ""
+msgstr "Wenn im Benutzerverzeichnis eine Textdatei mit dem Namen wxmaxima.rc liegt, führt wxMaxima alle darin befindlichen Befehle automatisch bei jedem Start aus. Wo das Benutzerverzeichnis liegt, wird mit dem Maxima-Befehl maxima_userdir; angezeigt. "
 
 #: ../../src/MaximaFileIO.cpp:398
 msgid "wxMaxima cannot read the xml contents of "
@@ -12009,7 +12009,7 @@ msgstr "wxMaxima kann den XML-Inhalt nicht öffnen in "
 #: ../../src/dialogs/ConfigDialogue.cpp:142
 #: ../../src/dialogs/ConfigDialogue.cpp:311
 msgid "wxMaxima configuration"
-msgstr ""
+msgstr "wxMaxima Konfiguration"
 
 #: ../../src/MaximaProcessManager.cpp:209
 msgid "wxMaxima could not start a server.\n\n"
@@ -12019,7 +12019,7 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:127
 msgid "wxMaxima dialogs set default values for inputs entries, one of which is '%'. If you have made a selection in your document, the selection will be used instead of '%'."
-msgstr ""
+msgstr "Dialoge in wxMaxima haben oft Standardeinträge in den Eingabefeldern, wie zum Beispiel '%' für das letzte Ergebnis. Haben Sie im Dokument einen Bereich markiert, wird dieser als Standardwert in das Eingabefeld übernommen."
 
 #: ../../src/MaximaCommandMenus.cpp:4544
 msgid "wxMaxima document"
@@ -12050,19 +12050,19 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:240
 msgid "wxMaxima is programmed in C++ using the wxWidgets toolkit and uses CMake as build system. You can contribute to wxMaxima, if you have some knowledge with this environment."
-msgstr ""
+msgstr "wxMaxima ist in C++ programmiert und verwendet das wxWidgets Tooklkit und CMake als Build-System. Sie können zu wxMaxima beitragen, wenn Sie Kenntnisse damit haben."
 
 #: ../../src/dialogs/TipOfTheDay.cpp:228
 msgid "wxMaxima needs more developers. It is an open source project where you can contribute. Join the wxMaxima development at: https://github.com/wxMaxima-developers/wxmaxima"
-msgstr ""
+msgstr "wxMaxima braucht mehr Entwickler. Es ist ein Open Source Programm und wer immer mithelfen will, kann dies unter https://github.com/wxMaxima-developers/wxmaxima tun."
 
 #: ../../src/dialogs/TipOfTheDay.cpp:224
 msgid "wxMaxima needs more translators. We do not speak every language. Help us to translate wxMaxima and the manual to your language. Join the wxMaxima development at: https://github.com/wxMaxima-developers/wxmaxima"
-msgstr ""
+msgstr "wxMaxima braucht mehr Übersetzer, da die Entwickler nicht jede Sprache sprechen. Wer immer dazu bereit ist, kann unter https://github.com/wxMaxima-developers/wxmaxima mithelfen, zu übersetzen."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:407
 msgid "wxMaxima normally stores the gnuplot sources for every plot made using draw() in order to be able to open plots interactively in gnuplot later. This setting defines the limit [in Megabytes per plot] for this feature."
-msgstr ""
+msgstr "wxMaxima speichert manchmal die Gnuplot-Quellen für jedes Diagramm, das mit Hilfe von draw() erzeugt wurde, um sie später interaktiv in Gnuplot öffnen zu können. Diese Einstellung speichert, bis wie viele Megabyte an Daten dies erfolgt."
 
 #: ../../src/dialogs/TipOfTheDay.cpp:172
 msgid "wxMaxima provides the \"table_form\" command that shows lists in an alternative form. One example would be:\n\n"
@@ -12081,7 +12081,7 @@ msgstr "wxMaxima erinnert sich an Antworten vom letzten Durchlauf und ist fähig
 
 #: ../../src/dialogs/ConfigDialogue.cpp:481
 msgid "wxMaxima remembers the answers to maxima's questions. If this checkbox is set it automatically offers to enter the last answer to this question the user has input."
-msgstr ""
+msgstr "wxMaxima erinnert sich an die Antworten, die der Benutzer auf Maxima's Fragen geantwortet hat Wenn dieses Häkchen gesetzt ist, bietet Maxima an, die letzte Antwort zu einer Frage einzutragen."
 
 #: ../../src/wxMaximaFrame.cpp:1933
 msgid "wxMaxima shows help in a browser"
@@ -12093,7 +12093,7 @@ msgstr "wxMaxima zeigt die Hilfe in der Seitenleiste"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1095
 msgid "wxMaxima startup file location: "
-msgstr ""
+msgstr "Ort, an dem diese Datei liegt: "
 
 #: ../../src/wxMaximaFrame.cpp:119
 #, c-format
@@ -12145,11 +12145,11 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:709
 msgid "x"
-msgstr ""
+msgstr "x"
 
 #: ../../src/wizards/DrawWiz.cpp:266
 msgid "x axis label"
-msgstr ""
+msgstr "Der Titel der x-Achse"
 
 #: ../../src/MaximaCommandMenus.cpp:2021
 msgid "x direction [in multiples of the tick frequency]"
@@ -12157,11 +12157,11 @@ msgstr "In x-Richtung [Vielfache der Anzahl der Zahlen]"
 
 #: ../../src/wizards/DrawWiz.cpp:269
 msgid "x range (automatic if incomplete)"
-msgstr ""
+msgstr "Der Bereich für die x-Achse (automatisch, wenn leer)"
 
 #: ../../src/sidebars/GreekSidebar.cpp:164
 msgid "xi"
-msgstr ""
+msgstr "xi"
 
 #: ../../src/MaximaFileIO.cpp:408 ../../src/MaximaFileIO.cpp:566
 msgid "xml contained in the file claims not to be a wxMaxima worksheet. "
@@ -12169,11 +12169,11 @@ msgstr "In der Datei enthaltenes xml behauptet, kein wxMaxima-Arbeitsblatt zu se
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:97
 msgid "xor"
-msgstr ""
+msgstr "Exklusiv Oder"
 
 #: ../../src/wizards/DrawWiz.cpp:279
 msgid "y axis label"
-msgstr ""
+msgstr "Der Titel der y-Achse"
 
 #: ../../src/MaximaCommandMenus.cpp:2022
 msgid "y direction [in multiples of the tick frequency]"
@@ -12181,7 +12181,7 @@ msgstr "in y-Richtung [in vielfachen der Anzahl der Zahlen]"
 
 #: ../../src/wizards/DrawWiz.cpp:282
 msgid "y range (automatic if incomplete)"
-msgstr ""
+msgstr "Der Bereich für die y-Achse (automatisch, wenn leer)"
 
 #: ../../src/MaximaCommandMenus.cpp:970
 msgid "y:"
@@ -12189,15 +12189,15 @@ msgstr ""
 
 #: ../../src/wizards/DrawWiz.cpp:294
 msgid "z axis label"
-msgstr ""
+msgstr "Der Titel der z-Achse"
 
 #: ../../src/wizards/DrawWiz.cpp:298
 msgid "z range (automatic if incomplete)"
-msgstr ""
+msgstr "Der Bereich für die z-Achse (automatisch, wenn leer)"
 
 #: ../../src/sidebars/GreekSidebar.cpp:156
 msgid "zeta"
-msgstr ""
+msgstr "zeta"
 
 #. type: Title #
 #: ../../info/wxmaxima.md:1

--- a/locales/wxMaxima/el.po
+++ b/locales/wxMaxima/el.po
@@ -314,7 +314,7 @@ msgstr "Αντιγραφή\tCtrl+C"
 
 #: ../../src/wizards/IntegrateWiz.cpp:39
 msgid "&Definite integration"
-msgstr ""
+msgstr "Ορισμένη ολοκλήρωση"
 
 #: ../../src/wxMaximaFrame.cpp:1658
 msgid "&Demoivre"
@@ -430,11 +430,11 @@ msgstr ""
 
 #: ../../src/wizards/IntegrateWiz.cpp:52
 msgid "&Numerical integration"
-msgstr ""
+msgstr "Αριθμητική Ολοκλήρωση"
 
 #: ../../src/wizards/SumWiz.cpp:44
 msgid "&Nusum"
-msgstr ""
+msgstr "Νusum"
 
 #: ../../src/main.cpp:675
 msgid "&Open\tCtrl+O"
@@ -450,7 +450,7 @@ msgstr "Γράφημα"
 
 #: ../../src/wizards/SeriesWiz.cpp:45
 msgid "&Power series"
-msgstr ""
+msgstr "Δυναμοσειρές"
 
 #: ../../src/wxMaximaFrame.cpp:655
 msgid "&Print...\tCtrl+P"
@@ -458,7 +458,7 @@ msgstr "Εκτύπωση...\tCtrl+P"
 
 #: ../../src/wizards/SubstituteWiz.cpp:38
 msgid "&Rational"
-msgstr ""
+msgstr "Ρητός(-ή)"
 
 #: ../../src/wxMaximaFrame.cpp:1631
 msgid "&Reduce Trigonometric"
@@ -490,11 +490,11 @@ msgstr "Επίλυση..."
 
 #: ../../src/wizards/Plot2dWiz.cpp:42
 msgid "&Special"
-msgstr ""
+msgstr "Ειδικό"
 
 #: ../../src/wizards/LimitWiz.cpp:45
 msgid "&Taylor series"
-msgstr ""
+msgstr "Σειρές Taylor"
 
 #: ../../src/wxMaximaFrame.cpp:1069
 msgid "&Time Display"
@@ -514,7 +514,7 @@ msgstr ""
 
 #: ../../src/wizards/Plot3dWiz.cpp:79
 msgid "&pm3d"
-msgstr ""
+msgstr "pm3d"
 
 #: ../../src/cells/AnimationCell.cpp:475
 msgid "(Animation)"
@@ -550,7 +550,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:183
 msgid "(Use default language)"
-msgstr ""
+msgstr "(Χρήση Προεπιλεγμένης Γλώσσας)"
 
 #: ../../src/MaximaCommandMenus.cpp:440
 msgid "(f(x),x,a,b)), Epsilon algorithm"
@@ -592,7 +592,7 @@ msgstr ""
 #: ../../src/wizards/IntegrateWiz.cpp:217 ../../src/wizards/LimitWiz.cpp:132
 #: ../../src/wizards/LimitWiz.cpp:142
 msgid "- Infinity"
-msgstr ""
+msgstr "- 'Απειρο"
 
 #: ../../src/MaximaOutputAppender.cpp:116
 msgid "... [suppressed additional lines as the output is longer than allowed in the wxMaxima configuration] "
@@ -649,7 +649,7 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:102
 msgid "A 'horizontal cursor' was introduced in wxMaxima 0.8.0. It looks like a horizontal line between cells. It indicates where a new cell will appear if you type or paste text or execute a menu command."
-msgstr ""
+msgstr "Ένας οριζόντιος κέρσορας πρωτοεμφανίστηκε στο wxMaxima 0.8.0. Φαίνεται ως μία οριζόντια γραμμή μεταξύ των κελιών. Υποδεικνύει που θα εμφανιστεί ένα νέο κελί αν γράψετε ή επικολλήσετε κείμενο ή εκτελέσετε μια εντολή."
 
 #: ../../src/MaximaCommandMenus.cpp:3039
 msgid "A Ctrl-F event"
@@ -916,7 +916,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:389
 msgid "Additional parameters for Maxima (e.g. -l clisp)."
-msgstr ""
+msgstr "Επιπρόσθετοι παράμετροι για το maxima (π.χ. -l clisp)"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1543
 msgid "Additional parameters for Maxima (restart Maxima after changes)"
@@ -1012,7 +1012,7 @@ msgstr ""
 
 #: ../../src/dialogs/BinaryNameCtrl.cpp:69
 msgid "All|*"
-msgstr ""
+msgstr "Όλα|*"
 
 #: ../../src/wxMaximaFrame.cpp:800
 msgid "Always after underscores"
@@ -1291,7 +1291,7 @@ msgstr ""
 
 #: ../../src/wizards/BC2Wiz.cpp:59
 msgid "BC2"
-msgstr ""
+msgstr "BC2"
 
 #: ../../src/MaximaManual.cpp:559
 msgid "Background task that compiles the Manual anchors scheduled."
@@ -1358,7 +1358,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2109
 msgid "Bold"
-msgstr ""
+msgstr "Έντονα"
 
 #: ../../src/wxMaxima.cpp:2259
 msgid "Both horizontal and vertical cursor active at the same time"
@@ -1388,7 +1388,7 @@ msgstr ""
 #: ../../src/wizards/CsvWiz.cpp:131 ../../src/wizards/Plot2dWiz.cpp:114
 #: ../../src/wizards/Plot3dWiz.cpp:109
 msgid "Browse"
-msgstr ""
+msgstr "Πλοήγηση"
 
 #: ../../src/wxMathml.cpp:101
 msgid "Bug: After removing the whitespace wxMathml.lisp is shorter than expected!"
@@ -1767,7 +1767,7 @@ msgstr ""
 
 #: ../../src/sidebars/MathSidebar.cpp:62
 msgid "Canonical (tr)"
-msgstr ""
+msgstr "Κανονική μορφή (τρ)"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:188
 msgid "Catalan"
@@ -1941,7 +1941,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2100
 msgid "Choose font"
-msgstr ""
+msgstr "Επιλογή γραμματοσειράς"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:793
 msgid "Choose how mathematical output is formatted:\n"
@@ -2126,7 +2126,7 @@ msgstr ""
 
 #: ../../src/wizards/MatWiz.cpp:155
 msgid "Columns:"
-msgstr ""
+msgstr "Στήλες:"
 
 #: ../../src/wxMaximaFrame.cpp:1621
 msgid "Combine factorials in an expression"
@@ -2142,11 +2142,11 @@ msgstr ""
 
 #: ../../src/wizards/Plot2dWiz.cpp:626
 msgid "Comma separated x coordinates"
-msgstr ""
+msgstr "Συντεταγμένες του x χωρισμένες με κόμμα"
 
 #: ../../src/wizards/Plot2dWiz.cpp:627
 msgid "Comma separated y coordinates"
-msgstr ""
+msgstr "Συντεταγμένες του y χωρισμένες με κόμμα"
 
 #: ../../src/MaximaCommandMenus.cpp:4071
 msgid "Comma-separated arguments"
@@ -2372,7 +2372,7 @@ msgstr "Συνθήκη:"
 #: ../../src/dialogs/ConfigDialogue.cpp:2641
 #: ../../src/dialogs/ConfigDialogue.cpp:2647
 msgid "Config file (*.ini)|*.ini"
-msgstr ""
+msgstr "Αρχείο Config (*.ini)|*.ini"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2539
 #, c-format
@@ -2404,7 +2404,7 @@ msgstr ""
 #: ../../src/wizards/IntegrateWiz.cpp:208 ../../src/wizards/LimitWiz.cpp:133
 #: ../../src/wizards/SeriesWiz.cpp:105
 msgid "Constant"
-msgstr ""
+msgstr "Σταθερά"
 
 #: ../../src/MaximaCommandMenus.cpp:1102
 msgid "Construct a fraction"
@@ -2878,7 +2878,7 @@ msgstr ""
 
 #: ../../src/worksheet/Worksheet.cpp:6115
 msgid "Cursor"
-msgstr ""
+msgstr "Κέρσορας"
 
 #: ../../src/Styles.cpp:126
 msgid "Cursor color"
@@ -2900,11 +2900,11 @@ msgstr "Αποκοπή επιλογής"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:193
 msgid "Czech"
-msgstr ""
+msgstr "Τσεχικά"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:194
 msgid "Danish"
-msgstr ""
+msgstr "Δανικά"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2069
 msgid "Dark"
@@ -3121,7 +3121,7 @@ msgstr ""
 
 #: ../../src/wizards/SeriesWiz.cpp:42
 msgid "Depth:"
-msgstr ""
+msgstr "Βάθος:"
 
 #: ../../src/MaximaCommandMenus.cpp:994
 msgid "Derivate of y at that point:"
@@ -3188,7 +3188,7 @@ msgstr ""
 
 #: ../../src/sidebars/MathSidebar.cpp:80
 msgid "Diff..."
-msgstr ""
+msgstr "Παραγώγιση..."
 
 #: ../../src/dialogs/DiffFrame.cpp:308
 #, c-format
@@ -3217,7 +3217,7 @@ msgstr ""
 
 #: ../../src/wizards/LimitWiz.cpp:41
 msgid "Direction:"
-msgstr ""
+msgstr "Κατεύθυνση:"
 
 #: ../../src/wxMaximaFrame.cpp:1246
 msgid "Directory operations"
@@ -3229,7 +3229,7 @@ msgstr ""
 
 #: ../../src/wizards/Plot2dWiz.cpp:418 ../../src/wizards/Plot2dWiz.cpp:619
 msgid "Discrete plot"
-msgstr ""
+msgstr "Διακριτή σχεδίαση."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:699
 msgid "Display"
@@ -3571,7 +3571,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:196
 msgid "English"
-msgstr ""
+msgstr "Αγγλικά"
 
 #: ../../src/wizards/DrawWiz.cpp:552
 msgid "Enhanced 3D settings:"
@@ -3583,7 +3583,7 @@ msgstr ""
 
 #: ../../src/sidebars/StatSidebar.cpp:106
 msgid "Enter Matrix..."
-msgstr ""
+msgstr "Εισαγωγή πίνακα..."
 
 #: ../../src/MaximaCommandMenus.cpp:2255
 msgid "Enter UUID to jump to:"
@@ -3603,7 +3603,7 @@ msgstr "Εισαγωγή εξίσωσης για ρητή απλοποίηση:"
 
 #: ../../src/wizards/SystemWiz.cpp:50
 msgid "Enter comma separated list of variables."
-msgstr ""
+msgstr "Εισαγωγή λίστας μεταβλητών χωρισμένες με κόμμα"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:921
 msgid "Enter evaluates cells, Ctrl+Enter adds newlines"
@@ -3623,7 +3623,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:388
 msgid "Enter the path to the Maxima executable."
-msgstr ""
+msgstr "Εισαγωγή της διαδρομής στο εκτελέσιμο αρχείο του maxima."
 
 #: ../../src/MaximaCommandMenus.cpp:1103
 msgid "Enumerator:"
@@ -3870,7 +3870,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2659
 msgid "Example text"
-msgstr ""
+msgstr "Παράδειγμα κειμένου"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1547
 msgid "Examples:"
@@ -3886,11 +3886,11 @@ msgstr ""
 
 #: ../../src/sidebars/MathSidebar.cpp:53
 msgid "Expand"
-msgstr ""
+msgstr "Ανάπτυξη"
 
 #: ../../src/sidebars/MathSidebar.cpp:68
 msgid "Expand (tr)"
-msgstr ""
+msgstr "Ανάπτυξη (τρ)"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:356
 msgid "Expand Expression"
@@ -4216,7 +4216,7 @@ msgstr ""
 
 #: ../../src/sidebars/MathSidebar.cpp:50
 msgid "Factor"
-msgstr ""
+msgstr "Παραγοντοποίηση"
 
 #: ../../src/wxMaximaFrame.cpp:1558
 msgid "Factor Complex"
@@ -4489,7 +4489,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:873
 msgid "Fixed font in text controls"
-msgstr ""
+msgstr "Σταθερή γραμματοσειρά στον έλεγχο κειμένου"
 
 #: ../../src/MaximaCommandMenus.cpp:4039
 msgid "Flush stream"
@@ -4533,7 +4533,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2047
 msgid "Fonts"
-msgstr ""
+msgstr "Γραμματοσειρές"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:442
 msgid "For each Text-, Sectioning or code cell wxMaxima can display a bracket showing the extend of the cell and allowing to fold it. This setting now tells if this bracket is to be printed, as well."
@@ -4561,7 +4561,7 @@ msgstr ""
 
 #: ../../src/wizards/Plot2dWiz.cpp:69 ../../src/wizards/Plot3dWiz.cpp:60
 msgid "Format:"
-msgstr ""
+msgstr "Μορφή:"
 
 #: ../../src/worksheet/Worksheet.cpp:301 ../../src/wxMaxima.cpp:3521
 msgid "Forwarding the keyboard focus to a text control"
@@ -4626,7 +4626,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:198
 msgid "French"
-msgstr ""
+msgstr "Γαλλικά"
 
 #: ../../src/wxMaximaFrame.cpp:1447
 msgid "Frobenius Norm sqrt(sum((A(i,j))^2)) (complex)"
@@ -4765,7 +4765,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:201
 msgid "German"
-msgstr ""
+msgstr "Γερμανικά"
 
 #: ../../src/wxMaximaFrame.cpp:1656
 msgid "Get &Imaginary Part"
@@ -4853,7 +4853,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:202
 msgid "Greek"
-msgstr ""
+msgstr "Ελληνικά"
 
 #: ../../src/wxMaximaFrame.cpp:281
 msgid "Greek Letters"
@@ -4869,7 +4869,7 @@ msgstr ""
 
 #: ../../src/wizards/Plot3dWiz.cpp:52
 msgid "Grid:"
-msgstr ""
+msgstr "Πλέγμα:"
 
 #: ../../src/wxMaximaFrame.cpp:1852
 msgid "Guess an exact number that could be meant by this float"
@@ -5046,7 +5046,7 @@ msgstr "Ιστόγραμμα"
 
 #: ../../src/sidebars/StatSidebar.cpp:85
 msgid "Histogram..."
-msgstr ""
+msgstr "Ιστόγραμμα..."
 
 #: ../../src/wxMaximaFrame.cpp:246
 msgid "History"
@@ -5058,7 +5058,7 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:105
 msgid "Horizontal cursor works like a normal cursor, but it operates on cells: press up or down arrow to move it, holding down Shift while moving will select cells, pressing backspace or delete twice will delete a cell next to it."
-msgstr ""
+msgstr "Ο οριζόντιος κέρσορας λειτουργεί σαν κανονικός κέρσορας,αλλά ενεργεί στα κελιά: (α) πίεστε το πάνω ή το κάτω βέλος για να τον μετακινήσετε, (β) κρατώντας πατημένο το Shift ενώ τον μετακινείτε, επιλέγει κελιά, και (γ) πιέζοντας το backspace ή το delete 2 φορές διαγράφει ένα κελί δίπλα του."
 
 #: ../../src/wxMaximaFrame.cpp:1563
 msgid "Horner's rule"
@@ -5078,7 +5078,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:205
 msgid "Hungarian"
-msgstr ""
+msgstr "Ουγγρικά"
 
 #: ../../src/wxMaximaFrame.cpp:1147
 msgid "I/O"
@@ -5189,7 +5189,7 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:122
 msgid "If your calculation is taking too long to evaluate, you can try 'Maxima->Interrupt' or 'Maxima->Restart Maxima' menu commands."
-msgstr ""
+msgstr "Αν ο υπολογισμός σας καθυστερεί πολύ, μπορείτε να δοκιμάσετε τις εντολές του μενού 'Maxima->Διακοπή' ή 'Maxima->Επανεκκίνηση Maxima'."
 
 #: ../../src/MaximaManual.cpp:420
 msgid "Ignoring the cache version for the manual anchors."
@@ -5197,7 +5197,7 @@ msgstr ""
 
 #: ../../src/sidebars/FormatSidebar.cpp:66
 msgid "Image"
-msgstr ""
+msgstr "Εικόνα"
 
 #: ../../src/Image.cpp:110
 msgid "Image data had zero length!"
@@ -5326,7 +5326,7 @@ msgstr ""
 #: ../../src/wizards/IntegrateWiz.cpp:215 ../../src/wizards/LimitWiz.cpp:132
 #: ../../src/wizards/LimitWiz.cpp:140
 msgid "Infinity"
-msgstr ""
+msgstr "Άπειρο"
 
 #: ../../src/wxMaximaFrame.cpp:1986
 msgid "Info about Maxima build"
@@ -5804,11 +5804,11 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:207
 msgid "Italian"
-msgstr ""
+msgstr "Ιταλικά"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2111
 msgid "Italic"
-msgstr ""
+msgstr "Πλάγια γραφή"
 
 #: ../../src/MaximaCommandMenus.cpp:1617 ../../src/MaximaCommandMenus.cpp:1623
 msgid "Item"
@@ -5820,7 +5820,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:208
 msgid "Japanese"
-msgstr ""
+msgstr "Ιαπωνικά"
 
 #: ../../src/MaximaCommandMenus.cpp:2255
 msgid "Jump to UUID"
@@ -5916,11 +5916,11 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:470
 msgid "Language used for wxMaxima GUI."
-msgstr ""
+msgstr "Γλώσσα που χρησιμοποιείται για το GUI του wxMaxima"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1311
 msgid "Language:"
-msgstr ""
+msgstr "Γλώσσα:"
 
 #: ../../src/MaximaCommandMenus.cpp:251
 msgid "Laplace"
@@ -5979,7 +5979,7 @@ msgstr "Παρεμβολή ελαχίστων τετραγώνων"
 
 #: ../../src/sidebars/StatSidebar.cpp:79
 msgid "Least Squares Fit..."
-msgstr ""
+msgstr "Παρεμβολή ελαχίστων τετραγώνων..."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2007
 msgid "Left"
@@ -6037,7 +6037,7 @@ msgstr "Όριο"
 
 #: ../../src/sidebars/MathSidebar.cpp:86
 msgid "Limit..."
-msgstr ""
+msgstr "Όριο..."
 
 #: ../../src/sidebars/DrawSidebar.cpp:88
 msgid "Line color"
@@ -6178,7 +6178,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2162
 msgid "Load"
-msgstr ""
+msgstr "Φόρτωση"
 
 #: ../../src/MaximaCommandMenus.cpp:2356
 msgid "Load Package"
@@ -6218,7 +6218,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2645
 msgid "Load style from file"
-msgstr ""
+msgstr "Φόρτωση στυλ από αρχείο"
 
 #: ../../src/wxMaximaFrame.cpp:1232
 msgid "Load the file/dir operations (operatingsystem)"
@@ -6551,7 +6551,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1437
 msgid "Maxima program:"
-msgstr ""
+msgstr "Πρόγραμμα Maxima:"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:382
 msgid "Maxima provides no \"forget all\" command that flushes all settings a maxima session could make. wxMaxima therefore normally defaults to starting a fresh maxima process every time the worksheet is to be re-evaluated. As this needs a little bit of time this switch allows to disable this behavior."
@@ -6786,11 +6786,11 @@ msgstr ""
 
 #: ../../src/sidebars/StatSidebar.cpp:70
 msgid "Mean Difference Test..."
-msgstr ""
+msgstr "Τεστ μέσης διαφοράς..."
 
 #: ../../src/sidebars/StatSidebar.cpp:67
 msgid "Mean Test..."
-msgstr ""
+msgstr "Τεστ μέσης τιμής..."
 
 #: ../../src/sidebars/StatSidebar.cpp:52
 msgid "Mean..."
@@ -6823,7 +6823,7 @@ msgstr ""
 
 #: ../../src/wizards/IntegrateWiz.cpp:55
 msgid "Method:"
-msgstr ""
+msgstr "Μέθοδος:"
 
 #: ../../src/wxMaximaFrame.cpp:1360
 msgid "Methods of generating a matrix"
@@ -6922,7 +6922,7 @@ msgstr ""
 
 #: ../../src/wizards/MatWiz.cpp:163
 msgid "Name:"
-msgstr ""
+msgstr "Όνομα:"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:216
 msgid "Nepali"
@@ -6998,7 +6998,7 @@ msgstr ""
 
 #: ../../src/wizards/SubstituteWiz.cpp:35
 msgid "New value:"
-msgstr ""
+msgstr "Νέα τιμή:"
 
 #: ../../src/MaximaCommandMenus.cpp:151 ../../src/MaximaCommandMenus.cpp:171
 #: ../../src/MaximaCommandMenus.cpp:254 ../../src/MaximaCommandMenus.cpp:259
@@ -7303,7 +7303,7 @@ msgstr ""
 
 #: ../../src/wizards/SubstituteWiz.cpp:32
 msgid "Old value:"
-msgstr ""
+msgstr "Παλιά τιμή:"
 
 #: ../../src/MaximaCommandMenus.cpp:151 ../../src/MaximaCommandMenus.cpp:172
 #: ../../src/MaximaCommandMenus.cpp:253 ../../src/MaximaCommandMenus.cpp:259
@@ -7432,7 +7432,7 @@ msgstr "Επιλογές"
 
 #: ../../src/wizards/Plot2dWiz.cpp:75 ../../src/wizards/Plot3dWiz.cpp:66
 msgid "Options:"
-msgstr ""
+msgstr "Επιλογές:"
 
 #: ../../src/dialogs/FindReplacePane.cpp:109
 msgid "Output"
@@ -7505,7 +7505,7 @@ msgstr "Προσέγγιση Pade σειράς Taylor"
 
 #: ../../src/sidebars/FormatSidebar.cpp:69
 msgid "Pagebreak"
-msgstr ""
+msgstr "Αλλαγή σελίδας"
 
 #: ../../src/wxMaximaFrame.cpp:1674
 msgid "Parallel Substitute..."
@@ -7533,7 +7533,7 @@ msgstr ""
 
 #: ../../src/wizards/Plot2dWiz.cpp:417 ../../src/wizards/Plot2dWiz.cpp:523
 msgid "Parametric plot"
-msgstr ""
+msgstr "Παραμετρικό γράφημα"
 
 #: ../../src/MaximaCommandMenus.cpp:4211
 msgid "Parse string"
@@ -7611,7 +7611,7 @@ msgstr "Παρακαλώ ρυθμίστε το wxMaxima μεσα απο το μ�
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2606
 msgid "Please restart wxMaxima for changes to take effect!"
-msgstr ""
+msgstr "Παρακαλώ κάντε επανεκκίνηση του wxMaxima για να ενεργοποιηθούν οι αλλαγές!"
 
 #: ../../src/MaximaCommandMenus.cpp:2250
 msgid "Please select exactly 2 or 3 files."
@@ -7689,7 +7689,7 @@ msgstr ""
 
 #: ../../src/wizards/Plot2dWiz.cpp:84 ../../src/wizards/Plot3dWiz.cpp:80
 msgid "Plot to file:"
-msgstr ""
+msgstr "Γράφημα σε αρχείο:"
 
 #: ../../src/wxMaximaFrame.cpp:341 ../../src/wxMaximaFrame.cpp:749
 msgid "Plot using Draw"
@@ -7723,7 +7723,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:219
 msgid "Polish"
-msgstr ""
+msgstr "Πολωνικά"
 
 #: ../../src/MaximaCommandMenus.cpp:215 ../../src/MaximaCommandMenus.cpp:220
 #: ../../src/MaximaCommandMenus.cpp:225
@@ -7759,7 +7759,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:221
 msgid "Portuguese (Brazilian)"
-msgstr ""
+msgstr "Πορτογαλλικά(Βραζιλίας)"
 
 #: ../../src/wxMaximaFrame.cpp:1223
 msgid "Position of a match"
@@ -7775,7 +7775,7 @@ msgstr ""
 
 #: ../../src/wizards/Plot2dWiz.cpp:474 ../../src/wizards/Plot3dWiz.cpp:422
 msgid "Postscript file (*.eps)|*.eps|All|*"
-msgstr ""
+msgstr "Αρχείο Postscript (*.eps)|*.eps|All|*"
 
 #: ../../src/MaximaCommandMenus.cpp:190
 msgid "Power series"
@@ -8037,7 +8037,7 @@ msgstr ""
 
 #: ../../src/sidebars/StatSidebar.cpp:103
 msgid "Read Matrix..."
-msgstr ""
+msgstr "Aνάγνωση πίνακα..."
 
 #: ../../src/MaximaCommandMenus.cpp:4008
 msgid "Read a structure field"
@@ -8174,7 +8174,7 @@ msgstr ""
 
 #: ../../src/sidebars/MathSidebar.cpp:56
 msgid "Rectform"
-msgstr ""
+msgstr "Καρτεσιανή μορφή"
 
 #: ../../src/wxMaximaFrame.cpp:1677
 msgid "Recursive Substitute..."
@@ -8198,7 +8198,7 @@ msgstr ""
 
 #: ../../src/sidebars/MathSidebar.cpp:71
 msgid "Reduce (tr)"
-msgstr ""
+msgstr "Αναγωγή (τρ)"
 
 #: ../../src/wxMaximaFrame.cpp:1632
 msgid "Reduce trigonometric expression"
@@ -8586,7 +8586,7 @@ msgstr ""
 
 #: ../../src/wizards/MatWiz.cpp:152
 msgid "Rows:"
-msgstr ""
+msgstr "Γραμμές:"
 
 #: ../../src/MaximaCommandMenus.cpp:1391
 msgid "Rule"
@@ -8656,7 +8656,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:223
 msgid "Russian"
-msgstr ""
+msgstr "Ρωσικά"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1578
 msgid "SBCL: use <int>Mbytes of heap"
@@ -8758,7 +8758,7 @@ msgstr "Αποθήκευση εγγράφου ως"
 
 #: ../../src/wizards/Plot2dWiz.cpp:473 ../../src/wizards/Plot3dWiz.cpp:421
 msgid "Save plot to file"
-msgstr ""
+msgstr "Αποθήκευση γραφήματος σε αρχείο"
 
 #: ../../src/wxMaximaFrame.cpp:713
 msgid "Save selection from document to an image file"
@@ -8770,7 +8770,7 @@ msgstr "Αποθήκευση επιλογής σε αρχείο"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2640
 msgid "Save style to file"
-msgstr ""
+msgstr "Αποθήκευση στυλ σε αρχείο"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1384
 msgid "Save the worksheet automatically"
@@ -8802,7 +8802,7 @@ msgstr "Διάγραμμα διασποράς"
 
 #: ../../src/sidebars/StatSidebar.cpp:88
 msgid "Scatterplot..."
-msgstr ""
+msgstr "Διάγραμμα διασποράς..."
 
 #: ../../src/Autocomplete.cpp:157
 msgid "Scheduling a background task that compiles a new list of autocompletable maxima commands."
@@ -8893,7 +8893,7 @@ msgstr "Επιλογή υποδείγματος"
 #: ../../src/wizards/IntegrateWiz.cpp:208 ../../src/wizards/LimitWiz.cpp:133
 #: ../../src/wizards/SeriesWiz.cpp:105
 msgid "Select a constant"
-msgstr ""
+msgstr "Επιλογή μιας μεταβλητής"
 
 #: ../../src/ToolBar.cpp:390 ../../src/ToolBar.cpp:392
 #: ../../src/wxMaximaFrame.cpp:710
@@ -9002,7 +9002,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:479
 msgid "Set fixed font in text controls."
-msgstr ""
+msgstr "Ορισμός σταθερού μεγέθους γραμματοσειράς στους ελέγχους κειμένου."
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:68
 #: ../../src/worksheet/WorksheetContextMenu.cpp:250
@@ -9229,7 +9229,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:465
 msgid "Show long expressions in wxMaxima document."
-msgstr ""
+msgstr "Εμφάνιση μεγάλων παραστάσεων στο έγγραφο του wxMaxima"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:722
 msgid "Show long expressions:"
@@ -9334,7 +9334,7 @@ msgstr ""
 
 #: ../../src/sidebars/MathSidebar.cpp:44
 msgid "Simplify"
-msgstr ""
+msgstr "Απλοποίηση"
 
 #: ../../src/wxMaximaFrame.cpp:1550
 msgid "Simplify &Radicals..."
@@ -9342,11 +9342,11 @@ msgstr ""
 
 #: ../../src/sidebars/MathSidebar.cpp:47
 msgid "Simplify (r)"
-msgstr ""
+msgstr "Απλοποίηση (ρ)"
 
 #: ../../src/sidebars/MathSidebar.cpp:65
 msgid "Simplify (tr)"
-msgstr ""
+msgstr "Απλοποίηση (τρ)"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:352
 msgid "Simplify Expression"
@@ -9386,7 +9386,7 @@ msgstr ""
 
 #: ../../src/wizards/SumWiz.cpp:68
 msgid "Simplify the sum"
-msgstr ""
+msgstr "Απλοποίηση αθροίσματος"
 
 #: ../../src/wxMaximaFrame.cpp:1629
 msgid "Simplify trigonometric expression"
@@ -9451,7 +9451,7 @@ msgstr ""
 
 #: ../../src/wizards/BC2Wiz.cpp:30
 msgid "Solution:"
-msgstr ""
+msgstr "Λύση:"
 
 #: ../../src/MaximaCommandMenus.cpp:3446
 msgid "Solve"
@@ -9491,7 +9491,7 @@ msgstr "Επίλυση ΣΔΕ με Laplace..."
 
 #: ../../src/sidebars/MathSidebar.cpp:77
 msgid "Solve ODE..."
-msgstr ""
+msgstr "Επίλυση ΣΔΕ..."
 
 #: ../../src/wxMaximaFrame.cpp:1432
 msgid "Solve a linear equation system using dgesv"
@@ -9618,12 +9618,12 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:227
 msgid "Spanish"
-msgstr ""
+msgstr "Ισπανικά"
 
 #: ../../src/wizards/IntegrateWiz.cpp:44 ../../src/wizards/IntegrateWiz.cpp:50
 #: ../../src/wizards/LimitWiz.cpp:38 ../../src/wizards/SeriesWiz.cpp:39
 msgid "Special"
-msgstr ""
+msgstr "Ειδικός"
 
 #: ../../src/wizards/DrawWiz.cpp:918
 msgid "Speed versus accuracy"
@@ -9834,15 +9834,15 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:282
 msgid "Style"
-msgstr ""
+msgstr "Στυλ"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2082
 msgid "Styles"
-msgstr ""
+msgstr "Στυλ"
 
 #: ../../src/sidebars/StatSidebar.cpp:112
 msgid "Subsample..."
-msgstr ""
+msgstr "Υποδείγμα..."
 
 #: ../../src/ToolBar.cpp:484 ../../src/sidebars/FormatSidebar.cpp:54
 msgid "Subsection"
@@ -9862,7 +9862,7 @@ msgstr ""
 
 #: ../../src/sidebars/MathSidebar.cpp:59
 msgid "Subst..."
-msgstr ""
+msgstr "Αντικατάσταση..."
 
 #: ../../src/MaximaCommandMenus.cpp:715 ../../src/MaximaCommandMenus.cpp:3490
 #: ../../src/MaximaCommandMenus.cpp:4500 ../../src/wizards/SubstituteWiz.cpp:53
@@ -10138,7 +10138,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:492
 msgid "The default port used for communication between Maxima and wxMaxima."
-msgstr ""
+msgstr "Η προεπιλεγμένη θύρα που χρησιμοποιείται για την επικοινωνία μεταξύ του Maxima και του wxMaxima"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:412
 msgid "The default width for embedded plots. Can be read out or overridden by the maxima variable wxplot_size"
@@ -10520,7 +10520,7 @@ msgstr ""
 
 #: ../../src/wizards/Plot2dWiz.cpp:65 ../../src/wizards/Plot2dWiz.cpp:505
 msgid "Ticks:"
-msgstr ""
+msgstr "Σημάνσεις:"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1359
 msgid "Time [in Minutes] between autosaves"
@@ -10548,7 +10548,7 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:89
 msgid "Title, section and subsection cells can be folded to hide their contents. To fold or unfold, click in the square next to the cell. If you shift-click, all sublevels of that cell will also fold/unfold."
-msgstr ""
+msgstr "Ο τίτλος, η ενότητα και η υποενότητα των κελιών μπορούν να αναδιπλωθούν και να αποκρύψουν τα περιεχόμενά τους. Για την δίπλωση ή ξεδίπλωση, καντε κλικ στο τετραγωνάκι που βρίσκεται δίπλα απο το κελί. Επιπλέον αν κανετε shift-κλικ, ολα τα υποεπίπεδα του κελιού επίσης θα διπλωθούν/ξεδιπλωθούν."
 
 #: ../../src/wxMaximaFrame.cpp:1831
 msgid "To &Bigfloat"
@@ -10576,7 +10576,7 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:124
 msgid "To plot in polar coordinates, select 'set polar' in the Options entry for Plot2d dialog. You can also plot in spherical and cylindrical coordinates in 3D."
-msgstr ""
+msgstr "Για να σχεδιάσετε σε πολικές συντεταγμένες, επιλέξτε 'set polar' στην καταχώρηση Επιλογές στον διάλογο του Plot2d. Μπορείτε επίσης να σχεδιάσετε σε σφαιρικές και κυλινδρικές συντεταγμένες σε 3-Δ."
 
 #: ../../src/dialogs/TipOfTheDay.cpp:131
 msgid "To put parentheses around an expression, select it, and press '(' or ')' depending on where you want the cursor to appear afterwards."
@@ -10584,7 +10584,7 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:137
 msgid "To save the size and position of wxMaxima windows between session, use 'Edit->Configure' dialog."
-msgstr ""
+msgstr "Για να αποθηκεύσετε το μέγεθος και τη θέση από τα παράθυρα του wxMaxima μεταξύ διαφορετικών συνεδριών, χρησιμοποιήστε το διάλογο 'Επεξεργασία->Ρυθμίσεις'"
 
 #: ../../src/dialogs/TipOfTheDay.cpp:51
 msgid "To start using wxMaxima right away, start typing your command. An input cell should appear. Then press Shift-Enter to evaluate your command."
@@ -10804,7 +10804,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:231
 msgid "Ukrainian"
-msgstr ""
+msgstr "Ουκρανικά"
 
 #: ../../src/wxMaxima.cpp:3164
 msgid "Un-closed parenthesis"
@@ -10835,7 +10835,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2115
 msgid "Underlined"
-msgstr ""
+msgstr "Υπογραμμισμένος"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:745
 msgid "Underscore converts to subscripts:"
@@ -10983,7 +10983,7 @@ msgstr ""
 
 #: ../../src/wizards/SumWiz.cpp:69
 msgid "Use Gosper algorithm"
-msgstr ""
+msgstr "Χρήση του αλγορίθμου του Gosper"
 
 #: ../../src/sidebars/RegexCtrl.cpp:133
 msgid "Use RegEx filtering"
@@ -11011,7 +11011,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:849
 msgid "Use centered dot character for multiplication"
-msgstr ""
+msgstr "Χρήση κεντραρισμένης τελείας για πολλαπλασιασμό"
 
 #: ../../src/wxMaximaFrame.cpp:1745
 msgid "Use list"
@@ -11268,7 +11268,7 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:134
 msgid "When applying functions with one argument from menus, the default argument is '%'. To apply the function to some other value, select it in the document before executing a menu command."
-msgstr ""
+msgstr "Όταν εφαρμόζετε συναρτήσεις με ένα όρισμα από καταλόγους επιλογής, το προεπιλεγμένο όρισμα είναι το '%'.Για να εφαρμόσετε τη συνάρτηση σε κάποια άλλη τιμή, επιλέξτε την στο κείμενο προτού να εκτελέσετε μία εντολή από τον κατάλογο."
 
 #: ../../src/wxMaximaFrame.cpp:1092
 msgid "When to invoke the lisp compiler's debugger"
@@ -11355,7 +11355,7 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:64
 msgid "You can access the last output using the variable '%'. You can access the output of previous commands using variables '%on' where n is the number of output."
-msgstr ""
+msgstr "Μπορείτε να έχετε πρόσβαση στο τελευταίο αποτέσμα χρησιμοποιώντας τη μεταβλητή ‘%’. Μπορείτε να έχετε πρόσβαση σε αποτελέσματα προηγούμενων εντολών χρησιμοποιώντας τις μεταβλητές ‘%on’ όπου n είναι ο αριθμός της αποτελέσματος."
 
 #: ../../src/dialogs/TipOfTheDay.cpp:118
 msgid "You can evaluate your whole document by using 'Cell->Evaluate All Cells' menu command or the appropriate key shortcut. The cells will be evaluated in the order they appear in the document."
@@ -11367,7 +11367,7 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:92
 msgid "You can hide output part of cells by clicking in the triangle on the left side of cells. This works on text cells also."
-msgstr ""
+msgstr "Μπορείτε να κρύψετε το μέρος των αποτελεσμάτων των κελιών κάνοντας κλικ στο τρίγωνο στα αριστερά των κελιών. Ανάλογο ισχύει επίσης και για τα κελιά κειμένου."
 
 #: ../../src/dialogs/TipOfTheDay.cpp:81
 msgid "You can insert different types of 'cells' in wxMaxima documents using the 'Cell' menu. Note that only 'input cells' can be evaluated, while others are used for commenting and structuring your calculations."
@@ -11375,7 +11375,7 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:112
 msgid "You can select multiple cells either with a mouse - click'n'drag from between cells or from a cell bracket on the left - or with a keyboard - hold down Shift while moving the horizontal cursor - and then operate on selection. This comes in handy when you want to delete or evaluate multiple cells."
-msgstr ""
+msgstr "Μπορείτε να επιλέξετε πολλαπλά κελιά είτε με το ποντίκι – κάνοντας κλικ και σέρνωντας το ποντίκι από ανάμεσα στα κελιά ή από το άγκιστρο στα αριστερά του κελιού - είτε με το πληκτρολόγιο - κρατώντας πατημένο το Shift ενώ μετακινείτε τον οριζόντιο κέρσορα - και μετά να εκτελέσετε κάτι στην επιλογή. Αυτό είναι χρήσιμο αν θέλετε να διαγράψετε ή να υπολογίσετε πολλαπλά κελιά."
 
 #: ../../src/dialogs/TipOfTheDay.cpp:232
 msgid "You found a bug in wxMaxima? Please report it at https://github.com/wxMaxima-developers/wxmaxima/issues\n"
@@ -11451,7 +11451,7 @@ msgstr ""
 
 #: ../../src/wizards/MatWiz.cpp:160
 msgid "antisymmetric"
-msgstr ""
+msgstr "αντισυμμετρικός"
 
 #: ../../src/wxMaximaFrame.cpp:1727
 msgid "apply function to each element"
@@ -11479,7 +11479,7 @@ msgstr ""
 
 #: ../../src/wizards/LimitWiz.cpp:42
 msgid "both sides"
-msgstr ""
+msgstr "από τις δύο πλευρές"
 
 #: ../../src/wxMaximaFrame.cpp:1173
 msgid "char to Ascii code..."
@@ -11497,7 +11497,7 @@ msgstr ""
 #: ../../src/wizards/Plot2dWiz.cpp:70 ../../src/wizards/Plot2dWiz.cpp:372
 #: ../../src/wizards/Plot3dWiz.cpp:61 ../../src/wizards/Plot3dWiz.cpp:358
 msgid "default"
-msgstr ""
+msgstr "προεπιλογή"
 
 #: ../../src/sidebars/GreekSidebar.cpp:154
 msgid "delta"
@@ -11505,7 +11505,7 @@ msgstr ""
 
 #: ../../src/wizards/MatWiz.cpp:159
 msgid "diagonal"
-msgstr ""
+msgstr "διαγώνιος"
 
 #: ../../src/cells/FracCell.cpp:73
 msgid "diff(): Cannot find the multiplication sign I should hide"
@@ -11587,7 +11587,7 @@ msgstr ""
 
 #: ../../src/wizards/MatWiz.cpp:159
 msgid "general"
-msgstr ""
+msgstr "γενικός"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1630
 msgid "gnuplot: Without command console"
@@ -11610,7 +11610,7 @@ msgstr ""
 #: ../../src/wizards/Plot3dWiz.cpp:61 ../../src/wizards/Plot3dWiz.cpp:194
 #: ../../src/wizards/Plot3dWiz.cpp:358 ../../src/wizards/Plot3dWiz.cpp:386
 msgid "inline"
-msgstr ""
+msgstr "inline"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:104
 msgid "intersection"
@@ -11630,7 +11630,7 @@ msgstr ""
 
 #: ../../src/wizards/LimitWiz.cpp:42
 msgid "left"
-msgstr ""
+msgstr "από αριστερά"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:117
 msgid "less or equal"
@@ -11642,7 +11642,7 @@ msgstr ""
 
 #: ../../src/wizards/Plot2dWiz.cpp:54 ../../src/wizards/Plot2dWiz.cpp:64
 msgid "logscale"
-msgstr ""
+msgstr "λογαριθμική κλίμακα"
 
 #: ../../src/wizards/DrawWiz.cpp:822
 msgid "matrix([x_1,x_2,...],[y_1,y_2,...])"
@@ -11825,7 +11825,7 @@ msgstr ""
 
 #: ../../src/wizards/LimitWiz.cpp:42
 msgid "right"
-msgstr ""
+msgstr "από δεξιά"
 
 #: ../../src/wizards/DrawWiz.cpp:310
 msgid "secondary x axis label"
@@ -11877,7 +11877,7 @@ msgstr ""
 
 #: ../../src/wizards/MatWiz.cpp:160
 msgid "symmetric"
-msgstr ""
+msgstr "συμμετρικός"
 
 #: ../../src/MaximaCommandMenus.cpp:970
 msgid "t:"
@@ -11982,7 +11982,7 @@ msgstr ""
 #: ../../src/dialogs/ConfigDialogue.cpp:142
 #: ../../src/dialogs/ConfigDialogue.cpp:311
 msgid "wxMaxima configuration"
-msgstr ""
+msgstr "Ρυθμίσεις του wxMaxima"
 
 #: ../../src/MaximaProcessManager.cpp:209
 msgid "wxMaxima could not start a server.\n\n"
@@ -11992,7 +11992,7 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:127
 msgid "wxMaxima dialogs set default values for inputs entries, one of which is '%'. If you have made a selection in your document, the selection will be used instead of '%'."
-msgstr ""
+msgstr "Οι διάλογοι του wxMaxima καθορίζουν προεπιλεγμένες τιμές σε καταχωρημένες γραμμές εντολών μία από τις οποίες είναι το '%'. Αν έχετε κάνει μια επιλογή στο έγγραφό σας, η επιλογή αυτή θα χρησιμοποιηθεί στη θέση του '%'."
 
 #: ../../src/MaximaCommandMenus.cpp:4544
 msgid "wxMaxima document"

--- a/locales/wxMaxima/es.po
+++ b/locales/wxMaxima/es.po
@@ -53,23 +53,23 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1569
 msgid "      -X \"--control-stack-size <int>\""
-msgstr ""
+msgstr "      -X \"--control-stack-size <int>\""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1568
 msgid "      -X \"--dynamic-space-size <int>\""
-msgstr ""
+msgstr "      -X \"--dynamic-space-size <int>\""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1572
 msgid "      -X '--control-stack-size <int>'"
-msgstr ""
+msgstr "      -X '--control-stack-size <int>'"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1571
 msgid "      -X '--dynamic-space-size <int>'"
-msgstr ""
+msgstr "      -X '--dynamic-space-size <int>'"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1551
 msgid "      -l <name>"
-msgstr ""
+msgstr "      -l <nombre>"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1557
 msgid "      -u <versionnumber>"
@@ -167,7 +167,7 @@ msgstr " (Formato de archivo (WXM versión 1, primera línea del archivo) no rec
 #: ../../src/cells/ImgCell.cpp:212 ../../src/cells/ImgCell.cpp:214
 #: ../../src/cells/ImgCell.cpp:216
 msgid " (Graphics) "
-msgstr ""
+msgstr " (Gráficos) "
 
 #: ../../src/cells/EditorCell.cpp:3551 ../../src/cells/EditorCell.cpp:3820
 #: ../../src/cells/EditorCell.cpp:3945
@@ -177,7 +177,7 @@ msgstr ""
 
 #: ../../src/cells/EditorCell.cpp:3553
 msgid " ... + 1 hidden line"
-msgstr ""
+msgstr " ... + 1 línea ocultada"
 
 #: ../../src/dialogs/TipOfTheDay.cpp:273
 msgid " Did you know? "
@@ -193,15 +193,15 @@ msgstr " Error, si uno es complejo"
 
 #: ../../src/wizards/DrawWiz.cpp:964 ../../src/wizards/DrawWiz.cpp:980
 msgid " samples"
-msgstr ""
+msgstr " muestras"
 
 #: ../../src/wizards/DrawWiz.cpp:929 ../../src/wizards/DrawWiz.cpp:945
 msgid " samples, on demand split "
-msgstr ""
+msgstr " muestras, en demanda desglose "
 
 #: ../../src/wizards/DrawWiz.cpp:933 ../../src/wizards/DrawWiz.cpp:952
 msgid " times"
-msgstr ""
+msgstr " veces"
 
 #: ../../src/MaximaCommandMenus.cpp:4413
 msgid "\".\" = \"The current directory\"\n"
@@ -216,7 +216,7 @@ msgstr "\"..\" significa \"un directorio arriba\"."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1208
 msgid "\"Copy LaTeX\" adds equation markers"
-msgstr ""
+msgstr "«Copiar LaTeX» agregue marcadores de ecuaciones"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:446
 msgid "\"MathML (rendered by the browser)\" is the recommended choice: every current browser renders MathML natively and instantly, and the exported page needs no JavaScript and makes no requests to any external server.\n"
@@ -226,11 +226,11 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:930
 msgid "\"Numpad Enter\" always evaluates cells"
-msgstr ""
+msgstr "\"Introducir Numpad\" siempre evalúa celdas"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:90
 msgid "\"implies\" symbol"
-msgstr ""
+msgstr "símbolo «implica»"
 
 #: ../../src/dialogs/DiffFrame.cpp:306
 #, c-format
@@ -317,7 +317,7 @@ msgstr "&Copiar\tCtrl+C"
 
 #: ../../src/wizards/IntegrateWiz.cpp:39
 msgid "&Definite integration"
-msgstr ""
+msgstr "&Integración definida"
 
 #: ../../src/wxMaximaFrame.cpp:1658
 msgid "&Demoivre"
@@ -433,11 +433,11 @@ msgstr "Salida &numérica"
 
 #: ../../src/wizards/IntegrateWiz.cpp:52
 msgid "&Numerical integration"
-msgstr ""
+msgstr "&Integración numérica"
 
 #: ../../src/wizards/SumWiz.cpp:44
 msgid "&Nusum"
-msgstr ""
+msgstr "&Númsum"
 
 #: ../../src/main.cpp:675
 msgid "&Open\tCtrl+O"
@@ -453,7 +453,7 @@ msgstr "&Tramado"
 
 #: ../../src/wizards/SeriesWiz.cpp:45
 msgid "&Power series"
-msgstr ""
+msgstr "Series de &potencias"
 
 #: ../../src/wxMaximaFrame.cpp:655
 msgid "&Print...\tCtrl+P"
@@ -461,7 +461,7 @@ msgstr "&Imprimir…\tCtrl+P"
 
 #: ../../src/wizards/SubstituteWiz.cpp:38
 msgid "&Rational"
-msgstr ""
+msgstr "&Racional"
 
 #: ../../src/wxMaximaFrame.cpp:1631
 msgid "&Reduce Trigonometric"
@@ -493,11 +493,11 @@ msgstr "&Resolver…"
 
 #: ../../src/wizards/Plot2dWiz.cpp:42
 msgid "&Special"
-msgstr ""
+msgstr "&Especial"
 
 #: ../../src/wizards/LimitWiz.cpp:45
 msgid "&Taylor series"
-msgstr ""
+msgstr "Series de &Taylor"
 
 #: ../../src/wxMaximaFrame.cpp:1069
 msgid "&Time Display"
@@ -517,7 +517,7 @@ msgstr ""
 
 #: ../../src/wizards/Plot3dWiz.cpp:79
 msgid "&pm3d"
-msgstr ""
+msgstr "&pm3d"
 
 #: ../../src/cells/AnimationCell.cpp:475
 msgid "(Animation)"
@@ -549,11 +549,11 @@ msgstr ""
 
 #: ../../src/sidebars/VariablesPane.cpp:254
 msgid "(Not a valid variable name)"
-msgstr ""
+msgstr "(No un nombre de variable válido)"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:183
 msgid "(Use default language)"
-msgstr ""
+msgstr "(Emplear idioma predet.)"
 
 #: ../../src/MaximaCommandMenus.cpp:440
 msgid "(f(x),x,a,b)), Epsilon algorithm"
@@ -587,7 +587,7 @@ msgstr "(f(x),x,y) con singularidades+descontinuidades"
 #: ../../src/wizards/DrawWiz.cpp:303 ../../src/wizards/DrawWiz.cpp:320
 #: ../../src/wizards/DrawWiz.cpp:335
 msgid "-"
-msgstr ""
+msgstr "-"
 
 #: ../../src/wizards/IntegrateWiz.cpp:192
 #: ../../src/wizards/IntegrateWiz.cpp:202
@@ -595,7 +595,7 @@ msgstr ""
 #: ../../src/wizards/IntegrateWiz.cpp:217 ../../src/wizards/LimitWiz.cpp:132
 #: ../../src/wizards/LimitWiz.cpp:142
 msgid "- Infinity"
-msgstr ""
+msgstr "- Infinito"
 
 #: ../../src/MaximaOutputAppender.cpp:116
 msgid "... [suppressed additional lines as the output is longer than allowed in the wxMaxima configuration] "
@@ -611,11 +611,11 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:77
 msgid "1/2"
-msgstr ""
+msgstr "½"
 
 #: ../../src/sidebars/DrawSidebar.cpp:45
 msgid "2D"
-msgstr ""
+msgstr "2D"
 
 #: ../../src/wxMaximaFrame.cpp:1346
 msgid "2D Array to Matrix..."
@@ -639,7 +639,7 @@ msgstr ""
 
 #: ../../src/sidebars/DrawSidebar.cpp:49
 msgid "3D"
-msgstr ""
+msgstr "3D"
 
 #: ../../src/wxMaxima.cpp:1833
 #, c-format
@@ -652,7 +652,7 @@ msgstr "Un \":lisp\" como la primera instrucción puede fallar para enviar una s
 
 #: ../../src/dialogs/TipOfTheDay.cpp:102
 msgid "A 'horizontal cursor' was introduced in wxMaxima 0.8.0. It looks like a horizontal line between cells. It indicates where a new cell will appear if you type or paste text or execute a menu command."
-msgstr ""
+msgstr "Se ha introducido en wxMaxima 0.8.0 un 'cursor horizontal'. Su aspecto es el de una línea horizontal entre celdas. Se indica dónde aparecerá una nueva celda al escribir o copiar una instrucción nueva."
 
 #: ../../src/MaximaCommandMenus.cpp:3039
 msgid "A Ctrl-F event"
@@ -678,7 +678,7 @@ msgstr "Un evento encontrado, %s"
 
 #: ../../src/wizards/ListSortWiz.cpp:63
 msgid "A function f(a,b), named"
-msgstr ""
+msgstr "Una función f(a,b), nombrada"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:784
 msgid "A function returning integers"
@@ -690,7 +690,7 @@ msgstr "Una función devolviendo números positivos"
 
 #: ../../src/wizards/DrawWiz.cpp:164
 msgid "A good example equation would be x^2+y^2=1"
-msgstr ""
+msgstr "Un buen ejemplo de ecuación podría ser x^2+y^2=1"
 
 #: ../../src/cells/GroupCell.cpp:2193 ../../src/cells/GroupCell.cpp:2196
 msgid "A heading"
@@ -718,11 +718,11 @@ msgstr ""
 
 #: ../../src/cells/GroupCell.cpp:2175
 msgid "A page break"
-msgstr ""
+msgstr "Un salto de página"
 
 #: ../../src/dialogs/TipOfTheDay.cpp:168
 msgid "A plot to be embedded into the work sheet by preceding its name with a \"wx\". \"draw\" can be replaced by \"wxdraw\", plot by \"wxplot\" etc."
-msgstr ""
+msgstr "Un trazado para ser embebido en la hoja del cuaderno para preceder su nombre con un «wx». «draw» puede ser sustituido por «wxdraw», trazado por «wxplot» etc."
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:735
 msgid "A rational variable"
@@ -734,7 +734,7 @@ msgstr "Una función asociativa por la derecha"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:436
 msgid "A scale factor for the printout. Helpful for printing big equations on small pdf pages."
-msgstr ""
+msgstr "Un factor de escala para la impresión. Útil para imprimir ecuaciones grandes en páginas psf pqueñas."
 
 #: ../../src/wxMaximaFrame.cpp:1671
 msgid "A search-and-replace for equations"
@@ -742,27 +742,27 @@ msgstr "Un buscar-y-sustituir para ecuaciones"
 
 #: ../../src/cells/EditorCell.cpp:4522 ../../src/cells/GroupCell.cpp:2184
 msgid "A section heading"
-msgstr ""
+msgstr "Una sección de cabecera"
 
 #: ../../src/wizards/DrawWiz.cpp:479
 msgid "A static plot"
-msgstr ""
+msgstr "Un tramado estático"
 
 #: ../../src/cells/EditorCell.cpp:4534
 msgid "A sub-sub-sub-subsection heading"
-msgstr ""
+msgstr "Una cabecera de sub-sub-sub-subsección"
 
 #: ../../src/cells/EditorCell.cpp:4531
 msgid "A sub-sub-subsection heading"
-msgstr ""
+msgstr "Una cabecera de sub-sub-subsección"
 
 #: ../../src/cells/EditorCell.cpp:4528 ../../src/cells/GroupCell.cpp:2190
 msgid "A sub-subsection heading"
-msgstr ""
+msgstr "Una cabecera de subsubsección"
 
 #: ../../src/cells/EditorCell.cpp:4525 ../../src/cells/GroupCell.cpp:2187
 msgid "A subsection heading"
-msgstr ""
+msgstr "Una cabecera de subsección"
 
 #: ../../src/wxMaximaFrame.cpp:1673
 msgid "A subst with basic maths knowledge"
@@ -770,7 +770,7 @@ msgstr "Una subcadena con conocimiento matemático básico"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:239
 msgid "A symbol from the configuration dialogue"
-msgstr ""
+msgstr "Un símbolo desde el diálogo de configuración"
 
 #: ../../src/cells/GroupCell.cpp:2181
 msgid "A text cell"
@@ -807,7 +807,7 @@ msgstr "Mates ASCII"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1618
 msgid "Abort evaluation on error"
-msgstr ""
+msgstr "Interrupción de cálculo debido a error"
 
 #: ../../src/MaximaEvaluator.cpp:214
 #, c-format
@@ -840,7 +840,7 @@ msgstr ""
 
 #: ../../src/sidebars/DrawSidebar.cpp:103
 msgid "Accuracy"
-msgstr ""
+msgstr "Precisión"
 
 #: ../../src/wxMaximaFrame.cpp:1405
 msgid "Ad&joint Matrix"
@@ -860,7 +860,7 @@ msgstr "Agrega un elemento nuevo al inicio del listado. útil para crear pilas."
 
 #: ../../src/sidebars/VariablesPane.cpp:228
 msgid "Add all"
-msgstr ""
+msgstr "Agregar todo"
 
 #: ../../src/MaximaCommandMenus.cpp:1621
 msgid "Add an element to the end of a list"
@@ -880,11 +880,11 @@ msgstr "Agregar igualdad al simplificador racional"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:204
 msgid "Add more symbols"
-msgstr ""
+msgstr "Agregar más símbolos"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1262
 msgid "Add the .wxmx file to the HTML export"
-msgstr ""
+msgstr "Agregar fichero .wxmx a la exportación HTML"
 
 #: ../../src/wxMaximaFrame.cpp:1049
 msgid "Add to &Path..."
@@ -892,7 +892,7 @@ msgstr "Agregar por &ruta…"
 
 #: ../../src/sidebars/UnicodeSidebar.cpp:105
 msgid "Add to symbols Sidebar"
-msgstr ""
+msgstr "Agregar a símbolos de barra Lateral"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:304
 #: ../../src/worksheet/WorksheetContextMenu.cpp:337
@@ -903,23 +903,23 @@ msgstr "Agregar al listado de vigía"
 #: ../../src/sidebars/XmlInspector.cpp:147
 #, c-format
 msgid "Added much text (%li chars) to the XML inspector."
-msgstr ""
+msgstr "Mucho texto agregado (%li caracteres) al inspector XML."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1896
 msgid "Additional clipboard formats to put on the clipboard on ordinary copy"
-msgstr ""
+msgstr "Formatos de portapapeles adicionales para poner en el portapapeles en copias ordinarias"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:393
 msgid "Additional commands to be added to the preamble of LaTeX output for pdftex."
-msgstr ""
+msgstr "Instrucciones adicionales para añadir al preámbulo LaTeX para pdfTex."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1187
 msgid "Additional lines for the TeX preamble:"
-msgstr ""
+msgstr "Líneas adicionales para el preámbulo de TeX:"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:389
 msgid "Additional parameters for Maxima (e.g. -l clisp)."
-msgstr ""
+msgstr "Parámetros adicionales para ‘Maxima’ (p. e. -l clisp)."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1543
 msgid "Additional parameters for Maxima (restart Maxima after changes)"
@@ -927,7 +927,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1318
 msgid "Additional symbols for the \"symbols\" sidebar:"
-msgstr ""
+msgstr "Símbolos adicionales para la barra de «símbolos» lateral:"
 
 #: ../../src/wxMaximaFrame.cpp:1599
 msgid "Additionally: log(a*b)=log(a)+log(b)"
@@ -987,7 +987,7 @@ msgstr "Todos los tipos operables (*.wxm, *.wxmx, *.mac, *.out, *.xml)|*.wxm;*.w
 
 #: ../../src/dialogs/ConfigDialogue.cpp:750
 msgid "All variable names"
-msgstr ""
+msgstr "Todos los nombres de variables"
 
 #: ../../src/wxMaximaFrame.cpp:770
 msgid "All visible sidebars"
@@ -1015,7 +1015,7 @@ msgstr ""
 
 #: ../../src/dialogs/BinaryNameCtrl.cpp:69
 msgid "All|*"
-msgstr ""
+msgstr "Todos|*"
 
 #: ../../src/wxMaximaFrame.cpp:800
 msgid "Always after underscores"
@@ -1035,7 +1035,7 @@ msgstr "Siempre muestra todos los dígitos"
 
 #: ../../src/wizards/DrawWiz.cpp:484
 msgid "An animation with multiple frames"
-msgstr ""
+msgstr "Una animación con múltiples marcos"
 
 #: ../../src/cells/GroupCell.cpp:2202
 msgid "An image cell"
@@ -1193,7 +1193,7 @@ msgstr "Código ASCII a carácter…"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1397
 msgid "Ask to save untitled documents"
-msgstr ""
+msgstr "Preguntar para guardar documentos no titulados"
 
 #: ../../src/dialogs/MaximaNotStartingDialog.cpp:36
 msgid "Asking the user for the location of a working maxima binary"
@@ -1217,7 +1217,7 @@ msgstr "Atención: extrayendo un elemento de listado aleatorio no es eficiente p
 
 #: ../../src/dialogs/ConfigDialogue.cpp:897
 msgid "Auto-indent new lines"
-msgstr ""
+msgstr "Auto-indentar nuevas líneas"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:893
 msgid "Auto-insert closing parenthesis"
@@ -1227,11 +1227,11 @@ msgstr ""
 #: ../../src/dialogs/ConfigDialogue.cpp:1472
 #: ../../src/dialogs/MaximaNotStartingDialog.cpp:43
 msgid "Autodetect"
-msgstr ""
+msgstr "Autodetectar"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1236
 msgid "Automatic"
-msgstr ""
+msgstr "Automático"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:391
 msgid "Automatic labels"
@@ -1240,7 +1240,7 @@ msgstr "Etiquetas automáticas"
 #: ../../src/dialogs/ConfigDialogue.cpp:769
 #, c-format
 msgid "Automatic labels (%i1, %o1,...)"
-msgstr ""
+msgstr "Autoetiquetados (%i1, %o1,…)"
 
 #: ../../src/wxMaximaFrame.cpp:986
 msgid "Automatically answer questions"
@@ -1287,15 +1287,15 @@ msgstr "Auto-suscribir esta variable"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:734
 msgid "Autowrap long lines:"
-msgstr ""
+msgstr "Autocortar líneas largas:"
 
 #: ../../src/sidebars/DrawSidebar.cpp:75
 msgid "Axis"
-msgstr ""
+msgstr "Eje"
 
 #: ../../src/wizards/BC2Wiz.cpp:59
 msgid "BC2"
-msgstr ""
+msgstr "FC2"
 
 #: ../../src/MaximaManual.cpp:559
 msgid "Background task that compiles the Manual anchors scheduled."
@@ -1303,7 +1303,7 @@ msgstr "Tarea en segundo plano que compila los anclajes del Manual planificado."
 
 #: ../../src/sidebars/StatSidebar.cpp:91
 msgid "Barsplot..."
-msgstr ""
+msgstr "Traza de barras…"
 
 #: ../../src/wxMaximaFrame.cpp:1384
 msgid "Basic matrix operations"
@@ -1342,27 +1342,27 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:141
 msgid "Besides the global undo functionality that is active when the cursor is between cells, wxMaxima has a per-cell undo function that is active if the cursor is inside a cell. Pressing Ctrl+Z inside a cell can therefore been used for a fine-pitch undo that doesn't affect latter changes made in other cells."
-msgstr ""
+msgstr "Junto con la funcionalidad habitual de deshacer que está activa cuando el cursor está entre celdas, wxMaxima tiene una función de deshacer que es activa si el cursor está dentro de una celda. Pulsando Ctrl+Z dentro de una celda permite hacer cambios que solo afectan a ella misma."
 
 #: ../../src/sidebars/GreekSidebar.cpp:179
 msgid "Beta"
-msgstr ""
+msgstr "Beta"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1898
 msgid "Bitmap"
-msgstr ""
+msgstr "Dispersión de bit"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1273
 msgid "Bitmap scale for export:"
-msgstr ""
+msgstr "Escala dispersión de bit para exportar:"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1223
 msgid "Bitmaps"
-msgstr ""
+msgstr "Dispersión de varios bit"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2109
 msgid "Bold"
-msgstr ""
+msgstr "Bastardilla"
 
 #: ../../src/wxMaxima.cpp:2259
 msgid "Both horizontal and vertical cursor active at the same time"
@@ -1386,13 +1386,13 @@ msgstr ""
 
 #: ../../src/sidebars/StatSidebar.cpp:97
 msgid "Boxplot..."
-msgstr ""
+msgstr "Traza de cajas…"
 
 #: ../../src/dialogs/BinaryNameCtrl.cpp:42 ../../src/wizards/CsvWiz.cpp:57
 #: ../../src/wizards/CsvWiz.cpp:131 ../../src/wizards/Plot2dWiz.cpp:114
 #: ../../src/wizards/Plot3dWiz.cpp:109
 msgid "Browse"
-msgstr ""
+msgstr "Examinar"
 
 #: ../../src/wxMathml.cpp:101
 msgid "Bug: After removing the whitespace wxMathml.lisp is shorter than expected!"
@@ -1441,7 +1441,7 @@ msgstr "Gazapo: salida HTML no es XML válido"
 
 #: ../../src/cells/Cell.cpp:289
 msgid "Bug: Math Cell that claims to have no group Cell it belongs to"
-msgstr ""
+msgstr "Defecto: celda sin grupo al que pertenecer"
 
 #: ../../src/Configuration.h:741
 msgid "Bug: Maximum number of digits that is to be displayed is too low!"
@@ -1453,7 +1453,7 @@ msgstr "Gazapo: faltan contenidos"
 
 #: ../../src/cells/GroupCell.cpp:1498
 msgid "Bug: No image counter to write to!"
-msgstr ""
+msgstr "Defecto: ¡sin contador de imagen para a quien escribir!"
 
 #: ../../src/cells/AnimationCell.cpp:543 ../../src/cells/EditorCell.cpp:2968
 #: ../../src/cells/ImgCell.cpp:353 ../../src/graphical_io/BitmapOut.cpp:161
@@ -1472,7 +1472,7 @@ msgstr "Gazapo: el portapapeles ya está abierto"
 
 #: ../../src/cells/EditorCell.cpp:3051
 msgid "Bug: The clipboard isn't open on pasting into an editor cell"
-msgstr ""
+msgstr "Defecto: el portapapeles no está abierto al pegar dentro de una celda del editor"
 
 #: ../../src/cells/GroupCell.cpp:2288
 msgid "Bug: The predecessor to a GroupCell is not a GroupCell."
@@ -1484,7 +1484,7 @@ msgstr ""
 
 #: ../../src/cells/GroupCell.cpp:340
 msgid "Bug: Trying to append NULL to a group cell."
-msgstr ""
+msgstr "Defecto: intentando agregar NULL a un grupo de celdas."
 
 #: ../../src/worksheet/Worksheet.cpp:5939
 msgid "Bug: Trying to move a title out by one sectioning unit"
@@ -1508,7 +1508,7 @@ msgstr "Gazapo: acción de deshacer con ambos contenidos de celda cambian y suma
 
 #: ../../src/cells/EditorCell.cpp:4541
 msgid "Bug: Unknown type of text"
-msgstr ""
+msgstr "Defecto: tipado de texto desconocido"
 
 #: ../../src/cells/EditorCell.cpp:3981 ../../src/cells/TextCell.cpp:479
 msgid "Bug: dc == NULL"
@@ -1516,11 +1516,11 @@ msgstr ""
 
 #: ../../src/cells/EditorCell.cpp:2637
 msgid "Bug: x position of cell is unknown!"
-msgstr ""
+msgstr "Defecto: ¡posición x de celda es desconocida!"
 
 #: ../../src/cells/EditorCell.cpp:2638
 msgid "Bug: y position of cell is unknown!"
-msgstr ""
+msgstr "Defecto: ¡posición y de celda es desconocida!"
 
 #: ../../src/wxMaximaFrame.cpp:1985
 msgid "Build &Info"
@@ -1533,7 +1533,7 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:54
 msgid "By default, Shift-Enter is used to evaluate commands, while Enter is used for multiline input. This behaviour can be changed in 'Edit->Configure' dialog by checking 'Enter evaluates cells'. This switches the roles of these two key commands."
-msgstr ""
+msgstr "Por defecto, Mayús+Entrar se utiliza para evaluar instrucciones, mientras Entrar se utiliza para introducir multilíneas. Este comportamiento se puede cambiar en el diálogo 'Editar→Configuración' marcando 'Introduzca evaluación de celdas'. Esto intercambiarán los roles de estas dos teclas de instrucciones."
 
 #: ../../src/MaximaCommandMenus.cpp:4087
 msgid "Byte:"
@@ -1771,11 +1771,11 @@ msgstr "No se puede iniciar el binario máximo"
 
 #: ../../src/sidebars/MathSidebar.cpp:62
 msgid "Canonical (tr)"
-msgstr ""
+msgstr "Canónico (tr)"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:188
 msgid "Catalan"
-msgstr ""
+msgstr "Catalán"
 
 #: ../../src/MaximaCommandMenus.cpp:466
 msgid "Cauchy principal value of f(x)/(x-c), finite interval"
@@ -1832,7 +1832,7 @@ msgstr "Cambiar directorio…"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:859
 msgid "Change names of greek letters to greek letters"
-msgstr ""
+msgstr "Cambia los nombres de letras griegas a letras griegas"
 
 #: ../../src/wxMaximaFrame.cpp:1073
 msgid "Change the 2d display algorithm used to display math output"
@@ -1840,7 +1840,7 @@ msgstr "Modificar el algoritmo de pantalla 2d empleado para enseñar la salida m
 
 #: ../../src/dialogs/ConfigDialogue.cpp:489
 msgid "Change the text \"alpha\" and \"beta\" to the corresponding greek letter?"
-msgstr ""
+msgstr "¿Cambiar el texto \"alfa\" y \"beta\" a la letra griega correspondiente?"
 
 #: ../../src/MaximaCommandMenus.cpp:136
 msgid "Change variable"
@@ -1921,15 +1921,15 @@ msgstr "Comprueba si la versión más moderna de wxMaxima está disponible."
 
 #: ../../src/sidebars/GreekSidebar.cpp:199
 msgid "Chi"
-msgstr ""
+msgstr "Ji"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:189
 msgid "Chinese (Simplified)"
-msgstr ""
+msgstr "chino (simplificado)"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:190
 msgid "Chinese (traditional)"
-msgstr ""
+msgstr "chino (tradicional)"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1554
 msgid "Choose a Lisp Maxima was compiled with"
@@ -1945,7 +1945,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2100
 msgid "Choose font"
-msgstr ""
+msgstr "Elija tipografía"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:793
 msgid "Choose how mathematical output is formatted:\n"
@@ -1956,12 +1956,12 @@ msgstr ""
 
 #: ../../src/wizards/PlotFormatWiz.cpp:31
 msgid "Choose new plot format:"
-msgstr ""
+msgstr "Elegir un formato de tramado nuevo:"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2432
 #, c-format
 msgid "Choose the %s Font"
-msgstr ""
+msgstr "Elija la tipografía %s"
 
 #: ../../src/wxMaximaFrame.cpp:837
 msgid "Choose the parenthesis type for Matrices"
@@ -1997,7 +1997,7 @@ msgstr "Purga todos los grados-fs"
 
 #: ../../src/sidebars/History.cpp:116
 msgid "Clear all history"
-msgstr ""
+msgstr "Purga todo el histórico"
 
 #: ../../src/wxMaximaFrame.cpp:1034
 msgid "Clear all labels"
@@ -2029,7 +2029,7 @@ msgstr "Vacía todas las variables"
 
 #: ../../src/sidebars/History.cpp:115
 msgid "Clear the selection"
-msgstr ""
+msgstr "Purga la selección"
 
 #: ../../src/cells/FontVariantCache.cpp:44
 #, c-format
@@ -2038,7 +2038,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1926
 msgid "Clipboard format parameters"
-msgstr ""
+msgstr "Parámetros del formato portapapeles"
 
 #: ../../src/wxMaximaFrame.cpp:637
 msgid "Close\tCtrl+W"
@@ -2130,7 +2130,7 @@ msgstr ""
 
 #: ../../src/wizards/MatWiz.cpp:155
 msgid "Columns:"
-msgstr ""
+msgstr "Columnas:"
 
 #: ../../src/wxMaximaFrame.cpp:1621
 msgid "Combine factorials in an expression"
@@ -2146,11 +2146,11 @@ msgstr "Coma seguida de paréntesis que cierra"
 
 #: ../../src/wizards/Plot2dWiz.cpp:626
 msgid "Comma separated x coordinates"
-msgstr ""
+msgstr "Coordenadas x separadas por comas"
 
 #: ../../src/wizards/Plot2dWiz.cpp:627
 msgid "Comma separated y coordinates"
-msgstr ""
+msgstr "Coordenadas y separadas por comas"
 
 #: ../../src/MaximaCommandMenus.cpp:4071
 msgid "Comma-separated arguments"
@@ -2236,11 +2236,11 @@ msgstr "Instrucción:"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1145
 msgid "Commands that are executed at every start of maxima."
-msgstr ""
+msgstr "Instrucciones que son ejecutadas en cada inicio de ‘maxima‘."
 
 #: ../../src/cells/EditorCell.cpp:4538
 msgid "Comment (ordinary worksheet text that isn't fed to maxima)"
-msgstr ""
+msgstr "Comentario (texto de cuaderno ordinario que está enlazado a ‘maxima’)"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:465
 msgid "Comment Selection"
@@ -2376,16 +2376,16 @@ msgstr "Condición:"
 #: ../../src/dialogs/ConfigDialogue.cpp:2641
 #: ../../src/dialogs/ConfigDialogue.cpp:2647
 msgid "Config file (*.ini)|*.ini"
-msgstr ""
+msgstr "Fichero de configuración (*.ini)|*.ini"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2539
 #, c-format
 msgid "Config item \"%s\" was of an unknown type"
-msgstr ""
+msgstr "Elemento config \"%s\" fue de un tipo desconocido"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2607
 msgid "Configuration warning"
-msgstr ""
+msgstr "Configuración de aviso"
 
 #: ../../src/ToolBar.cpp:367 ../../src/ToolBar.cpp:369
 #: ../../src/wxMaximaFrame.cpp:722 ../../src/wxMaximaFrame.cpp:724
@@ -2394,7 +2394,7 @@ msgstr "Configurar wxMaxima"
 
 #: ../../src/wizards/DrawWiz.cpp:829
 msgid "Connect the dots"
-msgstr ""
+msgstr "Conectar los puntos"
 
 #: ../../src/MaximaProcessManager.cpp:163
 msgid "Connection attempt, but connection failed."
@@ -2408,7 +2408,7 @@ msgstr "Conexión a ‘Maxima’ perdida."
 #: ../../src/wizards/IntegrateWiz.cpp:208 ../../src/wizards/LimitWiz.cpp:133
 #: ../../src/wizards/SeriesWiz.cpp:105
 msgid "Constant"
-msgstr ""
+msgstr "Constante"
 
 #: ../../src/MaximaCommandMenus.cpp:1102
 msgid "Construct a fraction"
@@ -2420,7 +2420,7 @@ msgstr "Construir fracción…"
 
 #: ../../src/sidebars/VariablesPane.cpp:58
 msgid "Contents"
-msgstr ""
+msgstr "Índice"
 
 #: ../../src/MaximaCommandMenus.cpp:3970
 msgid "Contents:"
@@ -2436,27 +2436,27 @@ msgstr "&Ayuda distinguiendo contexto\tF1"
 
 #: ../../src/sidebars/DrawSidebar.cpp:80
 msgid "Contour"
-msgstr ""
+msgstr "Contorno"
 
 #: ../../src/sidebars/DrawSidebar.cpp:101
 msgid "Contour lines for 3d plots"
-msgstr ""
+msgstr "Líneas de contorno para trazados de 3d"
 
 #: ../../src/wizards/DrawWiz.cpp:648
 msgid "Contour lines on surface and Bottom"
-msgstr ""
+msgstr "Líneas de contorno sobre la cubierta y Fondo"
 
 #: ../../src/wizards/DrawWiz.cpp:644
 msgid "Contour lines on the Bottom"
-msgstr ""
+msgstr "Líneas de contorno sobre el Fondo"
 
 #: ../../src/wizards/DrawWiz.cpp:641
 msgid "Contour lines on the Surface"
-msgstr ""
+msgstr "Líneas de contorno sobre la Cubierta"
 
 #: ../../src/wizards/DrawWiz.cpp:629
 msgid "Contour lines settings for the following 3d plots"
-msgstr ""
+msgstr "Opciones de líneas del contorno para los siguientes tramados 3d"
 
 #: ../../src/wxMaximaFrame.cpp:1579
 msgid "Contract Logarithms"
@@ -2750,22 +2750,22 @@ msgstr "Botón de Copiar, Cortar y Pegar"
 #: ../../src/dialogs/ConfigDialogue.cpp:2523
 #, c-format
 msgid "Copying config bool \"%s\""
-msgstr ""
+msgstr "Copiando bool config \"%s\""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2533
 #, c-format
 msgid "Copying config float \"%s\""
-msgstr ""
+msgstr "Copiando flotante config \"%s\""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2528
 #, c-format
 msgid "Copying config int \"%s\""
-msgstr ""
+msgstr "Copiando config int \"%s\""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2518
 #, c-format
 msgid "Copying config string \"%s\""
-msgstr ""
+msgstr "Copiando cadena config \"%s\""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:191
 msgid "Corsican"
@@ -2858,7 +2858,7 @@ msgstr "Crea un listado desde elementos separados por comas"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1389
 msgid "Create scalable plots."
-msgstr ""
+msgstr "Crea trazas escalables."
 
 #: ../../src/wxMaximaFrame.cpp:1116
 msgid "Create struct..."
@@ -2882,7 +2882,7 @@ msgstr ""
 
 #: ../../src/worksheet/Worksheet.cpp:6115
 msgid "Cursor"
-msgstr ""
+msgstr "Cursor"
 
 #: ../../src/Styles.cpp:126
 msgid "Cursor color"
@@ -2904,11 +2904,11 @@ msgstr "Cortar selección"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:193
 msgid "Czech"
-msgstr ""
+msgstr "checo"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:194
 msgid "Danish"
-msgstr ""
+msgstr "danés"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2069
 msgid "Dark"
@@ -2924,7 +2924,7 @@ msgstr "Fichero de datos (*.csv, *.tab, *.txt)|*.csv;*.tab;*.txt"
 
 #: ../../src/wizards/DrawWiz.cpp:810
 msgid "Data format"
-msgstr ""
+msgstr "Formato de datos"
 
 #: ../../src/MaximaCommandMenus.cpp:1767 ../../src/MaximaCommandMenus.cpp:1772
 #: ../../src/MaximaCommandMenus.cpp:1777 ../../src/MaximaCommandMenus.cpp:1781
@@ -2978,15 +2978,15 @@ msgstr "Decrementa función f(x)<x"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1336
 msgid "Default animation framerate:"
-msgstr ""
+msgstr "Tasa predet. del marco de animación:"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:717
 msgid "Default plot size for new maxima sessions:"
-msgstr ""
+msgstr "Tamaño de traza predet. para sesiones ‘maxima’ nuevas:"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1534
 msgid "Default port for communication with wxMaxima:"
-msgstr ""
+msgstr "Puerto de comunicación predeterminado con wxMaxima:"
 
 #: ../../src/MaximaCommandMenus.cpp:3946
 msgid "Define a function"
@@ -3026,7 +3026,7 @@ msgstr "Definir estructura…"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:404
 msgid "Define the default speed (in frames per second) animations are played back with."
-msgstr ""
+msgstr "Define la frecuencia de imágenes (marcos por segundos) para la reproducción de animaciones."
 
 #: ../../src/wxMaximaFrame.cpp:1114
 msgid "Define variable..."
@@ -3099,7 +3099,7 @@ msgstr "Delimitador:"
 
 #: ../../src/sidebars/GreekSidebar.cpp:181
 msgid "Delta"
-msgstr ""
+msgstr "Delta"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:110
 #: ../../src/worksheet/WorksheetContextMenu.cpp:558
@@ -3125,7 +3125,7 @@ msgstr "Dependencias"
 
 #: ../../src/wizards/SeriesWiz.cpp:42
 msgid "Depth:"
-msgstr ""
+msgstr "Profundidad:"
 
 #: ../../src/MaximaCommandMenus.cpp:994
 msgid "Derivate of y at that point:"
@@ -3160,7 +3160,7 @@ msgstr ""
 
 #: ../../src/sidebars/StatSidebar.cpp:61
 msgid "Deviation..."
-msgstr ""
+msgstr "Desviación…"
 
 #: ../../src/wxMaximaFrame.cpp:1534
 msgid "Di&vide Polynomials..."
@@ -3172,7 +3172,7 @@ msgstr ""
 
 #: ../../src/sidebars/DrawSidebar.cpp:71
 msgid "Diagram title"
-msgstr ""
+msgstr "Título Diagramático"
 
 #: ../../src/sidebars/HelpBrowser.cpp:51
 msgid "Didn't find an installed offline manual."
@@ -3192,7 +3192,7 @@ msgstr ""
 
 #: ../../src/sidebars/MathSidebar.cpp:80
 msgid "Diff..."
-msgstr ""
+msgstr "Difer…"
 
 #: ../../src/dialogs/DiffFrame.cpp:308
 #, c-format
@@ -3221,7 +3221,7 @@ msgstr "Diferencia la expresión n veces"
 
 #: ../../src/wizards/LimitWiz.cpp:41
 msgid "Direction:"
-msgstr ""
+msgstr "Dirección:"
 
 #: ../../src/wxMaximaFrame.cpp:1246
 msgid "Directory operations"
@@ -3233,11 +3233,11 @@ msgstr ""
 
 #: ../../src/wizards/Plot2dWiz.cpp:418 ../../src/wizards/Plot2dWiz.cpp:619
 msgid "Discrete plot"
-msgstr ""
+msgstr "Tramado discreto"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:699
 msgid "Display"
-msgstr ""
+msgstr "Pantalla"
 
 #: ../../src/wxMaximaFrame.cpp:1075
 msgid "Display Te&X Form"
@@ -3360,11 +3360,11 @@ msgstr "El documento ha sido guardado empleando una versión más moderna de wxM
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1170
 msgid "Documentclass for TeX export:"
-msgstr ""
+msgstr "Clase documental para exportar en TeX:"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1178
 msgid "Documentclass options:"
-msgstr ""
+msgstr "Opciones Documentclass:"
 
 #: ../../src/wxMaximaFrame.cpp:807
 msgid "Don't autosubscript after an underscore"
@@ -3410,19 +3410,19 @@ msgstr "No emplee paréntesis para matrices"
 
 #: ../../src/dialogs/DiffFrame.cpp:428 ../../src/dialogs/FindReplacePane.cpp:83
 msgid "Down"
-msgstr ""
+msgstr "Descender"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:185
 msgid "Drag-and-drop unicode symbols here"
-msgstr ""
+msgstr "Arrastre y suelte símbolos Unicode aquí"
 
 #: ../../src/wizards/DrawWiz.cpp:155
 msgid "Draw all points where an equation is true."
-msgstr ""
+msgstr "Dibuja todos los puntos donde una ecuación sea verdadera."
 
 #: ../../src/wizards/DrawWiz.cpp:802
 msgid "Draw points"
-msgstr ""
+msgstr "Puntos de dibujo"
 
 #: ../../src/MaximaCommandMenus.cpp:1536
 msgid "Drop the first n list elements"
@@ -3542,7 +3542,7 @@ msgstr "Encontrado una evento de zócalo desconocida."
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:129
 msgid "End of proof"
-msgstr ""
+msgstr "Final de prueba"
 
 #: ../../src/MaximaCommandMenus.cpp:1024
 msgid "End of t:"
@@ -3550,19 +3550,19 @@ msgstr "Final de t:"
 
 #: ../../src/wizards/DrawWiz.cpp:71 ../../src/wizards/DrawWiz.cpp:176
 msgid "End of the x value"
-msgstr ""
+msgstr "Final del valor x"
 
 #: ../../src/wizards/DrawWiz.cpp:88 ../../src/wizards/DrawWiz.cpp:191
 msgid "End of the y value"
-msgstr ""
+msgstr "Final del valor y"
 
 #: ../../src/wizards/DrawWiz.cpp:208
 msgid "End of the z value"
-msgstr ""
+msgstr "Final del valor z"
 
 #: ../../src/wizards/DrawWiz.cpp:760
 msgid "End value of the parameter"
-msgstr ""
+msgstr "Valor final del parámetro"
 
 #: ../../src/MaximaResponseReader.cpp:432
 #: ../../src/MaximaResponseReader.cpp:586
@@ -3575,19 +3575,19 @@ msgstr "Formato de ingeniería  (12.1e6 etc.)"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:196
 msgid "English"
-msgstr ""
+msgstr "inglés"
 
 #: ../../src/wizards/DrawWiz.cpp:552
 msgid "Enhanced 3D settings:"
-msgstr ""
+msgstr "Mejora de opciones 3D:"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1919
 msgid "Enhanced meta file (emf)"
-msgstr ""
+msgstr "Fichero meta mejorado (emf)"
 
 #: ../../src/sidebars/StatSidebar.cpp:106
 msgid "Enter Matrix..."
-msgstr ""
+msgstr "Introducir matriz…"
 
 #: ../../src/MaximaCommandMenus.cpp:2255
 msgid "Enter UUID to jump to:"
@@ -3599,7 +3599,7 @@ msgstr "Introduzca una matriz"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:925
 msgid "Enter adds newlines, Ctrl+Enter evaluates cells"
-msgstr ""
+msgstr "Retorno agrega líneas nuevas, Ctrl+Retorno evalúa celdas"
 
 #: ../../src/MaximaCommandMenus.cpp:873
 msgid "Enter an equation for rational simplification:"
@@ -3607,11 +3607,11 @@ msgstr "Introduce una ecuación para simplificación racional:"
 
 #: ../../src/wizards/SystemWiz.cpp:50
 msgid "Enter comma separated list of variables."
-msgstr ""
+msgstr "Introduce una lista de variables separadas por comas."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:921
 msgid "Enter evaluates cells, Ctrl+Enter adds newlines"
-msgstr ""
+msgstr "Retorno evalúa celdas, Ctrl+Retorno agrega líneas nuevas"
 
 #: ../../src/MaximaCommandMenus.cpp:1357
 msgid "Enter matrix"
@@ -3627,7 +3627,7 @@ msgstr "Introduzca una nueva precisión para reales grandes:"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:388
 msgid "Enter the path to the Maxima executable."
-msgstr ""
+msgstr "Introducir la ruta al ejecutable Maxima."
 
 #: ../../src/MaximaCommandMenus.cpp:1103
 msgid "Enumerator:"
@@ -3639,11 +3639,11 @@ msgstr "Variables del entorno"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1605
 msgid "Environment variables for maxima"
-msgstr ""
+msgstr "Variables del entorno para ‘maxima’"
 
 #: ../../src/sidebars/GreekSidebar.cpp:182
 msgid "Epsilon"
-msgstr ""
+msgstr "Épsilon"
 
 #: ../../src/MaximaCommandMenus.cpp:299
 msgid "Epsilon:"
@@ -3682,7 +3682,7 @@ msgstr "Ecuación:"
 
 #: ../../src/dialogs/TipOfTheDay.cpp:196
 msgid "Equations have several advantages over functions. For example they can be manipulated with factor(), expand() and similar functions. They can easily be introduced one into another. Also they are always printed out as 2D maths."
-msgstr ""
+msgstr "Ecuaciones tienen varias desventajas sobre funciones. Por ejemplo pueden ser manipulados con factor(), expan() y funciones similares. Pueden introducirse fácilmente una en otro. También son simple impresas como matemáticas de 2D."
 
 #: ../../src/MaximaFileIO.cpp:64 ../../src/MaximaFileIO.cpp:121
 #: ../../src/MaximaFileIO.cpp:130 ../../src/MaximaFileIO.cpp:399
@@ -3738,11 +3738,11 @@ msgstr "Escape a todos los caracteres especiales en una cadena. El resultado es 
 
 #: ../../src/sidebars/GreekSidebar.cpp:184
 msgid "Eta"
-msgstr ""
+msgstr "Eta"
 
 #: ../../src/sidebars/TableOfContents.cpp:513
 msgid "Evaluate"
-msgstr ""
+msgstr "Evaluar"
 
 #: ../../src/wxMaximaFrame.cpp:1689
 msgid "Evaluate &Noun Forms..."
@@ -3876,11 +3876,11 @@ msgstr "Número par"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2659
 msgid "Example text"
-msgstr ""
+msgstr "Texto de ejemplo"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1547
 msgid "Examples:"
-msgstr ""
+msgstr "Ejemplos:"
 
 #: ../../src/wxMaximaFrame.cpp:1740
 msgid "Execute a command for each element of the list"
@@ -3892,11 +3892,11 @@ msgstr "Salir"
 
 #: ../../src/sidebars/MathSidebar.cpp:53
 msgid "Expand"
-msgstr ""
+msgstr "Expandir"
 
 #: ../../src/sidebars/MathSidebar.cpp:68
 msgid "Expand (tr)"
-msgstr ""
+msgstr "Expandir (tr)"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:356
 msgid "Expand Expression"
@@ -3941,7 +3941,7 @@ msgstr "Exportar"
 
 #: ../../src/sidebars/History.cpp:152
 msgid "Export As"
-msgstr ""
+msgstr "Exportar Como"
 
 #: ../../src/wxMaximaFrame.cpp:1742
 msgid "Export List to csv file..."
@@ -3957,15 +3957,15 @@ msgstr "Exporta una matriz a un fichero csv"
 
 #: ../../src/sidebars/History.cpp:102
 msgid "Export all history to a .mac file"
-msgstr ""
+msgstr "Exporta todo el historial a un fichero .mac"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1016
 msgid "Export all settings"
-msgstr ""
+msgstr "Exporta todas las opciones"
 
 #: ../../src/sidebars/History.cpp:105
 msgid "Export commands from the current maxima session to a .mac file"
-msgstr ""
+msgstr "Exporta instrucciones desde la sesión actual de ‘maxima’ al fichero .mac"
 
 #: ../../src/wxMaximaFrame.cpp:652
 msgid "Export document to a HTML or LaTeX file"
@@ -3973,7 +3973,7 @@ msgstr "Exportar documento a un fichero HTML o LaTeX"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1218
 msgid "Export equations to HTML as:"
-msgstr ""
+msgstr "Exportar ecuaciones a HTML como:"
 
 #: ../../src/wxMaximaFrame.cpp:600
 msgid "Export failed."
@@ -3989,7 +3989,7 @@ msgstr ""
 
 #: ../../src/sidebars/History.cpp:108
 msgid "Export selected commands to a .mac file"
-msgstr ""
+msgstr "Exporta instrucciones seleccionadas a un fichero .mac"
 
 #: ../../src/wxMaximaFrame.cpp:588
 msgid "Export successful."
@@ -4001,11 +4001,11 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1022
 msgid "Export the style settings"
-msgstr ""
+msgstr "Exporta las opciones del estilo"
 
 #: ../../src/sidebars/History.cpp:111
 msgid "Export visible commands to a .mac file"
-msgstr ""
+msgstr "Exporta instrucciones visibles a un fichero .mac"
 
 #: ../../src/MaximaCommandMenus.cpp:3417
 #, c-format
@@ -4019,7 +4019,7 @@ msgstr ""
 
 #: ../../src/sidebars/History.cpp:228
 msgid "Exporting to .mac file failed!"
-msgstr ""
+msgstr "¡Ha fallado la exportación al fichero .mac!"
 
 #: ../../src/MaximaCommandMenus.cpp:2343
 msgid "Exporting to HTML failed!"
@@ -4055,19 +4055,19 @@ msgstr "Expresión o una enumeración de expresiones separadas por coma"
 
 #: ../../src/wizards/DrawWiz.cpp:733
 msgid "Expression that calculates the x value"
-msgstr ""
+msgstr "Expresión que calcula el valor x"
 
 #: ../../src/wizards/DrawWiz.cpp:738
 msgid "Expression that calculates the y value"
-msgstr ""
+msgstr "Expresión que calcula el valor y"
 
 #: ../../src/wizards/DrawWiz.cpp:744
 msgid "Expression that calculates the z value"
-msgstr ""
+msgstr "Expresión que calcula el valor z"
 
 #: ../../src/wizards/DrawWiz.cpp:56
 msgid "Expression to plot"
-msgstr ""
+msgstr "Expresión a tramar"
 
 #: ../../src/wxMaximaFrame.cpp:1122
 msgid "Expression to string..."
@@ -4222,7 +4222,7 @@ msgstr "Extrae un rectángulo desde un repertorio de 2D y lo convierte a una mat
 
 #: ../../src/sidebars/MathSidebar.cpp:50
 msgid "Factor"
-msgstr ""
+msgstr "Factorizar"
 
 #: ../../src/wxMaximaFrame.cpp:1558
 msgid "Factor Complex"
@@ -4297,7 +4297,7 @@ msgstr "Campos:"
 #: ../../src/cells/GroupCell.cpp:2115
 #, c-format
 msgid "Figure %d:"
-msgstr ""
+msgstr "Figura %d:"
 
 #: ../../src/main.cpp:678
 msgid "File"
@@ -4349,7 +4349,7 @@ msgstr "Nombre de archivo o un listado de nombres de archivos separados por coma
 
 #: ../../src/sidebars/DrawSidebar.cpp:93
 msgid "Fill color"
-msgstr ""
+msgstr "Color de relleno"
 
 #: ../../src/ToolBar.cpp:401 ../../src/ToolBar.cpp:403
 msgid "Find"
@@ -4470,7 +4470,7 @@ msgstr "Encuentra el sumatorio máximo de los valores absolutos de una fila de m
 
 #: ../../src/dialogs/FindReplacePane.cpp:46
 msgid "Find:"
-msgstr ""
+msgstr "Encontrar:"
 
 #: ../../src/wxMaximaFrame.cpp:1869
 msgid "Fine-tune the display of engineering-format numbers"
@@ -4478,7 +4478,7 @@ msgstr "Ajuste fino del despliegue de números en formato de ingeniería"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:197
 msgid "Finnish"
-msgstr ""
+msgstr "finlandés"
 
 #: ../../src/wxMaximaFrame.cpp:1749
 msgid "First"
@@ -4491,11 +4491,11 @@ msgstr "Ajustando curvas a medición de datos"
 #: ../../src/dialogs/ConfigDialogue.cpp:1404
 #, c-format
 msgid "Fix reordered reference indices (of %i, %o) before saving"
-msgstr ""
+msgstr "Fijar índices referenciados reordenados (de %i, %o) antes de guardar"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:873
 msgid "Fixed font in text controls"
-msgstr ""
+msgstr "Tipograma de ancho fijo en controles de texto"
 
 #: ../../src/MaximaCommandMenus.cpp:4039
 msgid "Flush stream"
@@ -4523,11 +4523,11 @@ msgstr ""
 
 #: ../../src/wizards/DrawWiz.cpp:341
 msgid "Following plots use secondary x axis"
-msgstr ""
+msgstr "Siguiendo tramas utiliza eje secundario x"
 
 #: ../../src/wizards/DrawWiz.cpp:347
 msgid "Following plots use secondary y axis"
-msgstr ""
+msgstr "Siguiendo tramas utiliza eje secundario y"
 
 #: ../../src/sidebars/PerformanceSidebar.cpp:37
 msgid "Font cache hits:"
@@ -4539,11 +4539,11 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2047
 msgid "Fonts"
-msgstr ""
+msgstr "Tipogramas"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:442
 msgid "For each Text-, Sectioning or code cell wxMaxima can display a bracket showing the extend of the cell and allowing to fold it. This setting now tells if this bracket is to be printed, as well."
-msgstr ""
+msgstr "Por cada Text-, Seccionando o código de celdas wxMaxima puede enseñar un corchete mostrando la extensión de la celta y permitiendo encarpetarlo. Esta configuración ahora exprresa si este corchete está para ser impreso, también."
 
 #: ../../src/ToolBar.cpp:495
 msgid "For faster creation of cells the following shortcuts exist:\n\n"
@@ -4575,7 +4575,7 @@ msgstr "Para bucle…"
 
 #: ../../src/wizards/Plot2dWiz.cpp:69 ../../src/wizards/Plot3dWiz.cpp:60
 msgid "Format:"
-msgstr ""
+msgstr "Formato:"
 
 #: ../../src/worksheet/Worksheet.cpp:301 ../../src/wxMaxima.cpp:3521
 msgid "Forwarding the keyboard focus to a text control"
@@ -4620,15 +4620,15 @@ msgstr "Marco %li de %li"
 
 #: ../../src/wizards/DrawWiz.cpp:488
 msgid "Frame counter"
-msgstr ""
+msgstr "Contador de marco"
 
 #: ../../src/wizards/DrawWiz.cpp:499
 msgid "Frame counter end"
-msgstr ""
+msgstr "Final del contador de marco"
 
 #: ../../src/wizards/DrawWiz.cpp:494
 msgid "Frame counter start"
-msgstr ""
+msgstr "Inicio del contador de marco"
 
 #: ../../src/MaximaCommandMenus.cpp:102
 msgid "Frame rate"
@@ -4640,7 +4640,7 @@ msgstr "Libera todos los ítemes no utilizado ahora"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:198
 msgid "French"
-msgstr ""
+msgstr "francés"
 
 #: ../../src/wxMaximaFrame.cpp:1447
 msgid "Frobenius Norm sqrt(sum((A(i,j))^2)) (complex)"
@@ -4723,11 +4723,11 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:199
 msgid "Galician"
-msgstr ""
+msgstr "gallego"
 
 #: ../../src/sidebars/GreekSidebar.cpp:180
 msgid "Gamma"
-msgstr ""
+msgstr "Gamma"
 
 #: ../../src/wxMaximaFrame.cpp:316
 msgid "General Math"
@@ -4779,7 +4779,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:201
 msgid "German"
-msgstr ""
+msgstr "alemán"
 
 #: ../../src/wxMaximaFrame.cpp:1656
 msgid "Get &Imaginary Part"
@@ -4867,7 +4867,7 @@ msgstr "¿Mayor, ignorando caso?…"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:202
 msgid "Greek"
-msgstr ""
+msgstr "griego"
 
 #: ../../src/wxMaximaFrame.cpp:281
 msgid "Greek Letters"
@@ -4879,11 +4879,11 @@ msgstr "Letras griegas\tAlt+Mayús+G"
 
 #: ../../src/sidebars/DrawSidebar.cpp:97
 msgid "Grid"
-msgstr ""
+msgstr "Cuadrícula"
 
 #: ../../src/wizards/Plot3dWiz.cpp:52
 msgid "Grid:"
-msgstr ""
+msgstr "Cuadrícula:"
 
 #: ../../src/wxMaximaFrame.cpp:1852
 msgid "Guess an exact number that could be meant by this float"
@@ -4891,7 +4891,7 @@ msgstr "Adivina un número exacto que pudo ser dicho por este flotante"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1215
 msgid "HTML"
-msgstr ""
+msgstr "HTML"
 
 #: ../../src/MaximaCommandMenus.cpp:2279
 msgid "HTML file (*.html)|*.html|maxima batch file (*.mac)|*.mac|LaTeX file (*.tex)|*.tex"
@@ -4939,7 +4939,7 @@ msgstr "Ayuda"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1461
 msgid "Help browser:"
-msgstr ""
+msgstr "Explorador de ayuda:"
 
 #: ../../src/ToolBar.cpp:835
 msgid "Help button"
@@ -4958,7 +4958,7 @@ msgstr ""
 
 #: ../../src/sidebars/TableOfContents.cpp:510
 msgid "Hide"
-msgstr ""
+msgstr "Ocultar"
 
 #: ../../src/ToolBar.cpp:471 ../../src/ToolBar.cpp:473
 msgid "Hide Code"
@@ -4998,7 +4998,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:487
 msgid "Hide all multiplication signs that aren't really necessary for understanding the equation"
-msgstr ""
+msgstr "Oculta todos los signos de multiplicación que no son realmente necesarios para entender la ecuación"
 
 #: ../../src/wxMaximaFrame.cpp:767
 msgid "Hide all panes"
@@ -5018,15 +5018,15 @@ msgstr "Ocultar puntos de multiplicación"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:854
 msgid "Hide multiplication signs, if possible"
-msgstr ""
+msgstr "Oculta signos de multiplicación, si es posible"
 
 #: ../../src/wizards/DrawWiz.cpp:555
 msgid "Hide objects behind the surface"
-msgstr ""
+msgstr "Oculta objetos bajo la superficie"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:502
 msgid "Hide the brackets that mark the extend of the worksheet cells at the worksheet's right side and that contain the \"hide\" button of the cell if the cells aren't active."
-msgstr ""
+msgstr "Oculta los corchetes que marcan la extensión de las celdas de la hoja en el lado derecho de ella y que contiene el botón “oculto” de la celda si ésta no está activada."
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:702
 #: ../../src/worksheet/WorksheetContextMenu.cpp:835
@@ -5060,7 +5060,7 @@ msgstr "Histograma"
 
 #: ../../src/sidebars/StatSidebar.cpp:85
 msgid "Histogram..."
-msgstr ""
+msgstr "Histograma…"
 
 #: ../../src/wxMaximaFrame.cpp:246
 msgid "History"
@@ -5072,7 +5072,7 @@ msgstr "Historia\tAlt+Mayús+I"
 
 #: ../../src/dialogs/TipOfTheDay.cpp:105
 msgid "Horizontal cursor works like a normal cursor, but it operates on cells: press up or down arrow to move it, holding down Shift while moving will select cells, pressing backspace or delete twice will delete a cell next to it."
-msgstr ""
+msgstr "El cursor horizontal funciona como un cursor normal, pero opera con celdas: pulsar cursores arriba y abajo para moverlo; manteniendo pulsada la tecla Mayúscula mientras se mueve se seleccionan celdas, pulsando Retroceso o Borrar dos veces borrará una celda contigua."
 
 #: ../../src/wxMaximaFrame.cpp:1563
 msgid "Horner's rule"
@@ -5080,7 +5080,7 @@ msgstr "Regla de Horner"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:918
 msgid "Hotkeys for sending commands to maxima"
-msgstr ""
+msgstr "Teclas especiales para enviar instrucciones a ‘maxima’"
 
 #: ../../src/MaximaCommandMenus.cpp:398
 msgid "How many digits to show:"
@@ -5092,7 +5092,7 @@ msgstr "Como desplegar ecuaciones nuevas"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:205
 msgid "Hungarian"
-msgstr ""
+msgstr "húngaro"
 
 #: ../../src/wxMaximaFrame.cpp:1147
 msgid "I/O"
@@ -5100,7 +5100,7 @@ msgstr "E/S"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:121
 msgid "Identical to"
-msgstr ""
+msgstr "Idéntico a"
 
 #: ../../src/MaximaCommandMenus.cpp:3874
 msgid "If a program doesn't need local variables, Maxima allows putting the commands between parentheses. The result of the last operation is the return value of the program."
@@ -5108,51 +5108,51 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:145
 msgid "If maxima versions compiled with different lisps are installed: The name of the lisp to use by default"
-msgstr ""
+msgstr "Si se instalan las versiones de ‘maxima’ compiladas con lisps diferentes: el nombre del lisp a utilizar por defecto"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:174
 msgid "If maxima was compiled by GCL: Garbage Collect at minimum allocation past this heapsize"
-msgstr ""
+msgstr "Si ‘maxima’ fue compilado por GCL: Recolección de Basura en alojamiento mínimo pasa este tamaño de cabecera"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:171
 msgid "If maxima was compiled by GCL: Minimum allocation fraction between Garbage Collects"
-msgstr ""
+msgstr "Si ‘maxima’ fue compilado por GCL: fracción de alojamiento mínimo entre Recolecciones de Basura"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:168
 msgid "If maxima was compiled by GCL: Only garbage collect past this heapsize fraction of working mem"
-msgstr ""
+msgstr "Si ‘maxima’ fue compilado por GCL: solamente la recolección de basura en esta fracción del tamaño de la cabecera de mem de trabajo"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:180
 msgid "If maxima was compiled by GCL: Share the allocated memory between gcl processes. Allows more than one gcl-compiled maxima to run at the same time, but might provoke crashes."
-msgstr ""
+msgstr "Si ‘maxima’ fue compilado por GCL: comparta la memoria alojada entre procesos gcl.  Permita más de un ‘maxima’ compilada con gcl para ejecutar a la vez, pero tal vez provoque cuelgues."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:177
 msgid "If maxima was compiled by GCL: The fraction of the total installed RAM to reserve for maxima"
-msgstr ""
+msgstr "Si ‘maxima’ fue compilado por GCL: la fracción total de la RAM instalada a reservar para ‘maxima’"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:375
 msgid "If multiple cells are evaluated in one go: Abort evaluation if wxMaxima detects that maxima has encountered any error."
-msgstr ""
+msgstr "Si múltiples celdas son evaluadas de una vez: interrumpe el cálculo si wxMaxima detecta que 'maxima' ha encontrado un error."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:727
 msgid "If not extremely long"
-msgstr ""
+msgstr "Si no es extremadamente largo"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:726
 msgid "If not very long"
-msgstr ""
+msgstr "Si no es muy largo"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:418
 msgid "If numbers are getting longer than this number of digits they will be displayed abbreviated by an ellipsis."
-msgstr ""
+msgstr "Si los números son más largos que esta cantidad de dígitos, se enseñarán de forma abreviada con tres puntos suspensivos."
 
 #: ../../src/dialogs/TipOfTheDay.cpp:181
 msgid "If the \"Autosave\" functionality is enabled in the configuration dialogue wxMaxima acts like mobile apps that backup the file every few minutes and save it on closing."
-msgstr ""
+msgstr "Si está activada la función \"Auto-guardar\" en el diálogo de configuración wxMaxima actúa como apps móviles que respalda el fichero cada pocos minutos y lo guardan al cerrar."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:396
 msgid "If the font provides big parenthesis symbols: Use them when big parenthesis are needed for maths display."
-msgstr ""
+msgstr "Si la tipografía proporciona símbolos de paréntesis grandes: Empléelos cuando paréntesis grandes son necesarios para enseñar matemáticas."
 
 #: ../../src/cells/TextCell.cpp:327
 msgid "If the thing maxima complains about actually looks like a polynomial you can try running it through ratdisrep() in order to fix that problem."
@@ -5168,15 +5168,15 @@ msgstr "Si es conocido el tipo de un parámetro de función cuando compile una f
 
 #: ../../src/dialogs/ConfigDialogue.cpp:399
 msgid "If this checkbox is checked wxMaxima automatically saves the file closing and every few minutes giving wxMaxima a more cellphone-app-like feel as the file is virtually always saved. If this checkbox is unchecked from time to time a backup is made in the temp folder instead."
-msgstr ""
+msgstr "Si esta casilla está marcada wxMaxima automáticamente guarda el fichero al cerrar y cada pocos minutos permitinendo que wxMaxima se sienta más como una aplicación del teléfono que el fichero es guardado siempre virtualmente.  Si esta casilla no esta marcada se hace de tiempo a tiempo dentro de la carpeta temporal (temp)."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:378
 msgid "If this checkbox is set a new code cell is opened as soon as maxima requests data. If it isn't set a new code cell is opened in this case as soon as the user starts typing in code."
-msgstr ""
+msgstr "Si esta casilla está marcada una celda de código se abre tan pronto como ‘maxima’ solicita los datos.  Si no está puesta una celda de código nueva es abierta en este caso tan pronto como el usuario comience a teclear en el código."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:372
 msgid "If this checkbox isn't checked the current command is sent to maxima only on pressing Ctrl+Enter"
-msgstr ""
+msgstr "Si esta casilla no está marcada la instrucción actual es enviada a ‘maxima’ solamente al pulsar Ctrl+Intro"
 
 #: ../../src/MathParser.cpp:945
 msgid "If this isn't a function returning a lambda() expression a multiplication sign (*) between closing and opening parenthesis is missing here."
@@ -5189,7 +5189,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:439
 msgid "If this option is set the .wxmx source of the current file is copied to a place a link to is put into the result of an export."
-msgstr ""
+msgstr "Si esta opción está activa, la contenido .wxmx del fichero actual se copia en un lugar hacia el que se podrá enlazar."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1873
 msgid "If unset, Maxima's output is announced to the screen reader as maths in a linear text form. Set this option if your screen reader can speak MathML properly."
@@ -5201,11 +5201,11 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:76
 msgid "If you type an operator (one of +*/^=,) as the first symbol in an input cell, % will be automatically inserted before the operator, as on a graphing calculator. You can disable this feature from the 'Edit->Configure' dialog."
-msgstr ""
+msgstr "Si se teclea un operador (+*/^=,) como primer símbolo en una celda de entrada, se insertará automáticamente % antes del operador como en una calculadora gráfica. Se puede desactivar esta acción en el diálogo 'Editar→Configurar'."
 
 #: ../../src/dialogs/TipOfTheDay.cpp:122
 msgid "If your calculation is taking too long to evaluate, you can try 'Maxima->Interrupt' or 'Maxima->Restart Maxima' menu commands."
-msgstr ""
+msgstr "Si un cálculo dura mucho tiempo, se puede parar seleccionando '‘Maxima’ → Interrumpir' o '‘Maxima’ → Reiniciar Maxima' en el menú de instrucciones."
 
 #: ../../src/MaximaManual.cpp:420
 msgid "Ignoring the cache version for the manual anchors."
@@ -5213,7 +5213,7 @@ msgstr "Descartando la versión del caché para los anclajes manuales."
 
 #: ../../src/sidebars/FormatSidebar.cpp:66
 msgid "Image"
-msgstr ""
+msgstr "Imagen"
 
 #: ../../src/Image.cpp:110
 msgid "Image data had zero length!"
@@ -5235,15 +5235,15 @@ msgstr "ImageCell sin imagen."
 
 #: ../../src/sidebars/DrawSidebar.cpp:60
 msgid "Implicit Plot"
-msgstr ""
+msgstr "Trazado Implícito"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1028
 msgid "Import settings"
-msgstr ""
+msgstr "Importar opciones"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1013
 msgid "Import+Export"
-msgstr ""
+msgstr "Importar+Exportar"
 
 #: ../../src/MathParser.cpp:395
 msgid "Importing compressed gnuplot sources for an animation"
@@ -5282,7 +5282,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:421
 msgid "In the LaTeX output: Put exponents after an eventual subscript instead of above it. Might increase readability for some fonts and short subscripts."
-msgstr ""
+msgstr "En la exportación LaTeX: ponga exponentes posteriores a una subexpresión en lugar de encima de ellas. Quizá facilitar la lectura con algunas tipografías y subscriptores breves."
 
 #: ../../src/MaximaCommandMenus.cpp:1869
 msgid "Include columns:"
@@ -5294,15 +5294,15 @@ msgstr "Incrementa función f(x)>x"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:884
 msgid "Incremental Search"
-msgstr ""
+msgstr "Búsqueda incremental"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:844
 msgid "Indent equations by the label width"
-msgstr ""
+msgstr "Indentar ecuaciones por la anchura de la etiqueta"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:512
 msgid "Indent maths so all lines are in par with the first line that starts after the label."
-msgstr ""
+msgstr "Indentar matemáticas tal como todas líneas están en pares con la primera línea que inicie la etiqueta."
 
 #: ../../src/sidebars/TableOfContents.cpp:583
 msgid "Indentation"
@@ -5343,7 +5343,7 @@ msgstr ""
 #: ../../src/wizards/IntegrateWiz.cpp:215 ../../src/wizards/LimitWiz.cpp:132
 #: ../../src/wizards/LimitWiz.cpp:140
 msgid "Infinity"
-msgstr ""
+msgstr "Infinito"
 
 #: ../../src/wxMaximaFrame.cpp:1986
 msgid "Info about Maxima build"
@@ -5401,7 +5401,7 @@ msgstr "Insertar"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:889
 msgid "Insert % before an operator at the beginning of a cell"
-msgstr ""
+msgstr "Insertar % antes de un operador al inicio de una celda"
 
 #: ../../src/wxMaximaFrame.cpp:939
 msgid "Insert &Section Cell\tCtrl+3"
@@ -5549,11 +5549,11 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:749
 msgid "Integers and single letters"
-msgstr ""
+msgstr "Enteros y letras únicas"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:113
 msgid "Integral sign"
-msgstr ""
+msgstr "Símbolo integral"
 
 #: ../../src/MaximaCommandMenus.cpp:149 ../../src/MaximaCommandMenus.cpp:170
 msgid "Integral/Sum:"
@@ -5587,15 +5587,15 @@ msgstr "Integrar…"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:834
 msgid "Intelligently hide cell brackets"
-msgstr ""
+msgstr "Ocultar corchetes de celda inteligentemente"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:881
 msgid "Interaction"
-msgstr ""
+msgstr "Interacción"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1349
 msgid "Interactive popup memory limit [MB/plot]:"
-msgstr ""
+msgstr "Límite de memoria aparecida interactiva [MB/trama]:"
 
 #: ../../src/wxMaximaFrame.cpp:1774
 msgid "Interleave"
@@ -5660,7 +5660,7 @@ msgstr "Introduce una o más asignaciones en una expresión"
 
 #: ../../src/sidebars/RegexCtrl.cpp:40
 msgid "Invalid RegEx!"
-msgstr ""
+msgstr "¡ExReg no válida!"
 
 #: ../../src/MathParser.cpp:1338
 #, c-format
@@ -5677,7 +5677,7 @@ msgstr "T&ransformada inversa de Laplace…"
 
 #: ../../src/sidebars/GreekSidebar.cpp:186
 msgid "Iota"
-msgstr ""
+msgstr "Iota"
 
 #: ../../src/MaximaCommandMenus.cpp:4150
 msgid "Is Char 1 greater than Char2, if case is ignored?"
@@ -5793,7 +5793,7 @@ msgstr "¿Es mayúscula?…"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:498
 msgid "Issue a notification if maxima finishes calculating while the wxMaxima window isn't in focus."
-msgstr ""
+msgstr "Emitir una notificación si ‘maxima’ finaliza calculando mientras que la ventana de wxMaxima no está en el foco."
 
 #: ../../src/worksheet/Worksheet.cpp:4237
 msgid "Issuing the active cell's undo function"
@@ -5805,7 +5805,7 @@ msgstr "Emitiendo la función deshacer del cuaderno"
 
 #: ../../src/dialogs/TipOfTheDay.cpp:185
 msgid "It is possible to add custom symbols to the \"symbols\" sidebar by copying them into the respective field in the configuration dialogue."
-msgstr ""
+msgstr "Es posible agregar símbolos personales a la barra lateral \"símbolos\" copiándolos dentro del campo respectivo dentro del diálogo de configuración."
 
 #: ../../src/dialogs/TipOfTheDay.cpp:152
 msgid "It is possible to define reusable Maxima libraries with wxMaxima that can be later loaded by using the load() function. All that has to be done is to export a file in the .mac or to save it in the .wxm format. Note, though, that a few special characters like the \"not equal\" symbol for \"#\" are handled by wxMaxima, not by Maxima and therefore cannot be recognized on load()."
@@ -5813,19 +5813,19 @@ msgstr ""
 
 #: ../../src/wizards/DrawWiz.cpp:476
 msgid "It needs to be filled with objects to draw afterwards."
-msgstr ""
+msgstr "Requiere ser rellenado con objetos para dibujar después."
 
 #: ../../src/wizards/ActualValuesStorageWiz.cpp:38
 msgid "It therefore makes sense to apply the known values for variables as late as possible."
-msgstr ""
+msgstr "Por lo tanto crea tiene sentido aplicar los valores conocidos para variables como después sea posible."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:207
 msgid "Italian"
-msgstr ""
+msgstr "italiano"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2111
 msgid "Italic"
-msgstr ""
+msgstr "Itálica"
 
 #: ../../src/MaximaCommandMenus.cpp:1617 ../../src/MaximaCommandMenus.cpp:1623
 msgid "Item"
@@ -5837,7 +5837,7 @@ msgstr "Nombre iterador:"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:208
 msgid "Japanese"
-msgstr ""
+msgstr "japonés"
 
 #: ../../src/MaximaCommandMenus.cpp:2255
 msgid "Jump to UUID"
@@ -5865,16 +5865,16 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:210
 msgid "Kabyle"
-msgstr ""
+msgstr "Kabil"
 
 #: ../../src/sidebars/GreekSidebar.cpp:187
 msgid "Kappa"
-msgstr ""
+msgstr "Kappa"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:864
 #, c-format
 msgid "Keep percent sign with special symbols: %e, %i, etc."
-msgstr ""
+msgstr "Mantener el símbolo porcentual en constantes especiales: %e, %i, etc."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:212
 msgid "Korean"
@@ -5902,19 +5902,19 @@ msgstr "L[inf] Normal (real)"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1166
 msgid "LaTeX"
-msgstr ""
+msgstr "LaTeX"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1199
 msgid "LaTeX: Place exponents after, instead above subscripts"
-msgstr ""
+msgstr "LaTeX: colocar exponentes después de las expresiones, en lugar de sobre ellas"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1204
 msgid "LaTeX: Use the \"partial derivative\" symbol to represent diff()"
-msgstr ""
+msgstr "LaTeX: utilizar el símbolo de «derivada parcial» para representar diff()"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:758
 msgid "Label width:"
-msgstr ""
+msgstr "Anchura de etiqueta:"
 
 #: ../../src/wxMaximaFrame.cpp:1059
 msgid "Labels"
@@ -5935,11 +5935,11 @@ msgstr "Lamda genera una función, pero no proporciona un nombre.\n"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:470
 msgid "Language used for wxMaxima GUI."
-msgstr ""
+msgstr "Idioma empleado en el IGU de wxMaxima."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1311
 msgid "Language:"
-msgstr ""
+msgstr "Idioma:"
 
 #: ../../src/MaximaCommandMenus.cpp:251
 msgid "Laplace"
@@ -5986,7 +5986,7 @@ msgstr "Error al lanzar el explorador de ayuda predeterminado del sistema."
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:126
 msgid "Leads to"
-msgstr ""
+msgstr "Tiende a"
 
 #: ../../src/wxMaximaFrame.cpp:1530
 msgid "Least Common Multiple..."
@@ -5998,7 +5998,7 @@ msgstr "Ajuste por Mínimos Cuadrados"
 
 #: ../../src/sidebars/StatSidebar.cpp:79
 msgid "Least Squares Fit..."
-msgstr ""
+msgstr "Ajuste por mínimos cuadrados…"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2007
 msgid "Left"
@@ -6040,7 +6040,7 @@ msgstr ""
 #: ../../src/dialogs/LicenseDialog.cpp:63
 #: ../../src/dialogs/LicenseDialog.cpp:77
 msgid "License"
-msgstr ""
+msgstr "Reconocimiento"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2068
 msgid "Light"
@@ -6056,15 +6056,15 @@ msgstr "Límite"
 
 #: ../../src/sidebars/MathSidebar.cpp:86
 msgid "Limit..."
-msgstr ""
+msgstr "Límite…"
 
 #: ../../src/sidebars/DrawSidebar.cpp:88
 msgid "Line color"
-msgstr ""
+msgstr "Color lineal"
 
 #: ../../src/sidebars/StatSidebar.cpp:76
 msgid "Linear Regression..."
-msgstr ""
+msgstr "Regresión lineal…"
 
 #: ../../src/MaximaCommandMenus.cpp:4068
 msgid "Lisp format string:"
@@ -6112,15 +6112,15 @@ msgstr "Índice de directorio…"
 
 #: ../../src/wizards/ListSortWiz.cpp:34
 msgid "List name:"
-msgstr ""
+msgstr "Nombre de lista:"
 
 #: ../../src/sidebars/VariablesPane.cpp:188
 msgid "List of arrays"
-msgstr ""
+msgstr "Listado de unimatrices"
 
 #: ../../src/sidebars/VariablesPane.cpp:191
 msgid "List of changed options"
-msgstr ""
+msgstr "Listado de opciones modificadas"
 
 #: ../../src/MaximaCommandMenus.cpp:4197
 msgid "List of char to String"
@@ -6144,31 +6144,31 @@ msgstr ""
 
 #: ../../src/sidebars/VariablesPane.cpp:200
 msgid "List of structs"
-msgstr ""
+msgstr "Listado de estructuras"
 
 #: ../../src/sidebars/VariablesPane.cpp:197
 msgid "List of user aliases"
-msgstr ""
+msgstr "Listado de aliases del usuario"
 
 #: ../../src/sidebars/VariablesPane.cpp:185
 msgid "List of user functions"
-msgstr ""
+msgstr "Listado de funciones del usuario"
 
 #: ../../src/sidebars/VariablesPane.cpp:194
 msgid "List of user rules"
-msgstr ""
+msgstr "Listado de reglas del usuario"
 
 #: ../../src/sidebars/VariablesPane.cpp:182
 msgid "List of user variables"
-msgstr ""
+msgstr "Listado de variables del usuario"
 
 #: ../../src/sidebars/VariablesPane.cpp:206
 msgid "List of user-defined derivatives"
-msgstr ""
+msgstr "Listado de derivaciones definidas por usuario"
 
 #: ../../src/sidebars/VariablesPane.cpp:216
 msgid "List of user-defined let rule packages"
-msgstr ""
+msgstr "Listado de paquetes de reglas definidas por usuario"
 
 #: ../../src/sidebars/VariablesPane.cpp:212
 msgid "List of user-defined macros"
@@ -6176,7 +6176,7 @@ msgstr ""
 
 #: ../../src/sidebars/VariablesPane.cpp:209
 msgid "List of user-defined properties"
-msgstr ""
+msgstr "Listado de propiedades definidas por usuario"
 
 #: ../../src/MaximaCommandMenus.cpp:1575
 msgid "List with values"
@@ -6197,7 +6197,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2162
 msgid "Load"
-msgstr ""
+msgstr "Cargar"
 
 #: ../../src/MaximaCommandMenus.cpp:2356
 msgid "Load Package"
@@ -6237,7 +6237,7 @@ msgstr "Cargar lisp…"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2645
 msgid "Load style from file"
-msgstr ""
+msgstr "Leer estilo desde un fichero"
 
 #: ../../src/wxMaximaFrame.cpp:1232
 msgid "Load the file/dir operations (operatingsystem)"
@@ -6253,7 +6253,7 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:128
 msgid "Long Right arrow"
-msgstr ""
+msgstr "Larga Derecha flecha"
 
 #: ../../src/MaximaCommandMenus.cpp:1409
 msgid "Loop variable"
@@ -6273,7 +6273,7 @@ msgstr "M&atriz"
 
 #: ../../src/sidebars/XmlInspector.cpp:104
 msgid "MAXIMA RESPONSE:"
-msgstr ""
+msgstr "RESPUESTA DE ‘MAXIMA’:"
 
 #: ../../src/MaximaCommandMenus.cpp:3965
 msgid "Macro contents:"
@@ -6337,7 +6337,7 @@ msgstr "Distribuir función a una matriz, afectando todo de sus clones"
 
 #: ../../src/dialogs/FindReplacePane.cpp:71
 msgid "Match Case"
-msgstr ""
+msgstr "Distinguir MAY/min"
 
 #: ../../src/Styles.cpp:139
 msgid "Math Default"
@@ -6361,11 +6361,11 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1906
 msgid "MathML as HTML"
-msgstr ""
+msgstr "MathML como HTML"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1902
 msgid "MathML description"
-msgstr ""
+msgstr "Descripción MathML"
 
 #: ../../src/wxMaximaFrame.cpp:307
 msgid "Mathematical Symbols"
@@ -6445,11 +6445,11 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:281
 msgid "Maxima"
-msgstr ""
+msgstr "‘Maxima’"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1433
 msgid "Maxima Location"
-msgstr ""
+msgstr "Ubicación de ‘Maxima’"
 
 #: ../../src/MaximaCommandMenus.cpp:619
 msgid "Maxima allows making functions \"nouns\", which means that they aren't automatically evaluated as soon as Maxima encounters them.\n"
@@ -6483,19 +6483,19 @@ msgstr "‘Maxima‘ simplifica automáticamente expresiones que obtenga como en
 
 #: ../../src/cells/EditorCell.cpp:4516
 msgid "Maxima code"
-msgstr ""
+msgstr "Código de ‘Maxima’"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1110
 msgid "Maxima commands to be executed at every start of Maxima"
-msgstr ""
+msgstr "Funciones de ‘Maxima’ para ser ejecutadas en cada inicio de ‘Maxima’"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1063
 msgid "Maxima commands to be executed every time wxMaxima starts Maxima"
-msgstr ""
+msgstr "Funciones de ‘Maxima’ para ser ejecutadas cada vez que se wxMaxima inicializa ‘Maxima’"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1507
 msgid "Maxima configuration"
-msgstr ""
+msgstr "Configuración de ‘Maxima’"
 
 #: ../../src/MaximaResponseReader.cpp:346
 msgid "Maxima didn't attempt to authenticate!"
@@ -6571,11 +6571,11 @@ msgstr "Proceso ‘Maxima’ terminado inesperadamente."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1437
 msgid "Maxima program:"
-msgstr ""
+msgstr "Programa ‘Maxima’:"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:382
 msgid "Maxima provides no \"forget all\" command that flushes all settings a maxima session could make. wxMaxima therefore normally defaults to starting a fresh maxima process every time the worksheet is to be re-evaluated. As this needs a little bit of time this switch allows to disable this behavior."
-msgstr ""
+msgstr "‘Maxima’ no proporciona ninguna instrucción de tipo «olvidar todo» que deshaga todas las opciones de la sesión de 'maxima' pueda hacer. wxMaxima entonces normalmente comienza un proceso nuevo, fresco, de 'maxima' cada vez que el cuaderno está para ser re-evaluado. Como esto requiere un poco de tiempo este característica puede ser desactivada."
 
 #: ../../src/Styles.cpp:108
 msgid "Maxima question labels"
@@ -6595,7 +6595,7 @@ msgstr "‘Maxima’ nos envía un conjunto de variables nuevo para el listado d
 
 #: ../../src/sidebars/History.cpp:153
 msgid "Maxima session (*.mac)|*.mac"
-msgstr ""
+msgstr "Sesión de ‘Maxima’ (*.mac)|*.mac"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1518 ../../src/wxMaximaFrame.cpp:1981
 msgid "Maxima shows help in a browser"
@@ -6627,11 +6627,11 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1143
 msgid "Maxima startup file location: "
-msgstr ""
+msgstr "Lugar del fichero de inicio ‘Maxima‘: "
 
 #: ../../src/dialogs/TipOfTheDay.cpp:68
 msgid "Maxima supports three types of numbers: exact fractions (which can be generated for example by typing 1/10), IEEE floating-point numbers (0.2) and arbitrary precision big floats (1b-1). Note that, owing to their nature as binary (not decimal) numbers, there is for example no way to generate an IEEE floating-point number that exactly equals 0.1. If floating-point numbers are used instead of fractions, Maxima will therefore sometimes have to introduce a (very small) error and use things like 3602879701896397/36028797018963968 for 0.1."
-msgstr ""
+msgstr "‘Maxima’ admite tres tipos de números: fracciones exactas (que pueden ser generados por ejemplo tecleando 1/10), coma real común IEEE (0'2) y reales grandes de precisión arbitraria (1b-1). Nótese que dada su representación binaria interna (no decimal), no es posible disponer de un número de común IEEE que sea exactamente igual a 0'1. Si se utilizan números en coma real (flotante) en lugar de fracciones, 'Maxima' puede introducir (pequeños) errores y utilizar, por ejemplo, la fracción 3602879701896397/36028797018963968 en lugar de 0'1."
 
 #: ../../src/wxMaximaFrame.cpp:1265
 msgid "Maxima to other language"
@@ -6647,7 +6647,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1615
 msgid "Maxima usage"
-msgstr ""
+msgstr "Empleo de ‘Maxima’"
 
 #: ../../src/MaximaResponseReader.cpp:776
 #, c-format
@@ -6743,7 +6743,7 @@ msgstr ""
 
 #: ../../src/wizards/ActualValuesStorageWiz.cpp:34
 msgid "Maxima's power lies in symbolic operations."
-msgstr ""
+msgstr "Potencia de ‘Maxima’ yace en operaciones simbólicas."
 
 #: ../../src/StatusBar.cpp:365
 msgid "Maxima's reader is in Lisp mode (after to_lisp()).\n"
@@ -6790,7 +6790,7 @@ msgstr "Valor absoluto máximo escrito sin exponente"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1931
 msgid "Maximum bitmap size on clipboard [Mb]:"
-msgstr ""
+msgstr "Tamaño de asignación de bit máxima sobre portapapeles [Ms]:"
 
 #: ../../src/MaximaCommandMenus.cpp:488 ../../src/MaximaCommandMenus.cpp:501
 #: ../../src/MaximaCommandMenus.cpp:516 ../../src/MaximaCommandMenus.cpp:530
@@ -6807,15 +6807,15 @@ msgstr ""
 
 #: ../../src/sidebars/StatSidebar.cpp:70
 msgid "Mean Difference Test..."
-msgstr ""
+msgstr "Test diferencial de medias…"
 
 #: ../../src/sidebars/StatSidebar.cpp:67
 msgid "Mean Test..."
-msgstr ""
+msgstr "Test media…"
 
 #: ../../src/sidebars/StatSidebar.cpp:52
 msgid "Mean..."
-msgstr ""
+msgstr "Media…"
 
 #: ../../src/MaximaCommandMenus.cpp:1806
 msgid "Mean:"
@@ -6823,7 +6823,7 @@ msgstr "Media:"
 
 #: ../../src/sidebars/StatSidebar.cpp:55
 msgid "Median..."
-msgstr ""
+msgstr "Mediana…"
 
 #: ../../src/wxMaximaFrame.cpp:1961
 msgid "Memoizing"
@@ -6844,7 +6844,7 @@ msgstr "Mensaje de la salida estándar de ‘Maxima’: "
 
 #: ../../src/wizards/IntegrateWiz.cpp:55
 msgid "Method:"
-msgstr ""
+msgstr "Método:"
 
 #: ../../src/wxMaximaFrame.cpp:1360
 msgid "Methods of generating a matrix"
@@ -6870,7 +6870,7 @@ msgstr "Valor absoluto mínimo escrito sin exponente:"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1270
 msgid "Misc"
-msgstr ""
+msgstr "Misc"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1963
 msgid "Misc settings"
@@ -6911,7 +6911,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:189
 msgid "Mu"
-msgstr ""
+msgstr "Mu"
 
 #: ../../src/wxMaximaFrame.cpp:1386
 msgid "Multiplication, exponent and similar"
@@ -6935,7 +6935,7 @@ msgstr "Nombre de t:"
 
 #: ../../src/wizards/DrawWiz.cpp:750
 msgid "Name of the parameter"
-msgstr ""
+msgstr "Nombre del parámetro"
 
 #: ../../src/MaximaCommandMenus.cpp:1019
 msgid "Name of x:"
@@ -6943,7 +6943,7 @@ msgstr "Nombre de x:"
 
 #: ../../src/wizards/MatWiz.cpp:163
 msgid "Name:"
-msgstr ""
+msgstr "Nombre:"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:216
 msgid "Nepali"
@@ -7006,7 +7006,7 @@ msgstr "Crear documento"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:901
 msgid "New lines: Jump to text"
-msgstr ""
+msgstr "Crear líneas: Ir al texto"
 
 #: ../../src/MaximaResponseReader.cpp:1015
 #, c-format
@@ -7019,7 +7019,7 @@ msgstr "Parte nueva:"
 
 #: ../../src/wizards/SubstituteWiz.cpp:35
 msgid "New value:"
-msgstr ""
+msgstr "Crear valor:"
 
 #: ../../src/MaximaCommandMenus.cpp:151 ../../src/MaximaCommandMenus.cpp:171
 #: ../../src/MaximaCommandMenus.cpp:254 ../../src/MaximaCommandMenus.cpp:259
@@ -7057,7 +7057,7 @@ msgstr ""
 
 #: ../../src/wizards/DrawWiz.cpp:636
 msgid "No contour lines"
-msgstr ""
+msgstr "Sin líneas de contorno"
 
 #: ../../src/dialogs/DiffFrame.cpp:304
 msgid "No differences"
@@ -7094,11 +7094,11 @@ msgstr "¡No se encontraron coincidencias!"
 
 #: ../../src/wizards/DrawWiz.cpp:651
 msgid "No plot, only contour lines"
-msgstr ""
+msgstr "Sin trama, solo líneas de contorno"
 
 #: ../../src/wizards/DrawWiz.cpp:837
 msgid "No points"
-msgstr ""
+msgstr "Sin puntos"
 
 #: ../../src/MaximaResponseReader.cpp:145
 msgid "No topics found in topic flag"
@@ -7114,7 +7114,7 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:179
 msgid "Non-builtin symbols"
-msgstr ""
+msgstr "Sin símbolos empotrados"
 
 #: ../../src/wxMaximaFrame.cpp:834
 msgid "None"
@@ -7122,7 +7122,7 @@ msgstr "Ninguno"
 
 #: ../../src/sidebars/StatSidebar.cpp:73
 msgid "Normality Test..."
-msgstr ""
+msgstr "Test de normalidad…"
 
 #: ../../src/cells/TextCell.cpp:271
 msgid "Normally computers use floating-point numbers that can be handled incredibly fast while being accurate to dozens of digits. They will, though, introduce a small error into some common numbers. For example 0.1 is represented as 3602879701896397/36028797018963968.\n"
@@ -7133,11 +7133,11 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:431
 msgid "Normally html expects images to be rather low-res but space saving. These images tend to look rather blurry when viewed on modern screens. Therefore this setting was introduces that selects the factor by which the HTML export increases the resolution in respect to the default value."
-msgstr ""
+msgstr "Normalmente html espera que las imágenes sean de baja resolución para ahorrar memoria. Estas imágenes tienden a verse borrosas en pantallas modernas. Esta opción se introduce para seleccionar el factor mediante el cual la exportación HTML aumenta la resolución respecto de su valor por defecto."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:217
 msgid "Norwegian"
-msgstr ""
+msgstr "noruego"
 
 #: ../../src/MaximaCommandMenus.cpp:1351
 msgid "Not a valid matrix dimension!"
@@ -7173,7 +7173,7 @@ msgstr "Ninguna evaluación de disparador como no esté funcionando ningún proc
 
 #: ../../src/sidebars/GreekSidebar.cpp:190
 msgid "Nu"
-msgstr ""
+msgstr "Nu"
 
 #: ../../src/MaximaCommandMenus.cpp:177
 msgid "Num. deg:"
@@ -7316,7 +7316,7 @@ msgstr "Número impar"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:910
 msgid "Offer answers for questions known from previous runs"
-msgstr ""
+msgstr "Ofrece respuestas para preguntas conocidas desde ejecuciones anteriores"
 
 #: ../../src/cells/TextCell.cpp:332
 msgid "Often caused by recursive function calls. Some lisps allow increasing the control stack size using command-line arguments."
@@ -7324,7 +7324,7 @@ msgstr ""
 
 #: ../../src/wizards/SubstituteWiz.cpp:32
 msgid "Old value:"
-msgstr ""
+msgstr "Valor antiguo:"
 
 #: ../../src/MaximaCommandMenus.cpp:151 ../../src/MaximaCommandMenus.cpp:172
 #: ../../src/MaximaCommandMenus.cpp:253 ../../src/MaximaCommandMenus.cpp:259
@@ -7333,11 +7333,11 @@ msgstr "Variable antigua:"
 
 #: ../../src/sidebars/GreekSidebar.cpp:201
 msgid "Omega"
-msgstr ""
+msgstr "Omega"
 
 #: ../../src/sidebars/GreekSidebar.cpp:192
 msgid "Omicron"
-msgstr ""
+msgstr "Ómicron"
 
 #: ../../src/wxMaximaFrame.cpp:1089
 msgid "On all errors"
@@ -7361,7 +7361,7 @@ msgstr "Solamente Enteros y letras únicas"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:771
 msgid "Only user-defined labels"
-msgstr ""
+msgstr "Únicamente etiquetas definidas por el usuario"
 
 #: ../../src/MaximaCommandMenus.cpp:2197 ../../src/ToolBar.cpp:330
 #: ../../src/ToolBar.cpp:333 ../../src/main.cpp:882
@@ -7370,7 +7370,7 @@ msgstr "Abrir"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:905
 msgid "Open a cell when Maxima expects input"
-msgstr ""
+msgstr "Abre una celda cuando 'maxima' espera una entrada"
 
 #: ../../src/wxMaximaFrame.cpp:629
 msgid "Open a document"
@@ -7444,7 +7444,7 @@ msgstr "Optimizar para memoria"
 
 #: ../../src/wizards/DrawWiz.cpp:97
 msgid "Optional: A 2nd expression that defines a region to fill"
-msgstr ""
+msgstr "Opcional: Una 2ª expresión que define una región a rellenar"
 
 #: ../../src/ToolBar.cpp:367 ../../src/ToolBar.cpp:369
 #: ../../src/dialogs/ConfigDialogue.cpp:284
@@ -7453,7 +7453,7 @@ msgstr "Opciones"
 
 #: ../../src/wizards/Plot2dWiz.cpp:75 ../../src/wizards/Plot3dWiz.cpp:66
 msgid "Options:"
-msgstr ""
+msgstr "Opciones:"
 
 #: ../../src/dialogs/FindReplacePane.cpp:109
 msgid "Output"
@@ -7514,7 +7514,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:458
 msgid "PNG images can be read by old wxMaxima versions - but aren't really scalable."
-msgstr ""
+msgstr "Las imágenes PNG pueden ser leídas por las versiones antiguas de wxMaxima - pero no son realmente escalables."
 
 #: ../../src/MaximaCommandMenus.cpp:175
 msgid "Pade approximation"
@@ -7526,7 +7526,7 @@ msgstr "Aproximación de Padé de una serie de Taylor"
 
 #: ../../src/sidebars/FormatSidebar.cpp:69
 msgid "Pagebreak"
-msgstr ""
+msgstr "Salto de página"
 
 #: ../../src/wxMaximaFrame.cpp:1674
 msgid "Parallel Substitute..."
@@ -7538,7 +7538,7 @@ msgstr "Sustitución paralela"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:124
 msgid "Parallel to"
-msgstr ""
+msgstr "Paralelo a"
 
 #: ../../src/MaximaCommandMenus.cpp:3991
 msgid "Parameter name:"
@@ -7550,11 +7550,11 @@ msgstr "Parámetro(s):"
 
 #: ../../src/sidebars/DrawSidebar.cpp:64
 msgid "Parametric Plot"
-msgstr ""
+msgstr "Tramado Paramétrico"
 
 #: ../../src/wizards/Plot2dWiz.cpp:417 ../../src/wizards/Plot2dWiz.cpp:523
 msgid "Parametric plot"
-msgstr ""
+msgstr "Tramado paramétrico"
 
 #: ../../src/MaximaCommandMenus.cpp:4211
 msgid "Parse string"
@@ -7608,7 +7608,7 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:125
 msgid "Perpendicular to"
-msgstr ""
+msgstr "Perpendicular a"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:218
 msgid "Persian"
@@ -7616,15 +7616,15 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:198
 msgid "Phi"
-msgstr ""
+msgstr "Fi"
 
 #: ../../src/sidebars/GreekSidebar.cpp:193
 msgid "Pi"
-msgstr ""
+msgstr "Pi"
 
 #: ../../src/sidebars/StatSidebar.cpp:94
 msgid "Piechart..."
-msgstr ""
+msgstr "Diagrama sectorial…"
 
 #: ../../src/wxMaxima.cpp:1585
 msgid "Please configure wxMaxima with 'Edit->Configure'."
@@ -7632,7 +7632,7 @@ msgstr "Configure wxMaxima con 'Editar→Configurar'."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2606
 msgid "Please restart wxMaxima for changes to take effect!"
-msgstr ""
+msgstr "¡Reinicie wxMaxima para que los cambios tengan efecto!"
 
 #: ../../src/MaximaCommandMenus.cpp:2250
 msgid "Please select exactly 2 or 3 files."
@@ -7673,16 +7673,16 @@ msgstr "Tramado 3D…"
 
 #: ../../src/wizards/DrawWiz.cpp:713
 msgid "Plot a parametric curve"
-msgstr ""
+msgstr "Tramar en una curva paramétrica"
 
 #: ../../src/wizards/DrawWiz.cpp:45 ../../src/wizards/DrawWiz.cpp:148
 #: ../../src/wizards/DrawWiz.cpp:255
 msgid "Plot an explicit expression"
-msgstr ""
+msgstr "Trama una expresión explícita"
 
 #: ../../src/wizards/DrawWiz.cpp:53
 msgid "Plot an expression, for example sin(x) or (x+1)^2."
-msgstr ""
+msgstr "Trama una expresión, por ejemplo sin(x) o (x+1)^2."
 
 #: ../../src/MaximaCommandMenus.cpp:1776
 msgid "Plot as bars"
@@ -7706,11 +7706,11 @@ msgstr "Tramado en 3 dimensiones"
 
 #: ../../src/sidebars/DrawSidebar.cpp:83
 msgid "Plot name"
-msgstr ""
+msgstr "Tramado nombrado"
 
 #: ../../src/wizards/Plot2dWiz.cpp:84 ../../src/wizards/Plot3dWiz.cpp:80
 msgid "Plot to file:"
-msgstr ""
+msgstr "Tramado al fichero:"
 
 #: ../../src/wxMaximaFrame.cpp:341 ../../src/wxMaximaFrame.cpp:749
 msgid "Plot using Draw"
@@ -7730,7 +7730,7 @@ msgstr "Puntear el valor es conocido en:"
 
 #: ../../src/wizards/DrawWiz.cpp:842
 msgid "Point type:"
-msgstr ""
+msgstr "Tipo de punto:"
 
 #: ../../src/MaximaCommandMenus.cpp:186 ../../src/MaximaCommandMenus.cpp:1090
 #: ../../src/wizards/BC2Wiz.cpp:33 ../../src/wizards/BC2Wiz.cpp:39
@@ -7740,11 +7740,11 @@ msgstr "Punto:"
 
 #: ../../src/sidebars/DrawSidebar.cpp:67
 msgid "Points"
-msgstr ""
+msgstr "Puntos"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:219
 msgid "Polish"
-msgstr ""
+msgstr "polaco"
 
 #: ../../src/MaximaCommandMenus.cpp:215 ../../src/MaximaCommandMenus.cpp:220
 #: ../../src/MaximaCommandMenus.cpp:225
@@ -7780,7 +7780,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:221
 msgid "Portuguese (Brazilian)"
-msgstr ""
+msgstr "portugués (brasileño)"
 
 #: ../../src/wxMaximaFrame.cpp:1223
 msgid "Position of a match"
@@ -7796,7 +7796,7 @@ msgstr ""
 
 #: ../../src/wizards/Plot2dWiz.cpp:474 ../../src/wizards/Plot3dWiz.cpp:422
 msgid "Postscript file (*.eps)|*.eps|All|*"
-msgstr ""
+msgstr "Fichero PostScript (*.eps)|*.eps|Todos|*"
 
 #: ../../src/MaximaCommandMenus.cpp:190
 msgid "Power series"
@@ -7844,7 +7844,7 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:146
 msgid "Pressing Ctrl+Space or Ctrl+Tab starts an autocomplete function that can not only complete all functions that are integrated into the Maxima core and their parameters: It also knows about parameters from currently loaded packages and from functions that are defined in the current file."
-msgstr ""
+msgstr "Pulsando Ctrl+Espacio o Ctrl+Tabulador se inicia una función de autocompletado que puede no solo completar todas las funciones que están integradas en el núcleo de 'maxima' y sus parámetros: También conoce acerca de parámetros desde los paquetes actualmente cargados y desde funciones que están definidas en el fichero actual."
 
 #: ../../src/wxMaximaFrame.cpp:961
 msgid "Previous Command\tAlt+Up"
@@ -7881,11 +7881,11 @@ msgstr "Escribe números de coma-flotante con exponente divisible entre 3"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1968
 msgid "Print scale:"
-msgstr ""
+msgstr "Declarar escala:"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1981
 msgid "Print the cell brackets [drawn to their left]"
-msgstr ""
+msgstr "Imprimir los corchetes de celda [dibujados a su izquierda]"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:287
 msgid "Printout settings"
@@ -7948,7 +7948,7 @@ msgstr "Producto"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:123
 msgid "Product sign"
-msgstr ""
+msgstr "Símbolo productorio"
 
 #: ../../src/wxMaximaFrame.cpp:1129
 msgid "Program"
@@ -7972,7 +7972,7 @@ msgstr "Bloque del programa, ninguna variable local…"
 
 #: ../../src/sidebars/GreekSidebar.cpp:200
 msgid "Psi"
-msgstr ""
+msgstr "Psi"
 
 #: ../../src/wxMaximaFrame.cpp:1788
 msgid "Push"
@@ -7996,7 +7996,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1910
 msgid "RTF with OMML maths"
-msgstr ""
+msgstr "RTF con matemáticas OMML"
 
 #: ../../src/MaximaCommandMenus.cpp:207
 msgid "Range radius:"
@@ -8058,7 +8058,7 @@ msgstr "Leer Directorio"
 
 #: ../../src/sidebars/StatSidebar.cpp:103
 msgid "Read Matrix..."
-msgstr ""
+msgstr "Leer matriz…"
 
 #: ../../src/MaximaCommandMenus.cpp:4008
 msgid "Read a structure field"
@@ -8074,7 +8074,7 @@ msgstr "Leer carácter"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2488
 msgid "Read config to file"
-msgstr ""
+msgstr "Leer configuración al fichero"
 
 #: ../../src/MaximaCommandMenus.cpp:4405
 msgid "Read environment variable"
@@ -8187,7 +8187,7 @@ msgstr "Recibió un promt de ‘maxima’: %s"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1327
 msgid "Recent files list length:"
-msgstr ""
+msgstr "Listado largo de ficheros recientes:"
 
 #: ../../src/wxMaximaFrame.cpp:634
 msgid "Recover unsaved"
@@ -8195,7 +8195,7 @@ msgstr "Cobertura no guardada"
 
 #: ../../src/sidebars/MathSidebar.cpp:56
 msgid "Rectform"
-msgstr ""
+msgstr "Forma Cartesiana"
 
 #: ../../src/wxMaximaFrame.cpp:1677
 msgid "Recursive Substitute..."
@@ -8219,7 +8219,7 @@ msgstr "Rehacer última modificación"
 
 #: ../../src/sidebars/MathSidebar.cpp:71
 msgid "Reduce (tr)"
-msgstr ""
+msgstr "Reducir (tr)"
 
 #: ../../src/wxMaximaFrame.cpp:1632
 msgid "Reduce trigonometric expression"
@@ -8269,11 +8269,11 @@ msgstr "Recargar imagen «%s»"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:997
 msgid "Reload all GUI settings from disc"
-msgstr ""
+msgstr "Recargar todas las opciones IGU desde el disco"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1004
 msgid "Reload the style settings from disc"
-msgstr ""
+msgstr "Recargar las opciones del estilo desde un disco"
 
 #: ../../src/MaximaCommandMenus.cpp:3212
 #, c-format
@@ -8282,15 +8282,15 @@ msgstr "Recargando archivo de imagen %s."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2573
 msgid "Reloading the configuration from disc"
-msgstr ""
+msgstr "Recargando la configuración desde el disco"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2581
 msgid "Reloading the styles from disc"
-msgstr ""
+msgstr "Recargando los estilos desde el disco"
 
 #: ../../src/sidebars/VariablesPane.cpp:220
 msgid "Remove"
-msgstr ""
+msgstr "Retirar"
 
 #: ../../src/wxMaximaFrame.cpp:917
 msgid "Remove All Output"
@@ -8306,7 +8306,7 @@ msgstr ""
 
 #: ../../src/sidebars/VariablesPane.cpp:225
 msgid "Remove all"
-msgstr ""
+msgstr "Retirar todo"
 
 #: ../../src/wxMaximaFrame.cpp:1785
 msgid "Remove all list elements that appear twice in a row. Normally used in conjunction with sort."
@@ -8386,7 +8386,7 @@ msgstr "Repetición de multiplicación elemento-por-elemento"
 
 #: ../../src/dialogs/FindReplacePane.cpp:117
 msgid "Replace All"
-msgstr ""
+msgstr "Remplazar todo"
 
 #: ../../src/MaximaCommandMenus.cpp:4350
 msgid "Replace all regex matches"
@@ -8415,7 +8415,7 @@ msgstr "%li ocurrencias reemplazadas."
 
 #: ../../src/dialogs/FindReplacePane.cpp:62
 msgid "Replacement:"
-msgstr ""
+msgstr "Remplazo:"
 
 #: ../../src/MaximaCommandMenus.cpp:768
 msgid "Replaces the subexpression that part(expr, n_1, n_2, ...) would select by a new value. The part numbers form a path: n_1 selects a part of the expression, n_2 a part of that, and so on."
@@ -8427,7 +8427,7 @@ msgstr "Enviar un defecto"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:983
 msgid "Reset all GUI settings"
-msgstr ""
+msgstr "Restablece todas las opciones IGU"
 
 #: ../../src/wxMaximaFrame.cpp:1030
 msgid "Reset option variables"
@@ -8435,12 +8435,12 @@ msgstr "Restablecer variables de opción"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:990
 msgid "Reset the Style settings"
-msgstr ""
+msgstr "Restablece las opciones de Estilo"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2557
 #: ../../src/dialogs/ConfigDialogue.cpp:2565
 msgid "Resetting all configuration settings"
-msgstr ""
+msgstr "Restablece todas las opciones de configuración"
 
 #: ../../src/ToolBar.cpp:411 ../../src/ToolBar.cpp:417
 #: ../../src/wxMaximaFrame.cpp:1008
@@ -8530,7 +8530,7 @@ msgstr ""
 
 #: ../../src/wizards/DrawWiz.cpp:836
 msgid "Reuse last"
-msgstr ""
+msgstr "Reutilizar último"
 
 #: ../../src/wxMaximaFrame.cpp:1780
 msgid "Reverse"
@@ -8546,15 +8546,15 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:295
 msgid "Revert all to defaults"
-msgstr ""
+msgstr "Revertir todo a predeterminado"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:980
 msgid "Revert changes"
-msgstr ""
+msgstr "Revertir modificaciones"
 
 #: ../../src/sidebars/GreekSidebar.cpp:194
 msgid "Rho"
-msgstr ""
+msgstr "Ro"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2015
 msgid "Right"
@@ -8567,7 +8567,7 @@ msgstr "Matriz der:"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:127
 msgid "Right arrow"
-msgstr ""
+msgstr "Flecha derecha"
 
 #: ../../src/MaximaCommandMenus.cpp:1380
 msgid "Right end"
@@ -8607,7 +8607,7 @@ msgstr ""
 
 #: ../../src/wizards/MatWiz.cpp:152
 msgid "Rows:"
-msgstr ""
+msgstr "Filas:"
 
 #: ../../src/MaximaCommandMenus.cpp:1391
 msgid "Rule"
@@ -8677,7 +8677,7 @@ msgstr "Ejecuten cada elemento a través de una expresión"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:223
 msgid "Russian"
-msgstr ""
+msgstr "ruso"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1578
 msgid "SBCL: use <int>Mbytes of heap"
@@ -8689,11 +8689,11 @@ msgstr ""
 
 #: ../../src/sidebars/XmlInspector.cpp:78
 msgid "SENT TO MAXIMA:"
-msgstr ""
+msgstr "ENVIADO A ‘MAXIMA’:"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1224
 msgid "SVG graphics"
-msgstr ""
+msgstr "Gráficos SVG"
 
 #: ../../src/MaximaCommandMenus.cpp:1810
 msgid "Sample 1:"
@@ -8709,19 +8709,19 @@ msgstr "Muestra:"
 
 #: ../../src/wizards/DrawWiz.cpp:956
 msgid "Samples for explicit and parametric plots:"
-msgstr ""
+msgstr "Muestras para tramados explícitos y paramétricos:"
 
 #: ../../src/wizards/DrawWiz.cpp:969
 msgid "Samples for implicit plots and regions:"
-msgstr ""
+msgstr "Muestras para tramados implícitos y regiones:"
 
 #: ../../src/wizards/DrawWiz.cpp:937
 msgid "Samples for implicit plots:"
-msgstr ""
+msgstr "Muestras de tramados implícitos:"
 
 #: ../../src/wizards/DrawWiz.cpp:924
 msgid "Samples on a line:"
-msgstr ""
+msgstr "Muestras en una línea:"
 
 #: ../../src/ToolBar.cpp:331 ../../src/ToolBar.cpp:334
 #: ../../src/dialogs/ConfigDialogue.cpp:2163 ../../src/wxMaxima.cpp:3507
@@ -8766,7 +8766,7 @@ msgstr "Guardar como lisp…"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2478
 msgid "Save config to file"
-msgstr ""
+msgstr "Guardar configuración al fichero"
 
 #: ../../src/ToolBar.cpp:331 ../../src/ToolBar.cpp:334
 #: ../../src/wxMaximaFrame.cpp:639
@@ -8779,7 +8779,7 @@ msgstr "Guardar documento como"
 
 #: ../../src/wizards/Plot2dWiz.cpp:473 ../../src/wizards/Plot3dWiz.cpp:421
 msgid "Save plot to file"
-msgstr ""
+msgstr "Guarda tramado a fichero"
 
 #: ../../src/wxMaximaFrame.cpp:713
 msgid "Save selection from document to an image file"
@@ -8791,11 +8791,11 @@ msgstr "Guardar selección en un fichero"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2640
 msgid "Save style to file"
-msgstr ""
+msgstr "Guardar estilo a un fichero"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1384
 msgid "Save the worksheet automatically"
-msgstr ""
+msgstr "Guarda el cuaderno automáticamente"
 
 #: ../../src/MaximaFileIO.cpp:873
 msgid "Saving failed!"
@@ -8811,7 +8811,7 @@ msgstr "Guardado correcto, pero los archivos resultantes han desaparecido ?!?."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1914
 msgid "Scalable Vector Graphics (svg)"
-msgstr ""
+msgstr "Gráficos Vectoriales Escalables (svg)"
 
 #: ../../src/MaximaCommandMenus.cpp:3536
 msgid "Scalable Vector image (*.svg)|*.svg|Compressed Scalable Vector Image (*.svgz)|*.svgz|PNG image (*.png)|*.png|JPEG image (*.jpg)|*.jpg|GIF image (*.gif)|*.gif|Windows bitmap (*.bmp)|*.bmp|"
@@ -8823,7 +8823,7 @@ msgstr "Trama de Dispersión"
 
 #: ../../src/sidebars/StatSidebar.cpp:88
 msgid "Scatterplot..."
-msgstr ""
+msgstr "Trama de dispersión…"
 
 #: ../../src/Autocomplete.cpp:157
 msgid "Scheduling a background task that compiles a new list of autocompletable maxima commands."
@@ -8871,7 +8871,7 @@ msgstr ""
 
 #: ../../src/wizards/DrawWiz.cpp:158
 msgid "See also the speed <-> accuracy button."
-msgstr ""
+msgstr "También vea el botón de velocidad <-> exactitud."
 
 #: ../../src/MaximaCommandMenus.cpp:4030
 msgid "Seek to position"
@@ -8887,7 +8887,7 @@ msgstr "Parece que el paquete con los ficheros compartidos de ‘maxima’ no es
 
 #: ../../src/sidebars/TableOfContents.cpp:511
 msgid "Select"
-msgstr ""
+msgstr "Selección"
 
 #: ../../src/MaximaCommandMenus.cpp:2239
 msgid "Select 2 or 3 files to compare"
@@ -8914,7 +8914,7 @@ msgstr "Seleccionar Submuestra"
 #: ../../src/wizards/IntegrateWiz.cpp:208 ../../src/wizards/LimitWiz.cpp:133
 #: ../../src/wizards/SeriesWiz.cpp:105
 msgid "Select a constant"
-msgstr ""
+msgstr "Selecciona una constante"
 
 #: ../../src/ToolBar.cpp:390 ../../src/ToolBar.cpp:392
 #: ../../src/wxMaximaFrame.cpp:710
@@ -8935,7 +8935,7 @@ msgstr "Seleccionar el algoritmo de vista matemática"
 
 #: ../../src/dialogs/TipOfTheDay.cpp:109
 msgid "Selecting a part of an output and right-clicking on the selection will bring up a menu with convenient functions that will operate on the selection."
-msgstr ""
+msgstr "Seleccionando una parte del resultado y pulsando el botón secundario emergerá un menú con funciones que se podrán aplicar sobre la selección."
 
 #: ../../src/Styles.cpp:127
 msgid "Selection color"
@@ -9023,7 +9023,7 @@ msgstr "Ajustar &precisión real grande…"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:479
 msgid "Set fixed font in text controls."
-msgstr ""
+msgstr "Ajusta un tipo de letra de tamaño constante para controles de texto."
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:68
 #: ../../src/worksheet/WorksheetContextMenu.cpp:250
@@ -9040,7 +9040,7 @@ msgstr "Fijar variable principal…"
 
 #: ../../src/dialogs/MaxSizeChooser.cpp:29
 msgid "Set maximum image size [in mm]"
-msgstr ""
+msgstr "Establece el tamaño máximo de la imagen [en mm]"
 
 #: ../../src/wxMaximaFrame.cpp:1810
 msgid "Set plot format"
@@ -9100,7 +9100,7 @@ msgstr "Establecer disminución al 80%"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:163
 msgid "Sets the language, line ending type and charset encoding programs will use"
-msgstr ""
+msgstr "Establece el idioma, tipo de línea de final y conjunto de caracteres de codificación de programas que serán utilizados"
 
 #: ../../src/MaximaEvaluator.cpp:574
 #, c-format
@@ -9113,24 +9113,24 @@ msgstr "Ajustar intérprete y formatos de ayuda"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:165
 msgid "Setting this to \"cat\" causes gnuplot not to halt if there is much output"
-msgstr ""
+msgstr "Estableciendo esto a \"cat\" causa que gnuplot no detenga si hay mucha salida"
 
 #: ../../src/wizards/DrawWiz.cpp:546
 msgid "Settings for the following 3d plots"
-msgstr ""
+msgstr "Opciones para los siguientes tramados 3d"
 
 #: ../../src/wizards/DrawWiz.cpp:462
 #, c-format
 msgid "Setup a %iD scene"
-msgstr ""
+msgstr "Configurar una escena %iD"
 
 #: ../../src/sidebars/DrawSidebar.cpp:48
 msgid "Setup a 2D plot"
-msgstr ""
+msgstr "Preparar un tramado 2D"
 
 #: ../../src/sidebars/DrawSidebar.cpp:52
 msgid "Setup a 3D plot"
-msgstr ""
+msgstr "Preparar un tramado 3D"
 
 #: ../../src/wxMaximaFrame.cpp:1326
 msgid "Setup atvalues for solving ODE with Laplace transformation"
@@ -9142,11 +9142,11 @@ msgstr "Preparar cálculo de módulo"
 
 #: ../../src/sidebars/DrawSidebar.cpp:78
 msgid "Setup the axis"
-msgstr ""
+msgstr "Configura el eje"
 
 #: ../../src/wizards/DrawWiz.cpp:263
 msgid "Setup the axis for the current plot."
-msgstr ""
+msgstr "Configura el eje para el tramado actual."
 
 #: ../../src/MaximaCommandMenus.cpp:411
 msgid "Setup the engineering format"
@@ -9194,7 +9194,7 @@ msgstr "Mostrar todas las instrucciones similares a:"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:206
 msgid "Show all unicode symbols"
-msgstr ""
+msgstr "Muestra todos los símbolos Unicode"
 
 #: ../../src/MaximaCommandMenus.cpp:2111
 msgid "Show an example for the command:"
@@ -9206,7 +9206,7 @@ msgstr "Muestra un ejemplo de utilización"
 
 #: ../../src/sidebars/History.cpp:121
 msgid "Show commands from current session only"
-msgstr ""
+msgstr "Muestra instrucciones únicamente desde la sesión actual"
 
 #: ../../src/wxMaximaFrame.cpp:1921
 msgid "Show commands similar to"
@@ -9242,7 +9242,7 @@ msgstr "Muestra etiquetas de entrada"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:766
 msgid "Show labels:"
-msgstr ""
+msgstr "Mostrar etiquetas:"
 
 #: ../../src/wxMaximaFrame.cpp:787
 msgid "Show lisp representation"
@@ -9250,11 +9250,11 @@ msgstr "Muestra representación lisp"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:465
 msgid "Show long expressions in wxMaxima document."
-msgstr ""
+msgstr "Mostrar expresiones largas en el documento de wxMaxima."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:722
 msgid "Show long expressions:"
-msgstr ""
+msgstr "Mostrar expresiones largas:"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:377
 msgid "Show max. 100 digits"
@@ -9318,7 +9318,7 @@ msgstr "¿Muestro el botón deshacer y rehacer?"
 
 #: ../../src/dialogs/TipOfTheDay.cpp:288
 msgid "Show tips at Startup"
-msgstr ""
+msgstr "Mostrar consejos al Inicio"
 
 #: ../../src/wxMaximaFrame.cpp:1040 ../../src/wxMaximaFrame.cpp:1045
 msgid "Show used + to-be-freed memory"
@@ -9343,7 +9343,7 @@ msgstr "Barras laterales"
 
 #: ../../src/sidebars/GreekSidebar.cpp:195
 msgid "Sigma"
-msgstr ""
+msgstr "Sigma"
 
 #: ../../src/dialogs/FindReplacePane.cpp:88
 msgid "Simple"
@@ -9355,7 +9355,7 @@ msgstr ""
 
 #: ../../src/sidebars/MathSidebar.cpp:44
 msgid "Simplify"
-msgstr ""
+msgstr "Simplificar"
 
 #: ../../src/wxMaximaFrame.cpp:1550
 msgid "Simplify &Radicals..."
@@ -9363,11 +9363,11 @@ msgstr "Simplificar &radicales…"
 
 #: ../../src/sidebars/MathSidebar.cpp:47
 msgid "Simplify (r)"
-msgstr ""
+msgstr "Simplificar (r)"
 
 #: ../../src/sidebars/MathSidebar.cpp:65
 msgid "Simplify (tr)"
-msgstr ""
+msgstr "Simplificar (tr)"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:352
 msgid "Simplify Expression"
@@ -9407,7 +9407,7 @@ msgstr "Simplificar sumatorios"
 
 #: ../../src/wizards/SumWiz.cpp:68
 msgid "Simplify the sum"
-msgstr ""
+msgstr "Simplificar la suma"
 
 #: ../../src/wxMaximaFrame.cpp:1629
 msgid "Simplify trigonometric expression"
@@ -9472,7 +9472,7 @@ msgstr "Solución del EDO:"
 
 #: ../../src/wizards/BC2Wiz.cpp:30
 msgid "Solution:"
-msgstr ""
+msgstr "Solución:"
 
 #: ../../src/MaximaCommandMenus.cpp:3446
 msgid "Solve"
@@ -9512,7 +9512,7 @@ msgstr "Resolver EDO con Lapla&ce…"
 
 #: ../../src/sidebars/MathSidebar.cpp:77
 msgid "Solve ODE..."
-msgstr ""
+msgstr "Resolver EDO…"
 
 #: ../../src/wxMaximaFrame.cpp:1432
 msgid "Solve a linear equation system using dgesv"
@@ -9620,7 +9620,7 @@ msgstr "Ordenar"
 
 #: ../../src/wizards/ListSortWiz.cpp:41
 msgid "Sort Criterion:"
-msgstr ""
+msgstr "Criterio de ordenación:"
 
 #: ../../src/MaximaCommandMenus.cpp:1500
 msgid "Sort a list"
@@ -9640,16 +9640,16 @@ msgstr "Listado origen:"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:227
 msgid "Spanish"
-msgstr ""
+msgstr "español"
 
 #: ../../src/wizards/IntegrateWiz.cpp:44 ../../src/wizards/IntegrateWiz.cpp:50
 #: ../../src/wizards/LimitWiz.cpp:38 ../../src/wizards/SeriesWiz.cpp:39
 msgid "Special"
-msgstr ""
+msgstr "Especial"
 
 #: ../../src/wizards/DrawWiz.cpp:918
 msgid "Speed versus accuracy"
-msgstr ""
+msgstr "Velocidad frente a precisión"
 
 #: ../../src/MaximaCommandMenus.cpp:4241
 msgid "Split"
@@ -9689,7 +9689,7 @@ msgstr "Iniciar Animación"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1622
 msgid "Start a new maxima for each re-evaluation"
-msgstr ""
+msgstr "Inicializar un 'maxima' nuevo para cada re-evaluación"
 
 #: ../../src/MaximaCommandMenus.cpp:1023
 msgid "Start of t:"
@@ -9697,15 +9697,15 @@ msgstr "Comienzo de t:"
 
 #: ../../src/wizards/DrawWiz.cpp:66 ../../src/wizards/DrawWiz.cpp:171
 msgid "Start of the x value"
-msgstr ""
+msgstr "Inicio del valor x"
 
 #: ../../src/wizards/DrawWiz.cpp:83 ../../src/wizards/DrawWiz.cpp:186
 msgid "Start of the y value"
-msgstr ""
+msgstr "Inicio del valor y"
 
 #: ../../src/wizards/DrawWiz.cpp:203
 msgid "Start of the z value"
-msgstr ""
+msgstr "Inicio del valor z"
 
 #: ../../src/ToolBar.cpp:507 ../../src/ToolBar.cpp:519
 msgid "Start or Stop animation"
@@ -9717,11 +9717,11 @@ msgstr "Iniciar y detener la animación seleccionada que ha sido creada con la c
 
 #: ../../src/dialogs/ConfigDialogue.cpp:496
 msgid "Start searching while the phrase to search for is still being typed."
-msgstr ""
+msgstr "Iniciar buscando mientras la frase a buscar está aún siendo tecleada."
 
 #: ../../src/wizards/DrawWiz.cpp:755
 msgid "Start value of the parameter"
-msgstr ""
+msgstr "Valor inicial del parámetro"
 
 #: ../../src/wxMaxima.cpp:403
 msgid "Starting Maxima process failed"
@@ -9746,7 +9746,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:286
 msgid "Startup commands"
-msgstr ""
+msgstr "Funciones de inicio"
 
 #: ../../src/wxMaximaFrame.cpp:266
 msgid "Statistics"
@@ -9856,15 +9856,15 @@ msgstr "Estructuras"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:282
 msgid "Style"
-msgstr ""
+msgstr "Estilo"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2082
 msgid "Styles"
-msgstr ""
+msgstr "Estilos"
 
 #: ../../src/sidebars/StatSidebar.cpp:112
 msgid "Subsample..."
-msgstr ""
+msgstr "Submuestra…"
 
 #: ../../src/ToolBar.cpp:484 ../../src/sidebars/FormatSidebar.cpp:54
 msgid "Subsection"
@@ -9884,7 +9884,7 @@ msgstr "Sustitución es una mejor cadena-búsqueda-y-sustituir para expresiones.
 
 #: ../../src/sidebars/MathSidebar.cpp:59
 msgid "Subst..."
-msgstr ""
+msgstr "Sust…"
 
 #: ../../src/MaximaCommandMenus.cpp:715 ../../src/MaximaCommandMenus.cpp:3490
 #: ../../src/MaximaCommandMenus.cpp:4500 ../../src/wizards/SubstituteWiz.cpp:53
@@ -9960,7 +9960,7 @@ msgstr "Sumatorio"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:122
 msgid "Sum sign"
-msgstr ""
+msgstr "Signo sumatorio"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:228
 msgid "Swedish"
@@ -9989,7 +9989,7 @@ msgstr "Símbolos\tAlt+Mayús+Y"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:472
 msgid "Symbols that are entered or copied here will appear in the symbols sidebar so they can be entered into the worksheet easily."
-msgstr ""
+msgstr "Símbolos que han entrado o copiado aquí aparecerá dentro de la barra lateral en inglés para que puedan ser introducidos dentro la la hoja de trabajo fácilmente."
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:778
 msgid "Symmetric function: f(x)=f(-x)"
@@ -10017,7 +10017,7 @@ msgstr "Índice de contenidos\tAlt+Mayús+T"
 
 #: ../../src/wizards/DrawWiz.cpp:561
 msgid "Take surface color from steepness"
-msgstr ""
+msgstr "Tomar color de superficie desde escarpado"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:229
 msgid "Tamil"
@@ -10025,7 +10025,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:196
 msgid "Tau"
-msgstr ""
+msgstr "Tau"
 
 #: ../../src/MaximaCommandMenus.cpp:181
 msgid "Taylor series"
@@ -10061,7 +10061,7 @@ msgstr "Dice a ‘maxima‘ mostrar la ayuda para ?, ?? y describe() en la conso
 
 #: ../../src/dialogs/ConfigDialogue.cpp:148
 msgid "Tells maxima where to store the result of compiling libraries"
-msgstr ""
+msgstr "Dice ‘maxima’ donde almacenar el resultado de bibliotecas compiladas"
 
 #: ../../src/ToolBar.cpp:481 ../../src/sidebars/FormatSidebar.cpp:45
 msgid "Text"
@@ -10073,7 +10073,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:738
 msgid "Text Only"
-msgstr ""
+msgstr "Solo Texto"
 
 #: ../../src/Styles.cpp:122
 msgid "Text cell background"
@@ -10104,7 +10104,7 @@ msgstr "Los procesos de ‘Maxima’ no ofrecen un segmento de memoria compartid
 
 #: ../../src/dialogs/ConfigDialogue.cpp:392
 msgid "The URL MathJaX.js should be downloaded from by our HTML export."
-msgstr ""
+msgstr "La URL MathJax.js debería ser descargarse por nuestro exportador HTML."
 
 #: ../../src/cells/TextCell.cpp:336
 msgid "The [] or the part() command tried to access a list or matrix element that doesn't exist."
@@ -10112,7 +10112,7 @@ msgstr ""
 
 #: ../../src/sidebars/DrawSidebar.cpp:106
 msgid "The accuracy versus speed tradeoff"
-msgstr ""
+msgstr "La precisión frente a velocidad obtenida"
 
 #: ../../src/cells/TextCell.cpp:357
 msgid "The argument of a function was of the wrong type. Most probably an equation was expected but was lacking an \"=\"."
@@ -10136,7 +10136,7 @@ msgstr "Las operaciones clásicas de uno utiliza típicamente matrices para"
 
 #: ../../src/sidebars/DrawSidebar.cpp:91
 msgid "The color of the next line to draw"
-msgstr ""
+msgstr "El color de la siguiente linea a dibujar"
 
 #: ../../src/MaximaCommandMenus.cpp:4005
 msgid "The comma-separated contents of the struct fields"
@@ -10156,48 +10156,48 @@ msgstr "El actual Asistente"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:415
 msgid "The default height for embedded plots. Can be read out or overridden by the maxima variable wxplot_size."
-msgstr ""
+msgstr "La altura de las tramas por defecto empotradas.  Puede ser leída o descartada por la variable de 'maxima' wxplot_size."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:492
 msgid "The default port used for communication between Maxima and wxMaxima."
-msgstr ""
+msgstr "El puerto predeterminado para comunicación entre 'maxima' y wxMaxima."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:412
 msgid "The default width for embedded plots. Can be read out or overridden by the maxima variable wxplot_size"
-msgstr ""
+msgstr "La anchura por defecto de las tramas empotrados.  Puede ser leída o descartada por la variable de ‘maxima’ wxplot_size"
 
 #: ../../src/sidebars/DrawSidebar.cpp:74
 msgid "The diagram title"
-msgstr ""
+msgstr "El título del diagrama"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2401
 #, c-format
 msgid "The directory %s with maxima's startup file doesn't exist. Trying to create it..."
-msgstr ""
+msgstr "El directorio %s con el fichero de inicio de ‘maxima’ no existe.  Intentando crearlo…"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:150
 msgid "The directory containing the startup files, any user libraries and, if MAXIMA_OBJDIR isn't set the subdirectory with the results from compiling maxima libraries."
-msgstr ""
+msgstr "El directorio conteniendo los ficheros de inicio, cualquier biblioteca del usuario y, si no está establecido MAXIMA_OBJDIR, el subdirectorio con el resultado desde la compilación de bibliotecas de ‘maxima’."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:154
 msgid "The directory maxima places temporary files in, for example plots that are to be included in the worksheet."
-msgstr ""
+msgstr "El directorio de lugares dentro del cual los ficheros temporales de ‘maxima’ se encuentran, por ejemplo tramas\nque son para ser incluidas dentro del cuaderno de trabajo."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:157
 msgid "The directory the compiled versions of maxima are placed in"
-msgstr ""
+msgstr "El directorio donde las versiones compiladas de ‘maxima’ se encuentren"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:159
 msgid "The directory the maxima manual can be found in"
-msgstr ""
+msgstr "El directorio dentro del cual puede encontrarse el manual de ‘maxima’"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:160
 msgid "The directory the user's home directory is in"
-msgstr ""
+msgstr "El directorio dentro del cual el directorio inicial del usuario está dentro"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:475
 msgid "The document class LaTeX is instructed to use for our documents."
-msgstr ""
+msgstr "La clase de documento que utilizará LaTeX para nuestros documentos."
 
 #: ../../src/MaximaCommandMenus.cpp:1832
 msgid "The equation to fit the data to"
@@ -10214,7 +10214,7 @@ msgstr ""
 
 #: ../../src/sidebars/DrawSidebar.cpp:96
 msgid "The fill color for the next objects"
-msgstr ""
+msgstr "Este color de relleno para los objetos siguientes"
 
 #: ../../src/cells/TextCell.cpp:354
 msgid "The first argument of subst() isn't an equation or a list of equations. Most probably it was lacking an \"=\"."
@@ -10226,7 +10226,7 @@ msgstr "La invocación a función cuyos argumentos extraer"
 
 #: ../../src/sidebars/DrawSidebar.cpp:100
 msgid "The grid in the background of the diagram"
-msgstr ""
+msgstr "La rejilla dentro del fondo del diagrama"
 
 #: ../../src/wxMaximaFrame.cpp:1332
 msgid "The half of the equation that is to the left of the \"=\""
@@ -10261,11 +10261,11 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:223
 msgid "The key combination Shift+Space results in a non-breakable space."
-msgstr ""
+msgstr "La combinación de teclas Mayús+Espacio resulta en un espacio no rompible."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:162
 msgid "The list of directories the operating system looks for programs in"
-msgstr ""
+msgstr "El listado de directorios del sistema operativo busca programas en"
 
 #: ../../src/cells/TextCell.cpp:293
 msgid "The list of time-dependent variables to solve to doesn't match the time-dependent variables the list of dgls contains."
@@ -10293,7 +10293,7 @@ msgstr "El manual de ‘wxMaxima‘"
 
 #: ../../src/dialogs/MaxSizeChooser.cpp:59
 msgid "The maximum size for this image. Values <= 0 mean: Unspecified."
-msgstr ""
+msgstr "El tamaño máximo para esta imagen. Valores <= 0 signidican: inespecificado."
 
 #: ../../src/MaximaCommandMenus.cpp:3937
 msgid "The name of a function we don't want to be evaluated here"
@@ -10325,11 +10325,11 @@ msgstr "El nombre de la variable que contendrá el elemento actual"
 
 #: ../../src/sidebars/DrawSidebar.cpp:86
 msgid "The next plot's title"
-msgstr ""
+msgstr "El siguiente título del tramado"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:494
 msgid "The number of recently opened files that is to be remembered."
-msgstr ""
+msgstr "El número de ficheros recientemente abierto que está para ser recordado."
 
 #: ../../src/MaximaCommandMenus.cpp:1471
 msgid "The number of the item which is stepped from \"Index Start\" to \"Index End\"."
@@ -10337,12 +10337,12 @@ msgstr "El número del elemento el cual está dividido desde «Inicio de índice
 
 #: ../../src/dialogs/ConfigDialogue.cpp:477
 msgid "The options the document class LaTeX is instructed to use for our documents gets."
-msgstr ""
+msgstr "Las opciones de la clase del documento LaTeX está instruida para utilizar por para obtener nuestros documentos."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1065
 #: ../../src/dialogs/ConfigDialogue.cpp:1112
 msgid "The part of the output of these commands that isn't declared as \"math\" might be suppressed by wxMaxima. As always maxima commands are required to end in a \";\" or a \"$\""
-msgstr ""
+msgstr "La parte de la salida de estas instrucciones que no son declaradas como ‘math’ quizá están suprimidas por wxMaxima. Como siempre los instrucciones de ‘maxima’ son requeridos para finalizar en un “;” o un “$”"
 
 #: ../../src/dialogs/ResolutionChooser.cpp:51
 msgid "The resolution for this image."
@@ -10409,7 +10409,7 @@ msgstr "La solución de variable necesita ser en el formulario\n"
 
 #: ../../src/sidebars/DrawSidebar.cpp:58
 msgid "The standard plot command: Plot an equation as a curve"
-msgstr ""
+msgstr "La instrucción de trama común: tramar una ecuación como una curva"
 
 #: ../../src/cells/TextCell.cpp:267
 msgid "The value of few special variables is assigned by Maxima and cannot be changed by the user. Also a few constructs aren't variable names and therefore cannot be written to."
@@ -10445,7 +10445,7 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:95
 msgid "There are many resources about Maxima and wxMaxima on the internet. Visit https://wxMaxima-developers.github.io/wxmaxima/help.html for more information and to find tutorials on using wxMaxima and Maxima."
-msgstr ""
+msgstr "Hay muchos recursos acerca de ‘Maxima’ y wm‘Maxima’ en Internet. Visite https://wxMaxima-developers.github.io/wxMaxima/help.html para más información y para encontrar tutoriales sobre utilización de wxMaxima y ‘Maxima’."
 
 #: ../../src/dialogs/TipOfTheDay.cpp:251
 msgid "There is a discussion forum for wxMaxima at https://github.com/wxMaxima-developers/wxmaxima/discussions.\n"
@@ -10495,7 +10495,7 @@ msgstr "Hubo un error en el XML que describiría el mensaje de la barra de estad
 
 #: ../../src/sidebars/GreekSidebar.cpp:185
 msgid "Theta"
-msgstr ""
+msgstr "Theta"
 
 #: ../../src/dialogs/LicenseDialog.cpp:85
 msgid "Third-party notices"
@@ -10517,7 +10517,7 @@ msgstr "Este fichero está generado por wxMaxima\n"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1097
 msgid "This file won't be read by maxima if maxima is used without wxMaxima. In order to add startup commands that are executed in this case, too, please add them to maxima-init.mac, instead."
-msgstr ""
+msgstr "Este fichero no sería leído por ‘maxima’ si ‘maxima’ no está utilizado sin wxMaxima. Con el fin de añadir instrucciones de inicio que sean ejecutadas en este caso, también, añádalos a maxima-init.mac, en su lugar."
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:764
 msgid "This function will return even integers"
@@ -10550,7 +10550,7 @@ msgstr ""
 #: ../../src/wizards/DrawWiz.cpp:471
 #, c-format
 msgid "This wizard setups a %iD scene."
-msgstr ""
+msgstr "Este asistente configura un escenario %iD."
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:752
 msgid "Throw an error if this symbol is used before assigning it any contents"
@@ -10558,7 +10558,7 @@ msgstr "Lanza un error si este símbolo es utilizado antes de asignarlo en cualq
 
 #: ../../src/wizards/Plot2dWiz.cpp:65 ../../src/wizards/Plot2dWiz.cpp:505
 msgid "Ticks:"
-msgstr ""
+msgstr "Graduaciones:"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1359
 msgid "Time [in Minutes] between autosaves"
@@ -10570,7 +10570,7 @@ msgstr "Veces:"
 
 #: ../../src/dialogs/TipOfTheDay.cpp:49 ../../src/dialogs/TipOfTheDay.cpp:267
 msgid "Tip of the day"
-msgstr ""
+msgstr "Consejo del día"
 
 #: ../../src/ToolBar.cpp:482 ../../src/sidebars/FormatSidebar.cpp:48
 msgid "Title"
@@ -10586,7 +10586,7 @@ msgstr "Celda títular (Cabecera 1)"
 
 #: ../../src/dialogs/TipOfTheDay.cpp:89
 msgid "Title, section and subsection cells can be folded to hide their contents. To fold or unfold, click in the square next to the cell. If you shift-click, all sublevels of that cell will also fold/unfold."
-msgstr ""
+msgstr "Las celdas de título, sección y subsección se pueden plegar para ocultar sus contenidos.  Tanto para plegarlas como para desplegarlas pulse en el cuadrado contiguo a la celda.  Si al mismo tiempo se pulsa Mayús, todas los subniveles serán plegados/desplegados."
 
 #: ../../src/wxMaximaFrame.cpp:1831
 msgid "To &Bigfloat"
@@ -10614,19 +10614,19 @@ msgstr "Para número exacto"
 
 #: ../../src/dialogs/TipOfTheDay.cpp:124
 msgid "To plot in polar coordinates, select 'set polar' in the Options entry for Plot2d dialog. You can also plot in spherical and cylindrical coordinates in 3D."
-msgstr ""
+msgstr "Para tramar en coordenadas polares, seleccionar 'set polar' en la entrada de Opciones del cuadro de diálogo de Plot2d. También se puede representar en coordenadas esféricas y cilíndricas en 3D."
 
 #: ../../src/dialogs/TipOfTheDay.cpp:131
 msgid "To put parentheses around an expression, select it, and press '(' or ')' depending on where you want the cursor to appear afterwards."
-msgstr ""
+msgstr "Para colocar paréntesis alrededor de una expresión, selecciónese ésta y presiónese '(' o ')', dependiendo de dónde quiere que se coloque el cursor."
 
 #: ../../src/dialogs/TipOfTheDay.cpp:137
 msgid "To save the size and position of wxMaxima windows between session, use 'Edit->Configure' dialog."
-msgstr ""
+msgstr "Para guardar el tamaño y la posición de la ventana de wxMaxima entre sesiones, utilice el diálogo 'Editar → Configurar'."
 
 #: ../../src/dialogs/TipOfTheDay.cpp:51
 msgid "To start using wxMaxima right away, start typing your command. An input cell should appear. Then press Shift-Enter to evaluate your command."
-msgstr ""
+msgstr "Para comenzar a utilizar wxMaxima de inmediato, comience tecleando una instrucción. Debería aparecer una celda de entrada. Entonces pulse Mayús+Retorno para evaluar su instrucción."
 
 #: ../../src/MaximaCommandMenus.cpp:318 ../../src/wizards/IntegrateWiz.cpp:47
 #: ../../src/wizards/Plot2dWiz.cpp:51 ../../src/wizards/Plot2dWiz.cpp:61
@@ -10814,7 +10814,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:230
 msgid "Turkish"
-msgstr ""
+msgstr "turco"
 
 #: ../../src/wxMaximaFrame.cpp:1965
 msgid "Tutorials"
@@ -10830,7 +10830,7 @@ msgstr "Tipo"
 
 #: ../../src/cells/EditorCell.cpp:4550
 msgid "Type in text"
-msgstr ""
+msgstr "Teclear en texto"
 
 #: ../../src/MaximaCommandMenus.cpp:3992 ../../src/wizards/MatWiz.cpp:158
 msgid "Type:"
@@ -10850,7 +10850,7 @@ msgstr "UTF8 a código Unicode apunta…"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:231
 msgid "Ukrainian"
-msgstr ""
+msgstr "ucraniano"
 
 #: ../../src/wxMaxima.cpp:3164
 msgid "Un-closed parenthesis"
@@ -10877,15 +10877,15 @@ msgstr "Indefinido"
 #: ../../src/sidebars/VariablesPane.cpp:303
 #: ../../src/sidebars/VariablesPane.cpp:386
 msgid "Undefined"
-msgstr ""
+msgstr "Indefinido"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2115
 msgid "Underlined"
-msgstr ""
+msgstr "Subrayada"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:745
 msgid "Underscore converts to subscripts:"
-msgstr ""
+msgstr "Subrayado convierte a subcadenas:"
 
 #: ../../src/ToolBar.cpp:354 ../../src/ToolBar.cpp:357
 msgid "Undo"
@@ -10918,7 +10918,7 @@ msgstr "Desplegar todas las secciones"
 
 #: ../../src/sidebars/TableOfContents.cpp:507
 msgid "Unhide"
-msgstr ""
+msgstr "Desocultar"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:665
 msgid "Unhide Heading 5"
@@ -10974,7 +10974,7 @@ msgstr "Código Unicode apunta a números UTF8"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:180
 msgid "Unicode symbols:"
-msgstr ""
+msgstr "Símbolos Unicode:"
 
 #: ../../src/MaximaCommandMenus.cpp:3890
 msgid "Unlike in other programming language return() only exits from the current loop or block(), not from the whole function."
@@ -10990,11 +10990,11 @@ msgstr "Cadena de texto sin terminar."
 
 #: ../../src/wizards/ActualValuesStorageWiz.cpp:43
 msgid "Until then the actual values for all variables can be kept in a list."
-msgstr ""
+msgstr "Hasta entonces los valores actuales para todas las variables pueden ser conservadas en una lista."
 
 #: ../../src/dialogs/DiffFrame.cpp:429 ../../src/dialogs/FindReplacePane.cpp:80
 msgid "Up"
-msgstr ""
+msgstr "Ascender"
 
 #: ../../src/MaximaEvaluator.cpp:629
 msgid "Updating maxima's configuration"
@@ -11017,7 +11017,7 @@ msgstr "Cota superior:"
 
 #: ../../src/sidebars/GreekSidebar.cpp:197
 msgid "Upsilon"
-msgstr ""
+msgstr "Upsilon"
 
 #: ../../src/wxMaximaFrame.cpp:829
 msgid "Use \"<\" and \">\" as parenthesis for matrices"
@@ -11029,7 +11029,7 @@ msgstr ""
 
 #: ../../src/wizards/SumWiz.cpp:69
 msgid "Use Gosper algorithm"
-msgstr ""
+msgstr "Emplear algoritmo Gosper"
 
 #: ../../src/sidebars/RegexCtrl.cpp:133
 msgid "Use RegEx filtering"
@@ -11053,11 +11053,11 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:485
 msgid "Use centered dot and Minus, not Star and Hyphen"
-msgstr ""
+msgstr "Emplear punto central (·) y resta (-), no estrella (*) y guión largo (_)"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:849
 msgid "Use centered dot character for multiplication"
-msgstr ""
+msgstr "Emplear punto centrado como operador de multiplicación"
 
 #: ../../src/wxMaximaFrame.cpp:1745
 msgid "Use list"
@@ -11081,11 +11081,11 @@ msgstr "Utilizar campo de estructura…"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:425
 msgid "Use the \"partial derivative\" symbol to represent the fraction that represents a diff() when exporting LaTeX"
-msgstr ""
+msgstr "Emplear el símbolo «derivada parcial» para representar la fracción diff() al exportar a LaTeX"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2052
 msgid "Use unicode Math Symbols, if available"
-msgstr ""
+msgstr "Emplear símbolos matemáticos Unicode, si se disponen"
 
 #: ../../src/wxMaximaFrame.cpp:832
 msgid "Use vertical lines instead of parenthesis for matrices"
@@ -11100,7 +11100,7 @@ msgstr "Solo etiquetas usuario"
 #: ../../src/dialogs/ConfigDialogue.cpp:1480
 #: ../../src/dialogs/MaximaNotStartingDialog.cpp:54
 msgid "User specified"
-msgstr ""
+msgstr "Usuario especificado"
 
 #: ../../src/Styles.cpp:110
 msgid "User-defined labels"
@@ -11108,7 +11108,7 @@ msgstr "Etiquetas definidas por el usuario"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:770
 msgid "User-defined labels if available"
-msgstr ""
+msgstr "Etiquetas definidas por el usuario si son disponibles"
 
 #: ../../src/MaximaManual.cpp:500
 msgid "Using Maxima help file from wxMaxima configuration file (helpFile=...))"
@@ -11146,7 +11146,7 @@ msgstr "Validado que la representación del documento XML actualmente es XML vá
 #: ../../src/dialogs/ConfigDialogue.cpp:542
 #: ../../src/wizards/ActualValuesStorageWiz.cpp:49
 msgid "Value"
-msgstr ""
+msgstr "Valor"
 
 #: ../../src/MaximaCommandMenus.cpp:756
 msgid "Value at a given point"
@@ -11186,15 +11186,15 @@ msgstr ""
 
 #: ../../src/wizards/DrawWiz.cpp:61 ../../src/wizards/DrawWiz.cpp:166
 msgid "Variable for the x value"
-msgstr ""
+msgstr "Variable para el valor x"
 
 #: ../../src/wizards/DrawWiz.cpp:78 ../../src/wizards/DrawWiz.cpp:181
 msgid "Variable for the y value"
-msgstr ""
+msgstr "Variable para el valor y"
 
 #: ../../src/wizards/DrawWiz.cpp:198
 msgid "Variable for the z value"
-msgstr ""
+msgstr "Variable para el valor z"
 
 #: ../../src/MaximaCommandMenus.cpp:1586 ../../src/MaximaCommandMenus.cpp:2990
 #: ../../src/MaximaCommandMenus.cpp:2996
@@ -11242,7 +11242,7 @@ msgstr ""
 
 #: ../../src/sidebars/StatSidebar.cpp:58
 msgid "Variance..."
-msgstr ""
+msgstr "Varianza…"
 
 #: ../../src/WXMXformat.cpp:339
 msgid "Verified that we are able to read the whole .zip archive we produced."
@@ -11270,7 +11270,7 @@ msgstr "Esperando que el hilo que interpreta el manual de ‘maxima’ termine"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1410
 msgid "Warn if an inactive window is idle"
-msgstr ""
+msgstr "Advertir si una ventana inactiva está ociosa"
 
 #: ../../src/MathParser.cpp:1343 ../../src/MaximaFileIO.cpp:536
 #: ../../src/MaximaResponseReader.cpp:361 ../../src/wxMaxima.cpp:1583
@@ -11315,7 +11315,7 @@ msgstr "Qué hacer:"
 
 #: ../../src/dialogs/TipOfTheDay.cpp:134
 msgid "When applying functions with one argument from menus, the default argument is '%'. To apply the function to some other value, select it in the document before executing a menu command."
-msgstr ""
+msgstr "Cuando se aplican funciones con un argumento del menú, el argumento predeterminado es '%'. Para aplicar la función a otro valor, selecciónelo en el documento antes de ejecutar la instrucción del menú."
 
 #: ../../src/wxMaximaFrame.cpp:1092
 msgid "When to invoke the lisp compiler's debugger"
@@ -11343,7 +11343,7 @@ msgstr "Intentará generar una pila de traza, si el programa revienta"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:280
 msgid "Worksheet"
-msgstr ""
+msgstr "Hoja del Cuaderno"
 
 #: ../../src/MaximaResponseReader.cpp:117
 #, c-format
@@ -11364,7 +11364,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:428
 msgid "Wrap equations exported by the \"copy as LaTeX\" feature between \\[ and \\] as equation markers"
-msgstr ""
+msgstr "Envuelve ecuaciones exportadas con \"copiar como LaTeX\" entre \\[ y \\] como marcadores de ecuaciones"
 
 #: ../../src/worksheet/Worksheet.cpp:5190
 msgid "Wrapped search"
@@ -11386,7 +11386,7 @@ msgstr "Ha escrito el informe de tipo mime"
 #: ../../src/wizards/DrawWiz.cpp:961 ../../src/wizards/DrawWiz.cpp:974
 #: ../../src/wizards/DrawWiz.cpp:977
 msgid "X"
-msgstr ""
+msgstr "X"
 
 #: ../../src/MathParser.cpp:1279
 msgid "XML nesting limit exceeded"
@@ -11394,19 +11394,19 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:191
 msgid "Xi"
-msgstr ""
+msgstr "Xi"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:728
 msgid "Yes"
-msgstr ""
+msgstr "Sí"
 
 #: ../../src/dialogs/TipOfTheDay.cpp:64
 msgid "You can access the last output using the variable '%'. You can access the output of previous commands using variables '%on' where n is the number of output."
-msgstr ""
+msgstr "Se puede acceder a la última salida empleando la variable '%'. Se puede acceder a la salida de las instrucciones anteriores empleando las variables '%on' donde ‘n’ es el número de la salida."
 
 #: ../../src/dialogs/TipOfTheDay.cpp:118
 msgid "You can evaluate your whole document by using 'Cell->Evaluate All Cells' menu command or the appropriate key shortcut. The cells will be evaluated in the order they appear in the document."
-msgstr ""
+msgstr "Se puede evaluar el documento completo seleccionando 'Celda → Evaluar todas las celdas' en el menú de instrucciones. Las celdas se evaluarán en el orden en que aparecen en el documento."
 
 #: ../../src/dialogs/TipOfTheDay.cpp:98
 msgid "You can get help on a Maxima function by selecting or clicking on the function name and pressing F1. wxMaxima will search the help index for the selection or the word under the cursor."
@@ -11414,15 +11414,15 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:92
 msgid "You can hide output part of cells by clicking in the triangle on the left side of cells. This works on text cells also."
-msgstr ""
+msgstr "Se puede ocultar la parte del resultado de una celda pulsando sobre el triángulo a su izquierda. Esto también es aplicable a celdas de texto."
 
 #: ../../src/dialogs/TipOfTheDay.cpp:81
 msgid "You can insert different types of 'cells' in wxMaxima documents using the 'Cell' menu. Note that only 'input cells' can be evaluated, while others are used for commenting and structuring your calculations."
-msgstr ""
+msgstr "Se pueden incluir diferentes tipos de 'celdas' en un documento de wxMaxima seleccionando el menú 'Celda'. Téngase en cuenta que sólo 'celdas de entrada' se pueden evaluar, mientras que el resto se utiliza para comentarios y estructuración del documento."
 
 #: ../../src/dialogs/TipOfTheDay.cpp:112
 msgid "You can select multiple cells either with a mouse - click'n'drag from between cells or from a cell bracket on the left - or with a keyboard - hold down Shift while moving the horizontal cursor - and then operate on selection. This comes in handy when you want to delete or evaluate multiple cells."
-msgstr ""
+msgstr "Se pueden seleccionar varias celdas, bien con el ratón, pulsando y arrastrando entre celdas o corchetes de celdas, bien con el teclado, manteniendo pulsada la tecla de Mayúsculas mientras se mueve el cursor horizontal, para luego operar sobre la selección. Esto será útil cuando se quieran borrar o evaluar varias celdas a la vez."
 
 #: ../../src/dialogs/TipOfTheDay.cpp:232
 msgid "You found a bug in wxMaxima? Please report it at https://github.com/wxMaxima-developers/wxmaxima/issues\n"
@@ -11450,7 +11450,7 @@ msgstr "La versión de wxMaxima está actualizada."
 
 #: ../../src/sidebars/GreekSidebar.cpp:183
 msgid "Zeta"
-msgstr ""
+msgstr "Zeta"
 
 #: ../../src/wxMaximaFrame.cpp:842
 msgid "Zoom &In\tCtrl++"
@@ -11478,11 +11478,11 @@ msgstr "[ no guardado* ]"
 
 #: ../../src/wizards/DrawWiz.cpp:819 ../../src/wizards/DrawWiz.cpp:825
 msgid "[[x_1,x_2,...],[y_1,y_2,...]]"
-msgstr ""
+msgstr "[[x_1,x_2,…],[y_1,y_2,…]]"
 
 #: ../../src/wizards/DrawWiz.cpp:814
 msgid "[x_1, x_2,...] or [x_1, x_2,...],[y_1, y_2,...] or matrix([x_1,y_1],[x_2,y_2],...)"
-msgstr ""
+msgstr "[x_1, x_2,…] o [x_1, x_2,…],[y_1, y_2,…] o matrix([x_1,y_1],[x_2,y_2],…)"
 
 #: ../../src/wizards/ListSortWiz.cpp:46
 msgid "a<b (Maxima default)"
@@ -11490,15 +11490,15 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:151
 msgid "alpha"
-msgstr ""
+msgstr "alfa"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:95
 msgid "and"
-msgstr ""
+msgstr "y"
 
 #: ../../src/wizards/MatWiz.cpp:160
 msgid "antisymmetric"
-msgstr ""
+msgstr "antisimétrica"
 
 #: ../../src/wxMaximaFrame.cpp:1727
 msgid "apply function to each element"
@@ -11522,11 +11522,11 @@ msgstr "como almacén para valores actuales desde variables"
 
 #: ../../src/sidebars/GreekSidebar.cpp:152
 msgid "beta"
-msgstr ""
+msgstr "beta"
 
 #: ../../src/wizards/LimitWiz.cpp:42
 msgid "both sides"
-msgstr ""
+msgstr "ambos lados"
 
 #: ../../src/wxMaximaFrame.cpp:1173
 msgid "char to Ascii code..."
@@ -11534,7 +11534,7 @@ msgstr "caracter a código ASCII…"
 
 #: ../../src/sidebars/GreekSidebar.cpp:172
 msgid "chi"
-msgstr ""
+msgstr "ji"
 
 #: ../../src/MaximaFileIO.cpp:318
 #, c-format
@@ -11544,15 +11544,15 @@ msgstr ""
 #: ../../src/wizards/Plot2dWiz.cpp:70 ../../src/wizards/Plot2dWiz.cpp:372
 #: ../../src/wizards/Plot3dWiz.cpp:61 ../../src/wizards/Plot3dWiz.cpp:358
 msgid "default"
-msgstr ""
+msgstr "predeterminado"
 
 #: ../../src/sidebars/GreekSidebar.cpp:154
 msgid "delta"
-msgstr ""
+msgstr "delta"
 
 #: ../../src/wizards/MatWiz.cpp:159
 msgid "diagonal"
-msgstr ""
+msgstr "diagonal"
 
 #: ../../src/cells/FracCell.cpp:73
 msgid "diff(): Cannot find the multiplication sign I should hide"
@@ -11568,19 +11568,19 @@ msgstr "hacer por cada elemento"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:92
 msgid "empty"
-msgstr ""
+msgstr "vacío"
 
 #: ../../src/sidebars/GreekSidebar.cpp:155
 msgid "epsilon"
-msgstr ""
+msgstr "épsilon"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:100
 msgid "equivalent"
-msgstr ""
+msgstr "equivalente"
 
 #: ../../src/sidebars/GreekSidebar.cpp:157
 msgid "eta"
-msgstr ""
+msgstr "eta"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:799
 msgid "ev() shall evaluate this automatically"
@@ -11588,7 +11588,7 @@ msgstr "ev() evaluará esto automáticamente"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:88
 msgid "exists"
-msgstr ""
+msgstr "existe"
 
 #: ../../src/MaximaCommandMenus.cpp:3942
 msgid "expression:"
@@ -11630,11 +11630,11 @@ msgstr "función"
 
 #: ../../src/sidebars/GreekSidebar.cpp:153
 msgid "gamma"
-msgstr ""
+msgstr "gamma 𝛾"
 
 #: ../../src/wizards/MatWiz.cpp:159
 msgid "general"
-msgstr ""
+msgstr "común"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1630
 msgid "gnuplot: Without command console"
@@ -11642,11 +11642,11 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:118
 msgid "greater than or equal"
-msgstr ""
+msgstr "mayor o igual que"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:87
 msgid "in"
-msgstr ""
+msgstr "interno"
 
 #: ../../src/wxMaximaFrame.cpp:784
 msgid "in 2D"
@@ -11657,31 +11657,31 @@ msgstr "en 2D"
 #: ../../src/wizards/Plot3dWiz.cpp:61 ../../src/wizards/Plot3dWiz.cpp:194
 #: ../../src/wizards/Plot3dWiz.cpp:358 ../../src/wizards/Plot3dWiz.cpp:386
 msgid "inline"
-msgstr ""
+msgstr "alineado"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:104
 msgid "intersection"
-msgstr ""
+msgstr "intersección"
 
 #: ../../src/sidebars/GreekSidebar.cpp:159
 msgid "iota"
-msgstr ""
+msgstr "iota"
 
 #: ../../src/sidebars/GreekSidebar.cpp:160
 msgid "kappa"
-msgstr ""
+msgstr "kappa"
 
 #: ../../src/sidebars/GreekSidebar.cpp:161
 msgid "lambda"
-msgstr ""
+msgstr "lambda"
 
 #: ../../src/wizards/LimitWiz.cpp:42
 msgid "left"
-msgstr ""
+msgstr "izquierda"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:117
 msgid "less or equal"
-msgstr ""
+msgstr "menor o igual"
 
 #: ../../src/MaximaCommandMenus.cpp:1567
 msgid "list"
@@ -11689,11 +11689,11 @@ msgstr "enumeración"
 
 #: ../../src/wizards/Plot2dWiz.cpp:54 ../../src/wizards/Plot2dWiz.cpp:64
 msgid "logscale"
-msgstr ""
+msgstr "escala log"
 
 #: ../../src/wizards/DrawWiz.cpp:822
 msgid "matrix([x_1,x_2,...],[y_1,y_2,...])"
-msgstr ""
+msgstr "matrix([x_1,x_2,…],[y_1,y_2,…])"
 
 #: ../../src/wxMaximaFrame.cpp:1439
 msgid "max(abs(A(i,j))) (complex)"
@@ -11705,15 +11705,15 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:162
 msgid "mu"
-msgstr ""
+msgstr "mu"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:120
 msgid "much greater than"
-msgstr ""
+msgstr "mucho mayor que"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:119
 msgid "much less than"
-msgstr ""
+msgstr "mucho menor que"
 
 #: ../../src/MaximaCommandMenus.cpp:1232
 msgid "m×n Matrix A:"
@@ -11726,11 +11726,11 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:112
 msgid "nabla sign"
-msgstr ""
+msgstr "signo nabla"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:98
 msgid "nand"
-msgstr ""
+msgstr "y neg"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:772
 msgid "nary: f(x, f(y,z)) = foo(x,y,z)"
@@ -11738,23 +11738,23 @@ msgstr "nada: f(x, f(y,z)) = foo(x,y,z)"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:99
 msgid "nor"
-msgstr ""
+msgstr "o neg"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:102
 msgid "not"
-msgstr ""
+msgstr "no"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:116
 msgid "not bytewise identical"
-msgstr ""
+msgstr "no idéntico bit a bit"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:108
 msgid "not subset"
-msgstr ""
+msgstr "no subconjunto"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:107
 msgid "not subset or equal"
-msgstr ""
+msgstr "no subconjunto o igual"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:796
 msgid "noun: Not evaluated by default"
@@ -11766,7 +11766,7 @@ msgstr "enésimo"
 
 #: ../../src/sidebars/GreekSidebar.cpp:163
 msgid "nu"
-msgstr ""
+msgstr "nu"
 
 #: ../../src/MaximaCommandMenus.cpp:1233
 msgid "n×1 Matrix b:"
@@ -11774,15 +11774,15 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:174
 msgid "omega"
-msgstr ""
+msgstr "omega"
 
 #: ../../src/sidebars/GreekSidebar.cpp:165
 msgid "omicron"
-msgstr ""
+msgstr "ómicron"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:96
 msgid "or"
-msgstr ""
+msgstr "o"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:793
 msgid "outative: f(2*x) = 2*f(x)"
@@ -11799,19 +11799,19 @@ msgstr "parte:"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:111
 msgid "partial sign"
-msgstr ""
+msgstr "símbolo parcial"
 
 #: ../../src/sidebars/GreekSidebar.cpp:171
 msgid "phi"
-msgstr ""
+msgstr "fi"
 
 #: ../../src/sidebars/GreekSidebar.cpp:166
 msgid "pi"
-msgstr ""
+msgstr "pi"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:101
 msgid "plus or minus"
-msgstr ""
+msgstr "±"
 
 #: ../../src/MaximaCommandMenus.cpp:196
 msgid "point:"
@@ -11836,11 +11836,11 @@ msgstr "printf…"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:115
 msgid "proportional to"
-msgstr ""
+msgstr "proporcional a"
 
 #: ../../src/sidebars/GreekSidebar.cpp:173
 msgid "psi"
-msgstr ""
+msgstr "psi"
 
 #: ../../src/MaximaCommandMenus.cpp:642
 msgid "radcan() is a powerful tools for simplification trigonometric functions but needs to be taken with care: If a function has more than one branch radcan uses the one that looks like it would fit best, not necessarily the one that makes sense for the problem that resulted in the Expression that is to be simplified."
@@ -11868,31 +11868,31 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:167
 msgid "rho"
-msgstr ""
+msgstr "ro"
 
 #: ../../src/wizards/LimitWiz.cpp:42
 msgid "right"
-msgstr ""
+msgstr "derecha"
 
 #: ../../src/wizards/DrawWiz.cpp:310
 msgid "secondary x axis label"
-msgstr ""
+msgstr "etiqueta eje x secundario"
 
 #: ../../src/wizards/DrawWiz.cpp:315
 msgid "secondary x range (automatic if incomplete)"
-msgstr ""
+msgstr "rango x secundario (automático si incompleto)"
 
 #: ../../src/wizards/DrawWiz.cpp:325
 msgid "secondary y axis label"
-msgstr ""
+msgstr "etiqueta eje y secundaria"
 
 #: ../../src/wizards/DrawWiz.cpp:330
 msgid "secondary y range (automatic if incomplete)"
-msgstr ""
+msgstr "rango y secundario (automático si incompleto)"
 
 #: ../../src/sidebars/GreekSidebar.cpp:168
 msgid "sigma"
-msgstr ""
+msgstr "signa"
 
 #: ../../src/MaximaCommandMenus.cpp:3447
 msgid "solve() will solve a list of equations only if for n independent equations there are n variables to solve to.\n"
@@ -11916,19 +11916,19 @@ msgstr "resuelve una ecuación de la forma\n"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:81
 msgid "sqrt (needs parenthesis for its argument to work as a Maxima command)"
-msgstr ""
+msgstr "sqrt (necesita paréntesis para su argumento para que funciona como una instrucción de ‘Maxima’)"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:106
 msgid "subset"
-msgstr ""
+msgstr "subconjunto"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:105
 msgid "subset or equal"
-msgstr ""
+msgstr "subconjunto o igual"
 
 #: ../../src/wizards/MatWiz.cpp:160
 msgid "symmetric"
-msgstr ""
+msgstr "simétrica"
 
 #: ../../src/MaximaCommandMenus.cpp:970
 msgid "t:"
@@ -11936,7 +11936,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:169
 msgid "tau"
-msgstr ""
+msgstr "tau"
 
 #: ../../src/cells/TextCell.cpp:340
 msgid "the [] operator tried to extract an element of a list, a matrix, an equation or an array. But instead of an integer number something was used whose numerical value is unknown or not an integer.\n"
@@ -11945,31 +11945,31 @@ msgstr ""
 
 #: ../../src/wizards/DrawWiz.cpp:725
 msgid "the x and the y coordinate."
-msgstr ""
+msgstr "las coordinadas ‘x’ e ‘y’."
 
 #: ../../src/wizards/DrawWiz.cpp:729
 msgid "the x, the y and the z coordinate."
-msgstr ""
+msgstr "las coordinadas ‘x’, ‘y’ y ‘z’."
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:89
 msgid "there is no"
-msgstr ""
+msgstr "no hay"
 
 #: ../../src/sidebars/GreekSidebar.cpp:158
 msgid "theta"
-msgstr ""
+msgstr "theta"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:78
 msgid "to the power of 2"
-msgstr ""
+msgstr "al cuadrado"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:79
 msgid "to the power of 3"
-msgstr ""
+msgstr "al cubo"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:103
 msgid "union"
-msgstr ""
+msgstr "unión"
 
 #: ../../src/wxMaximaFrame.cpp:1109
 msgid "unnamed function (lambda)..."
@@ -11986,7 +11986,7 @@ msgstr "sin título"
 
 #: ../../src/sidebars/GreekSidebar.cpp:170
 msgid "upsilon"
-msgstr ""
+msgstr "upsilon"
 
 #: ../../src/wxMaximaFrame.cpp:1737
 msgid "use as function arguments"
@@ -12033,7 +12033,7 @@ msgstr "wxMaxima no puede leer el contenido xml de "
 #: ../../src/dialogs/ConfigDialogue.cpp:142
 #: ../../src/dialogs/ConfigDialogue.cpp:311
 msgid "wxMaxima configuration"
-msgstr ""
+msgstr "Configuración de wxMaxima"
 
 #: ../../src/MaximaProcessManager.cpp:209
 msgid "wxMaxima could not start a server.\n\n"
@@ -12043,7 +12043,7 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:127
 msgid "wxMaxima dialogs set default values for inputs entries, one of which is '%'. If you have made a selection in your document, the selection will be used instead of '%'."
-msgstr ""
+msgstr "En diálogos de wxMaxima  establecen valores predeterminados para entrada, una de las cuales es '%'.  Si ha hecho una selección en el documento, ésta será utilizada en lugar de '%'."
 
 #: ../../src/MaximaCommandMenus.cpp:4544
 msgid "wxMaxima document"
@@ -12078,15 +12078,15 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:228
 msgid "wxMaxima needs more developers. It is an open source project where you can contribute. Join the wxMaxima development at: https://github.com/wxMaxima-developers/wxmaxima"
-msgstr ""
+msgstr "wxMaxima necesita más desarrolladores.  Es un proyecto de código fuente abierto donde puede contribuir.  Únase al desarrollo de wxmaxima en: https://github.com/wxMaxima-developers/wxmaxima"
 
 #: ../../src/dialogs/TipOfTheDay.cpp:224
 msgid "wxMaxima needs more translators. We do not speak every language. Help us to translate wxMaxima and the manual to your language. Join the wxMaxima development at: https://github.com/wxMaxima-developers/wxmaxima"
-msgstr ""
+msgstr "wxMaxima necesita más traductores.  No hablamos cada idioma.  Ayúdenos para traducir a wxMaxima y el manual a su idioma.  Únase a los desarrolladores de wxMaxima en: https://github.com/wxMaxima-developers/wxmaxima"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:407
 msgid "wxMaxima normally stores the gnuplot sources for every plot made using draw() in order to be able to open plots interactively in gnuplot later. This setting defines the limit [in Megabytes per plot] for this feature."
-msgstr ""
+msgstr "wxMaxima normalmente almacena las fuentes gnuplot para cada trama hecha utilizando draw() con el fin de ser capaz de abrir tramas interactivamente en gnuplot posteriormente.  Esta opción define el límite [ en Megabytes por trama] para esta característica."
 
 #: ../../src/dialogs/TipOfTheDay.cpp:172
 msgid "wxMaxima provides the \"table_form\" command that shows lists in an alternative form. One example would be:\n\n"
@@ -12105,7 +12105,7 @@ msgstr "wxMaxima recuerda respuestas desde la última ejecución y es capaz de o
 
 #: ../../src/dialogs/ConfigDialogue.cpp:481
 msgid "wxMaxima remembers the answers to maxima's questions. If this checkbox is set it automatically offers to enter the last answer to this question the user has input."
-msgstr ""
+msgstr "wxMaxima recuerda las respuestas a las preguntas de ‘maxima’.  Si en esta casilla está establecida ésta automáticamente ofrece introducir al última respuesta a esta pregunta que el usuario ha introducido."
 
 #: ../../src/wxMaximaFrame.cpp:1933
 msgid "wxMaxima shows help in a browser"
@@ -12117,7 +12117,7 @@ msgstr "wxMaxima muestra ayuda en la barra lateral"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1095
 msgid "wxMaxima startup file location: "
-msgstr ""
+msgstr "Lugar del fichero de inicio wxMaxima: "
 
 #: ../../src/wxMaximaFrame.cpp:119
 #, c-format
@@ -12169,11 +12169,11 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:709
 msgid "x"
-msgstr ""
+msgstr "x"
 
 #: ../../src/wizards/DrawWiz.cpp:266
 msgid "x axis label"
-msgstr ""
+msgstr "etiquetar eje x"
 
 #: ../../src/MaximaCommandMenus.cpp:2021
 msgid "x direction [in multiples of the tick frequency]"
@@ -12181,11 +12181,11 @@ msgstr "dirección x"
 
 #: ../../src/wizards/DrawWiz.cpp:269
 msgid "x range (automatic if incomplete)"
-msgstr ""
+msgstr "rango x (automático si incompleto)"
 
 #: ../../src/sidebars/GreekSidebar.cpp:164
 msgid "xi"
-msgstr ""
+msgstr "xi"
 
 #: ../../src/MaximaFileIO.cpp:408 ../../src/MaximaFileIO.cpp:566
 msgid "xml contained in the file claims not to be a wxMaxima worksheet. "
@@ -12193,11 +12193,11 @@ msgstr "xml contenido en el fichero dice que no es un cuaderno de wxMaxima. "
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:97
 msgid "xor"
-msgstr ""
+msgstr "oex"
 
 #: ../../src/wizards/DrawWiz.cpp:279
 msgid "y axis label"
-msgstr ""
+msgstr "etiqueta eje y"
 
 #: ../../src/MaximaCommandMenus.cpp:2022
 msgid "y direction [in multiples of the tick frequency]"
@@ -12205,7 +12205,7 @@ msgstr "dirección y"
 
 #: ../../src/wizards/DrawWiz.cpp:282
 msgid "y range (automatic if incomplete)"
-msgstr ""
+msgstr "rango y (automático si incompleto)"
 
 #: ../../src/MaximaCommandMenus.cpp:970
 msgid "y:"
@@ -12213,15 +12213,15 @@ msgstr ""
 
 #: ../../src/wizards/DrawWiz.cpp:294
 msgid "z axis label"
-msgstr ""
+msgstr "etiquetar eje z"
 
 #: ../../src/wizards/DrawWiz.cpp:298
 msgid "z range (automatic if incomplete)"
-msgstr ""
+msgstr "rango z (automático si incompleto)"
 
 #: ../../src/sidebars/GreekSidebar.cpp:156
 msgid "zeta"
-msgstr ""
+msgstr "zeta"
 
 #. type: Title #
 #: ../../info/wxmaxima.md:1

--- a/locales/wxMaxima/fi.po
+++ b/locales/wxMaxima/fi.po
@@ -67,7 +67,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1551
 msgid "      -l <name>"
-msgstr ""
+msgstr "      -l <nimi>"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1557
 msgid "      -u <versionnumber>"
@@ -165,7 +165,7 @@ msgstr ""
 #: ../../src/cells/ImgCell.cpp:212 ../../src/cells/ImgCell.cpp:214
 #: ../../src/cells/ImgCell.cpp:216
 msgid " (Graphics) "
-msgstr ""
+msgstr " (Grafiikat) "
 
 #: ../../src/cells/EditorCell.cpp:3551 ../../src/cells/EditorCell.cpp:3820
 #: ../../src/cells/EditorCell.cpp:3945
@@ -213,7 +213,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1208
 msgid "\"Copy LaTeX\" adds equation markers"
-msgstr ""
+msgstr "\"Kopioi LaTeX\" lisää kaavamerkinnät"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:446
 msgid "\"MathML (rendered by the browser)\" is the recommended choice: every current browser renders MathML natively and instantly, and the exported page needs no JavaScript and makes no requests to any external server.\n"
@@ -314,7 +314,7 @@ msgstr "&Kopioi\tCtrl+C"
 
 #: ../../src/wizards/IntegrateWiz.cpp:39
 msgid "&Definite integration"
-msgstr ""
+msgstr "&Määrätty integraali"
 
 #: ../../src/wxMaximaFrame.cpp:1658
 msgid "&Demoivre"
@@ -430,7 +430,7 @@ msgstr ""
 
 #: ../../src/wizards/IntegrateWiz.cpp:52
 msgid "&Numerical integration"
-msgstr ""
+msgstr "&Numeerinen integrointi"
 
 #: ../../src/wizards/SumWiz.cpp:44
 msgid "&Nusum"
@@ -450,7 +450,7 @@ msgstr "&Kuvaaja"
 
 #: ../../src/wizards/SeriesWiz.cpp:45
 msgid "&Power series"
-msgstr ""
+msgstr "&Potenssisarja"
 
 #: ../../src/wxMaximaFrame.cpp:655
 msgid "&Print...\tCtrl+P"
@@ -458,7 +458,7 @@ msgstr "&Tulosta...\tCtrl+P"
 
 #: ../../src/wizards/SubstituteWiz.cpp:38
 msgid "&Rational"
-msgstr ""
+msgstr "&Rationaali"
 
 #: ../../src/wxMaximaFrame.cpp:1631
 msgid "&Reduce Trigonometric"
@@ -494,7 +494,7 @@ msgstr ""
 
 #: ../../src/wizards/LimitWiz.cpp:45
 msgid "&Taylor series"
-msgstr ""
+msgstr "&Taylorin sarja"
 
 #: ../../src/wxMaximaFrame.cpp:1069
 msgid "&Time Display"
@@ -550,7 +550,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:183
 msgid "(Use default language)"
-msgstr ""
+msgstr "(Käytä oletuskieltä)"
 
 #: ../../src/MaximaCommandMenus.cpp:440
 msgid "(f(x),x,a,b)), Epsilon algorithm"
@@ -592,7 +592,7 @@ msgstr ""
 #: ../../src/wizards/IntegrateWiz.cpp:217 ../../src/wizards/LimitWiz.cpp:132
 #: ../../src/wizards/LimitWiz.cpp:142
 msgid "- Infinity"
-msgstr ""
+msgstr "- Ääretön"
 
 #: ../../src/MaximaOutputAppender.cpp:116
 msgid "... [suppressed additional lines as the output is longer than allowed in the wxMaxima configuration] "
@@ -608,7 +608,7 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:77
 msgid "1/2"
-msgstr ""
+msgstr "1/2"
 
 #: ../../src/sidebars/DrawSidebar.cpp:45
 msgid "2D"
@@ -649,7 +649,7 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:102
 msgid "A 'horizontal cursor' was introduced in wxMaxima 0.8.0. It looks like a horizontal line between cells. It indicates where a new cell will appear if you type or paste text or execute a menu command."
-msgstr ""
+msgstr "'Horisontaalinen kursori' lisättiin wxMaximan 0.8.0 versioon. Se näyttää vaakasuuntaiselta viivalta solujen välissä. 'Horisontaalinen kursori' näyttää minne uusi solu muodostetaan kirjoittaessasi tai liitttäessäsi tekstiä tai suorittaessasi valikkokomennon."
 
 #: ../../src/MaximaCommandMenus.cpp:3039
 msgid "A Ctrl-F event"
@@ -804,7 +804,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1618
 msgid "Abort evaluation on error"
-msgstr ""
+msgstr "Virhe"
 
 #: ../../src/MaximaEvaluator.cpp:214
 #, c-format
@@ -984,7 +984,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:750
 msgid "All variable names"
-msgstr ""
+msgstr "Kaikki muuttujanimet"
 
 #: ../../src/wxMaximaFrame.cpp:770
 msgid "All visible sidebars"
@@ -1012,7 +1012,7 @@ msgstr ""
 
 #: ../../src/dialogs/BinaryNameCtrl.cpp:69
 msgid "All|*"
-msgstr ""
+msgstr "Kaikki | *"
 
 #: ../../src/wxMaximaFrame.cpp:800
 msgid "Always after underscores"
@@ -1189,7 +1189,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1397
 msgid "Ask to save untitled documents"
-msgstr ""
+msgstr "Ehdota nimettömien asiakirjojen tallentamista"
 
 #: ../../src/dialogs/MaximaNotStartingDialog.cpp:36
 msgid "Asking the user for the location of a working maxima binary"
@@ -1299,7 +1299,7 @@ msgstr ""
 
 #: ../../src/sidebars/StatSidebar.cpp:91
 msgid "Barsplot..."
-msgstr ""
+msgstr "Palkkikaavio..."
 
 #: ../../src/wxMaximaFrame.cpp:1384
 msgid "Basic matrix operations"
@@ -1342,7 +1342,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:179
 msgid "Beta"
-msgstr ""
+msgstr "Beta"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1898
 msgid "Bitmap"
@@ -1358,7 +1358,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2109
 msgid "Bold"
-msgstr ""
+msgstr "Lihavoi"
 
 #: ../../src/wxMaxima.cpp:2259
 msgid "Both horizontal and vertical cursor active at the same time"
@@ -1382,13 +1382,13 @@ msgstr ""
 
 #: ../../src/sidebars/StatSidebar.cpp:97
 msgid "Boxplot..."
-msgstr ""
+msgstr "Laatikkokaavio..."
 
 #: ../../src/dialogs/BinaryNameCtrl.cpp:42 ../../src/wizards/CsvWiz.cpp:57
 #: ../../src/wizards/CsvWiz.cpp:131 ../../src/wizards/Plot2dWiz.cpp:114
 #: ../../src/wizards/Plot3dWiz.cpp:109
 msgid "Browse"
-msgstr ""
+msgstr "Selaa"
 
 #: ../../src/wxMathml.cpp:101
 msgid "Bug: After removing the whitespace wxMathml.lisp is shorter than expected!"
@@ -1767,11 +1767,11 @@ msgstr ""
 
 #: ../../src/sidebars/MathSidebar.cpp:62
 msgid "Canonical (tr)"
-msgstr ""
+msgstr "Kanoninen (tr)"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:188
 msgid "Catalan"
-msgstr ""
+msgstr "Katalaani"
 
 #: ../../src/MaximaCommandMenus.cpp:466
 msgid "Cauchy principal value of f(x)/(x-c), finite interval"
@@ -1917,7 +1917,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:199
 msgid "Chi"
-msgstr ""
+msgstr "Khii"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:189
 msgid "Chinese (Simplified)"
@@ -1941,7 +1941,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2100
 msgid "Choose font"
-msgstr ""
+msgstr "Valitse fontti"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:793
 msgid "Choose how mathematical output is formatted:\n"
@@ -1952,7 +1952,7 @@ msgstr ""
 
 #: ../../src/wizards/PlotFormatWiz.cpp:31
 msgid "Choose new plot format:"
-msgstr ""
+msgstr "Valitse uusi kuvaajalaji:"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2432
 #, c-format
@@ -2126,7 +2126,7 @@ msgstr ""
 
 #: ../../src/wizards/MatWiz.cpp:155
 msgid "Columns:"
-msgstr ""
+msgstr "Sarakkeet:"
 
 #: ../../src/wxMaximaFrame.cpp:1621
 msgid "Combine factorials in an expression"
@@ -2142,11 +2142,11 @@ msgstr ""
 
 #: ../../src/wizards/Plot2dWiz.cpp:626
 msgid "Comma separated x coordinates"
-msgstr ""
+msgstr "Pilkuilla erotetut x-koordinaatit"
 
 #: ../../src/wizards/Plot2dWiz.cpp:627
 msgid "Comma separated y coordinates"
-msgstr ""
+msgstr "Pilkuilla erotetut y-koordinaatit"
 
 #: ../../src/MaximaCommandMenus.cpp:4071
 msgid "Comma-separated arguments"
@@ -2372,7 +2372,7 @@ msgstr "Ehto:"
 #: ../../src/dialogs/ConfigDialogue.cpp:2641
 #: ../../src/dialogs/ConfigDialogue.cpp:2647
 msgid "Config file (*.ini)|*.ini"
-msgstr ""
+msgstr "Asetustiedosto (*.ini)|*.ini"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2539
 #, c-format
@@ -2404,7 +2404,7 @@ msgstr ""
 #: ../../src/wizards/IntegrateWiz.cpp:208 ../../src/wizards/LimitWiz.cpp:133
 #: ../../src/wizards/SeriesWiz.cpp:105
 msgid "Constant"
-msgstr ""
+msgstr "Vakio"
 
 #: ../../src/MaximaCommandMenus.cpp:1102
 msgid "Construct a fraction"
@@ -2878,7 +2878,7 @@ msgstr ""
 
 #: ../../src/worksheet/Worksheet.cpp:6115
 msgid "Cursor"
-msgstr ""
+msgstr "Kursori"
 
 #: ../../src/Styles.cpp:126
 msgid "Cursor color"
@@ -2900,11 +2900,11 @@ msgstr "Leikkaa valitun"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:193
 msgid "Czech"
-msgstr ""
+msgstr "Tsekki"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:194
 msgid "Danish"
-msgstr ""
+msgstr "Tanska"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2069
 msgid "Dark"
@@ -3095,7 +3095,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:181
 msgid "Delta"
-msgstr ""
+msgstr "delta"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:110
 #: ../../src/worksheet/WorksheetContextMenu.cpp:558
@@ -3121,7 +3121,7 @@ msgstr ""
 
 #: ../../src/wizards/SeriesWiz.cpp:42
 msgid "Depth:"
-msgstr ""
+msgstr "Syvyys:"
 
 #: ../../src/MaximaCommandMenus.cpp:994
 msgid "Derivate of y at that point:"
@@ -3156,7 +3156,7 @@ msgstr ""
 
 #: ../../src/sidebars/StatSidebar.cpp:61
 msgid "Deviation..."
-msgstr ""
+msgstr "Derivointi..."
 
 #: ../../src/wxMaximaFrame.cpp:1534
 msgid "Di&vide Polynomials..."
@@ -3188,7 +3188,7 @@ msgstr ""
 
 #: ../../src/sidebars/MathSidebar.cpp:80
 msgid "Diff..."
-msgstr ""
+msgstr "Deri..."
 
 #: ../../src/dialogs/DiffFrame.cpp:308
 #, c-format
@@ -3217,7 +3217,7 @@ msgstr ""
 
 #: ../../src/wizards/LimitWiz.cpp:41
 msgid "Direction:"
-msgstr ""
+msgstr "Suunta:"
 
 #: ../../src/wxMaximaFrame.cpp:1246
 msgid "Directory operations"
@@ -3538,7 +3538,7 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:129
 msgid "End of proof"
-msgstr ""
+msgstr "Todistuksen loppu"
 
 #: ../../src/MaximaCommandMenus.cpp:1024
 msgid "End of t:"
@@ -3571,7 +3571,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:196
 msgid "English"
-msgstr ""
+msgstr "Englanti"
 
 #: ../../src/wizards/DrawWiz.cpp:552
 msgid "Enhanced 3D settings:"
@@ -3583,7 +3583,7 @@ msgstr ""
 
 #: ../../src/sidebars/StatSidebar.cpp:106
 msgid "Enter Matrix..."
-msgstr ""
+msgstr "Syötä matriisi..."
 
 #: ../../src/MaximaCommandMenus.cpp:2255
 msgid "Enter UUID to jump to:"
@@ -3639,7 +3639,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:182
 msgid "Epsilon"
-msgstr ""
+msgstr "Epsilon:"
 
 #: ../../src/MaximaCommandMenus.cpp:299
 msgid "Epsilon:"
@@ -3732,7 +3732,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:184
 msgid "Eta"
-msgstr ""
+msgstr "Eeta"
 
 #: ../../src/sidebars/TableOfContents.cpp:513
 msgid "Evaluate"
@@ -3870,7 +3870,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2659
 msgid "Example text"
-msgstr ""
+msgstr "Esimerkkiteksti"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1547
 msgid "Examples:"
@@ -3886,11 +3886,11 @@ msgstr ""
 
 #: ../../src/sidebars/MathSidebar.cpp:53
 msgid "Expand"
-msgstr ""
+msgstr "Laajenna"
 
 #: ../../src/sidebars/MathSidebar.cpp:68
 msgid "Expand (tr)"
-msgstr ""
+msgstr "Laajenna (tr)"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:356
 msgid "Expand Expression"
@@ -4216,7 +4216,7 @@ msgstr ""
 
 #: ../../src/sidebars/MathSidebar.cpp:50
 msgid "Factor"
-msgstr ""
+msgstr "Tekijä"
 
 #: ../../src/wxMaximaFrame.cpp:1558
 msgid "Factor Complex"
@@ -4533,7 +4533,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2047
 msgid "Fonts"
-msgstr ""
+msgstr "Fontit"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:442
 msgid "For each Text-, Sectioning or code cell wxMaxima can display a bracket showing the extend of the cell and allowing to fold it. This setting now tells if this bracket is to be printed, as well."
@@ -4561,7 +4561,7 @@ msgstr ""
 
 #: ../../src/wizards/Plot2dWiz.cpp:69 ../../src/wizards/Plot3dWiz.cpp:60
 msgid "Format:"
-msgstr ""
+msgstr "Muoto:"
 
 #: ../../src/worksheet/Worksheet.cpp:301 ../../src/wxMaxima.cpp:3521
 msgid "Forwarding the keyboard focus to a text control"
@@ -4626,7 +4626,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:198
 msgid "French"
-msgstr ""
+msgstr "Ranska"
 
 #: ../../src/wxMaximaFrame.cpp:1447
 msgid "Frobenius Norm sqrt(sum((A(i,j))^2)) (complex)"
@@ -4709,11 +4709,11 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:199
 msgid "Galician"
-msgstr ""
+msgstr "Galicia"
 
 #: ../../src/sidebars/GreekSidebar.cpp:180
 msgid "Gamma"
-msgstr ""
+msgstr "gamma"
 
 #: ../../src/wxMaximaFrame.cpp:316
 msgid "General Math"
@@ -4765,7 +4765,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:201
 msgid "German"
-msgstr ""
+msgstr "Saksa"
 
 #: ../../src/wxMaximaFrame.cpp:1656
 msgid "Get &Imaginary Part"
@@ -4853,7 +4853,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:202
 msgid "Greek"
-msgstr ""
+msgstr "Kreikka"
 
 #: ../../src/wxMaximaFrame.cpp:281
 msgid "Greek Letters"
@@ -4869,7 +4869,7 @@ msgstr ""
 
 #: ../../src/wizards/Plot3dWiz.cpp:52
 msgid "Grid:"
-msgstr ""
+msgstr "Ruudukko"
 
 #: ../../src/wxMaximaFrame.cpp:1852
 msgid "Guess an exact number that could be meant by this float"
@@ -5046,7 +5046,7 @@ msgstr "Histogrammi"
 
 #: ../../src/sidebars/StatSidebar.cpp:85
 msgid "Histogram..."
-msgstr ""
+msgstr "Histogrammi..."
 
 #: ../../src/wxMaximaFrame.cpp:246
 msgid "History"
@@ -5058,7 +5058,7 @@ msgstr "Historia\tAlt+Shift+H"
 
 #: ../../src/dialogs/TipOfTheDay.cpp:105
 msgid "Horizontal cursor works like a normal cursor, but it operates on cells: press up or down arrow to move it, holding down Shift while moving will select cells, pressing backspace or delete twice will delete a cell next to it."
-msgstr ""
+msgstr "Horisontaalinen kursori toimii kuten tavallinenkin kursori, mutta sitä käytetään soluissa: siirtääksesi kursoria ylös tai alas käytä nuolinäppäimiä, liikkuessasi ja pitäessäsi Shiftin pohjassa solut valikoituvat, painaessasi askelpalautinta/backspacea tai deleteä kahdesti poistaa solun kursorin vierestä."
 
 #: ../../src/wxMaximaFrame.cpp:1563
 msgid "Horner's rule"
@@ -5078,7 +5078,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:205
 msgid "Hungarian"
-msgstr ""
+msgstr "Unkari"
 
 #: ../../src/wxMaximaFrame.cpp:1147
 msgid "I/O"
@@ -5189,7 +5189,7 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:122
 msgid "If your calculation is taking too long to evaluate, you can try 'Maxima->Interrupt' or 'Maxima->Restart Maxima' menu commands."
-msgstr ""
+msgstr "Jos laskutoimituksesi laskeminen kestää liian kauan, voit käyttää 'Maxima->Keskeytä' tai 'Maxima->Uudelleenkäynnistä Maxima' valikkokomentoja."
 
 #: ../../src/MaximaManual.cpp:420
 msgid "Ignoring the cache version for the manual anchors."
@@ -5197,7 +5197,7 @@ msgstr ""
 
 #: ../../src/sidebars/FormatSidebar.cpp:66
 msgid "Image"
-msgstr ""
+msgstr "Kuva"
 
 #: ../../src/Image.cpp:110
 msgid "Image data had zero length!"
@@ -5326,7 +5326,7 @@ msgstr ""
 #: ../../src/wizards/IntegrateWiz.cpp:215 ../../src/wizards/LimitWiz.cpp:132
 #: ../../src/wizards/LimitWiz.cpp:140
 msgid "Infinity"
-msgstr ""
+msgstr "Ääretön"
 
 #: ../../src/wxMaximaFrame.cpp:1986
 msgid "Info about Maxima build"
@@ -5536,7 +5536,7 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:113
 msgid "Integral sign"
-msgstr ""
+msgstr "Integraali merkki"
 
 #: ../../src/MaximaCommandMenus.cpp:149 ../../src/MaximaCommandMenus.cpp:170
 msgid "Integral/Sum:"
@@ -5660,7 +5660,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:186
 msgid "Iota"
-msgstr ""
+msgstr "Ioota"
 
 #: ../../src/MaximaCommandMenus.cpp:4150
 msgid "Is Char 1 greater than Char2, if case is ignored?"
@@ -5804,11 +5804,11 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:207
 msgid "Italian"
-msgstr ""
+msgstr "Italia"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2111
 msgid "Italic"
-msgstr ""
+msgstr "Kursiivi"
 
 #: ../../src/MaximaCommandMenus.cpp:1617 ../../src/MaximaCommandMenus.cpp:1623
 msgid "Item"
@@ -5820,7 +5820,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:208
 msgid "Japanese"
-msgstr ""
+msgstr "Japani"
 
 #: ../../src/MaximaCommandMenus.cpp:2255
 msgid "Jump to UUID"
@@ -5852,7 +5852,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:187
 msgid "Kappa"
-msgstr ""
+msgstr "kappa"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:864
 #, c-format
@@ -5920,7 +5920,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1311
 msgid "Language:"
-msgstr ""
+msgstr "Kieli:"
 
 #: ../../src/MaximaCommandMenus.cpp:251
 msgid "Laplace"
@@ -5979,7 +5979,7 @@ msgstr "Pienimmän neliösumman sovitus"
 
 #: ../../src/sidebars/StatSidebar.cpp:79
 msgid "Least Squares Fit..."
-msgstr ""
+msgstr "Pienimmän neliösumman sovitus..."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2007
 msgid "Left"
@@ -6045,7 +6045,7 @@ msgstr ""
 
 #: ../../src/sidebars/StatSidebar.cpp:76
 msgid "Linear Regression..."
-msgstr ""
+msgstr "Lineaarinen regressio..."
 
 #: ../../src/MaximaCommandMenus.cpp:4068
 msgid "Lisp format string:"
@@ -6178,7 +6178,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2162
 msgid "Load"
-msgstr ""
+msgstr "Lataa"
 
 #: ../../src/MaximaCommandMenus.cpp:2356
 msgid "Load Package"
@@ -6218,7 +6218,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2645
 msgid "Load style from file"
-msgstr ""
+msgstr "Lataa tyyli tiedostosta"
 
 #: ../../src/wxMaximaFrame.cpp:1232
 msgid "Load the file/dir operations (operatingsystem)"
@@ -6922,7 +6922,7 @@ msgstr ""
 
 #: ../../src/wizards/MatWiz.cpp:163
 msgid "Name:"
-msgstr ""
+msgstr "Nimi:"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:216
 msgid "Nepali"
@@ -6998,7 +6998,7 @@ msgstr ""
 
 #: ../../src/wizards/SubstituteWiz.cpp:35
 msgid "New value:"
-msgstr ""
+msgstr "Uusi arvo:"
 
 #: ../../src/MaximaCommandMenus.cpp:151 ../../src/MaximaCommandMenus.cpp:171
 #: ../../src/MaximaCommandMenus.cpp:254 ../../src/MaximaCommandMenus.cpp:259
@@ -7116,7 +7116,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:217
 msgid "Norwegian"
-msgstr ""
+msgstr "Norja"
 
 #: ../../src/MaximaCommandMenus.cpp:1351
 msgid "Not a valid matrix dimension!"
@@ -7303,7 +7303,7 @@ msgstr ""
 
 #: ../../src/wizards/SubstituteWiz.cpp:32
 msgid "Old value:"
-msgstr ""
+msgstr "Vanha arvo:"
 
 #: ../../src/MaximaCommandMenus.cpp:151 ../../src/MaximaCommandMenus.cpp:172
 #: ../../src/MaximaCommandMenus.cpp:253 ../../src/MaximaCommandMenus.cpp:259
@@ -7312,7 +7312,7 @@ msgstr "Vanha muuttuja:"
 
 #: ../../src/sidebars/GreekSidebar.cpp:201
 msgid "Omega"
-msgstr ""
+msgstr "Oomega"
 
 #: ../../src/sidebars/GreekSidebar.cpp:192
 msgid "Omicron"
@@ -7505,7 +7505,7 @@ msgstr ""
 
 #: ../../src/sidebars/FormatSidebar.cpp:69
 msgid "Pagebreak"
-msgstr ""
+msgstr "Sivunvaihto"
 
 #: ../../src/wxMaximaFrame.cpp:1674
 msgid "Parallel Substitute..."
@@ -7517,7 +7517,7 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:124
 msgid "Parallel to"
-msgstr ""
+msgstr "Yhdensuuntaiset"
 
 #: ../../src/MaximaCommandMenus.cpp:3991
 msgid "Parameter name:"
@@ -7587,7 +7587,7 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:125
 msgid "Perpendicular to"
-msgstr ""
+msgstr "Kohtisuorassa"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:218
 msgid "Persian"
@@ -7595,15 +7595,15 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:198
 msgid "Phi"
-msgstr ""
+msgstr "Fii"
 
 #: ../../src/sidebars/GreekSidebar.cpp:193
 msgid "Pi"
-msgstr ""
+msgstr "Pii"
 
 #: ../../src/sidebars/StatSidebar.cpp:94
 msgid "Piechart..."
-msgstr ""
+msgstr "Sektoridiagrammi..."
 
 #: ../../src/wxMaxima.cpp:1585
 msgid "Please configure wxMaxima with 'Edit->Configure'."
@@ -7689,7 +7689,7 @@ msgstr ""
 
 #: ../../src/wizards/Plot2dWiz.cpp:84 ../../src/wizards/Plot3dWiz.cpp:80
 msgid "Plot to file:"
-msgstr ""
+msgstr "Kuvaaja tiedostoksi:"
 
 #: ../../src/wxMaximaFrame.cpp:341 ../../src/wxMaximaFrame.cpp:749
 msgid "Plot using Draw"
@@ -7723,7 +7723,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:219
 msgid "Polish"
-msgstr ""
+msgstr "Puola"
 
 #: ../../src/MaximaCommandMenus.cpp:215 ../../src/MaximaCommandMenus.cpp:220
 #: ../../src/MaximaCommandMenus.cpp:225
@@ -7759,7 +7759,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:221
 msgid "Portuguese (Brazilian)"
-msgstr ""
+msgstr "Portugali (Brasilian)"
 
 #: ../../src/wxMaximaFrame.cpp:1223
 msgid "Position of a match"
@@ -7951,7 +7951,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:200
 msgid "Psi"
-msgstr ""
+msgstr "Psii"
 
 #: ../../src/wxMaximaFrame.cpp:1788
 msgid "Push"
@@ -8533,7 +8533,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:194
 msgid "Rho"
-msgstr ""
+msgstr "Rhoo"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2015
 msgid "Right"
@@ -8586,7 +8586,7 @@ msgstr ""
 
 #: ../../src/wizards/MatWiz.cpp:152
 msgid "Rows:"
-msgstr ""
+msgstr "Rivit:"
 
 #: ../../src/MaximaCommandMenus.cpp:1391
 msgid "Rule"
@@ -8656,7 +8656,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:223
 msgid "Russian"
-msgstr ""
+msgstr "Venäjä"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1578
 msgid "SBCL: use <int>Mbytes of heap"
@@ -8758,7 +8758,7 @@ msgstr "Tallenna asiakirja nimellä"
 
 #: ../../src/wizards/Plot2dWiz.cpp:473 ../../src/wizards/Plot3dWiz.cpp:421
 msgid "Save plot to file"
-msgstr ""
+msgstr "Tallenna kuvaaja tiedostoksi "
 
 #: ../../src/wxMaximaFrame.cpp:713
 msgid "Save selection from document to an image file"
@@ -8770,7 +8770,7 @@ msgstr "Tallenna valinta tiedostoksi"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2640
 msgid "Save style to file"
-msgstr ""
+msgstr "Tallenna tyyli tiedostoksi"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1384
 msgid "Save the worksheet automatically"
@@ -8893,7 +8893,7 @@ msgstr ""
 #: ../../src/wizards/IntegrateWiz.cpp:208 ../../src/wizards/LimitWiz.cpp:133
 #: ../../src/wizards/SeriesWiz.cpp:105
 msgid "Select a constant"
-msgstr ""
+msgstr "Valitse vakio"
 
 #: ../../src/ToolBar.cpp:390 ../../src/ToolBar.cpp:392
 #: ../../src/wxMaximaFrame.cpp:710
@@ -9322,7 +9322,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:195
 msgid "Sigma"
-msgstr ""
+msgstr "Sigma"
 
 #: ../../src/dialogs/FindReplacePane.cpp:88
 msgid "Simple"
@@ -9334,7 +9334,7 @@ msgstr ""
 
 #: ../../src/sidebars/MathSidebar.cpp:44
 msgid "Simplify"
-msgstr ""
+msgstr "Sievennä"
 
 #: ../../src/wxMaximaFrame.cpp:1550
 msgid "Simplify &Radicals..."
@@ -9342,11 +9342,11 @@ msgstr ""
 
 #: ../../src/sidebars/MathSidebar.cpp:47
 msgid "Simplify (r)"
-msgstr ""
+msgstr "Sievennä (r)"
 
 #: ../../src/sidebars/MathSidebar.cpp:65
 msgid "Simplify (tr)"
-msgstr ""
+msgstr "Sievennä (tr)"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:352
 msgid "Simplify Expression"
@@ -9386,7 +9386,7 @@ msgstr ""
 
 #: ../../src/wizards/SumWiz.cpp:68
 msgid "Simplify the sum"
-msgstr ""
+msgstr "Sievennä summa"
 
 #: ../../src/wxMaximaFrame.cpp:1629
 msgid "Simplify trigonometric expression"
@@ -9451,7 +9451,7 @@ msgstr ""
 
 #: ../../src/wizards/BC2Wiz.cpp:30
 msgid "Solution:"
-msgstr ""
+msgstr "Ratkaisu:"
 
 #: ../../src/MaximaCommandMenus.cpp:3446
 msgid "Solve"
@@ -9618,7 +9618,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:227
 msgid "Spanish"
-msgstr ""
+msgstr "espanja"
 
 #: ../../src/wizards/IntegrateWiz.cpp:44 ../../src/wizards/IntegrateWiz.cpp:50
 #: ../../src/wizards/LimitWiz.cpp:38 ../../src/wizards/SeriesWiz.cpp:39
@@ -9834,11 +9834,11 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:282
 msgid "Style"
-msgstr ""
+msgstr "Tyyli"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2082
 msgid "Styles"
-msgstr ""
+msgstr "Tyylit"
 
 #: ../../src/sidebars/StatSidebar.cpp:112
 msgid "Subsample..."
@@ -9938,7 +9938,7 @@ msgstr "Summa"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:122
 msgid "Sum sign"
-msgstr ""
+msgstr "Summa-merkki"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:228
 msgid "Swedish"
@@ -10003,7 +10003,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:196
 msgid "Tau"
-msgstr ""
+msgstr "tau"
 
 #: ../../src/MaximaCommandMenus.cpp:181
 msgid "Taylor series"
@@ -10460,7 +10460,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:185
 msgid "Theta"
-msgstr ""
+msgstr "Theeta"
 
 #: ../../src/dialogs/LicenseDialog.cpp:85
 msgid "Third-party notices"
@@ -10768,7 +10768,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:230
 msgid "Turkish"
-msgstr ""
+msgstr "Turkki"
 
 #: ../../src/wxMaximaFrame.cpp:1965
 msgid "Tutorials"
@@ -10804,7 +10804,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:231
 msgid "Ukrainian"
-msgstr ""
+msgstr "Ukraina"
 
 #: ../../src/wxMaxima.cpp:3164
 msgid "Un-closed parenthesis"
@@ -10835,7 +10835,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2115
 msgid "Underlined"
-msgstr ""
+msgstr "Alleviivattu"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:745
 msgid "Underscore converts to subscripts:"
@@ -10983,7 +10983,7 @@ msgstr ""
 
 #: ../../src/wizards/SumWiz.cpp:69
 msgid "Use Gosper algorithm"
-msgstr ""
+msgstr "Käytä Gosperin algoritmia"
 
 #: ../../src/sidebars/RegexCtrl.cpp:133
 msgid "Use RegEx filtering"
@@ -11011,7 +11011,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:849
 msgid "Use centered dot character for multiplication"
-msgstr ""
+msgstr "Käytä keskitettyä pistettä kertolaskuissa"
 
 #: ../../src/wxMaximaFrame.cpp:1745
 msgid "Use list"
@@ -11196,7 +11196,7 @@ msgstr "Muuttujat:"
 
 #: ../../src/sidebars/StatSidebar.cpp:58
 msgid "Variance..."
-msgstr ""
+msgstr "Varianssi..."
 
 #: ../../src/WXMXformat.cpp:339
 msgid "Verified that we are able to read the whole .zip archive we produced."
@@ -11296,7 +11296,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:280
 msgid "Worksheet"
-msgstr ""
+msgstr "Työkirja"
 
 #: ../../src/MaximaResponseReader.cpp:117
 #, c-format
@@ -11347,19 +11347,19 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:191
 msgid "Xi"
-msgstr ""
+msgstr "Ksii"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:728
 msgid "Yes"
-msgstr ""
+msgstr "Kyllä"
 
 #: ../../src/dialogs/TipOfTheDay.cpp:64
 msgid "You can access the last output using the variable '%'. You can access the output of previous commands using variables '%on' where n is the number of output."
-msgstr ""
+msgstr "Pääset käyttämään viimeistä tulostetta muuttujalla '%'. Pääset käyttämään aiempien komentojen tulosteita muuttujalla '%on' jossa n on tulosteen numero. "
 
 #: ../../src/dialogs/TipOfTheDay.cpp:118
 msgid "You can evaluate your whole document by using 'Cell->Evaluate All Cells' menu command or the appropriate key shortcut. The cells will be evaluated in the order they appear in the document."
-msgstr ""
+msgstr "Voit laskea koko dokumentin käyttämällä 'Solu -> Laske kaikki solut' valikkokomentoja tai komennon näppäinyhdistelmällä. Solut lasketaan asiakirjassa olevan esiintymisjärjestyksensä mukaisesti."
 
 #: ../../src/dialogs/TipOfTheDay.cpp:98
 msgid "You can get help on a Maxima function by selecting or clicking on the function name and pressing F1. wxMaxima will search the help index for the selection or the word under the cursor."
@@ -11367,7 +11367,7 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:92
 msgid "You can hide output part of cells by clicking in the triangle on the left side of cells. This works on text cells also."
-msgstr ""
+msgstr "Voit piilottaa solujen tulososuuden painamalla solujen vasemman reunan kolmikulmiota. Sama toimii myös tekstisoluissa."
 
 #: ../../src/dialogs/TipOfTheDay.cpp:81
 msgid "You can insert different types of 'cells' in wxMaxima documents using the 'Cell' menu. Note that only 'input cells' can be evaluated, while others are used for commenting and structuring your calculations."
@@ -11375,7 +11375,7 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:112
 msgid "You can select multiple cells either with a mouse - click'n'drag from between cells or from a cell bracket on the left - or with a keyboard - hold down Shift while moving the horizontal cursor - and then operate on selection. This comes in handy when you want to delete or evaluate multiple cells."
-msgstr ""
+msgstr "Voit valita useita soluja joko hiirellä - napsauta ja raahaa solujen välillä tai vasemmalta soluryhmästä - tai näppäimistöllä - pidä Shift pohjassa liikuttaessasi horisontaalista kursoria - ja järjestele valintoja. Tällä tavoin on näppärää poistaa tai arvioida useita soluja kerralla."
 
 #: ../../src/dialogs/TipOfTheDay.cpp:232
 msgid "You found a bug in wxMaxima? Please report it at https://github.com/wxMaxima-developers/wxmaxima/issues\n"
@@ -11403,7 +11403,7 @@ msgstr "wxMaximassasi on viimeisin päivitys."
 
 #: ../../src/sidebars/GreekSidebar.cpp:183
 msgid "Zeta"
-msgstr ""
+msgstr "Zeeta"
 
 #: ../../src/wxMaximaFrame.cpp:842
 msgid "Zoom &In\tCtrl++"
@@ -11443,15 +11443,15 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:151
 msgid "alpha"
-msgstr ""
+msgstr "alfa"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:95
 msgid "and"
-msgstr ""
+msgstr "ja"
 
 #: ../../src/wizards/MatWiz.cpp:160
 msgid "antisymmetric"
-msgstr ""
+msgstr "epäsymmetrinen"
 
 #: ../../src/wxMaximaFrame.cpp:1727
 msgid "apply function to each element"
@@ -11475,11 +11475,11 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:152
 msgid "beta"
-msgstr ""
+msgstr "beeta"
 
 #: ../../src/wizards/LimitWiz.cpp:42
 msgid "both sides"
-msgstr ""
+msgstr "molemmat puolet"
 
 #: ../../src/wxMaximaFrame.cpp:1173
 msgid "char to Ascii code..."
@@ -11487,7 +11487,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:172
 msgid "chi"
-msgstr ""
+msgstr "khii"
 
 #: ../../src/MaximaFileIO.cpp:318
 #, c-format
@@ -11497,15 +11497,15 @@ msgstr ""
 #: ../../src/wizards/Plot2dWiz.cpp:70 ../../src/wizards/Plot2dWiz.cpp:372
 #: ../../src/wizards/Plot3dWiz.cpp:61 ../../src/wizards/Plot3dWiz.cpp:358
 msgid "default"
-msgstr ""
+msgstr "oletus"
 
 #: ../../src/sidebars/GreekSidebar.cpp:154
 msgid "delta"
-msgstr ""
+msgstr "delta"
 
 #: ../../src/wizards/MatWiz.cpp:159
 msgid "diagonal"
-msgstr ""
+msgstr "diagonaalinen"
 
 #: ../../src/cells/FracCell.cpp:73
 msgid "diff(): Cannot find the multiplication sign I should hide"
@@ -11521,19 +11521,19 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:92
 msgid "empty"
-msgstr ""
+msgstr "tyhjä"
 
 #: ../../src/sidebars/GreekSidebar.cpp:155
 msgid "epsilon"
-msgstr ""
+msgstr "epsilon"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:100
 msgid "equivalent"
-msgstr ""
+msgstr "ekvivalentti"
 
 #: ../../src/sidebars/GreekSidebar.cpp:157
 msgid "eta"
-msgstr ""
+msgstr "eeta"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:799
 msgid "ev() shall evaluate this automatically"
@@ -11541,7 +11541,7 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:88
 msgid "exists"
-msgstr ""
+msgstr "on olemassa"
 
 #: ../../src/MaximaCommandMenus.cpp:3942
 msgid "expression:"
@@ -11583,11 +11583,11 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:153
 msgid "gamma"
-msgstr ""
+msgstr "gamma"
 
 #: ../../src/wizards/MatWiz.cpp:159
 msgid "general"
-msgstr ""
+msgstr "yleinen"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1630
 msgid "gnuplot: Without command console"
@@ -11595,7 +11595,7 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:118
 msgid "greater than or equal"
-msgstr ""
+msgstr "suurempi tai yhtä suuri kuin"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:87
 msgid "in"
@@ -11610,15 +11610,15 @@ msgstr ""
 #: ../../src/wizards/Plot3dWiz.cpp:61 ../../src/wizards/Plot3dWiz.cpp:194
 #: ../../src/wizards/Plot3dWiz.cpp:358 ../../src/wizards/Plot3dWiz.cpp:386
 msgid "inline"
-msgstr ""
+msgstr "avoin"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:104
 msgid "intersection"
-msgstr ""
+msgstr "leikkaus"
 
 #: ../../src/sidebars/GreekSidebar.cpp:159
 msgid "iota"
-msgstr ""
+msgstr "ioota"
 
 #: ../../src/sidebars/GreekSidebar.cpp:160
 msgid "kappa"
@@ -11626,15 +11626,15 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:161
 msgid "lambda"
-msgstr ""
+msgstr "lambda"
 
 #: ../../src/wizards/LimitWiz.cpp:42
 msgid "left"
-msgstr ""
+msgstr "vasen"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:117
 msgid "less or equal"
-msgstr ""
+msgstr "pienempi tai yhtä suuri kuin"
 
 #: ../../src/MaximaCommandMenus.cpp:1567
 msgid "list"
@@ -11642,7 +11642,7 @@ msgstr ""
 
 #: ../../src/wizards/Plot2dWiz.cpp:54 ../../src/wizards/Plot2dWiz.cpp:64
 msgid "logscale"
-msgstr ""
+msgstr "logaritminen asteikko"
 
 #: ../../src/wizards/DrawWiz.cpp:822
 msgid "matrix([x_1,x_2,...],[y_1,y_2,...])"
@@ -11662,11 +11662,11 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:120
 msgid "much greater than"
-msgstr ""
+msgstr "paljon suurempi kuin"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:119
 msgid "much less than"
-msgstr ""
+msgstr "paljon pienempi kuin"
 
 #: ../../src/MaximaCommandMenus.cpp:1232
 msgid "m×n Matrix A:"
@@ -11695,7 +11695,7 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:102
 msgid "not"
-msgstr ""
+msgstr "ei"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:116
 msgid "not bytewise identical"
@@ -11703,11 +11703,11 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:108
 msgid "not subset"
-msgstr ""
+msgstr "ei osajoukko"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:107
 msgid "not subset or equal"
-msgstr ""
+msgstr "ei osajoukko tai yhtäsuuri"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:796
 msgid "noun: Not evaluated by default"
@@ -11727,7 +11727,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:174
 msgid "omega"
-msgstr ""
+msgstr "oomega"
 
 #: ../../src/sidebars/GreekSidebar.cpp:165
 msgid "omicron"
@@ -11735,7 +11735,7 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:96
 msgid "or"
-msgstr ""
+msgstr "tai"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:793
 msgid "outative: f(2*x) = 2*f(x)"
@@ -11756,11 +11756,11 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:171
 msgid "phi"
-msgstr ""
+msgstr "fii"
 
 #: ../../src/sidebars/GreekSidebar.cpp:166
 msgid "pi"
-msgstr ""
+msgstr "pii"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:101
 msgid "plus or minus"
@@ -11789,11 +11789,11 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:115
 msgid "proportional to"
-msgstr ""
+msgstr "verrannollinen"
 
 #: ../../src/sidebars/GreekSidebar.cpp:173
 msgid "psi"
-msgstr ""
+msgstr "psii"
 
 #: ../../src/MaximaCommandMenus.cpp:642
 msgid "radcan() is a powerful tools for simplification trigonometric functions but needs to be taken with care: If a function has more than one branch radcan uses the one that looks like it would fit best, not necessarily the one that makes sense for the problem that resulted in the Expression that is to be simplified."
@@ -11821,11 +11821,11 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:167
 msgid "rho"
-msgstr ""
+msgstr "rhoo"
 
 #: ../../src/wizards/LimitWiz.cpp:42
 msgid "right"
-msgstr ""
+msgstr "oikea"
 
 #: ../../src/wizards/DrawWiz.cpp:310
 msgid "secondary x axis label"
@@ -11845,7 +11845,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:168
 msgid "sigma"
-msgstr ""
+msgstr "sigma"
 
 #: ../../src/MaximaCommandMenus.cpp:3447
 msgid "solve() will solve a list of equations only if for n independent equations there are n variables to solve to.\n"
@@ -11869,15 +11869,15 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:106
 msgid "subset"
-msgstr ""
+msgstr "osajoukko"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:105
 msgid "subset or equal"
-msgstr ""
+msgstr "osajoukko tai yhtäsuuri"
 
 #: ../../src/wizards/MatWiz.cpp:160
 msgid "symmetric"
-msgstr ""
+msgstr "symmetrinen"
 
 #: ../../src/MaximaCommandMenus.cpp:970
 msgid "t:"
@@ -11885,7 +11885,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:169
 msgid "tau"
-msgstr ""
+msgstr "tau"
 
 #: ../../src/cells/TextCell.cpp:340
 msgid "the [] operator tried to extract an element of a list, a matrix, an equation or an array. But instead of an integer number something was used whose numerical value is unknown or not an integer.\n"
@@ -11902,23 +11902,23 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:89
 msgid "there is no"
-msgstr ""
+msgstr "Ei ole olemassa"
 
 #: ../../src/sidebars/GreekSidebar.cpp:158
 msgid "theta"
-msgstr ""
+msgstr "theeta"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:78
 msgid "to the power of 2"
-msgstr ""
+msgstr "potenssiin 2"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:79
 msgid "to the power of 3"
-msgstr ""
+msgstr "potenssiin 3"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:103
 msgid "union"
-msgstr ""
+msgstr "unioni"
 
 #: ../../src/wxMaximaFrame.cpp:1109
 msgid "unnamed function (lambda)..."
@@ -11982,7 +11982,7 @@ msgstr ""
 #: ../../src/dialogs/ConfigDialogue.cpp:142
 #: ../../src/dialogs/ConfigDialogue.cpp:311
 msgid "wxMaxima configuration"
-msgstr ""
+msgstr "wxMaxima asetukset"
 
 #: ../../src/MaximaProcessManager.cpp:209
 msgid "wxMaxima could not start a server.\n\n"
@@ -11992,7 +11992,7 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:127
 msgid "wxMaxima dialogs set default values for inputs entries, one of which is '%'. If you have made a selection in your document, the selection will be used instead of '%'."
-msgstr ""
+msgstr "wxMaxima dialogeissa oletusarvona syötteen merkinnälle on \"%\". Jos olet tehnyt valinnan dokumenttiin, valintaa käytetään \"%\" sijasta ."
 
 #: ../../src/MaximaCommandMenus.cpp:4544
 msgid "wxMaxima document"
@@ -12134,7 +12134,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:164
 msgid "xi"
-msgstr ""
+msgstr "ksii"
 
 #: ../../src/MaximaFileIO.cpp:408 ../../src/MaximaFileIO.cpp:566
 msgid "xml contained in the file claims not to be a wxMaxima worksheet. "
@@ -12170,7 +12170,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:156
 msgid "zeta"
-msgstr ""
+msgstr "zeeta"
 
 #. type: Title #
 #: ../../info/wxmaxima.md:1

--- a/locales/wxMaxima/fr.po
+++ b/locales/wxMaxima/fr.po
@@ -251,7 +251,7 @@ msgstr ""
 #: ../../src/worksheet/Worksheet.cpp:423
 #, c-format
 msgid "%s image, %li×%li, %li ppi"
-msgstr ""
+msgstr "%s image, %li×%li, %li ppi"
 
 #: ../../src/Autocomplete.cpp:405
 #, c-format
@@ -318,7 +318,7 @@ msgstr "&Copier\tCtrl+C"
 
 #: ../../src/wizards/IntegrateWiz.cpp:39
 msgid "&Definite integration"
-msgstr ""
+msgstr "Intégrale &définie"
 
 #: ../../src/wxMaximaFrame.cpp:1658
 msgid "&Demoivre"
@@ -434,11 +434,11 @@ msgstr "&Sortie numérique"
 
 #: ../../src/wizards/IntegrateWiz.cpp:52
 msgid "&Numerical integration"
-msgstr ""
+msgstr "Intégration &numérique"
 
 #: ../../src/wizards/SumWiz.cpp:44
 msgid "&Nusum"
-msgstr ""
+msgstr "&Nusum"
 
 #: ../../src/main.cpp:675
 msgid "&Open\tCtrl+O"
@@ -454,7 +454,7 @@ msgstr "Tracé de courbes"
 
 #: ../../src/wizards/SeriesWiz.cpp:45
 msgid "&Power series"
-msgstr ""
+msgstr "Série entière"
 
 #: ../../src/wxMaximaFrame.cpp:655
 msgid "&Print...\tCtrl+P"
@@ -462,7 +462,7 @@ msgstr "Im&primer\tCtrl+P"
 
 #: ../../src/wizards/SubstituteWiz.cpp:38
 msgid "&Rational"
-msgstr ""
+msgstr "&Rationnel"
 
 #: ../../src/wxMaximaFrame.cpp:1631
 msgid "&Reduce Trigonometric"
@@ -494,11 +494,11 @@ msgstr "&Résoudre…"
 
 #: ../../src/wizards/Plot2dWiz.cpp:42
 msgid "&Special"
-msgstr ""
+msgstr "&Spécial"
 
 #: ../../src/wizards/LimitWiz.cpp:45
 msgid "&Taylor series"
-msgstr ""
+msgstr "Série de Taylor :"
 
 #: ../../src/wxMaximaFrame.cpp:1069
 msgid "&Time Display"
@@ -518,7 +518,7 @@ msgstr ""
 
 #: ../../src/wizards/Plot3dWiz.cpp:79
 msgid "&pm3d"
-msgstr ""
+msgstr "&pm3d"
 
 #: ../../src/cells/AnimationCell.cpp:475
 msgid "(Animation)"
@@ -554,7 +554,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:183
 msgid "(Use default language)"
-msgstr ""
+msgstr "(Utiliser la langue par défaut)"
 
 #: ../../src/MaximaCommandMenus.cpp:440
 msgid "(f(x),x,a,b)), Epsilon algorithm"
@@ -596,7 +596,7 @@ msgstr ""
 #: ../../src/wizards/IntegrateWiz.cpp:217 ../../src/wizards/LimitWiz.cpp:132
 #: ../../src/wizards/LimitWiz.cpp:142
 msgid "- Infinity"
-msgstr ""
+msgstr "- Infini"
 
 #: ../../src/MaximaOutputAppender.cpp:116
 msgid "... [suppressed additional lines as the output is longer than allowed in the wxMaxima configuration] "
@@ -653,7 +653,7 @@ msgstr "Un \" :lisp \" en tant que première commande peut échouer à envoyer u
 
 #: ../../src/dialogs/TipOfTheDay.cpp:102
 msgid "A 'horizontal cursor' was introduced in wxMaxima 0.8.0. It looks like a horizontal line between cells. It indicates where a new cell will appear if you type or paste text or execute a menu command."
-msgstr ""
+msgstr "Un « curseur horizontal » a été introduit avec wxMaxima 0.8.0. Il ressemble à une ligne ligne horizontale entre les cellules et indique où apparaîtra une nouvelle cellule si vous tapez ou collez du texte, ou exécutez une commande du menu."
 
 #: ../../src/MaximaCommandMenus.cpp:3039
 msgid "A Ctrl-F event"
@@ -920,7 +920,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:389
 msgid "Additional parameters for Maxima (e.g. -l clisp)."
-msgstr ""
+msgstr "Paramètres supplémentaires pour Maxima (par exemple -l clisp)"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1543
 msgid "Additional parameters for Maxima (restart Maxima after changes)"
@@ -1016,7 +1016,7 @@ msgstr ""
 
 #: ../../src/dialogs/BinaryNameCtrl.cpp:69
 msgid "All|*"
-msgstr ""
+msgstr "Tous|*"
 
 #: ../../src/wxMaximaFrame.cpp:800
 msgid "Always after underscores"
@@ -1296,7 +1296,7 @@ msgstr ""
 
 #: ../../src/wizards/BC2Wiz.cpp:59
 msgid "BC2"
-msgstr ""
+msgstr "BC2"
 
 #: ../../src/MaximaManual.cpp:559
 msgid "Background task that compiles the Manual anchors scheduled."
@@ -1304,7 +1304,7 @@ msgstr "Tâche en arrière-plan qui compile les ancres du manuel planifiée."
 
 #: ../../src/sidebars/StatSidebar.cpp:91
 msgid "Barsplot..."
-msgstr ""
+msgstr "Diagramme en barres…"
 
 #: ../../src/wxMaximaFrame.cpp:1384
 msgid "Basic matrix operations"
@@ -1363,7 +1363,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2109
 msgid "Bold"
-msgstr ""
+msgstr "Gras"
 
 #: ../../src/wxMaxima.cpp:2259
 msgid "Both horizontal and vertical cursor active at the same time"
@@ -1387,13 +1387,13 @@ msgstr ""
 
 #: ../../src/sidebars/StatSidebar.cpp:97
 msgid "Boxplot..."
-msgstr ""
+msgstr "Diagramme en boîte…"
 
 #: ../../src/dialogs/BinaryNameCtrl.cpp:42 ../../src/wizards/CsvWiz.cpp:57
 #: ../../src/wizards/CsvWiz.cpp:131 ../../src/wizards/Plot2dWiz.cpp:114
 #: ../../src/wizards/Plot3dWiz.cpp:109
 msgid "Browse"
-msgstr ""
+msgstr "Parcourir"
 
 #: ../../src/wxMathml.cpp:101
 msgid "Bug: After removing the whitespace wxMathml.lisp is shorter than expected!"
@@ -1772,11 +1772,11 @@ msgstr "Impossible de démarrer l'exécutable de maxima"
 
 #: ../../src/sidebars/MathSidebar.cpp:62
 msgid "Canonical (tr)"
-msgstr ""
+msgstr "Canonique (expr. trig.)"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:188
 msgid "Catalan"
-msgstr ""
+msgstr "Catalan"
 
 #: ../../src/MaximaCommandMenus.cpp:466
 msgid "Cauchy principal value of f(x)/(x-c), finite interval"
@@ -1946,7 +1946,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2100
 msgid "Choose font"
-msgstr ""
+msgstr "Choisir la police"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:793
 msgid "Choose how mathematical output is formatted:\n"
@@ -2131,7 +2131,7 @@ msgstr "Colonnes"
 
 #: ../../src/wizards/MatWiz.cpp:155
 msgid "Columns:"
-msgstr ""
+msgstr "Colonnes :"
 
 #: ../../src/wxMaximaFrame.cpp:1621
 msgid "Combine factorials in an expression"
@@ -2147,11 +2147,11 @@ msgstr "Virgule directement suivie d’une parenthèse fermante"
 
 #: ../../src/wizards/Plot2dWiz.cpp:626
 msgid "Comma separated x coordinates"
-msgstr ""
+msgstr "Liste x séparée par des virgules"
 
 #: ../../src/wizards/Plot2dWiz.cpp:627
 msgid "Comma separated y coordinates"
-msgstr ""
+msgstr "Liste y séparée par des virgules"
 
 #: ../../src/MaximaCommandMenus.cpp:4071
 msgid "Comma-separated arguments"
@@ -2377,7 +2377,7 @@ msgstr "Condition :"
 #: ../../src/dialogs/ConfigDialogue.cpp:2641
 #: ../../src/dialogs/ConfigDialogue.cpp:2647
 msgid "Config file (*.ini)|*.ini"
-msgstr ""
+msgstr "Fichier de configuration (*.ini)|*.ini"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2539
 #, c-format
@@ -2409,7 +2409,7 @@ msgstr "La connexion à Maxima est perdue."
 #: ../../src/wizards/IntegrateWiz.cpp:208 ../../src/wizards/LimitWiz.cpp:133
 #: ../../src/wizards/SeriesWiz.cpp:105
 msgid "Constant"
-msgstr ""
+msgstr "Constante"
 
 #: ../../src/MaximaCommandMenus.cpp:1102
 msgid "Construct a fraction"
@@ -2883,7 +2883,7 @@ msgstr ""
 
 #: ../../src/worksheet/Worksheet.cpp:6115
 msgid "Cursor"
-msgstr ""
+msgstr "Curseur"
 
 #: ../../src/Styles.cpp:126
 msgid "Cursor color"
@@ -2905,11 +2905,11 @@ msgstr "Couper la sélection"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:193
 msgid "Czech"
-msgstr ""
+msgstr "Tchèque"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:194
 msgid "Danish"
-msgstr ""
+msgstr "Danois"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2069
 msgid "Dark"
@@ -2987,7 +2987,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1534
 msgid "Default port for communication with wxMaxima:"
-msgstr ""
+msgstr "Port utilisé par défaut pour la communication entre Maxima et wxMaxima :"
 
 #: ../../src/MaximaCommandMenus.cpp:3946
 msgid "Define a function"
@@ -3126,7 +3126,7 @@ msgstr "Dépendances"
 
 #: ../../src/wizards/SeriesWiz.cpp:42
 msgid "Depth:"
-msgstr ""
+msgstr "profondeur :"
 
 #: ../../src/MaximaCommandMenus.cpp:994
 msgid "Derivate of y at that point:"
@@ -3161,7 +3161,7 @@ msgstr ""
 
 #: ../../src/sidebars/StatSidebar.cpp:61
 msgid "Deviation..."
-msgstr ""
+msgstr "Écart-type"
 
 #: ../../src/wxMaximaFrame.cpp:1534
 msgid "Di&vide Polynomials..."
@@ -3193,7 +3193,7 @@ msgstr ""
 
 #: ../../src/sidebars/MathSidebar.cpp:80
 msgid "Diff..."
-msgstr ""
+msgstr "Dériver"
 
 #: ../../src/dialogs/DiffFrame.cpp:308
 #, c-format
@@ -3222,7 +3222,7 @@ msgstr "Dériver l'expression n fois"
 
 #: ../../src/wizards/LimitWiz.cpp:41
 msgid "Direction:"
-msgstr ""
+msgstr "selon la direction"
 
 #: ../../src/wxMaximaFrame.cpp:1246
 msgid "Directory operations"
@@ -3234,7 +3234,7 @@ msgstr ""
 
 #: ../../src/wizards/Plot2dWiz.cpp:418 ../../src/wizards/Plot2dWiz.cpp:619
 msgid "Discrete plot"
-msgstr ""
+msgstr "Graphe discret"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:699
 msgid "Display"
@@ -3254,7 +3254,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:820
 msgid "Display all digits"
-msgstr ""
+msgstr "Afficher tous les chiffres"
 
 #: ../../src/wxMaximaFrame.cpp:788
 msgid "Display an expression as maxima's internal lisp representation"
@@ -3576,7 +3576,7 @@ msgstr "Format technique (12,1e6, etc.)"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:196
 msgid "English"
-msgstr ""
+msgstr "Anglais"
 
 #: ../../src/wizards/DrawWiz.cpp:552
 msgid "Enhanced 3D settings:"
@@ -3588,7 +3588,7 @@ msgstr ""
 
 #: ../../src/sidebars/StatSidebar.cpp:106
 msgid "Enter Matrix..."
-msgstr ""
+msgstr "Entrer une matrice…"
 
 #: ../../src/MaximaCommandMenus.cpp:2255
 msgid "Enter UUID to jump to:"
@@ -3600,7 +3600,7 @@ msgstr "Entrer une matrice"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:925
 msgid "Enter adds newlines, Ctrl+Enter evaluates cells"
-msgstr ""
+msgstr "Entrée pour nouvelle ligne, Ctrl+Entrée pour évaluation des cellules"
 
 #: ../../src/MaximaCommandMenus.cpp:873
 msgid "Enter an equation for rational simplification:"
@@ -3608,11 +3608,11 @@ msgstr "Entrer une équation pour la simplification rationnelle :"
 
 #: ../../src/wizards/SystemWiz.cpp:50
 msgid "Enter comma separated list of variables."
-msgstr ""
+msgstr "Entrer une liste de variables séparées par des virgules"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:921
 msgid "Enter evaluates cells, Ctrl+Enter adds newlines"
-msgstr ""
+msgstr "Entrée pour nouvelle ligne, Ctrl+Entrée pour évaluation des cellules"
 
 #: ../../src/MaximaCommandMenus.cpp:1357
 msgid "Enter matrix"
@@ -3628,7 +3628,7 @@ msgstr "Entrer la nouvelle précision pour les grands flottants :"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:388
 msgid "Enter the path to the Maxima executable."
-msgstr ""
+msgstr "Entrez le chemin vers l'exécutable de Maxima :"
 
 #: ../../src/MaximaCommandMenus.cpp:1103
 msgid "Enumerator:"
@@ -3877,7 +3877,7 @@ msgstr "Nombre pair"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2659
 msgid "Example text"
-msgstr ""
+msgstr "Texte exemple…"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1547
 msgid "Examples:"
@@ -3893,11 +3893,11 @@ msgstr "Quitter"
 
 #: ../../src/sidebars/MathSidebar.cpp:53
 msgid "Expand"
-msgstr ""
+msgstr "Développer"
 
 #: ../../src/sidebars/MathSidebar.cpp:68
 msgid "Expand (tr)"
-msgstr ""
+msgstr "Développer (expr. trig.)"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:356
 msgid "Expand Expression"
@@ -4223,7 +4223,7 @@ msgstr "Extrait un rectangle d'un tableau 2D et le convertir en une matrice"
 
 #: ../../src/sidebars/MathSidebar.cpp:50
 msgid "Factor"
-msgstr ""
+msgstr "Factoriser"
 
 #: ../../src/wxMaximaFrame.cpp:1558
 msgid "Factor Complex"
@@ -4298,7 +4298,7 @@ msgstr "Champs :"
 #: ../../src/cells/GroupCell.cpp:2115
 #, c-format
 msgid "Figure %d:"
-msgstr ""
+msgstr "Figure %d:"
 
 #: ../../src/main.cpp:678
 msgid "File"
@@ -4479,7 +4479,7 @@ msgstr "Ajuster l'affichage des nombres au format ingénieur"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:197
 msgid "Finnish"
-msgstr ""
+msgstr "Finlandais"
 
 #: ../../src/wxMaximaFrame.cpp:1749
 msgid "First"
@@ -4496,7 +4496,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:873
 msgid "Fixed font in text controls"
-msgstr ""
+msgstr "Police à chasse fixe dans les contrôles de texte"
 
 #: ../../src/MaximaCommandMenus.cpp:4039
 msgid "Flush stream"
@@ -4540,7 +4540,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2047
 msgid "Fonts"
-msgstr ""
+msgstr "Polices"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:442
 msgid "For each Text-, Sectioning or code cell wxMaxima can display a bracket showing the extend of the cell and allowing to fold it. This setting now tells if this bracket is to be printed, as well."
@@ -4576,7 +4576,7 @@ msgstr "Boucle « pour »..."
 
 #: ../../src/wizards/Plot2dWiz.cpp:69 ../../src/wizards/Plot3dWiz.cpp:60
 msgid "Format:"
-msgstr ""
+msgstr "Format :"
 
 #: ../../src/worksheet/Worksheet.cpp:301 ../../src/wxMaxima.cpp:3521
 msgid "Forwarding the keyboard focus to a text control"
@@ -4641,7 +4641,7 @@ msgstr "Effacer maintenant tous les éléments inutilisés"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:198
 msgid "French"
-msgstr ""
+msgstr "Français"
 
 #: ../../src/wxMaximaFrame.cpp:1447
 msgid "Frobenius Norm sqrt(sum((A(i,j))^2)) (complex)"
@@ -4780,7 +4780,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:201
 msgid "German"
-msgstr ""
+msgstr "Allemand"
 
 #: ../../src/wxMaximaFrame.cpp:1656
 msgid "Get &Imaginary Part"
@@ -4868,7 +4868,7 @@ msgstr "Supérieur, en ignorant la casse ?…"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:202
 msgid "Greek"
-msgstr ""
+msgstr "Grec"
 
 #: ../../src/wxMaximaFrame.cpp:281
 msgid "Greek Letters"
@@ -4884,7 +4884,7 @@ msgstr ""
 
 #: ../../src/wizards/Plot3dWiz.cpp:52
 msgid "Grid:"
-msgstr ""
+msgstr "Grille :"
 
 #: ../../src/wxMaximaFrame.cpp:1852
 msgid "Guess an exact number that could be meant by this float"
@@ -5061,7 +5061,7 @@ msgstr "Histogramme"
 
 #: ../../src/sidebars/StatSidebar.cpp:85
 msgid "Histogram..."
-msgstr ""
+msgstr "Histogramme…"
 
 #: ../../src/wxMaximaFrame.cpp:246
 msgid "History"
@@ -5073,7 +5073,7 @@ msgstr "Historique\tAlt+Shift+I"
 
 #: ../../src/dialogs/TipOfTheDay.cpp:105
 msgid "Horizontal cursor works like a normal cursor, but it operates on cells: press up or down arrow to move it, holding down Shift while moving will select cells, pressing backspace or delete twice will delete a cell next to it."
-msgstr ""
+msgstr "Le curseur horizontal fonctionne comme un curseur normal, mais fonctionne sur les cellules : les touches Haut et Bas permettent de le déplacer, maintenir la touche Maj pendant le déplacement sélectionne les cellules, appuyer sur la touche Retour arr. ou Suppr. deux fois permet d'effacer la cellule sélectionnée."
 
 #: ../../src/wxMaximaFrame.cpp:1563
 msgid "Horner's rule"
@@ -5093,7 +5093,7 @@ msgstr "Comment afficher les nouvelles équations"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:205
 msgid "Hungarian"
-msgstr ""
+msgstr "Hongrois"
 
 #: ../../src/wxMaximaFrame.cpp:1147
 msgid "I/O"
@@ -5206,7 +5206,7 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:122
 msgid "If your calculation is taking too long to evaluate, you can try 'Maxima->Interrupt' or 'Maxima->Restart Maxima' menu commands."
-msgstr ""
+msgstr "Si votre calcul met trop de temps à être évalué, vous pouvez essayer \"Maxima->Interrompre\" puis \"Maxima->Redémarrer Maxima"
 
 #: ../../src/MaximaManual.cpp:420
 msgid "Ignoring the cache version for the manual anchors."
@@ -5214,7 +5214,7 @@ msgstr "La version en cache des ancres du manuel est ignorée."
 
 #: ../../src/sidebars/FormatSidebar.cpp:66
 msgid "Image"
-msgstr ""
+msgstr "Image"
 
 #: ../../src/Image.cpp:110
 msgid "Image data had zero length!"
@@ -5344,7 +5344,7 @@ msgstr ""
 #: ../../src/wizards/IntegrateWiz.cpp:215 ../../src/wizards/LimitWiz.cpp:132
 #: ../../src/wizards/LimitWiz.cpp:140
 msgid "Infinity"
-msgstr ""
+msgstr "Infini"
 
 #: ../../src/wxMaximaFrame.cpp:1986
 msgid "Info about Maxima build"
@@ -5822,11 +5822,11 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:207
 msgid "Italian"
-msgstr ""
+msgstr "Italien"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2111
 msgid "Italic"
-msgstr ""
+msgstr "Italique"
 
 #: ../../src/MaximaCommandMenus.cpp:1617 ../../src/MaximaCommandMenus.cpp:1623
 msgid "Item"
@@ -5838,7 +5838,7 @@ msgstr "Nom de l'itérateur :"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:208
 msgid "Japanese"
-msgstr ""
+msgstr "Japonais"
 
 #: ../../src/MaximaCommandMenus.cpp:2255
 msgid "Jump to UUID"
@@ -5875,7 +5875,7 @@ msgstr ""
 #: ../../src/dialogs/ConfigDialogue.cpp:864
 #, c-format
 msgid "Keep percent sign with special symbols: %e, %i, etc."
-msgstr ""
+msgstr "Conserver le signe pourcentage avec les symboles spéciaux: %e, %i, etc."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:212
 msgid "Korean"
@@ -5936,11 +5936,11 @@ msgstr "Lambda génère une fonction, mais ne lui donne pas de nom.\n"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:470
 msgid "Language used for wxMaxima GUI."
-msgstr ""
+msgstr "Langue utilisée pour l'interface de wxMaxima"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1311
 msgid "Language:"
-msgstr ""
+msgstr "Langue :"
 
 #: ../../src/MaximaCommandMenus.cpp:251
 msgid "Laplace"
@@ -5999,7 +5999,7 @@ msgstr "Ajustement par la méthode des moindres carrés"
 
 #: ../../src/sidebars/StatSidebar.cpp:79
 msgid "Least Squares Fit..."
-msgstr ""
+msgstr "Ajustement par la méthode des moindres carrés…"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2007
 msgid "Left"
@@ -6057,7 +6057,7 @@ msgstr "Limite"
 
 #: ../../src/sidebars/MathSidebar.cpp:86
 msgid "Limit..."
-msgstr ""
+msgstr "Limite…"
 
 #: ../../src/sidebars/DrawSidebar.cpp:88
 msgid "Line color"
@@ -6065,7 +6065,7 @@ msgstr ""
 
 #: ../../src/sidebars/StatSidebar.cpp:76
 msgid "Linear Regression..."
-msgstr ""
+msgstr "Régression linéaire…"
 
 #: ../../src/MaximaCommandMenus.cpp:4068
 msgid "Lisp format string:"
@@ -6198,7 +6198,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2162
 msgid "Load"
-msgstr ""
+msgstr "Charger"
 
 #: ../../src/MaximaCommandMenus.cpp:2356
 msgid "Load Package"
@@ -6238,7 +6238,7 @@ msgstr "Charger lisp..."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2645
 msgid "Load style from file"
-msgstr ""
+msgstr "Charger un style à partir d'un fichier"
 
 #: ../../src/wxMaximaFrame.cpp:1232
 msgid "Load the file/dir operations (operatingsystem)"
@@ -6572,7 +6572,7 @@ msgstr "Le processus Maxima s’est terminé de manière inattendue."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1437
 msgid "Maxima program:"
-msgstr ""
+msgstr "Programme Maxima :"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:382
 msgid "Maxima provides no \"forget all\" command that flushes all settings a maxima session could make. wxMaxima therefore normally defaults to starting a fresh maxima process every time the worksheet is to be re-evaluated. As this needs a little bit of time this switch allows to disable this behavior."
@@ -6808,15 +6808,15 @@ msgstr ""
 
 #: ../../src/sidebars/StatSidebar.cpp:70
 msgid "Mean Difference Test..."
-msgstr ""
+msgstr "Test de la différence des moyennes…"
 
 #: ../../src/sidebars/StatSidebar.cpp:67
 msgid "Mean Test..."
-msgstr ""
+msgstr "Test sur la moyenne…"
 
 #: ../../src/sidebars/StatSidebar.cpp:52
 msgid "Mean..."
-msgstr ""
+msgstr "Moyenne…"
 
 #: ../../src/MaximaCommandMenus.cpp:1806
 msgid "Mean:"
@@ -6824,7 +6824,7 @@ msgstr "Moyenne :"
 
 #: ../../src/sidebars/StatSidebar.cpp:55
 msgid "Median..."
-msgstr ""
+msgstr "Médiane…"
 
 #: ../../src/wxMaximaFrame.cpp:1961
 msgid "Memoizing"
@@ -6845,7 +6845,7 @@ msgstr "Message de la sortie standard de Maxima : "
 
 #: ../../src/wizards/IntegrateWiz.cpp:55
 msgid "Method:"
-msgstr ""
+msgstr "Méthode :"
 
 #: ../../src/wxMaximaFrame.cpp:1360
 msgid "Methods of generating a matrix"
@@ -6944,7 +6944,7 @@ msgstr "Nom pour x :"
 
 #: ../../src/wizards/MatWiz.cpp:163
 msgid "Name:"
-msgstr ""
+msgstr "Nom :"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:216
 msgid "Nepali"
@@ -7020,7 +7020,7 @@ msgstr "Nouvelle partie :"
 
 #: ../../src/wizards/SubstituteWiz.cpp:35
 msgid "New value:"
-msgstr ""
+msgstr "Nouvelle valeur"
 
 #: ../../src/MaximaCommandMenus.cpp:151 ../../src/MaximaCommandMenus.cpp:171
 #: ../../src/MaximaCommandMenus.cpp:254 ../../src/MaximaCommandMenus.cpp:259
@@ -7123,7 +7123,7 @@ msgstr "Aucun"
 
 #: ../../src/sidebars/StatSidebar.cpp:73
 msgid "Normality Test..."
-msgstr ""
+msgstr "Test de normalité…"
 
 #: ../../src/cells/TextCell.cpp:271
 msgid "Normally computers use floating-point numbers that can be handled incredibly fast while being accurate to dozens of digits. They will, though, introduce a small error into some common numbers. For example 0.1 is represented as 3602879701896397/36028797018963968.\n"
@@ -7325,7 +7325,7 @@ msgstr ""
 
 #: ../../src/wizards/SubstituteWiz.cpp:32
 msgid "Old value:"
-msgstr ""
+msgstr "Ancienne valeur :"
 
 #: ../../src/MaximaCommandMenus.cpp:151 ../../src/MaximaCommandMenus.cpp:172
 #: ../../src/MaximaCommandMenus.cpp:253 ../../src/MaximaCommandMenus.cpp:259
@@ -7454,7 +7454,7 @@ msgstr ""
 
 #: ../../src/wizards/Plot2dWiz.cpp:75 ../../src/wizards/Plot3dWiz.cpp:66
 msgid "Options:"
-msgstr ""
+msgstr "Options :"
 
 #: ../../src/dialogs/FindReplacePane.cpp:109
 msgid "Output"
@@ -7527,7 +7527,7 @@ msgstr "Approximant de Padé d'un développement en série de Taylor"
 
 #: ../../src/sidebars/FormatSidebar.cpp:69
 msgid "Pagebreak"
-msgstr ""
+msgstr "Saut de page"
 
 #: ../../src/wxMaximaFrame.cpp:1674
 msgid "Parallel Substitute..."
@@ -7555,7 +7555,7 @@ msgstr ""
 
 #: ../../src/wizards/Plot2dWiz.cpp:417 ../../src/wizards/Plot2dWiz.cpp:523
 msgid "Parametric plot"
-msgstr ""
+msgstr "Courbe paramétrée"
 
 #: ../../src/MaximaCommandMenus.cpp:4211
 msgid "Parse string"
@@ -7625,7 +7625,7 @@ msgstr ""
 
 #: ../../src/sidebars/StatSidebar.cpp:94
 msgid "Piechart..."
-msgstr ""
+msgstr "Diagramme circulaire…"
 
 #: ../../src/wxMaxima.cpp:1585
 msgid "Please configure wxMaxima with 'Edit->Configure'."
@@ -7633,7 +7633,7 @@ msgstr "Configurer wxMaxima avec 'Édition->Configurer'."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2606
 msgid "Please restart wxMaxima for changes to take effect!"
-msgstr ""
+msgstr "Redémarrer wxMaxima pour que les changements prennent effet."
 
 #: ../../src/MaximaCommandMenus.cpp:2250
 msgid "Please select exactly 2 or 3 files."
@@ -7711,7 +7711,7 @@ msgstr ""
 
 #: ../../src/wizards/Plot2dWiz.cpp:84 ../../src/wizards/Plot3dWiz.cpp:80
 msgid "Plot to file:"
-msgstr ""
+msgstr "Tracer dans un fichier :"
 
 #: ../../src/wxMaximaFrame.cpp:341 ../../src/wxMaximaFrame.cpp:749
 msgid "Plot using Draw"
@@ -7745,7 +7745,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:219
 msgid "Polish"
-msgstr ""
+msgstr "Polonais"
 
 #: ../../src/MaximaCommandMenus.cpp:215 ../../src/MaximaCommandMenus.cpp:220
 #: ../../src/MaximaCommandMenus.cpp:225
@@ -7781,7 +7781,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:221
 msgid "Portuguese (Brazilian)"
-msgstr ""
+msgstr "Portugais (Brésil)"
 
 #: ../../src/wxMaximaFrame.cpp:1223
 msgid "Position of a match"
@@ -7797,7 +7797,7 @@ msgstr ""
 
 #: ../../src/wizards/Plot2dWiz.cpp:474 ../../src/wizards/Plot3dWiz.cpp:422
 msgid "Postscript file (*.eps)|*.eps|All|*"
-msgstr ""
+msgstr "Fichier postscript (*.eps)|*.eps|Tous|*"
 
 #: ../../src/MaximaCommandMenus.cpp:190
 msgid "Power series"
@@ -8059,7 +8059,7 @@ msgstr "Lire le répertoire"
 
 #: ../../src/sidebars/StatSidebar.cpp:103
 msgid "Read Matrix..."
-msgstr ""
+msgstr "&Lire la matrice…"
 
 #: ../../src/MaximaCommandMenus.cpp:4008
 msgid "Read a structure field"
@@ -8196,7 +8196,7 @@ msgstr "Récupération des données non sauvegardées"
 
 #: ../../src/sidebars/MathSidebar.cpp:56
 msgid "Rectform"
-msgstr ""
+msgstr "Forme cartésienne"
 
 #: ../../src/wxMaximaFrame.cpp:1677
 msgid "Recursive Substitute..."
@@ -8220,7 +8220,7 @@ msgstr "Refaire la dernière modification"
 
 #: ../../src/sidebars/MathSidebar.cpp:71
 msgid "Reduce (tr)"
-msgstr ""
+msgstr "Réduire (expr. trig.)"
 
 #: ../../src/wxMaximaFrame.cpp:1632
 msgid "Reduce trigonometric expression"
@@ -8608,7 +8608,7 @@ msgstr "Lignes"
 
 #: ../../src/wizards/MatWiz.cpp:152
 msgid "Rows:"
-msgstr ""
+msgstr "Lignes :"
 
 #: ../../src/MaximaCommandMenus.cpp:1391
 msgid "Rule"
@@ -8678,7 +8678,7 @@ msgstr "Calcul de chaque élément en utilisant une expression"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:223
 msgid "Russian"
-msgstr ""
+msgstr "Russe"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1578
 msgid "SBCL: use <int>Mbytes of heap"
@@ -8780,7 +8780,7 @@ msgstr "Sauvegarder le document sous"
 
 #: ../../src/wizards/Plot2dWiz.cpp:473 ../../src/wizards/Plot3dWiz.cpp:421
 msgid "Save plot to file"
-msgstr ""
+msgstr "Enregistrer le tracé dans un fichier "
 
 #: ../../src/wxMaximaFrame.cpp:713
 msgid "Save selection from document to an image file"
@@ -8792,7 +8792,7 @@ msgstr "Enregistrer la sélection dans un fichier"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2640
 msgid "Save style to file"
-msgstr ""
+msgstr "Enregistrer le style dans un fichier "
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1384
 msgid "Save the worksheet automatically"
@@ -8824,7 +8824,7 @@ msgstr "Nuage de points"
 
 #: ../../src/sidebars/StatSidebar.cpp:88
 msgid "Scatterplot..."
-msgstr ""
+msgstr "Nuage de points…"
 
 #: ../../src/Autocomplete.cpp:157
 msgid "Scheduling a background task that compiles a new list of autocompletable maxima commands."
@@ -8915,7 +8915,7 @@ msgstr "Choisir un sous-échantillon"
 #: ../../src/wizards/IntegrateWiz.cpp:208 ../../src/wizards/LimitWiz.cpp:133
 #: ../../src/wizards/SeriesWiz.cpp:105
 msgid "Select a constant"
-msgstr ""
+msgstr "Choisir une constante"
 
 #: ../../src/ToolBar.cpp:390 ../../src/ToolBar.cpp:392
 #: ../../src/wxMaximaFrame.cpp:710
@@ -9024,7 +9024,7 @@ msgstr "Régler la précision de la virgule flottante..."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:479
 msgid "Set fixed font in text controls."
-msgstr ""
+msgstr "Sélectionner une police à chasse fixe dans les entrées de texte."
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:68
 #: ../../src/worksheet/WorksheetContextMenu.cpp:250
@@ -9251,7 +9251,7 @@ msgstr "Montrer la représentation en lisp"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:465
 msgid "Show long expressions in wxMaxima document."
-msgstr ""
+msgstr "Montrer les expressions longues dans la console de wxMaxima"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:722
 msgid "Show long expressions:"
@@ -9356,7 +9356,7 @@ msgstr ""
 
 #: ../../src/sidebars/MathSidebar.cpp:44
 msgid "Simplify"
-msgstr ""
+msgstr "Simplifier"
 
 #: ../../src/wxMaximaFrame.cpp:1550
 msgid "Simplify &Radicals..."
@@ -9364,11 +9364,11 @@ msgstr "Simplifier des &radicaux..."
 
 #: ../../src/sidebars/MathSidebar.cpp:47
 msgid "Simplify (r)"
-msgstr ""
+msgstr "Simplifier (r)"
 
 #: ../../src/sidebars/MathSidebar.cpp:65
 msgid "Simplify (tr)"
-msgstr ""
+msgstr "Simplifier (expr. trig.)"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:352
 msgid "Simplify Expression"
@@ -9408,7 +9408,7 @@ msgstr "Simplifier les sommes"
 
 #: ../../src/wizards/SumWiz.cpp:68
 msgid "Simplify the sum"
-msgstr ""
+msgstr "Simplifier la somme"
 
 #: ../../src/wxMaximaFrame.cpp:1629
 msgid "Simplify trigonometric expression"
@@ -9473,7 +9473,7 @@ msgstr "Solution de l'EDO :"
 
 #: ../../src/wizards/BC2Wiz.cpp:30
 msgid "Solution:"
-msgstr ""
+msgstr "Solution :"
 
 #: ../../src/MaximaCommandMenus.cpp:3446
 msgid "Solve"
@@ -9513,7 +9513,7 @@ msgstr "Résoudre une équation différentielle avec Lapla&ce…"
 
 #: ../../src/sidebars/MathSidebar.cpp:77
 msgid "Solve ODE..."
-msgstr ""
+msgstr "Résoudre une équation différentielle…"
 
 #: ../../src/wxMaximaFrame.cpp:1432
 msgid "Solve a linear equation system using dgesv"
@@ -9641,12 +9641,12 @@ msgstr "Liste des sources :"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:227
 msgid "Spanish"
-msgstr ""
+msgstr "Espagnol"
 
 #: ../../src/wizards/IntegrateWiz.cpp:44 ../../src/wizards/IntegrateWiz.cpp:50
 #: ../../src/wizards/LimitWiz.cpp:38 ../../src/wizards/SeriesWiz.cpp:39
 msgid "Special"
-msgstr ""
+msgstr "Spécial"
 
 #: ../../src/wizards/DrawWiz.cpp:918
 msgid "Speed versus accuracy"
@@ -9857,15 +9857,15 @@ msgstr "Structures"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:282
 msgid "Style"
-msgstr ""
+msgstr "Style"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2082
 msgid "Styles"
-msgstr ""
+msgstr "Styles"
 
 #: ../../src/sidebars/StatSidebar.cpp:112
 msgid "Subsample..."
-msgstr ""
+msgstr "Sous-échantillon"
 
 #: ../../src/ToolBar.cpp:484 ../../src/sidebars/FormatSidebar.cpp:54
 msgid "Subsection"
@@ -9885,7 +9885,7 @@ msgstr "Subst est une meilleure fonction de recherche-et-remplacement de chaîne
 
 #: ../../src/sidebars/MathSidebar.cpp:59
 msgid "Subst..."
-msgstr ""
+msgstr "Substituer…"
 
 #: ../../src/MaximaCommandMenus.cpp:715 ../../src/MaximaCommandMenus.cpp:3490
 #: ../../src/MaximaCommandMenus.cpp:4500 ../../src/wizards/SubstituteWiz.cpp:53
@@ -10161,7 +10161,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:492
 msgid "The default port used for communication between Maxima and wxMaxima."
-msgstr ""
+msgstr "Le port par défaut utilisé pour la communication entre Maxima et wxMaxima"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:412
 msgid "The default width for embedded plots. Can be read out or overridden by the maxima variable wxplot_size"
@@ -10558,7 +10558,7 @@ msgstr "Indiquer une erreur si ce symbole est utilisé avant qu'il ne lui soit a
 
 #: ../../src/wizards/Plot2dWiz.cpp:65 ../../src/wizards/Plot2dWiz.cpp:505
 msgid "Ticks:"
-msgstr ""
+msgstr "Graduations :"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1359
 msgid "Time [in Minutes] between autosaves"
@@ -10586,7 +10586,7 @@ msgstr "Cellule de Titre (niveau 1)"
 
 #: ../../src/dialogs/TipOfTheDay.cpp:89
 msgid "Title, section and subsection cells can be folded to hide their contents. To fold or unfold, click in the square next to the cell. If you shift-click, all sublevels of that cell will also fold/unfold."
-msgstr ""
+msgstr "Les cellules de titre, section et sous-section peuvent être repliées pour masquer leur contenu. Pour replier ou déplier, cliquer dans le petit triangle à côté de la cellule. Si vous cliquez en enfonçant  la touche Maj, tous les sous-niveaux de cette cellule seront aussi repliés ou dépliés."
 
 #: ../../src/wxMaximaFrame.cpp:1831
 msgid "To &Bigfloat"
@@ -10614,7 +10614,7 @@ msgstr "En  valeur exacte"
 
 #: ../../src/dialogs/TipOfTheDay.cpp:124
 msgid "To plot in polar coordinates, select 'set polar' in the Options entry for Plot2d dialog. You can also plot in spherical and cylindrical coordinates in 3D."
-msgstr ""
+msgstr "Pour un tracé en coordonnées polaires, choisir 'set polar' dans le menu Options de la boîte de dialogue Courbe 2D. Vous pouvez aussi tracer en coordonnées sphériques ou cylindriques en 3D."
 
 #: ../../src/dialogs/TipOfTheDay.cpp:131
 msgid "To put parentheses around an expression, select it, and press '(' or ')' depending on where you want the cursor to appear afterwards."
@@ -10622,7 +10622,7 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:137
 msgid "To save the size and position of wxMaxima windows between session, use 'Edit->Configure' dialog."
-msgstr ""
+msgstr "Pour sauver la taille et la position de la fenêtre de wxMaxima d'une session à l'autre, utilisez 'Maxima->Configurer'."
 
 #: ../../src/dialogs/TipOfTheDay.cpp:51
 msgid "To start using wxMaxima right away, start typing your command. An input cell should appear. Then press Shift-Enter to evaluate your command."
@@ -10826,7 +10826,7 @@ msgstr "Test de Student (t-test) à 2 échantillons"
 
 #: ../../src/worksheet/Worksheet.cpp:6239
 msgid "Type"
-msgstr ""
+msgstr "Type"
 
 #: ../../src/cells/EditorCell.cpp:4550
 msgid "Type in text"
@@ -10850,7 +10850,7 @@ msgstr "UTF8 vers point de code Unicode..."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:231
 msgid "Ukrainian"
-msgstr ""
+msgstr "Ukrainien"
 
 #: ../../src/wxMaxima.cpp:3164
 msgid "Un-closed parenthesis"
@@ -10881,7 +10881,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2115
 msgid "Underlined"
-msgstr ""
+msgstr "Souligné"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:745
 msgid "Underscore converts to subscripts:"
@@ -11029,7 +11029,7 @@ msgstr ""
 
 #: ../../src/wizards/SumWiz.cpp:69
 msgid "Use Gosper algorithm"
-msgstr ""
+msgstr "Utiliser l'algorithme de Gosper"
 
 #: ../../src/sidebars/RegexCtrl.cpp:133
 msgid "Use RegEx filtering"
@@ -11057,7 +11057,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:849
 msgid "Use centered dot character for multiplication"
-msgstr ""
+msgstr "Utiliser le point pour désigner la multiplication"
 
 #: ../../src/wxMaximaFrame.cpp:1745
 msgid "Use list"
@@ -11242,7 +11242,7 @@ msgstr "Variables :"
 
 #: ../../src/sidebars/StatSidebar.cpp:58
 msgid "Variance..."
-msgstr ""
+msgstr "Variance…"
 
 #: ../../src/WXMXformat.cpp:339
 msgid "Verified that we are able to read the whole .zip archive we produced."
@@ -11315,7 +11315,7 @@ msgstr "Que faire :"
 
 #: ../../src/dialogs/TipOfTheDay.cpp:134
 msgid "When applying functions with one argument from menus, the default argument is '%'. To apply the function to some other value, select it in the document before executing a menu command."
-msgstr ""
+msgstr "En appliquant des fonctions avec un argument dans les menus, l'argument par défaut est '%'. Pour appliquer la fonction à une autre valeur, entrez-la dans la ligne d'entrée. Vous pouvez aussi sélectionner dans le document une (sous-)expression avant d'exécuter une commande de menu."
 
 #: ../../src/wxMaximaFrame.cpp:1092
 msgid "When to invoke the lisp compiler's debugger"
@@ -11402,7 +11402,7 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:64
 msgid "You can access the last output using the variable '%'. You can access the output of previous commands using variables '%on' where n is the number of output."
-msgstr ""
+msgstr "La variable '%' représente le dernier résultat obtenu. Les résultats précédents s'obtiennent en utilisant les variables '%on' où n est le numéro du résultat."
 
 #: ../../src/dialogs/TipOfTheDay.cpp:118
 msgid "You can evaluate your whole document by using 'Cell->Evaluate All Cells' menu command or the appropriate key shortcut. The cells will be evaluated in the order they appear in the document."
@@ -11414,7 +11414,7 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:92
 msgid "You can hide output part of cells by clicking in the triangle on the left side of cells. This works on text cells also."
-msgstr ""
+msgstr "Vous pouvez cacher la zone de sortie des cellules d'entrées en cliquant dans le triangle sur le coté gauche des cellules. Cela fonctionne également sur les cellules de texte."
 
 #: ../../src/dialogs/TipOfTheDay.cpp:81
 msgid "You can insert different types of 'cells' in wxMaxima documents using the 'Cell' menu. Note that only 'input cells' can be evaluated, while others are used for commenting and structuring your calculations."
@@ -11422,7 +11422,7 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:112
 msgid "You can select multiple cells either with a mouse - click'n'drag from between cells or from a cell bracket on the left - or with a keyboard - hold down Shift while moving the horizontal cursor - and then operate on selection. This comes in handy when you want to delete or evaluate multiple cells."
-msgstr ""
+msgstr "Vous pouvez sélectionner plusieurs cellules à la souris – cliquez et glissez-déposez entre cellules ou à partir d'un crochet de cellule sur la gauche. Au clavier,maintenez la touche Maj enfoncée tout en déplaçant le curseur horizontal. Ensuite, opérez sur la sélection. Utile pour supprimer ou évaluer plusieurs cellules."
 
 #: ../../src/dialogs/TipOfTheDay.cpp:232
 msgid "You found a bug in wxMaxima? Please report it at https://github.com/wxMaxima-developers/wxmaxima/issues\n"
@@ -11498,7 +11498,7 @@ msgstr ""
 
 #: ../../src/wizards/MatWiz.cpp:160
 msgid "antisymmetric"
-msgstr ""
+msgstr "antisymétrique"
 
 #: ../../src/wxMaximaFrame.cpp:1727
 msgid "apply function to each element"
@@ -11526,7 +11526,7 @@ msgstr ""
 
 #: ../../src/wizards/LimitWiz.cpp:42
 msgid "both sides"
-msgstr ""
+msgstr "des deux côtés :"
 
 #: ../../src/wxMaximaFrame.cpp:1173
 msgid "char to Ascii code..."
@@ -11544,7 +11544,7 @@ msgstr ""
 #: ../../src/wizards/Plot2dWiz.cpp:70 ../../src/wizards/Plot2dWiz.cpp:372
 #: ../../src/wizards/Plot3dWiz.cpp:61 ../../src/wizards/Plot3dWiz.cpp:358
 msgid "default"
-msgstr ""
+msgstr "par défaut"
 
 #: ../../src/sidebars/GreekSidebar.cpp:154
 msgid "delta"
@@ -11552,7 +11552,7 @@ msgstr ""
 
 #: ../../src/wizards/MatWiz.cpp:159
 msgid "diagonal"
-msgstr ""
+msgstr "diagonale"
 
 #: ../../src/cells/FracCell.cpp:73
 msgid "diff(): Cannot find the multiplication sign I should hide"
@@ -11634,7 +11634,7 @@ msgstr ""
 
 #: ../../src/wizards/MatWiz.cpp:159
 msgid "general"
-msgstr ""
+msgstr "général"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1630
 msgid "gnuplot: Without command console"
@@ -11657,7 +11657,7 @@ msgstr "en 2D"
 #: ../../src/wizards/Plot3dWiz.cpp:61 ../../src/wizards/Plot3dWiz.cpp:194
 #: ../../src/wizards/Plot3dWiz.cpp:358 ../../src/wizards/Plot3dWiz.cpp:386
 msgid "inline"
-msgstr ""
+msgstr "en ligne"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:104
 msgid "intersection"
@@ -11677,7 +11677,7 @@ msgstr ""
 
 #: ../../src/wizards/LimitWiz.cpp:42
 msgid "left"
-msgstr ""
+msgstr "à gauche"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:117
 msgid "less or equal"
@@ -11689,7 +11689,7 @@ msgstr "liste"
 
 #: ../../src/wizards/Plot2dWiz.cpp:54 ../../src/wizards/Plot2dWiz.cpp:64
 msgid "logscale"
-msgstr ""
+msgstr "échelle logarithmique"
 
 #: ../../src/wizards/DrawWiz.cpp:822
 msgid "matrix([x_1,x_2,...],[y_1,y_2,...])"
@@ -11734,7 +11734,7 @@ msgstr ""
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:772
 msgid "nary: f(x, f(y,z)) = foo(x,y,z)"
-msgstr ""
+msgstr "nary: f(x, f(y,z)) = foo(x,y,z)"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:99
 msgid "nor"
@@ -11872,7 +11872,7 @@ msgstr ""
 
 #: ../../src/wizards/LimitWiz.cpp:42
 msgid "right"
-msgstr ""
+msgstr "à droite"
 
 #: ../../src/wizards/DrawWiz.cpp:310
 msgid "secondary x axis label"
@@ -11929,7 +11929,7 @@ msgstr ""
 
 #: ../../src/wizards/MatWiz.cpp:160
 msgid "symmetric"
-msgstr ""
+msgstr "symétrique"
 
 #: ../../src/MaximaCommandMenus.cpp:970
 msgid "t:"
@@ -12034,7 +12034,7 @@ msgstr "wxMaxima ne peut pas lire le contenu xml de "
 #: ../../src/dialogs/ConfigDialogue.cpp:142
 #: ../../src/dialogs/ConfigDialogue.cpp:311
 msgid "wxMaxima configuration"
-msgstr ""
+msgstr "Configuration de wxMaxima "
 
 #: ../../src/MaximaProcessManager.cpp:209
 msgid "wxMaxima could not start a server.\n\n"
@@ -12045,7 +12045,7 @@ msgstr "wxMaxima n'a pas pu démarrer un serveur.\n\n"
 
 #: ../../src/dialogs/TipOfTheDay.cpp:127
 msgid "wxMaxima dialogs set default values for inputs entries, one of which is '%'. If you have made a selection in your document, the selection will be used instead of '%'."
-msgstr ""
+msgstr "wxMaxima donne des valeurs par défaut dans les champs d'entrée des boîtes de dialogue, l'une d'entre elles étant '%'. Si vous avez opéré une sélection dans votre document, cette sélection sera utilisée au lieu de '%'."
 
 #: ../../src/MaximaCommandMenus.cpp:4544
 msgid "wxMaxima document"

--- a/locales/wxMaxima/gl.po
+++ b/locales/wxMaxima/gl.po
@@ -67,7 +67,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1551
 msgid "      -l <name>"
-msgstr ""
+msgstr "      -l <nome>"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1557
 msgid "      -u <versionnumber>"
@@ -165,7 +165,7 @@ msgstr ""
 #: ../../src/cells/ImgCell.cpp:212 ../../src/cells/ImgCell.cpp:214
 #: ../../src/cells/ImgCell.cpp:216
 msgid " (Graphics) "
-msgstr ""
+msgstr " (Gráficos) "
 
 #: ../../src/cells/EditorCell.cpp:3551 ../../src/cells/EditorCell.cpp:3820
 #: ../../src/cells/EditorCell.cpp:3945
@@ -213,7 +213,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1208
 msgid "\"Copy LaTeX\" adds equation markers"
-msgstr ""
+msgstr "\"Copy LaTeX\" engade marcadores de ecuacións"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:446
 msgid "\"MathML (rendered by the browser)\" is the recommended choice: every current browser renders MathML natively and instantly, and the exported page needs no JavaScript and makes no requests to any external server.\n"
@@ -227,7 +227,7 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:90
 msgid "\"implies\" symbol"
-msgstr ""
+msgstr "símbolo \"implica\""
 
 #: ../../src/dialogs/DiffFrame.cpp:306
 #, c-format
@@ -314,7 +314,7 @@ msgstr ""
 
 #: ../../src/wizards/IntegrateWiz.cpp:39
 msgid "&Definite integration"
-msgstr ""
+msgstr "Integración &definida"
 
 #: ../../src/wxMaximaFrame.cpp:1658
 msgid "&Demoivre"
@@ -430,11 +430,11 @@ msgstr ""
 
 #: ../../src/wizards/IntegrateWiz.cpp:52
 msgid "&Numerical integration"
-msgstr ""
+msgstr "Integración &numérica"
 
 #: ../../src/wizards/SumWiz.cpp:44
 msgid "&Nusum"
-msgstr ""
+msgstr "&Nusum"
 
 #: ../../src/main.cpp:675
 msgid "&Open\tCtrl+O"
@@ -450,7 +450,7 @@ msgstr ""
 
 #: ../../src/wizards/SeriesWiz.cpp:45
 msgid "&Power series"
-msgstr ""
+msgstr "Serie de &potencias"
 
 #: ../../src/wxMaximaFrame.cpp:655
 msgid "&Print...\tCtrl+P"
@@ -458,7 +458,7 @@ msgstr ""
 
 #: ../../src/wizards/SubstituteWiz.cpp:38
 msgid "&Rational"
-msgstr ""
+msgstr "&Racional"
 
 #: ../../src/wxMaximaFrame.cpp:1631
 msgid "&Reduce Trigonometric"
@@ -490,11 +490,11 @@ msgstr ""
 
 #: ../../src/wizards/Plot2dWiz.cpp:42
 msgid "&Special"
-msgstr ""
+msgstr "Especial"
 
 #: ../../src/wizards/LimitWiz.cpp:45
 msgid "&Taylor series"
-msgstr ""
+msgstr "Serie de Taylor"
 
 #: ../../src/wxMaximaFrame.cpp:1069
 msgid "&Time Display"
@@ -514,7 +514,7 @@ msgstr ""
 
 #: ../../src/wizards/Plot3dWiz.cpp:79
 msgid "&pm3d"
-msgstr ""
+msgstr "&pm3D"
 
 #: ../../src/cells/AnimationCell.cpp:475
 msgid "(Animation)"
@@ -550,7 +550,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:183
 msgid "(Use default language)"
-msgstr ""
+msgstr "(Usar idioma predeterminado)"
 
 #: ../../src/MaximaCommandMenus.cpp:440
 msgid "(f(x),x,a,b)), Epsilon algorithm"
@@ -592,7 +592,7 @@ msgstr ""
 #: ../../src/wizards/IntegrateWiz.cpp:217 ../../src/wizards/LimitWiz.cpp:132
 #: ../../src/wizards/LimitWiz.cpp:142
 msgid "- Infinity"
-msgstr ""
+msgstr "- Infinito"
 
 #: ../../src/MaximaOutputAppender.cpp:116
 msgid "... [suppressed additional lines as the output is longer than allowed in the wxMaxima configuration] "
@@ -608,7 +608,7 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:77
 msgid "1/2"
-msgstr ""
+msgstr "1/2"
 
 #: ../../src/sidebars/DrawSidebar.cpp:45
 msgid "2D"
@@ -649,7 +649,7 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:102
 msgid "A 'horizontal cursor' was introduced in wxMaxima 0.8.0. It looks like a horizontal line between cells. It indicates where a new cell will appear if you type or paste text or execute a menu command."
-msgstr ""
+msgstr "Introduciuse en wxMaxima 0.8.0 un 'cursor horizontal'. O seu aspecto é o dunha líña horizontal entre celas, indicando onde aparecerá unha nova cela ó escribir ou copiar unha nova instrución."
 
 #: ../../src/MaximaCommandMenus.cpp:3039
 msgid "A Ctrl-F event"
@@ -804,7 +804,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1618
 msgid "Abort evaluation on error"
-msgstr ""
+msgstr "Interrupción do cálculo debido a erro"
 
 #: ../../src/MaximaEvaluator.cpp:214
 #, c-format
@@ -881,7 +881,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1262
 msgid "Add the .wxmx file to the HTML export"
-msgstr ""
+msgstr "Engadir arquivo .wxmx á exportación HTML"
 
 #: ../../src/wxMaximaFrame.cpp:1049
 msgid "Add to &Path..."
@@ -908,15 +908,15 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:393
 msgid "Additional commands to be added to the preamble of LaTeX output for pdftex."
-msgstr ""
+msgstr "Instruccións adicionais para engadir ó preámbulo LaTeX"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1187
 msgid "Additional lines for the TeX preamble:"
-msgstr ""
+msgstr "Liñas adicionais para o preámbulo de TeX"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:389
 msgid "Additional parameters for Maxima (e.g. -l clisp)."
-msgstr ""
+msgstr "Parámetros adicionais para Maxima (por exemplo, -l clisp)"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1543
 msgid "Additional parameters for Maxima (restart Maxima after changes)"
@@ -984,7 +984,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:750
 msgid "All variable names"
-msgstr ""
+msgstr "Todos os nomes de variables"
 
 #: ../../src/wxMaximaFrame.cpp:770
 msgid "All visible sidebars"
@@ -1012,7 +1012,7 @@ msgstr ""
 
 #: ../../src/dialogs/BinaryNameCtrl.cpp:69
 msgid "All|*"
-msgstr ""
+msgstr "Todos|*"
 
 #: ../../src/wxMaximaFrame.cpp:800
 msgid "Always after underscores"
@@ -1189,7 +1189,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1397
 msgid "Ask to save untitled documents"
-msgstr ""
+msgstr "Preguntar para gardar documentos non titulados"
 
 #: ../../src/dialogs/MaximaNotStartingDialog.cpp:36
 msgid "Asking the user for the location of a working maxima binary"
@@ -1291,7 +1291,7 @@ msgstr ""
 
 #: ../../src/wizards/BC2Wiz.cpp:59
 msgid "BC2"
-msgstr ""
+msgstr "BC2"
 
 #: ../../src/MaximaManual.cpp:559
 msgid "Background task that compiles the Manual anchors scheduled."
@@ -1299,7 +1299,7 @@ msgstr ""
 
 #: ../../src/sidebars/StatSidebar.cpp:91
 msgid "Barsplot..."
-msgstr ""
+msgstr "Diagrama de barras"
 
 #: ../../src/wxMaximaFrame.cpp:1384
 msgid "Basic matrix operations"
@@ -1342,7 +1342,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:179
 msgid "Beta"
-msgstr ""
+msgstr "Beta"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1898
 msgid "Bitmap"
@@ -1358,7 +1358,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2109
 msgid "Bold"
-msgstr ""
+msgstr "Negrita"
 
 #: ../../src/wxMaxima.cpp:2259
 msgid "Both horizontal and vertical cursor active at the same time"
@@ -1382,13 +1382,13 @@ msgstr ""
 
 #: ../../src/sidebars/StatSidebar.cpp:97
 msgid "Boxplot..."
-msgstr ""
+msgstr "Diagrama de caixas"
 
 #: ../../src/dialogs/BinaryNameCtrl.cpp:42 ../../src/wizards/CsvWiz.cpp:57
 #: ../../src/wizards/CsvWiz.cpp:131 ../../src/wizards/Plot2dWiz.cpp:114
 #: ../../src/wizards/Plot3dWiz.cpp:109
 msgid "Browse"
-msgstr ""
+msgstr "Navegar"
 
 #: ../../src/wxMathml.cpp:101
 msgid "Bug: After removing the whitespace wxMathml.lisp is shorter than expected!"
@@ -1421,15 +1421,15 @@ msgstr ""
 
 #: ../../src/worksheet/Worksheet.cpp:2234
 msgid "Bug: Got a question but no cell to answer it in"
-msgstr ""
+msgstr "Fallo: pregunta sen cela asociada"
 
 #: ../../src/worksheet/Worksheet.cpp:4283
 msgid "Bug: Got a request to delete the cell above the beginning of the worksheet."
-msgstr ""
+msgstr "Fallo: Solicitouse eliminar o contido dunha cela por riba do comezo da folla de traballo."
 
 #: ../../src/worksheet/WorksheetDocument.cpp:239
 msgid "Bug: Got a request to first change the contents of a cell and to then undelete it."
-msgstr ""
+msgstr "Fallo: Solicitado cambiar primeiro o contido dunha cela e logo non borrala."
 
 #: ../../src/worksheet/WorksheetExport.cpp:1576
 msgid "Bug: HTML output is no valid XML"
@@ -1437,7 +1437,7 @@ msgstr ""
 
 #: ../../src/cells/Cell.cpp:289
 msgid "Bug: Math Cell that claims to have no group Cell it belongs to"
-msgstr ""
+msgstr "Fallo: cela sen grupo ó que pertencer"
 
 #: ../../src/Configuration.h:741
 msgid "Bug: Maximum number of digits that is to be displayed is too low!"
@@ -1480,7 +1480,7 @@ msgstr ""
 
 #: ../../src/cells/GroupCell.cpp:340
 msgid "Bug: Trying to append NULL to a group cell."
-msgstr ""
+msgstr "Fallo: Intento de engadir NULL a un grupo de celas."
 
 #: ../../src/worksheet/Worksheet.cpp:5939
 msgid "Bug: Trying to move a title out by one sectioning unit"
@@ -1488,7 +1488,7 @@ msgstr ""
 
 #: ../../src/worksheet/Worksheet.cpp:4915
 msgid "Bug: Trying to move the horizontally-drawn cursor to a place inside a GroupCell."
-msgstr ""
+msgstr "Fallo: intento de mover cursor horizontal dentro dun grupo de celas."
 
 #: ../../src/TreeUndoAction.h:52 ../../src/TreeUndoAction.h:57
 msgid "Bug: Trying to record a cell contents change for undo without a cell."
@@ -1500,7 +1500,7 @@ msgstr ""
 
 #: ../../src/worksheet/WorksheetDocument.cpp:241
 msgid "Bug: Undo action with both cell contents change and cell addition."
-msgstr ""
+msgstr "Fallo: Acción de desfacer."
 
 #: ../../src/cells/EditorCell.cpp:4541
 msgid "Bug: Unknown type of text"
@@ -1767,11 +1767,11 @@ msgstr ""
 
 #: ../../src/sidebars/MathSidebar.cpp:62
 msgid "Canonical (tr)"
-msgstr ""
+msgstr "Canónico (tr)"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:188
 msgid "Catalan"
-msgstr ""
+msgstr "Catalán"
 
 #: ../../src/MaximaCommandMenus.cpp:466
 msgid "Cauchy principal value of f(x)/(x-c), finite interval"
@@ -1917,7 +1917,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:199
 msgid "Chi"
-msgstr ""
+msgstr "Ji"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:189
 msgid "Chinese (Simplified)"
@@ -1941,7 +1941,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2100
 msgid "Choose font"
-msgstr ""
+msgstr "Elixir tipografía"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:793
 msgid "Choose how mathematical output is formatted:\n"
@@ -1952,7 +1952,7 @@ msgstr ""
 
 #: ../../src/wizards/PlotFormatWiz.cpp:31
 msgid "Choose new plot format:"
-msgstr ""
+msgstr "Elixir un novo formato de gráficos:"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2432
 #, c-format
@@ -2126,7 +2126,7 @@ msgstr ""
 
 #: ../../src/wizards/MatWiz.cpp:155
 msgid "Columns:"
-msgstr ""
+msgstr "Columnas:"
 
 #: ../../src/wxMaximaFrame.cpp:1621
 msgid "Combine factorials in an expression"
@@ -2142,11 +2142,11 @@ msgstr ""
 
 #: ../../src/wizards/Plot2dWiz.cpp:626
 msgid "Comma separated x coordinates"
-msgstr ""
+msgstr "Coordenadas x separadas por comas."
 
 #: ../../src/wizards/Plot2dWiz.cpp:627
 msgid "Comma separated y coordinates"
-msgstr ""
+msgstr "Coordenadas y separadas por comas."
 
 #: ../../src/MaximaCommandMenus.cpp:4071
 msgid "Comma-separated arguments"
@@ -2240,7 +2240,7 @@ msgstr ""
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:465
 msgid "Comment Selection"
-msgstr ""
+msgstr "Comentar selección"
 
 #: ../../src/wxMaximaFrame.cpp:718
 msgid "Comment out the currently selected text"
@@ -2372,7 +2372,7 @@ msgstr ""
 #: ../../src/dialogs/ConfigDialogue.cpp:2641
 #: ../../src/dialogs/ConfigDialogue.cpp:2647
 msgid "Config file (*.ini)|*.ini"
-msgstr ""
+msgstr "Arquivo de configuración (*.ini)|*.ini"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2539
 #, c-format
@@ -2404,7 +2404,7 @@ msgstr ""
 #: ../../src/wizards/IntegrateWiz.cpp:208 ../../src/wizards/LimitWiz.cpp:133
 #: ../../src/wizards/SeriesWiz.cpp:105
 msgid "Constant"
-msgstr ""
+msgstr "Constante"
 
 #: ../../src/MaximaCommandMenus.cpp:1102
 msgid "Construct a fraction"
@@ -2878,7 +2878,7 @@ msgstr ""
 
 #: ../../src/worksheet/Worksheet.cpp:6115
 msgid "Cursor"
-msgstr ""
+msgstr "Cursor"
 
 #: ../../src/Styles.cpp:126
 msgid "Cursor color"
@@ -2900,11 +2900,11 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:193
 msgid "Czech"
-msgstr ""
+msgstr "Checo"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:194
 msgid "Danish"
-msgstr ""
+msgstr "Danés"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2069
 msgid "Dark"
@@ -2982,7 +2982,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1534
 msgid "Default port for communication with wxMaxima:"
-msgstr ""
+msgstr "Porto predeterminado para comunicación entre Maxima e wxMaxima"
 
 #: ../../src/MaximaCommandMenus.cpp:3946
 msgid "Define a function"
@@ -3022,7 +3022,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:404
 msgid "Define the default speed (in frames per second) animations are played back with."
-msgstr ""
+msgstr "Definir a frecuencia de imaxes para a reproducción de animacións."
 
 #: ../../src/wxMaximaFrame.cpp:1114
 msgid "Define variable..."
@@ -3043,7 +3043,7 @@ msgstr ""
 #: ../../src/worksheet/WorksheetContextMenu.cpp:157
 #: ../../src/worksheet/WorksheetContextMenu.cpp:298
 msgid "Delete Selection"
-msgstr ""
+msgstr "Borra selección"
 
 #: ../../src/wxMaximaFrame.cpp:1021
 msgid "Delete V&ariable..."
@@ -3095,7 +3095,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:181
 msgid "Delta"
-msgstr ""
+msgstr "Delta"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:110
 #: ../../src/worksheet/WorksheetContextMenu.cpp:558
@@ -3121,7 +3121,7 @@ msgstr ""
 
 #: ../../src/wizards/SeriesWiz.cpp:42
 msgid "Depth:"
-msgstr ""
+msgstr "Profundidad:"
 
 #: ../../src/MaximaCommandMenus.cpp:994
 msgid "Derivate of y at that point:"
@@ -3156,7 +3156,7 @@ msgstr ""
 
 #: ../../src/sidebars/StatSidebar.cpp:61
 msgid "Deviation..."
-msgstr ""
+msgstr "Desviación"
 
 #: ../../src/wxMaximaFrame.cpp:1534
 msgid "Di&vide Polynomials..."
@@ -3188,7 +3188,7 @@ msgstr ""
 
 #: ../../src/sidebars/MathSidebar.cpp:80
 msgid "Diff..."
-msgstr ""
+msgstr "Deriva"
 
 #: ../../src/dialogs/DiffFrame.cpp:308
 #, c-format
@@ -3205,7 +3205,7 @@ msgstr ""
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:363
 msgid "Differentiate..."
-msgstr ""
+msgstr "Deriva"
 
 #: ../../src/MaximaCommandMenus.cpp:264
 msgid "Differentiates an expression n times"
@@ -3217,7 +3217,7 @@ msgstr ""
 
 #: ../../src/wizards/LimitWiz.cpp:41
 msgid "Direction:"
-msgstr ""
+msgstr "Dirección:"
 
 #: ../../src/wxMaximaFrame.cpp:1246
 msgid "Directory operations"
@@ -3229,7 +3229,7 @@ msgstr ""
 
 #: ../../src/wizards/Plot2dWiz.cpp:418 ../../src/wizards/Plot2dWiz.cpp:619
 msgid "Discrete plot"
-msgstr ""
+msgstr "Gráfico de puntos"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:699
 msgid "Display"
@@ -3356,7 +3356,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1170
 msgid "Documentclass for TeX export:"
-msgstr ""
+msgstr "Clase de documento para exportar en TeX:"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1178
 msgid "Documentclass options:"
@@ -3538,7 +3538,7 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:129
 msgid "End of proof"
-msgstr ""
+msgstr "Fin de proba"
 
 #: ../../src/MaximaCommandMenus.cpp:1024
 msgid "End of t:"
@@ -3571,7 +3571,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:196
 msgid "English"
-msgstr ""
+msgstr "Inglés"
 
 #: ../../src/wizards/DrawWiz.cpp:552
 msgid "Enhanced 3D settings:"
@@ -3583,7 +3583,7 @@ msgstr ""
 
 #: ../../src/sidebars/StatSidebar.cpp:106
 msgid "Enter Matrix..."
-msgstr ""
+msgstr "Introduce matriz"
 
 #: ../../src/MaximaCommandMenus.cpp:2255
 msgid "Enter UUID to jump to:"
@@ -3603,7 +3603,7 @@ msgstr ""
 
 #: ../../src/wizards/SystemWiz.cpp:50
 msgid "Enter comma separated list of variables."
-msgstr ""
+msgstr "Introduce unha lista de variables separadas por comas."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:921
 msgid "Enter evaluates cells, Ctrl+Enter adds newlines"
@@ -3623,7 +3623,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:388
 msgid "Enter the path to the Maxima executable."
-msgstr ""
+msgstr "Introduce a ruta ó ejecutable Maxima."
 
 #: ../../src/MaximaCommandMenus.cpp:1103
 msgid "Enumerator:"
@@ -3639,7 +3639,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:182
 msgid "Epsilon"
-msgstr ""
+msgstr "Épsilon"
 
 #: ../../src/MaximaCommandMenus.cpp:299
 msgid "Epsilon:"
@@ -3732,7 +3732,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:184
 msgid "Eta"
-msgstr ""
+msgstr "Eta"
 
 #: ../../src/sidebars/TableOfContents.cpp:513
 msgid "Evaluate"
@@ -3793,24 +3793,24 @@ msgstr ""
 #: ../../src/worksheet/WorksheetContextMenu.cpp:196
 #: ../../src/worksheet/WorksheetContextMenu.cpp:509
 msgid "Evaluate Part\tShift+Ctrl+Enter"
-msgstr ""
+msgstr "Avaliar parte\tShift+Ctrl+Enter"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:202
 #: ../../src/worksheet/WorksheetContextMenu.cpp:514
 msgid "Evaluate Section\tShift+Ctrl+Enter"
-msgstr ""
+msgstr "Avaliar cela\tShift+Ctrl+Enter"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:216
 #: ../../src/worksheet/WorksheetContextMenu.cpp:524
 #: ../../src/worksheet/WorksheetContextMenu.cpp:651
 msgid "Evaluate Sub-Subsection\tShift+Ctrl+Enter"
-msgstr ""
+msgstr "Avaliar sub-subsección\tShift+Ctrl+Enter"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:209
 #: ../../src/worksheet/WorksheetContextMenu.cpp:519
 #: ../../src/worksheet/WorksheetContextMenu.cpp:640
 msgid "Evaluate Subsection\tShift+Ctrl+Enter"
-msgstr ""
+msgstr "Avaliar subsección\tShift+Ctrl+Enter"
 
 #: ../../src/wxMaximaFrame.cpp:879
 msgid "Evaluate active or selected cell(s)"
@@ -3870,7 +3870,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2659
 msgid "Example text"
-msgstr ""
+msgstr "Texto de exemplo"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1547
 msgid "Examples:"
@@ -3886,15 +3886,15 @@ msgstr ""
 
 #: ../../src/sidebars/MathSidebar.cpp:53
 msgid "Expand"
-msgstr ""
+msgstr "Expande"
 
 #: ../../src/sidebars/MathSidebar.cpp:68
 msgid "Expand (tr)"
-msgstr ""
+msgstr "Expande (tr)"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:356
 msgid "Expand Expression"
-msgstr ""
+msgstr "Expande expresión"
 
 #: ../../src/wxMaximaFrame.cpp:1562
 msgid "Expand an expression"
@@ -4216,7 +4216,7 @@ msgstr ""
 
 #: ../../src/sidebars/MathSidebar.cpp:50
 msgid "Factor"
-msgstr ""
+msgstr "Factoriza"
 
 #: ../../src/wxMaximaFrame.cpp:1558
 msgid "Factor Complex"
@@ -4224,7 +4224,7 @@ msgstr ""
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:354
 msgid "Factor Expression"
-msgstr ""
+msgstr "Factoriza expresión"
 
 #: ../../src/wxMaximaFrame.cpp:1556
 msgid "Factor Expression including subexpressions"
@@ -4291,7 +4291,7 @@ msgstr ""
 #: ../../src/cells/GroupCell.cpp:2115
 #, c-format
 msgid "Figure %d:"
-msgstr ""
+msgstr "Figura %d:"
 
 #: ../../src/main.cpp:678
 msgid "File"
@@ -4363,7 +4363,7 @@ msgstr ""
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:349
 msgid "Find Root..."
-msgstr ""
+msgstr "Calcula raíz..."
 
 #: ../../src/wxMaximaFrame.cpp:1508
 msgid "Find a (unconstrained) minimum of an expression"
@@ -4485,11 +4485,11 @@ msgstr ""
 #: ../../src/dialogs/ConfigDialogue.cpp:1404
 #, c-format
 msgid "Fix reordered reference indices (of %i, %o) before saving"
-msgstr ""
+msgstr "Axustar os índices de orde (%i e %o) antes de gardar"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:873
 msgid "Fixed font in text controls"
-msgstr ""
+msgstr "Tipografía proporcional en controis de texto"
 
 #: ../../src/MaximaCommandMenus.cpp:4039
 msgid "Flush stream"
@@ -4533,7 +4533,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2047
 msgid "Fonts"
-msgstr ""
+msgstr "Tipografía"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:442
 msgid "For each Text-, Sectioning or code cell wxMaxima can display a bracket showing the extend of the cell and allowing to fold it. This setting now tells if this bracket is to be printed, as well."
@@ -4561,7 +4561,7 @@ msgstr ""
 
 #: ../../src/wizards/Plot2dWiz.cpp:69 ../../src/wizards/Plot3dWiz.cpp:60
 msgid "Format:"
-msgstr ""
+msgstr "Formato:"
 
 #: ../../src/worksheet/Worksheet.cpp:301 ../../src/wxMaxima.cpp:3521
 msgid "Forwarding the keyboard focus to a text control"
@@ -4626,7 +4626,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:198
 msgid "French"
-msgstr ""
+msgstr "Francés"
 
 #: ../../src/wxMaximaFrame.cpp:1447
 msgid "Frobenius Norm sqrt(sum((A(i,j))^2)) (complex)"
@@ -4709,11 +4709,11 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:199
 msgid "Galician"
-msgstr ""
+msgstr "Galego"
 
 #: ../../src/sidebars/GreekSidebar.cpp:180
 msgid "Gamma"
-msgstr ""
+msgstr "Gamma"
 
 #: ../../src/wxMaximaFrame.cpp:316
 msgid "General Math"
@@ -4765,7 +4765,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:201
 msgid "German"
-msgstr ""
+msgstr "Alemán"
 
 #: ../../src/wxMaximaFrame.cpp:1656
 msgid "Get &Imaginary Part"
@@ -4837,7 +4837,7 @@ msgstr ""
 
 #: ../../src/worksheet/Worksheet.cpp:4296
 msgid "Got a request to undo an action that involves a delete which isn't possible at this moment."
-msgstr ""
+msgstr "Solicitouse unha acción de desfacer que requere un borrado que non é posible realizar neste intre."
 
 #: ../../src/wxMaximaFrame.cpp:1065
 msgid "Gradefs"
@@ -4853,7 +4853,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:202
 msgid "Greek"
-msgstr ""
+msgstr "Grego"
 
 #: ../../src/wxMaximaFrame.cpp:281
 msgid "Greek Letters"
@@ -4869,7 +4869,7 @@ msgstr ""
 
 #: ../../src/wizards/Plot3dWiz.cpp:52
 msgid "Grid:"
-msgstr ""
+msgstr "Cuadrícula:"
 
 #: ../../src/wxMaximaFrame.cpp:1852
 msgid "Guess an exact number that could be meant by this float"
@@ -5046,7 +5046,7 @@ msgstr ""
 
 #: ../../src/sidebars/StatSidebar.cpp:85
 msgid "Histogram..."
-msgstr ""
+msgstr "Histograma"
 
 #: ../../src/wxMaximaFrame.cpp:246
 msgid "History"
@@ -5058,7 +5058,7 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:105
 msgid "Horizontal cursor works like a normal cursor, but it operates on cells: press up or down arrow to move it, holding down Shift while moving will select cells, pressing backspace or delete twice will delete a cell next to it."
-msgstr ""
+msgstr "O cursor horizontal funciona como un cursor normal, pero opera con celas: pulsar cursores arriba e abaixo para movelo; mantendo pulsada a tecla 'Maiúscula' mentres se realiza o movimento se seleccionan celas, pulsando 'Retroceso' ou 'Espazo' dúas veces borrará a cela contigua."
 
 #: ../../src/wxMaximaFrame.cpp:1563
 msgid "Horner's rule"
@@ -5078,7 +5078,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:205
 msgid "Hungarian"
-msgstr ""
+msgstr "Húngaro"
 
 #: ../../src/wxMaximaFrame.cpp:1147
 msgid "I/O"
@@ -5086,7 +5086,7 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:121
 msgid "Identical to"
-msgstr ""
+msgstr "Idéntico a"
 
 #: ../../src/MaximaCommandMenus.cpp:3874
 msgid "If a program doesn't need local variables, Maxima allows putting the commands between parentheses. The result of the last operation is the return value of the program."
@@ -5118,19 +5118,19 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:375
 msgid "If multiple cells are evaluated in one go: Abort evaluation if wxMaxima detects that maxima has encountered any error."
-msgstr ""
+msgstr "Se múltiples celas son avaliadas dunha vez: interrumpe o cálculo se wxMaxima detecta que Maxima atopou un erro."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:727
 msgid "If not extremely long"
-msgstr ""
+msgstr "Se non é extremadamente largo"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:726
 msgid "If not very long"
-msgstr ""
+msgstr "Se non é moi largo"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:418
 msgid "If numbers are getting longer than this number of digits they will be displayed abbreviated by an ellipsis."
-msgstr ""
+msgstr "Se os números son máis longos ca esta cantidade de díxitos, amosaranse de forma abreviada e con puntos suspensivos."
 
 #: ../../src/dialogs/TipOfTheDay.cpp:181
 msgid "If the \"Autosave\" functionality is enabled in the configuration dialogue wxMaxima acts like mobile apps that backup the file every few minutes and save it on closing."
@@ -5173,7 +5173,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:439
 msgid "If this option is set the .wxmx source of the current file is copied to a place a link to is put into the result of an export."
-msgstr ""
+msgstr "Se esta opción está activa, a fuente .wxmx do arquivo actual cópiase nun lugar cara ó que se poderá facer ligazón."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1873
 msgid "If unset, Maxima's output is announced to the screen reader as maths in a linear text form. Set this option if your screen reader can speak MathML properly."
@@ -5185,11 +5185,11 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:76
 msgid "If you type an operator (one of +*/^=,) as the first symbol in an input cell, % will be automatically inserted before the operator, as on a graphing calculator. You can disable this feature from the 'Edit->Configure' dialog."
-msgstr ""
+msgstr "Se se escribe un operador (+*/^=,) como primer símbolo nunha cela de entrada, insertarase automáticamente % antes do operador como nunha calculadora gráfica. Se pode desactivar esta acción en 'Editar->Configurar'."
 
 #: ../../src/dialogs/TipOfTheDay.cpp:122
 msgid "If your calculation is taking too long to evaluate, you can try 'Maxima->Interrupt' or 'Maxima->Restart Maxima' menu commands."
-msgstr ""
+msgstr "Se un cálculo leva moito tempo, pódese parar seleccionando 'Maxima->Interrumpir' ou 'Maxima->Reiniciar Maxima' no menú."
 
 #: ../../src/MaximaManual.cpp:420
 msgid "Ignoring the cache version for the manual anchors."
@@ -5197,7 +5197,7 @@ msgstr ""
 
 #: ../../src/sidebars/FormatSidebar.cpp:66
 msgid "Image"
-msgstr ""
+msgstr "Imaxe"
 
 #: ../../src/Image.cpp:110
 msgid "Image data had zero length!"
@@ -5265,7 +5265,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:421
 msgid "In the LaTeX output: Put exponents after an eventual subscript instead of above it. Might increase readability for some fonts and short subscripts."
-msgstr ""
+msgstr "En exportación LaTeX: Poñer exponentes despois das expresións en lugar de colocalos enriba delas. Pode facilitar a lectura con algunhas fontes."
 
 #: ../../src/MaximaCommandMenus.cpp:1869
 msgid "Include columns:"
@@ -5326,7 +5326,7 @@ msgstr ""
 #: ../../src/wizards/IntegrateWiz.cpp:215 ../../src/wizards/LimitWiz.cpp:132
 #: ../../src/wizards/LimitWiz.cpp:140
 msgid "Infinity"
-msgstr ""
+msgstr "Infinito"
 
 #: ../../src/wxMaximaFrame.cpp:1986
 msgid "Info about Maxima build"
@@ -5384,7 +5384,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:889
 msgid "Insert % before an operator at the beginning of a cell"
-msgstr ""
+msgstr "Inserir % antes dun operador ó comezo dunha cela"
 
 #: ../../src/wxMaximaFrame.cpp:939
 msgid "Insert &Section Cell\tCtrl+3"
@@ -5432,15 +5432,15 @@ msgstr ""
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:435
 msgid "Insert Section Cell"
-msgstr ""
+msgstr "Nova cela de &sección\tF8"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:437
 msgid "Insert Subsection Cell"
-msgstr ""
+msgstr "Nova cela de subsección"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:440
 msgid "Insert Subsubsection Cell"
-msgstr ""
+msgstr "Inserir cela de subsubsección"
 
 #: ../../src/wxMaximaFrame.cpp:937
 msgid "Insert T&itle Cell\tCtrl+2"
@@ -5448,11 +5448,11 @@ msgstr ""
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:431
 msgid "Insert Text Cell"
-msgstr ""
+msgstr "Nova cela de texto"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:433
 msgid "Insert Title Cell"
-msgstr ""
+msgstr "Nova cela de título"
 
 #: ../../src/wxMaximaFrame.cpp:947
 msgid "Insert a new heading5 cell"
@@ -5536,7 +5536,7 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:113
 msgid "Integral sign"
-msgstr ""
+msgstr "Símbolo integral"
 
 #: ../../src/MaximaCommandMenus.cpp:149 ../../src/MaximaCommandMenus.cpp:170
 msgid "Integral/Sum:"
@@ -5566,7 +5566,7 @@ msgstr ""
 #: ../../src/sidebars/MathSidebar.cpp:83
 #: ../../src/worksheet/WorksheetContextMenu.cpp:361
 msgid "Integrate..."
-msgstr ""
+msgstr "Integra"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:834
 msgid "Intelligently hide cell brackets"
@@ -5660,7 +5660,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:186
 msgid "Iota"
-msgstr ""
+msgstr "Iota"
 
 #: ../../src/MaximaCommandMenus.cpp:4150
 msgid "Is Char 1 greater than Char2, if case is ignored?"
@@ -5804,11 +5804,11 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:207
 msgid "Italian"
-msgstr ""
+msgstr "Italiano"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2111
 msgid "Italic"
-msgstr ""
+msgstr "Itálica"
 
 #: ../../src/MaximaCommandMenus.cpp:1617 ../../src/MaximaCommandMenus.cpp:1623
 msgid "Item"
@@ -5820,7 +5820,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:208
 msgid "Japanese"
-msgstr ""
+msgstr "Xaponés"
 
 #: ../../src/MaximaCommandMenus.cpp:2255
 msgid "Jump to UUID"
@@ -5852,12 +5852,12 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:187
 msgid "Kappa"
-msgstr ""
+msgstr "Kappa"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:864
 #, c-format
 msgid "Keep percent sign with special symbols: %e, %i, etc."
-msgstr ""
+msgstr "Manter o símbolo porcentual en constantes especiais: %e, %i, etc."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:212
 msgid "Korean"
@@ -5889,11 +5889,11 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1199
 msgid "LaTeX: Place exponents after, instead above subscripts"
-msgstr ""
+msgstr "LaTeX: Colocar exponentes despois das expresións, en lugar de sobre elas"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1204
 msgid "LaTeX: Use the \"partial derivative\" symbol to represent diff()"
-msgstr ""
+msgstr "Latex: utilizar o símbolo de \"derivada parcial\" para representar diff()"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:758
 msgid "Label width:"
@@ -5916,11 +5916,11 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:470
 msgid "Language used for wxMaxima GUI."
-msgstr ""
+msgstr "Idioma usado na interface de usuario de wxMaxima."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1311
 msgid "Language:"
-msgstr ""
+msgstr "Idioma:"
 
 #: ../../src/MaximaCommandMenus.cpp:251
 msgid "Laplace"
@@ -5979,7 +5979,7 @@ msgstr ""
 
 #: ../../src/sidebars/StatSidebar.cpp:79
 msgid "Least Squares Fit..."
-msgstr ""
+msgstr "Axuste por mínimos cadrados"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2007
 msgid "Left"
@@ -6037,7 +6037,7 @@ msgstr ""
 
 #: ../../src/sidebars/MathSidebar.cpp:86
 msgid "Limit..."
-msgstr ""
+msgstr "Límite"
 
 #: ../../src/sidebars/DrawSidebar.cpp:88
 msgid "Line color"
@@ -6045,7 +6045,7 @@ msgstr ""
 
 #: ../../src/sidebars/StatSidebar.cpp:76
 msgid "Linear Regression..."
-msgstr ""
+msgstr "Regresión linear"
 
 #: ../../src/MaximaCommandMenus.cpp:4068
 msgid "Lisp format string:"
@@ -6178,7 +6178,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2162
 msgid "Load"
-msgstr ""
+msgstr "Carga"
 
 #: ../../src/MaximaCommandMenus.cpp:2356
 msgid "Load Package"
@@ -6218,7 +6218,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2645
 msgid "Load style from file"
-msgstr ""
+msgstr "Le estilo dende un arquivo"
 
 #: ../../src/wxMaximaFrame.cpp:1232
 msgid "Load the file/dir operations (operatingsystem)"
@@ -6551,7 +6551,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1437
 msgid "Maxima program:"
-msgstr ""
+msgstr "Programa Maxima:"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:382
 msgid "Maxima provides no \"forget all\" command that flushes all settings a maxima session could make. wxMaxima therefore normally defaults to starting a fresh maxima process every time the worksheet is to be re-evaluated. As this needs a little bit of time this switch allows to disable this behavior."
@@ -6786,15 +6786,15 @@ msgstr ""
 
 #: ../../src/sidebars/StatSidebar.cpp:70
 msgid "Mean Difference Test..."
-msgstr ""
+msgstr "Contraste de diferenza de medias"
 
 #: ../../src/sidebars/StatSidebar.cpp:67
 msgid "Mean Test..."
-msgstr ""
+msgstr "Contraste de medias"
 
 #: ../../src/sidebars/StatSidebar.cpp:52
 msgid "Mean..."
-msgstr ""
+msgstr "Media"
 
 #: ../../src/MaximaCommandMenus.cpp:1806
 msgid "Mean:"
@@ -6802,7 +6802,7 @@ msgstr ""
 
 #: ../../src/sidebars/StatSidebar.cpp:55
 msgid "Median..."
-msgstr ""
+msgstr "Mediana"
 
 #: ../../src/wxMaximaFrame.cpp:1961
 msgid "Memoizing"
@@ -6823,7 +6823,7 @@ msgstr ""
 
 #: ../../src/wizards/IntegrateWiz.cpp:55
 msgid "Method:"
-msgstr ""
+msgstr "Método:"
 
 #: ../../src/wxMaximaFrame.cpp:1360
 msgid "Methods of generating a matrix"
@@ -6922,7 +6922,7 @@ msgstr ""
 
 #: ../../src/wizards/MatWiz.cpp:163
 msgid "Name:"
-msgstr ""
+msgstr "Nome"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:216
 msgid "Nepali"
@@ -6998,7 +6998,7 @@ msgstr ""
 
 #: ../../src/wizards/SubstituteWiz.cpp:35
 msgid "New value:"
-msgstr ""
+msgstr "Novo valor:"
 
 #: ../../src/MaximaCommandMenus.cpp:151 ../../src/MaximaCommandMenus.cpp:171
 #: ../../src/MaximaCommandMenus.cpp:254 ../../src/MaximaCommandMenus.cpp:259
@@ -7101,7 +7101,7 @@ msgstr ""
 
 #: ../../src/sidebars/StatSidebar.cpp:73
 msgid "Normality Test..."
-msgstr ""
+msgstr "Contraste de normalidad"
 
 #: ../../src/cells/TextCell.cpp:271
 msgid "Normally computers use floating-point numbers that can be handled incredibly fast while being accurate to dozens of digits. They will, though, introduce a small error into some common numbers. For example 0.1 is represented as 3602879701896397/36028797018963968.\n"
@@ -7112,11 +7112,11 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:431
 msgid "Normally html expects images to be rather low-res but space saving. These images tend to look rather blurry when viewed on modern screens. Therefore this setting was introduces that selects the factor by which the HTML export increases the resolution in respect to the default value."
-msgstr ""
+msgstr "Normalmente html espera que as imaxes sexan de baixa resolución para aforrar memoria. Estas imaxes tenden a verse borrosas en pantallas modernas. Esta opción introdúcese para seleccionar o factor mediante o cal a exportación html aumenta a resolución respecto do seu valor por defecto."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:217
 msgid "Norwegian"
-msgstr ""
+msgstr "Noruego"
 
 #: ../../src/MaximaCommandMenus.cpp:1351
 msgid "Not a valid matrix dimension!"
@@ -7303,7 +7303,7 @@ msgstr ""
 
 #: ../../src/wizards/SubstituteWiz.cpp:32
 msgid "Old value:"
-msgstr ""
+msgstr "Valor antigo:"
 
 #: ../../src/MaximaCommandMenus.cpp:151 ../../src/MaximaCommandMenus.cpp:172
 #: ../../src/MaximaCommandMenus.cpp:253 ../../src/MaximaCommandMenus.cpp:259
@@ -7312,7 +7312,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:201
 msgid "Omega"
-msgstr ""
+msgstr "Omega"
 
 #: ../../src/sidebars/GreekSidebar.cpp:192
 msgid "Omicron"
@@ -7349,7 +7349,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:905
 msgid "Open a cell when Maxima expects input"
-msgstr ""
+msgstr "Abre unha cela cando Maxima espera unha entrada"
 
 #: ../../src/wxMaximaFrame.cpp:629
 msgid "Open a document"
@@ -7432,7 +7432,7 @@ msgstr ""
 
 #: ../../src/wizards/Plot2dWiz.cpp:75 ../../src/wizards/Plot3dWiz.cpp:66
 msgid "Options:"
-msgstr ""
+msgstr "Opcións:"
 
 #: ../../src/dialogs/FindReplacePane.cpp:109
 msgid "Output"
@@ -7505,7 +7505,7 @@ msgstr ""
 
 #: ../../src/sidebars/FormatSidebar.cpp:69
 msgid "Pagebreak"
-msgstr ""
+msgstr "Salto de páxina"
 
 #: ../../src/wxMaximaFrame.cpp:1674
 msgid "Parallel Substitute..."
@@ -7517,7 +7517,7 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:124
 msgid "Parallel to"
-msgstr ""
+msgstr "Paralelo a"
 
 #: ../../src/MaximaCommandMenus.cpp:3991
 msgid "Parameter name:"
@@ -7533,7 +7533,7 @@ msgstr ""
 
 #: ../../src/wizards/Plot2dWiz.cpp:417 ../../src/wizards/Plot2dWiz.cpp:523
 msgid "Parametric plot"
-msgstr ""
+msgstr "Gráfico paramétrico"
 
 #: ../../src/MaximaCommandMenus.cpp:4211
 msgid "Parse string"
@@ -7587,7 +7587,7 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:125
 msgid "Perpendicular to"
-msgstr ""
+msgstr "Perpendicular a"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:218
 msgid "Persian"
@@ -7595,15 +7595,15 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:198
 msgid "Phi"
-msgstr ""
+msgstr "Fi"
 
 #: ../../src/sidebars/GreekSidebar.cpp:193
 msgid "Pi"
-msgstr ""
+msgstr "Pi"
 
 #: ../../src/sidebars/StatSidebar.cpp:94
 msgid "Piechart..."
-msgstr ""
+msgstr "Diagrama de sectores"
 
 #: ../../src/wxMaxima.cpp:1585
 msgid "Please configure wxMaxima with 'Edit->Configure'."
@@ -7611,7 +7611,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2606
 msgid "Please restart wxMaxima for changes to take effect!"
-msgstr ""
+msgstr "Reinicie wxMaxima para que os cambios teñan efecto"
 
 #: ../../src/MaximaCommandMenus.cpp:2250
 msgid "Please select exactly 2 or 3 files."
@@ -7638,7 +7638,7 @@ msgstr ""
 #: ../../src/sidebars/MathSidebar.cpp:89
 #: ../../src/worksheet/WorksheetContextMenu.cpp:366
 msgid "Plot 2D..."
-msgstr ""
+msgstr "Gráficos 2D"
 
 #: ../../src/MaximaCommandMenus.cpp:85 ../../src/MaximaCommandMenus.cpp:3508
 #: ../../src/wizards/Plot3dWiz.cpp:103
@@ -7648,7 +7648,7 @@ msgstr ""
 #: ../../src/sidebars/MathSidebar.cpp:92
 #: ../../src/worksheet/WorksheetContextMenu.cpp:368
 msgid "Plot 3D..."
-msgstr ""
+msgstr "Gráficos 3D"
 
 #: ../../src/wizards/DrawWiz.cpp:713
 msgid "Plot a parametric curve"
@@ -7689,7 +7689,7 @@ msgstr ""
 
 #: ../../src/wizards/Plot2dWiz.cpp:84 ../../src/wizards/Plot3dWiz.cpp:80
 msgid "Plot to file:"
-msgstr ""
+msgstr "Gráfico a arquivo:"
 
 #: ../../src/wxMaximaFrame.cpp:341 ../../src/wxMaximaFrame.cpp:749
 msgid "Plot using Draw"
@@ -7723,7 +7723,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:219
 msgid "Polish"
-msgstr ""
+msgstr "Polaco"
 
 #: ../../src/MaximaCommandMenus.cpp:215 ../../src/MaximaCommandMenus.cpp:220
 #: ../../src/MaximaCommandMenus.cpp:225
@@ -7759,7 +7759,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:221
 msgid "Portuguese (Brazilian)"
-msgstr ""
+msgstr "Portugués (Brasileiro)"
 
 #: ../../src/wxMaximaFrame.cpp:1223
 msgid "Position of a match"
@@ -7775,7 +7775,7 @@ msgstr ""
 
 #: ../../src/wizards/Plot2dWiz.cpp:474 ../../src/wizards/Plot3dWiz.cpp:422
 msgid "Postscript file (*.eps)|*.eps|All|*"
-msgstr ""
+msgstr "Archivo postscript (*.eps)|*.eps|Todos|*"
 
 #: ../../src/MaximaCommandMenus.cpp:190
 msgid "Power series"
@@ -7823,7 +7823,7 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:146
 msgid "Pressing Ctrl+Space or Ctrl+Tab starts an autocomplete function that can not only complete all functions that are integrated into the Maxima core and their parameters: It also knows about parameters from currently loaded packages and from functions that are defined in the current file."
-msgstr ""
+msgstr "Premendo Ctrl+Space ou Ctrl+Tab iníciase a autocompleción."
 
 #: ../../src/wxMaximaFrame.cpp:961
 msgid "Previous Command\tAlt+Up"
@@ -7927,7 +7927,7 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:123
 msgid "Product sign"
-msgstr ""
+msgstr "Símbolo de produto"
 
 #: ../../src/wxMaximaFrame.cpp:1129
 msgid "Program"
@@ -7951,7 +7951,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:200
 msgid "Psi"
-msgstr ""
+msgstr "Psi"
 
 #: ../../src/wxMaximaFrame.cpp:1788
 msgid "Push"
@@ -8037,7 +8037,7 @@ msgstr ""
 
 #: ../../src/sidebars/StatSidebar.cpp:103
 msgid "Read Matrix..."
-msgstr ""
+msgstr "Le matriz"
 
 #: ../../src/MaximaCommandMenus.cpp:4008
 msgid "Read a structure field"
@@ -8174,7 +8174,7 @@ msgstr ""
 
 #: ../../src/sidebars/MathSidebar.cpp:56
 msgid "Rectform"
-msgstr ""
+msgstr "Forma cartesiá"
 
 #: ../../src/wxMaximaFrame.cpp:1677
 msgid "Recursive Substitute..."
@@ -8198,7 +8198,7 @@ msgstr ""
 
 #: ../../src/sidebars/MathSidebar.cpp:71
 msgid "Reduce (tr)"
-msgstr ""
+msgstr "Reduce (tr)"
 
 #: ../../src/wxMaximaFrame.cpp:1632
 msgid "Reduce trigonometric expression"
@@ -8533,7 +8533,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:194
 msgid "Rho"
-msgstr ""
+msgstr "Ro"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2015
 msgid "Right"
@@ -8586,7 +8586,7 @@ msgstr ""
 
 #: ../../src/wizards/MatWiz.cpp:152
 msgid "Rows:"
-msgstr ""
+msgstr "Filas:"
 
 #: ../../src/MaximaCommandMenus.cpp:1391
 msgid "Rule"
@@ -8656,7 +8656,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:223
 msgid "Russian"
-msgstr ""
+msgstr "Ruso"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1578
 msgid "SBCL: use <int>Mbytes of heap"
@@ -8709,7 +8709,7 @@ msgstr ""
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:55
 msgid "Save Animation..."
-msgstr ""
+msgstr "Garda animación"
 
 #: ../../src/MaximaFileIO.cpp:779
 msgid "Save As"
@@ -8721,7 +8721,7 @@ msgstr ""
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:50
 msgid "Save Image..."
-msgstr ""
+msgstr "Garda imaxe..."
 
 #: ../../src/MaximaCommandMenus.cpp:2866
 msgid "Save Selection to Image"
@@ -8758,7 +8758,7 @@ msgstr ""
 
 #: ../../src/wizards/Plot2dWiz.cpp:473 ../../src/wizards/Plot3dWiz.cpp:421
 msgid "Save plot to file"
-msgstr ""
+msgstr "Garda gráfico nun arquivo"
 
 #: ../../src/wxMaximaFrame.cpp:713
 msgid "Save selection from document to an image file"
@@ -8770,7 +8770,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2640
 msgid "Save style to file"
-msgstr ""
+msgstr "Garda estilo en arquivo"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1384
 msgid "Save the worksheet automatically"
@@ -8802,7 +8802,7 @@ msgstr ""
 
 #: ../../src/sidebars/StatSidebar.cpp:88
 msgid "Scatterplot..."
-msgstr ""
+msgstr "Diagrama dispersión"
 
 #: ../../src/Autocomplete.cpp:157
 msgid "Scheduling a background task that compiles a new list of autocompletable maxima commands."
@@ -8875,7 +8875,7 @@ msgstr ""
 #: ../../src/worksheet/WorksheetContextMenu.cpp:428
 #: ../../src/worksheet/WorksheetContextMenu.cpp:460
 msgid "Select All"
-msgstr ""
+msgstr "Selecciona todo"
 
 #: ../../src/wxMaximaFrame.cpp:710
 msgid "Select All\tCtrl+A"
@@ -8893,7 +8893,7 @@ msgstr ""
 #: ../../src/wizards/IntegrateWiz.cpp:208 ../../src/wizards/LimitWiz.cpp:133
 #: ../../src/wizards/SeriesWiz.cpp:105
 msgid "Select a constant"
-msgstr ""
+msgstr "Selecciona unha constante"
 
 #: ../../src/ToolBar.cpp:390 ../../src/ToolBar.cpp:392
 #: ../../src/wxMaximaFrame.cpp:710
@@ -9002,7 +9002,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:479
 msgid "Set fixed font in text controls."
-msgstr ""
+msgstr "Establece tipografía fixa nos controis de texto."
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:68
 #: ../../src/worksheet/WorksheetContextMenu.cpp:250
@@ -9229,7 +9229,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:465
 msgid "Show long expressions in wxMaxima document."
-msgstr ""
+msgstr "Amosa expresións longas no documento de wxMaxima."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:722
 msgid "Show long expressions:"
@@ -9322,7 +9322,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:195
 msgid "Sigma"
-msgstr ""
+msgstr "Sigma"
 
 #: ../../src/dialogs/FindReplacePane.cpp:88
 msgid "Simple"
@@ -9334,7 +9334,7 @@ msgstr ""
 
 #: ../../src/sidebars/MathSidebar.cpp:44
 msgid "Simplify"
-msgstr ""
+msgstr "Simplifica"
 
 #: ../../src/wxMaximaFrame.cpp:1550
 msgid "Simplify &Radicals..."
@@ -9342,15 +9342,15 @@ msgstr ""
 
 #: ../../src/sidebars/MathSidebar.cpp:47
 msgid "Simplify (r)"
-msgstr ""
+msgstr "Simplifica (r)"
 
 #: ../../src/sidebars/MathSidebar.cpp:65
 msgid "Simplify (tr)"
-msgstr ""
+msgstr "Simplifica (tr)"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:352
 msgid "Simplify Expression"
-msgstr ""
+msgstr "Simplifica expresión"
 
 #: ../../src/wxMaximaFrame.cpp:1605
 msgid "Simplify Logarithms"
@@ -9386,7 +9386,7 @@ msgstr ""
 
 #: ../../src/wizards/SumWiz.cpp:68
 msgid "Simplify the sum"
-msgstr ""
+msgstr "Simplifica a suma"
 
 #: ../../src/wxMaximaFrame.cpp:1629
 msgid "Simplify trigonometric expression"
@@ -9451,7 +9451,7 @@ msgstr ""
 
 #: ../../src/wizards/BC2Wiz.cpp:30
 msgid "Solution:"
-msgstr ""
+msgstr "Solución:"
 
 #: ../../src/MaximaCommandMenus.cpp:3446
 msgid "Solve"
@@ -9491,7 +9491,7 @@ msgstr ""
 
 #: ../../src/sidebars/MathSidebar.cpp:77
 msgid "Solve ODE..."
-msgstr ""
+msgstr "Resolve EDO"
 
 #: ../../src/wxMaximaFrame.cpp:1432
 msgid "Solve a linear equation system using dgesv"
@@ -9576,7 +9576,7 @@ msgstr ""
 #: ../../src/sidebars/MathSidebar.cpp:74
 #: ../../src/worksheet/WorksheetContextMenu.cpp:347
 msgid "Solve..."
-msgstr ""
+msgstr "Resolve"
 
 #: ../../src/wxMaximaFrame.cpp:1953
 msgid "Solving differential equations"
@@ -9618,12 +9618,12 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:227
 msgid "Spanish"
-msgstr ""
+msgstr "Español"
 
 #: ../../src/wizards/IntegrateWiz.cpp:44 ../../src/wizards/IntegrateWiz.cpp:50
 #: ../../src/wizards/LimitWiz.cpp:38 ../../src/wizards/SeriesWiz.cpp:39
 msgid "Special"
-msgstr ""
+msgstr "Especial"
 
 #: ../../src/wizards/DrawWiz.cpp:918
 msgid "Speed versus accuracy"
@@ -9663,7 +9663,7 @@ msgstr ""
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:60
 msgid "Start Animation"
-msgstr ""
+msgstr "Comeza animación"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1622
 msgid "Start a new maxima for each re-evaluation"
@@ -9834,15 +9834,15 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:282
 msgid "Style"
-msgstr ""
+msgstr "Estilo"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2082
 msgid "Styles"
-msgstr ""
+msgstr "Estilos"
 
 #: ../../src/sidebars/StatSidebar.cpp:112
 msgid "Subsample..."
-msgstr ""
+msgstr "Submostra"
 
 #: ../../src/ToolBar.cpp:484 ../../src/sidebars/FormatSidebar.cpp:54
 msgid "Subsection"
@@ -9862,7 +9862,7 @@ msgstr ""
 
 #: ../../src/sidebars/MathSidebar.cpp:59
 msgid "Subst..."
-msgstr ""
+msgstr "S&ubstitúe"
 
 #: ../../src/MaximaCommandMenus.cpp:715 ../../src/MaximaCommandMenus.cpp:3490
 #: ../../src/MaximaCommandMenus.cpp:4500 ../../src/wizards/SubstituteWiz.cpp:53
@@ -9938,7 +9938,7 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:122
 msgid "Sum sign"
-msgstr ""
+msgstr "Símbolo de suma"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:228
 msgid "Swedish"
@@ -10003,7 +10003,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:196
 msgid "Tau"
-msgstr ""
+msgstr "Tau"
 
 #: ../../src/MaximaCommandMenus.cpp:181
 msgid "Taylor series"
@@ -10134,15 +10134,15 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:415
 msgid "The default height for embedded plots. Can be read out or overridden by the maxima variable wxplot_size."
-msgstr ""
+msgstr "A altura por defecto dos gráficos empotrados. Pode ser lida ou ignorada pola variable wxplot_size."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:492
 msgid "The default port used for communication between Maxima and wxMaxima."
-msgstr ""
+msgstr "Porto predeterminado para comunicación entre Maxima e wxMaxima"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:412
 msgid "The default width for embedded plots. Can be read out or overridden by the maxima variable wxplot_size"
-msgstr ""
+msgstr "O ancho por defecto dos gráficos empotrados. Pode ser lido ou ignorado pola variable wxplot_size."
 
 #: ../../src/sidebars/DrawSidebar.cpp:74
 msgid "The diagram title"
@@ -10175,7 +10175,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:475
 msgid "The document class LaTeX is instructed to use for our documents."
-msgstr ""
+msgstr "A clase de documento que utilizará LaTeX para os nosos documentos."
 
 #: ../../src/MaximaCommandMenus.cpp:1832
 msgid "The equation to fit the data to"
@@ -10460,7 +10460,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:185
 msgid "Theta"
-msgstr ""
+msgstr "Theta"
 
 #: ../../src/dialogs/LicenseDialog.cpp:85
 msgid "Third-party notices"
@@ -10520,7 +10520,7 @@ msgstr ""
 
 #: ../../src/wizards/Plot2dWiz.cpp:65 ../../src/wizards/Plot2dWiz.cpp:505
 msgid "Ticks:"
-msgstr ""
+msgstr "Marcas de eixes:"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1359
 msgid "Time [in Minutes] between autosaves"
@@ -10548,7 +10548,7 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:89
 msgid "Title, section and subsection cells can be folded to hide their contents. To fold or unfold, click in the square next to the cell. If you shift-click, all sublevels of that cell will also fold/unfold."
-msgstr ""
+msgstr "As celas de título, sección e subsección pódense plegar para ocultar os sus contidos. Tanto para plegalas como para desplegalas fágase clic no cadrado contiguo á cela. Se ó mesmo tempo se preme 'Maiúsculas', todos os subniveis serán pregados/despregados."
 
 #: ../../src/wxMaximaFrame.cpp:1831
 msgid "To &Bigfloat"
@@ -10560,7 +10560,7 @@ msgstr ""
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:344
 msgid "To Float"
-msgstr ""
+msgstr "A real"
 
 #: ../../src/wxMaximaFrame.cpp:1834
 msgid "To Numeri&c\tCtrl+Shift+N"
@@ -10576,7 +10576,7 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:124
 msgid "To plot in polar coordinates, select 'set polar' in the Options entry for Plot2d dialog. You can also plot in spherical and cylindrical coordinates in 3D."
-msgstr ""
+msgstr "Para representar en coordenadas polares, seleccione 'set polar' na entrada de Opcións de cadro de diálogo de Plot2D. Tamén se puede representar en coordenadas esféricas e cilíndricas en 3D."
 
 #: ../../src/dialogs/TipOfTheDay.cpp:131
 msgid "To put parentheses around an expression, select it, and press '(' or ')' depending on where you want the cursor to appear afterwards."
@@ -10584,7 +10584,7 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:137
 msgid "To save the size and position of wxMaxima windows between session, use 'Edit->Configure' dialog."
-msgstr ""
+msgstr "Para gardar o tamaño e a posición da xanela de wxMaxima entre sesións, utilícese 'Edita->Configura'."
 
 #: ../../src/dialogs/TipOfTheDay.cpp:51
 msgid "To start using wxMaxima right away, start typing your command. An input cell should appear. Then press Shift-Enter to evaluate your command."
@@ -10768,7 +10768,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:230
 msgid "Turkish"
-msgstr ""
+msgstr "Turco"
 
 #: ../../src/wxMaximaFrame.cpp:1965
 msgid "Tutorials"
@@ -10804,7 +10804,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:231
 msgid "Ukrainian"
-msgstr ""
+msgstr "Ucraíno"
 
 #: ../../src/wxMaxima.cpp:3164
 msgid "Un-closed parenthesis"
@@ -10835,7 +10835,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2115
 msgid "Underlined"
-msgstr ""
+msgstr "Subraiado"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:745
 msgid "Underscore converts to subscripts:"
@@ -10983,7 +10983,7 @@ msgstr ""
 
 #: ../../src/wizards/SumWiz.cpp:69
 msgid "Use Gosper algorithm"
-msgstr ""
+msgstr "Usa algoritmo Gosper"
 
 #: ../../src/sidebars/RegexCtrl.cpp:133
 msgid "Use RegEx filtering"
@@ -11011,7 +11011,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:849
 msgid "Use centered dot character for multiplication"
-msgstr ""
+msgstr "Usa punto centrado como operador de multiplicación"
 
 #: ../../src/wxMaximaFrame.cpp:1745
 msgid "Use list"
@@ -11035,7 +11035,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:425
 msgid "Use the \"partial derivative\" symbol to represent the fraction that represents a diff() when exporting LaTeX"
-msgstr ""
+msgstr "Usar o símbolo \"derivada parcial\" para representar diff() ó exportar a LaTeX"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2052
 msgid "Use unicode Math Symbols, if available"
@@ -11196,7 +11196,7 @@ msgstr ""
 
 #: ../../src/sidebars/StatSidebar.cpp:58
 msgid "Variance..."
-msgstr ""
+msgstr "Varianza"
 
 #: ../../src/WXMXformat.cpp:339
 msgid "Verified that we are able to read the whole .zip archive we produced."
@@ -11268,7 +11268,7 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:134
 msgid "When applying functions with one argument from menus, the default argument is '%'. To apply the function to some other value, select it in the document before executing a menu command."
-msgstr ""
+msgstr "Cando se aplican funcións cun argumento dende o menú, o argumento predeterminado é '%'. Para aplicar a función a outro valor, seleccióneo no documento antes de executar a instrución do menú."
 
 #: ../../src/wxMaximaFrame.cpp:1092
 msgid "When to invoke the lisp compiler's debugger"
@@ -11296,7 +11296,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:280
 msgid "Worksheet"
-msgstr ""
+msgstr "Folla de traballo"
 
 #: ../../src/MaximaResponseReader.cpp:117
 #, c-format
@@ -11317,7 +11317,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:428
 msgid "Wrap equations exported by the \"copy as LaTeX\" feature between \\[ and \\] as equation markers"
-msgstr ""
+msgstr "Envolver ecuacións exportadas coa opción \"copiar como LaTeX\" entre corchetes como marcadores de ecuacións"
 
 #: ../../src/worksheet/Worksheet.cpp:5190
 msgid "Wrapped search"
@@ -11347,19 +11347,19 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:191
 msgid "Xi"
-msgstr ""
+msgstr "Xi"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:728
 msgid "Yes"
-msgstr ""
+msgstr "Si"
 
 #: ../../src/dialogs/TipOfTheDay.cpp:64
 msgid "You can access the last output using the variable '%'. You can access the output of previous commands using variables '%on' where n is the number of output."
-msgstr ""
+msgstr "Pódese acceder á última saída facendo uso da variable '%' . Asemade, pódese acceder ás saídas das instrucións previas usando as variables '%on', onde n é o número de etiqueta da saída."
 
 #: ../../src/dialogs/TipOfTheDay.cpp:118
 msgid "You can evaluate your whole document by using 'Cell->Evaluate All Cells' menu command or the appropriate key shortcut. The cells will be evaluated in the order they appear in the document."
-msgstr ""
+msgstr "Pode avaliar o documento completo seleccionando 'Cela-> Avalía todas as celas' no menú. As celas avaliaranse na orde na que aparecen no documento."
 
 #: ../../src/dialogs/TipOfTheDay.cpp:98
 msgid "You can get help on a Maxima function by selecting or clicking on the function name and pressing F1. wxMaxima will search the help index for the selection or the word under the cursor."
@@ -11367,7 +11367,7 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:92
 msgid "You can hide output part of cells by clicking in the triangle on the left side of cells. This works on text cells also."
-msgstr ""
+msgstr "Pódese ocultar a parte do resultado dunha cela facendo clic sobre o triángulo á súa esquerda. Isto tamén é aplicable ás celas de texto."
 
 #: ../../src/dialogs/TipOfTheDay.cpp:81
 msgid "You can insert different types of 'cells' in wxMaxima documents using the 'Cell' menu. Note that only 'input cells' can be evaluated, while others are used for commenting and structuring your calculations."
@@ -11375,7 +11375,7 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:112
 msgid "You can select multiple cells either with a mouse - click'n'drag from between cells or from a cell bracket on the left - or with a keyboard - hold down Shift while moving the horizontal cursor - and then operate on selection. This comes in handy when you want to delete or evaluate multiple cells."
-msgstr ""
+msgstr "Pódense seleccionar varias celas, ben co rato, faciendo clic e arrastrando entre celas ou corchetes de celas, ben co teclado, mantendo pulsada a tecla de Maiúsculas mentres se move o cursor horizontal, para logo operar sobre a selección. Isto será útil cando se queiran borrar ou avaliar varias celas a un tempo."
 
 #: ../../src/dialogs/TipOfTheDay.cpp:232
 msgid "You found a bug in wxMaxima? Please report it at https://github.com/wxMaxima-developers/wxmaxima/issues\n"
@@ -11403,7 +11403,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:183
 msgid "Zeta"
-msgstr ""
+msgstr "Zeta"
 
 #: ../../src/wxMaximaFrame.cpp:842
 msgid "Zoom &In\tCtrl++"
@@ -11443,15 +11443,15 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:151
 msgid "alpha"
-msgstr ""
+msgstr "alfa"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:95
 msgid "and"
-msgstr ""
+msgstr "and"
 
 #: ../../src/wizards/MatWiz.cpp:160
 msgid "antisymmetric"
-msgstr ""
+msgstr "antisimétrica"
 
 #: ../../src/wxMaximaFrame.cpp:1727
 msgid "apply function to each element"
@@ -11475,11 +11475,11 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:152
 msgid "beta"
-msgstr ""
+msgstr "beta"
 
 #: ../../src/wizards/LimitWiz.cpp:42
 msgid "both sides"
-msgstr ""
+msgstr "ambos os dous lados"
 
 #: ../../src/wxMaximaFrame.cpp:1173
 msgid "char to Ascii code..."
@@ -11487,7 +11487,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:172
 msgid "chi"
-msgstr ""
+msgstr "ji"
 
 #: ../../src/MaximaFileIO.cpp:318
 #, c-format
@@ -11497,15 +11497,15 @@ msgstr ""
 #: ../../src/wizards/Plot2dWiz.cpp:70 ../../src/wizards/Plot2dWiz.cpp:372
 #: ../../src/wizards/Plot3dWiz.cpp:61 ../../src/wizards/Plot3dWiz.cpp:358
 msgid "default"
-msgstr ""
+msgstr "predeterminado"
 
 #: ../../src/sidebars/GreekSidebar.cpp:154
 msgid "delta"
-msgstr ""
+msgstr "delta"
 
 #: ../../src/wizards/MatWiz.cpp:159
 msgid "diagonal"
-msgstr ""
+msgstr "diagonal"
 
 #: ../../src/cells/FracCell.cpp:73
 msgid "diff(): Cannot find the multiplication sign I should hide"
@@ -11521,19 +11521,19 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:92
 msgid "empty"
-msgstr ""
+msgstr "baleiro"
 
 #: ../../src/sidebars/GreekSidebar.cpp:155
 msgid "epsilon"
-msgstr ""
+msgstr "épsilon"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:100
 msgid "equivalent"
-msgstr ""
+msgstr "equivalente"
 
 #: ../../src/sidebars/GreekSidebar.cpp:157
 msgid "eta"
-msgstr ""
+msgstr "eta"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:799
 msgid "ev() shall evaluate this automatically"
@@ -11541,7 +11541,7 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:88
 msgid "exists"
-msgstr ""
+msgstr "existe"
 
 #: ../../src/MaximaCommandMenus.cpp:3942
 msgid "expression:"
@@ -11583,11 +11583,11 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:153
 msgid "gamma"
-msgstr ""
+msgstr "gamma"
 
 #: ../../src/wizards/MatWiz.cpp:159
 msgid "general"
-msgstr ""
+msgstr "xeral"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1630
 msgid "gnuplot: Without command console"
@@ -11595,11 +11595,11 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:118
 msgid "greater than or equal"
-msgstr ""
+msgstr "maior ou igual"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:87
 msgid "in"
-msgstr ""
+msgstr "en"
 
 #: ../../src/wxMaximaFrame.cpp:784
 msgid "in 2D"
@@ -11610,31 +11610,31 @@ msgstr ""
 #: ../../src/wizards/Plot3dWiz.cpp:61 ../../src/wizards/Plot3dWiz.cpp:194
 #: ../../src/wizards/Plot3dWiz.cpp:358 ../../src/wizards/Plot3dWiz.cpp:386
 msgid "inline"
-msgstr ""
+msgstr "en liña"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:104
 msgid "intersection"
-msgstr ""
+msgstr "intersección"
 
 #: ../../src/sidebars/GreekSidebar.cpp:159
 msgid "iota"
-msgstr ""
+msgstr "iota"
 
 #: ../../src/sidebars/GreekSidebar.cpp:160
 msgid "kappa"
-msgstr ""
+msgstr "kappa"
 
 #: ../../src/sidebars/GreekSidebar.cpp:161
 msgid "lambda"
-msgstr ""
+msgstr "lambda"
 
 #: ../../src/wizards/LimitWiz.cpp:42
 msgid "left"
-msgstr ""
+msgstr "esquerda"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:117
 msgid "less or equal"
-msgstr ""
+msgstr "menor ou igual"
 
 #: ../../src/MaximaCommandMenus.cpp:1567
 msgid "list"
@@ -11642,7 +11642,7 @@ msgstr ""
 
 #: ../../src/wizards/Plot2dWiz.cpp:54 ../../src/wizards/Plot2dWiz.cpp:64
 msgid "logscale"
-msgstr ""
+msgstr "escala logarítmica"
 
 #: ../../src/wizards/DrawWiz.cpp:822
 msgid "matrix([x_1,x_2,...],[y_1,y_2,...])"
@@ -11662,11 +11662,11 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:120
 msgid "much greater than"
-msgstr ""
+msgstr "moito maior que"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:119
 msgid "much less than"
-msgstr ""
+msgstr "moito menor que"
 
 #: ../../src/MaximaCommandMenus.cpp:1232
 msgid "m×n Matrix A:"
@@ -11683,7 +11683,7 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:98
 msgid "nand"
-msgstr ""
+msgstr "nand"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:772
 msgid "nary: f(x, f(y,z)) = foo(x,y,z)"
@@ -11691,23 +11691,23 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:99
 msgid "nor"
-msgstr ""
+msgstr "nor"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:102
 msgid "not"
-msgstr ""
+msgstr "not"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:116
 msgid "not bytewise identical"
-msgstr ""
+msgstr "non idéntico bit a bit"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:108
 msgid "not subset"
-msgstr ""
+msgstr "non subconxunto"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:107
 msgid "not subset or equal"
-msgstr ""
+msgstr "non subconxunto ou igual"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:796
 msgid "noun: Not evaluated by default"
@@ -11727,7 +11727,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:174
 msgid "omega"
-msgstr ""
+msgstr "omega"
 
 #: ../../src/sidebars/GreekSidebar.cpp:165
 msgid "omicron"
@@ -11735,7 +11735,7 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:96
 msgid "or"
-msgstr ""
+msgstr "or"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:793
 msgid "outative: f(2*x) = 2*f(x)"
@@ -11752,15 +11752,15 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:111
 msgid "partial sign"
-msgstr ""
+msgstr "símbolo parcial"
 
 #: ../../src/sidebars/GreekSidebar.cpp:171
 msgid "phi"
-msgstr ""
+msgstr "fi"
 
 #: ../../src/sidebars/GreekSidebar.cpp:166
 msgid "pi"
-msgstr ""
+msgstr "pi"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:101
 msgid "plus or minus"
@@ -11789,11 +11789,11 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:115
 msgid "proportional to"
-msgstr ""
+msgstr "proporcional a"
 
 #: ../../src/sidebars/GreekSidebar.cpp:173
 msgid "psi"
-msgstr ""
+msgstr "psi"
 
 #: ../../src/MaximaCommandMenus.cpp:642
 msgid "radcan() is a powerful tools for simplification trigonometric functions but needs to be taken with care: If a function has more than one branch radcan uses the one that looks like it would fit best, not necessarily the one that makes sense for the problem that resulted in the Expression that is to be simplified."
@@ -11821,11 +11821,11 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:167
 msgid "rho"
-msgstr ""
+msgstr "ro"
 
 #: ../../src/wizards/LimitWiz.cpp:42
 msgid "right"
-msgstr ""
+msgstr "dereita"
 
 #: ../../src/wizards/DrawWiz.cpp:310
 msgid "secondary x axis label"
@@ -11845,7 +11845,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:168
 msgid "sigma"
-msgstr ""
+msgstr "sigma"
 
 #: ../../src/MaximaCommandMenus.cpp:3447
 msgid "solve() will solve a list of equations only if for n independent equations there are n variables to solve to.\n"
@@ -11869,15 +11869,15 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:106
 msgid "subset"
-msgstr ""
+msgstr "subconxunto"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:105
 msgid "subset or equal"
-msgstr ""
+msgstr "subconxunto ou igual"
 
 #: ../../src/wizards/MatWiz.cpp:160
 msgid "symmetric"
-msgstr ""
+msgstr "simétrica"
 
 #: ../../src/MaximaCommandMenus.cpp:970
 msgid "t:"
@@ -11885,7 +11885,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:169
 msgid "tau"
-msgstr ""
+msgstr "tau"
 
 #: ../../src/cells/TextCell.cpp:340
 msgid "the [] operator tried to extract an element of a list, a matrix, an equation or an array. But instead of an integer number something was used whose numerical value is unknown or not an integer.\n"
@@ -11902,23 +11902,23 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:89
 msgid "there is no"
-msgstr ""
+msgstr "non hai"
 
 #: ../../src/sidebars/GreekSidebar.cpp:158
 msgid "theta"
-msgstr ""
+msgstr "theta"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:78
 msgid "to the power of 2"
-msgstr ""
+msgstr "á segunda potencia"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:79
 msgid "to the power of 3"
-msgstr ""
+msgstr "á terceira potencia"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:103
 msgid "union"
-msgstr ""
+msgstr "unión"
 
 #: ../../src/wxMaximaFrame.cpp:1109
 msgid "unnamed function (lambda)..."
@@ -11982,7 +11982,7 @@ msgstr ""
 #: ../../src/dialogs/ConfigDialogue.cpp:142
 #: ../../src/dialogs/ConfigDialogue.cpp:311
 msgid "wxMaxima configuration"
-msgstr ""
+msgstr "Configuración de wxMaxima"
 
 #: ../../src/MaximaProcessManager.cpp:209
 msgid "wxMaxima could not start a server.\n\n"
@@ -11992,7 +11992,7 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:127
 msgid "wxMaxima dialogs set default values for inputs entries, one of which is '%'. If you have made a selection in your document, the selection will be used instead of '%'."
-msgstr ""
+msgstr "Nos cadros de diálogo de wxMaxima aparecen entradas predeterminadas, unha das cales é '%'. Se fixo unha selección no documento, esta será utilizada en lugar de '%'."
 
 #: ../../src/MaximaCommandMenus.cpp:4544
 msgid "wxMaxima document"
@@ -12118,7 +12118,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:709
 msgid "x"
-msgstr ""
+msgstr "x"
 
 #: ../../src/wizards/DrawWiz.cpp:266
 msgid "x axis label"
@@ -12134,7 +12134,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:164
 msgid "xi"
-msgstr ""
+msgstr "xi"
 
 #: ../../src/MaximaFileIO.cpp:408 ../../src/MaximaFileIO.cpp:566
 msgid "xml contained in the file claims not to be a wxMaxima worksheet. "
@@ -12142,7 +12142,7 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:97
 msgid "xor"
-msgstr ""
+msgstr "xor"
 
 #: ../../src/wizards/DrawWiz.cpp:279
 msgid "y axis label"
@@ -12170,7 +12170,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:156
 msgid "zeta"
-msgstr ""
+msgstr "zeta"
 
 #. type: Title #
 #: ../../info/wxmaxima.md:1

--- a/locales/wxMaxima/hu.po
+++ b/locales/wxMaxima/hu.po
@@ -52,23 +52,23 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1569
 msgid "      -X \"--control-stack-size <int>\""
-msgstr ""
+msgstr "      -X \"--dinamikus-helyméret <int>\""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1568
 msgid "      -X \"--dynamic-space-size <int>\""
-msgstr ""
+msgstr "      -X \"--dinamikus-helyméret <int>\""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1572
 msgid "      -X '--control-stack-size <int>'"
-msgstr ""
+msgstr "      -X '--dinamikus-helyméret <int>'"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1571
 msgid "      -X '--dynamic-space-size <int>'"
-msgstr ""
+msgstr "      -X '--dinamikus-helyméret <int>'"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1551
 msgid "      -l <name>"
-msgstr ""
+msgstr "      -l <name>"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1557
 msgid "      -u <versionnumber>"
@@ -166,7 +166,7 @@ msgstr ""
 #: ../../src/cells/ImgCell.cpp:212 ../../src/cells/ImgCell.cpp:214
 #: ../../src/cells/ImgCell.cpp:216
 msgid " (Graphics) "
-msgstr ""
+msgstr " (Grafika) "
 
 #: ../../src/cells/EditorCell.cpp:3551 ../../src/cells/EditorCell.cpp:3820
 #: ../../src/cells/EditorCell.cpp:3945
@@ -176,7 +176,7 @@ msgstr ""
 
 #: ../../src/cells/EditorCell.cpp:3553
 msgid " ... + 1 hidden line"
-msgstr ""
+msgstr " ... + 1 rejtett sor"
 
 #: ../../src/dialogs/TipOfTheDay.cpp:273
 msgid " Did you know? "
@@ -192,15 +192,15 @@ msgstr ""
 
 #: ../../src/wizards/DrawWiz.cpp:964 ../../src/wizards/DrawWiz.cpp:980
 msgid " samples"
-msgstr ""
+msgstr " példák"
 
 #: ../../src/wizards/DrawWiz.cpp:929 ../../src/wizards/DrawWiz.cpp:945
 msgid " samples, on demand split "
-msgstr ""
+msgstr " minták, igény szerint szétszedve"
 
 #: ../../src/wizards/DrawWiz.cpp:933 ../../src/wizards/DrawWiz.cpp:952
 msgid " times"
-msgstr ""
+msgstr " ennyiszer"
 
 #: ../../src/MaximaCommandMenus.cpp:4413
 msgid "\".\" = \"The current directory\"\n"
@@ -215,7 +215,7 @@ msgstr "\"..\" azt jelenti, hogy \"egy könyvtárral feljebb\"."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1208
 msgid "\"Copy LaTeX\" adds equation markers"
-msgstr ""
+msgstr "A \"LaTeX másolás\" hozzáadja a kiemelt matematikai mód jeleit"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:446
 msgid "\"MathML (rendered by the browser)\" is the recommended choice: every current browser renders MathML natively and instantly, and the exported page needs no JavaScript and makes no requests to any external server.\n"
@@ -225,11 +225,11 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:930
 msgid "\"Numpad Enter\" always evaluates cells"
-msgstr ""
+msgstr "A \"Numpad Enter\" mindig kiértékeli a cellákat"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:90
 msgid "\"implies\" symbol"
-msgstr ""
+msgstr "\"következik\" jel"
 
 #: ../../src/dialogs/DiffFrame.cpp:306
 #, c-format
@@ -244,7 +244,7 @@ msgstr "%i cella a kiértékelési sorban"
 #: ../../src/sidebars/TableOfContents.cpp:570
 #, c-format
 msgid "%li Levels"
-msgstr ""
+msgstr "%li szintek"
 
 #: ../../src/worksheet/Worksheet.cpp:423
 #, c-format
@@ -316,7 +316,7 @@ msgstr "&Másolás\tCtrl+C"
 
 #: ../../src/wizards/IntegrateWiz.cpp:39
 msgid "&Definite integration"
-msgstr ""
+msgstr "&Határozott integrál"
 
 #: ../../src/wxMaximaFrame.cpp:1658
 msgid "&Demoivre"
@@ -432,11 +432,11 @@ msgstr "&Numerikus kimenet"
 
 #: ../../src/wizards/IntegrateWiz.cpp:52
 msgid "&Numerical integration"
-msgstr ""
+msgstr "&Numerikus integrálás"
 
 #: ../../src/wizards/SumWiz.cpp:44
 msgid "&Nusum"
-msgstr ""
+msgstr "&Numerikus összegzés"
 
 #: ../../src/main.cpp:675
 msgid "&Open\tCtrl+O"
@@ -452,7 +452,7 @@ msgstr "Á&brázolás"
 
 #: ../../src/wizards/SeriesWiz.cpp:45
 msgid "&Power series"
-msgstr ""
+msgstr "&Hatványsor"
 
 #: ../../src/wxMaximaFrame.cpp:655
 msgid "&Print...\tCtrl+P"
@@ -460,7 +460,7 @@ msgstr "&Nyomtatás...\tCtrl+P"
 
 #: ../../src/wizards/SubstituteWiz.cpp:38
 msgid "&Rational"
-msgstr ""
+msgstr "&Értelemszerűen (nem formálisan)"
 
 #: ../../src/wxMaximaFrame.cpp:1631
 msgid "&Reduce Trigonometric"
@@ -492,11 +492,11 @@ msgstr "&Megoldás..."
 
 #: ../../src/wizards/Plot2dWiz.cpp:42
 msgid "&Special"
-msgstr ""
+msgstr "&Különleges"
 
 #: ../../src/wizards/LimitWiz.cpp:45
 msgid "&Taylor series"
-msgstr ""
+msgstr "Taylor-sor használatával"
 
 #: ../../src/wxMaximaFrame.cpp:1069
 msgid "&Time Display"
@@ -516,7 +516,7 @@ msgstr "&Változók"
 
 #: ../../src/wizards/Plot3dWiz.cpp:79
 msgid "&pm3d"
-msgstr ""
+msgstr "&pm3d"
 
 #: ../../src/cells/AnimationCell.cpp:475
 msgid "(Animation)"
@@ -544,15 +544,15 @@ msgstr ""
 
 #: ../../src/sidebars/CharButton.cpp:211
 msgid "(Might not be displayed correctly in at least one of the worksheet fonts)"
-msgstr ""
+msgstr "(Lehet, hogy nem jelenik meg megfelelően a munkalapok legalább egyik betűtípusában)"
 
 #: ../../src/sidebars/VariablesPane.cpp:254
 msgid "(Not a valid variable name)"
-msgstr ""
+msgstr "(Nem egy érvényes változó neve)"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:183
 msgid "(Use default language)"
-msgstr ""
+msgstr "(Alapértelmezett nyelv)"
 
 #: ../../src/MaximaCommandMenus.cpp:440
 msgid "(f(x),x,a,b)), Epsilon algorithm"
@@ -586,7 +586,7 @@ msgstr "(f(x),x,y) szingularitásokkal+diszkontinuitásokkal"
 #: ../../src/wizards/DrawWiz.cpp:303 ../../src/wizards/DrawWiz.cpp:320
 #: ../../src/wizards/DrawWiz.cpp:335
 msgid "-"
-msgstr ""
+msgstr "-"
 
 #: ../../src/wizards/IntegrateWiz.cpp:192
 #: ../../src/wizards/IntegrateWiz.cpp:202
@@ -594,7 +594,7 @@ msgstr ""
 #: ../../src/wizards/IntegrateWiz.cpp:217 ../../src/wizards/LimitWiz.cpp:132
 #: ../../src/wizards/LimitWiz.cpp:142
 msgid "- Infinity"
-msgstr ""
+msgstr "- Végtelen"
 
 #: ../../src/MaximaOutputAppender.cpp:116
 msgid "... [suppressed additional lines as the output is longer than allowed in the wxMaxima configuration] "
@@ -606,15 +606,15 @@ msgstr ".wxm vágólap adatai szokatlan fejléccel"
 
 #: ../../src/sidebars/TableOfContents.cpp:567
 msgid "1 Level"
-msgstr ""
+msgstr "1 szint"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:77
 msgid "1/2"
-msgstr ""
+msgstr "1/2"
 
 #: ../../src/sidebars/DrawSidebar.cpp:45
 msgid "2D"
-msgstr ""
+msgstr "2D"
 
 #: ../../src/wxMaximaFrame.cpp:1346
 msgid "2D Array to Matrix..."
@@ -638,7 +638,7 @@ msgstr ""
 
 #: ../../src/sidebars/DrawSidebar.cpp:49
 msgid "3D"
-msgstr ""
+msgstr "3D"
 
 #: ../../src/wxMaxima.cpp:1833
 #, c-format
@@ -651,7 +651,7 @@ msgstr "Egy \":lisp\", mint első parancs lehet, hogy nem küld \"kész\" jelet.
 
 #: ../../src/dialogs/TipOfTheDay.cpp:102
 msgid "A 'horizontal cursor' was introduced in wxMaxima 0.8.0. It looks like a horizontal line between cells. It indicates where a new cell will appear if you type or paste text or execute a menu command."
-msgstr ""
+msgstr "A wxMaxima 0.8.0-ás verziójában megjelent egy 'vízszintes kurzor'. Úgy néz ki, mint egy cellák közti vízszintes vonal. Ott jelenik meg, ahol szöveg begépelésével, beillesztésével vagy egy menü parancs végrehajtásával egy új cella keletkezik."
 
 #: ../../src/MaximaCommandMenus.cpp:3039
 msgid "A Ctrl-F event"
@@ -677,7 +677,7 @@ msgstr ""
 
 #: ../../src/wizards/ListSortWiz.cpp:63
 msgid "A function f(a,b), named"
-msgstr ""
+msgstr "Egy f(a,b) függvény, megnevezett"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:784
 msgid "A function returning integers"
@@ -689,7 +689,7 @@ msgstr "Pozitív számokat visszaadó függvény"
 
 #: ../../src/wizards/DrawWiz.cpp:164
 msgid "A good example equation would be x^2+y^2=1"
-msgstr ""
+msgstr "Az x^2+y^2=1 egy jó példa lenne egyenletre"
 
 #: ../../src/cells/GroupCell.cpp:2193 ../../src/cells/GroupCell.cpp:2196
 msgid "A heading"
@@ -713,15 +713,15 @@ msgstr "Egy mátrix, amelyben minden sor változók halmaza"
 
 #: ../../src/dialogs/TipOfTheDay.cpp:84
 msgid "A new document format has been introduced in wxMaxima 0.8.2 that saves not only your input and text commentaries, but also the outputs of your calculations. When saving your document, select 'Whole document (*.wxmx)' format."
-msgstr ""
+msgstr "A wxMaxima 0.8.2-es verziójában új dokumentumformátumot vezettek be, amely nem csak a bemenetet és a szöveges megjegyzéseket menti, hanem a számítások kimenetét is. Használatához a dokumentum mentésénél válasszuk az 'Egész dokumentum: (*.wxmx)' formátumot."
 
 #: ../../src/cells/GroupCell.cpp:2175
 msgid "A page break"
-msgstr ""
+msgstr "Laptörés"
 
 #: ../../src/dialogs/TipOfTheDay.cpp:168
 msgid "A plot to be embedded into the work sheet by preceding its name with a \"wx\". \"draw\" can be replaced by \"wxdraw\", plot by \"wxplot\" etc."
-msgstr ""
+msgstr "Ha egy ábrát be akarunk illeszteni a dokumentumunkba, rakjunk a parancs neve elé egy \"wx\"-et. Használjunk tehát \"draw\" helyett \"wxdraw\"-t, \"plot\" helyett \"wxplot\"-ot, stb."
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:735
 msgid "A rational variable"
@@ -733,7 +733,7 @@ msgstr "Jobb-asszociatív függvény"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:436
 msgid "A scale factor for the printout. Helpful for printing big equations on small pdf pages."
-msgstr ""
+msgstr "Nyomtatásra szolgáló skála. Hasznos nagy egyenletek kinyomtatására kis pdf oldalakon."
 
 #: ../../src/wxMaximaFrame.cpp:1671
 msgid "A search-and-replace for equations"
@@ -741,27 +741,27 @@ msgstr "Egyenletek keresése és cseréje"
 
 #: ../../src/cells/EditorCell.cpp:4522 ../../src/cells/GroupCell.cpp:2184
 msgid "A section heading"
-msgstr ""
+msgstr "Fejezetcím"
 
 #: ../../src/wizards/DrawWiz.cpp:479
 msgid "A static plot"
-msgstr ""
+msgstr "Statikus ábrázolás"
 
 #: ../../src/cells/EditorCell.cpp:4534
 msgid "A sub-sub-sub-subsection heading"
-msgstr ""
+msgstr "Al-al-al-alfejezet cím"
 
 #: ../../src/cells/EditorCell.cpp:4531
 msgid "A sub-sub-subsection heading"
-msgstr ""
+msgstr "Al-al-alfejezet cím"
 
 #: ../../src/cells/EditorCell.cpp:4528 ../../src/cells/GroupCell.cpp:2190
 msgid "A sub-subsection heading"
-msgstr ""
+msgstr "Al-alfejezetcím"
 
 #: ../../src/cells/EditorCell.cpp:4525 ../../src/cells/GroupCell.cpp:2187
 msgid "A subsection heading"
-msgstr ""
+msgstr "Alfejezetcím"
 
 #: ../../src/wxMaximaFrame.cpp:1673
 msgid "A subst with basic maths knowledge"
@@ -769,7 +769,7 @@ msgstr "Alapvető matematikai ismeretekkel rendelkező rész"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:239
 msgid "A symbol from the configuration dialogue"
-msgstr ""
+msgstr "Egy szimbólum a beállításokból"
 
 #: ../../src/cells/GroupCell.cpp:2181
 msgid "A text cell"
@@ -806,7 +806,7 @@ msgstr "ASCII matematika"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1618
 msgid "Abort evaluation on error"
-msgstr ""
+msgstr "Kiértékelés megszakítása hiba esetén"
 
 #: ../../src/MaximaEvaluator.cpp:214
 #, c-format
@@ -839,7 +839,7 @@ msgstr ""
 
 #: ../../src/sidebars/DrawSidebar.cpp:103
 msgid "Accuracy"
-msgstr ""
+msgstr "Pontosság"
 
 #: ../../src/wxMaximaFrame.cpp:1405
 msgid "Ad&joint Matrix"
@@ -859,7 +859,7 @@ msgstr "Új elem hozzáadása a lista elejéhez. Hasznos kötegek létrehozásá
 
 #: ../../src/sidebars/VariablesPane.cpp:228
 msgid "Add all"
-msgstr ""
+msgstr "Mind hozzáadása"
 
 #: ../../src/MaximaCommandMenus.cpp:1621
 msgid "Add an element to the end of a list"
@@ -879,11 +879,11 @@ msgstr "Egyenlőség hozzáadása racionális egyszerűsítéshez"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:204
 msgid "Add more symbols"
-msgstr ""
+msgstr "További szimbólumok hozzáadása"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1262
 msgid "Add the .wxmx file to the HTML export"
-msgstr ""
+msgstr "A wxmx fájl HTML exportja"
 
 #: ../../src/wxMaximaFrame.cpp:1049
 msgid "Add to &Path..."
@@ -891,7 +891,7 @@ msgstr "&Hozzáadás az elérési úthoz..."
 
 #: ../../src/sidebars/UnicodeSidebar.cpp:105
 msgid "Add to symbols Sidebar"
-msgstr ""
+msgstr "Szimbólumok hozzáadása az oldalsávhoz"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:304
 #: ../../src/worksheet/WorksheetContextMenu.cpp:337
@@ -902,23 +902,23 @@ msgstr "Add a megnézendők listájához"
 #: ../../src/sidebars/XmlInspector.cpp:147
 #, c-format
 msgid "Added much text (%li chars) to the XML inspector."
-msgstr ""
+msgstr "Sok szöveget adott hozzá (%li karakterek) az XML lekérdezőhöz."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1896
 msgid "Additional clipboard formats to put on the clipboard on ordinary copy"
-msgstr ""
+msgstr "További vágólap formátumok, amelyeket a vágólapra helyezhet a szokásos példányon"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:393
 msgid "Additional commands to be added to the preamble of LaTeX output for pdftex."
-msgstr ""
+msgstr "További parancsok a LaTeX kimeneti fájl preambulumába."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1187
 msgid "Additional lines for the TeX preamble:"
-msgstr ""
+msgstr "További sorok a TeX preambulumba:"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:389
 msgid "Additional parameters for Maxima (e.g. -l clisp)."
-msgstr ""
+msgstr "A Maxima további paraméterei (pl. -l clisp)."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1543
 msgid "Additional parameters for Maxima (restart Maxima after changes)"
@@ -926,7 +926,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1318
 msgid "Additional symbols for the \"symbols\" sidebar:"
-msgstr ""
+msgstr "További szimbólumok a \"Szimbólumok\" oldalpanelra:"
 
 #: ../../src/wxMaximaFrame.cpp:1599
 msgid "Additionally: log(a*b)=log(a)+log(b)"
@@ -970,7 +970,7 @@ msgstr "Álnevek"
 
 #: ../../src/sidebars/TableOfContents.cpp:572
 msgid "All Levels"
-msgstr ""
+msgstr "Minden szint"
 
 #: ../../src/wxMaximaFrame.cpp:1751
 msgid "All but the 1st n elements"
@@ -986,7 +986,7 @@ msgstr "Minden megnyitható típus (*.wxm, *.wxmx, *.mac, *.out, *.xml)|*.wxm;*.
 
 #: ../../src/dialogs/ConfigDialogue.cpp:750
 msgid "All variable names"
-msgstr ""
+msgstr "Összes változónév"
 
 #: ../../src/wxMaximaFrame.cpp:770
 msgid "All visible sidebars"
@@ -1014,7 +1014,7 @@ msgstr ""
 
 #: ../../src/dialogs/BinaryNameCtrl.cpp:69
 msgid "All|*"
-msgstr ""
+msgstr "Minden fájl|*"
 
 #: ../../src/wxMaximaFrame.cpp:800
 msgid "Always after underscores"
@@ -1034,7 +1034,7 @@ msgstr "Mindig megmutatja az összes számjegyet"
 
 #: ../../src/wizards/DrawWiz.cpp:484
 msgid "An animation with multiple frames"
-msgstr ""
+msgstr "Animáció több képkockával"
 
 #: ../../src/cells/GroupCell.cpp:2202
 msgid "An image cell"
@@ -1192,7 +1192,7 @@ msgstr "Ascii kód a karakterhez..."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1397
 msgid "Ask to save untitled documents"
-msgstr ""
+msgstr "Rákérdez név nélküli dokumentum mentésére"
 
 #: ../../src/dialogs/MaximaNotStartingDialog.cpp:36
 msgid "Asking the user for the location of a working maxima binary"
@@ -1216,21 +1216,21 @@ msgstr "Figyelem: A véletlenszerű listaelemek kibontása nem hatékony hosszú
 
 #: ../../src/dialogs/ConfigDialogue.cpp:897
 msgid "Auto-indent new lines"
-msgstr ""
+msgstr "Új sorok automatikus behúzása"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:893
 msgid "Auto-insert closing parenthesis"
-msgstr ""
+msgstr "A záró zárójel automatikus beszúrása"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1441
 #: ../../src/dialogs/ConfigDialogue.cpp:1472
 #: ../../src/dialogs/MaximaNotStartingDialog.cpp:43
 msgid "Autodetect"
-msgstr ""
+msgstr "Automatikus felismerés"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1236
 msgid "Automatic"
-msgstr ""
+msgstr "Automatikus"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:391
 msgid "Automatic labels"
@@ -1239,7 +1239,7 @@ msgstr "Automatikus címkék"
 #: ../../src/dialogs/ConfigDialogue.cpp:769
 #, c-format
 msgid "Automatic labels (%i1, %o1,...)"
-msgstr ""
+msgstr "Automatikus címkék (%i1, %o1,...)"
 
 #: ../../src/wxMaximaFrame.cpp:986
 msgid "Automatically answer questions"
@@ -1251,7 +1251,7 @@ msgstr "Automatikusan kitöltött válaszok a legutóbbi futási eredmények ala
 
 #: ../../src/dialogs/ConfigDialogue.cpp:460
 msgid "Automatically insert a closing parenthesis the moment the user enters an opening one."
-msgstr ""
+msgstr "A záró zárójel automatikus beszúrása abban a pillanatban, amikor a felhasználó belép egy nyitó zárójelbe."
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:235
 #: ../../src/worksheet/WorksheetContextMenu.cpp:610
@@ -1286,15 +1286,15 @@ msgstr "Automatikus feliratkozás erre a változóra"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:734
 msgid "Autowrap long lines:"
-msgstr ""
+msgstr "Hosszú szövegek automatikus sortörése:"
 
 #: ../../src/sidebars/DrawSidebar.cpp:75
 msgid "Axis"
-msgstr ""
+msgstr "Tengely"
 
 #: ../../src/wizards/BC2Wiz.cpp:59
 msgid "BC2"
-msgstr ""
+msgstr "Peremérték probléma"
 
 #: ../../src/MaximaManual.cpp:559
 msgid "Background task that compiles the Manual anchors scheduled."
@@ -1302,7 +1302,7 @@ msgstr "A kézikönyv horgonyait fordító háttérfeladat ütemezve."
 
 #: ../../src/sidebars/StatSidebar.cpp:91
 msgid "Barsplot..."
-msgstr ""
+msgstr "Oszlopdiagram..."
 
 #: ../../src/wxMaximaFrame.cpp:1384
 msgid "Basic matrix operations"
@@ -1341,27 +1341,27 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:141
 msgid "Besides the global undo functionality that is active when the cursor is between cells, wxMaxima has a per-cell undo function that is active if the cursor is inside a cell. Pressing Ctrl+Z inside a cell can therefore been used for a fine-pitch undo that doesn't affect latter changes made in other cells."
-msgstr ""
+msgstr "A globális visszavonás mellett (ami akkor aktív, ha a kurzor a cellák között van), a wxMaximának van egy cellán belüli visszavonás funkcionalitása is, amely akkor működik, ha a kurzor a cellán belül van. Tehát ha a kurzor a cellán belül van és Ctrl+Z-t nyomunk, egy olyan visszavonást kapunk, mely nem aktív a cellán kívül."
 
 #: ../../src/sidebars/GreekSidebar.cpp:179
 msgid "Beta"
-msgstr ""
+msgstr "Béta"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1898
 msgid "Bitmap"
-msgstr ""
+msgstr "Bitkép"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1273
 msgid "Bitmap scale for export:"
-msgstr ""
+msgstr "Bitmap skála exportáláshoz:"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1223
 msgid "Bitmaps"
-msgstr ""
+msgstr "Bitképek"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2109
 msgid "Bold"
-msgstr ""
+msgstr "Félkövér"
 
 #: ../../src/wxMaxima.cpp:2259
 msgid "Both horizontal and vertical cursor active at the same time"
@@ -1385,13 +1385,13 @@ msgstr ""
 
 #: ../../src/sidebars/StatSidebar.cpp:97
 msgid "Boxplot..."
-msgstr ""
+msgstr "Doboz ábra..."
 
 #: ../../src/dialogs/BinaryNameCtrl.cpp:42 ../../src/wizards/CsvWiz.cpp:57
 #: ../../src/wizards/CsvWiz.cpp:131 ../../src/wizards/Plot2dWiz.cpp:114
 #: ../../src/wizards/Plot3dWiz.cpp:109
 msgid "Browse"
-msgstr ""
+msgstr "Böngészés"
 
 #: ../../src/wxMathml.cpp:101
 msgid "Bug: After removing the whitespace wxMathml.lisp is shorter than expected!"
@@ -1440,7 +1440,7 @@ msgstr "Hiba: A HTML kimenet nem érvényes XML"
 
 #: ../../src/cells/Cell.cpp:289
 msgid "Bug: Math Cell that claims to have no group Cell it belongs to"
-msgstr ""
+msgstr "Hiba: A matematika cella azt állítja, hogy nem tartozik egyetlen cellacsoporthoz sem"
 
 #: ../../src/Configuration.h:741
 msgid "Bug: Maximum number of digits that is to be displayed is too low!"
@@ -1452,7 +1452,7 @@ msgstr "Hiba: Hiányzó tartalmak"
 
 #: ../../src/cells/GroupCell.cpp:1498
 msgid "Bug: No image counter to write to!"
-msgstr ""
+msgstr "Hiba: A kép számlálója hiányzik!"
 
 #: ../../src/cells/AnimationCell.cpp:543 ../../src/cells/EditorCell.cpp:2968
 #: ../../src/cells/ImgCell.cpp:353 ../../src/graphical_io/BitmapOut.cpp:161
@@ -1471,7 +1471,7 @@ msgstr "Hiba: A vágólap már meg van nyitva"
 
 #: ../../src/cells/EditorCell.cpp:3051
 msgid "Bug: The clipboard isn't open on pasting into an editor cell"
-msgstr ""
+msgstr "Hiba: A vágólapot nem lehet megnyitni a szerkesztő cellába történő beillesztéskor"
 
 #: ../../src/cells/GroupCell.cpp:2288
 msgid "Bug: The predecessor to a GroupCell is not a GroupCell."
@@ -1483,7 +1483,7 @@ msgstr ""
 
 #: ../../src/cells/GroupCell.cpp:340
 msgid "Bug: Trying to append NULL to a group cell."
-msgstr ""
+msgstr "Hiba: Üres elemet kísérelt meg hozzáfűzni egy csoportcellához."
 
 #: ../../src/worksheet/Worksheet.cpp:5939
 msgid "Bug: Trying to move a title out by one sectioning unit"
@@ -1507,7 +1507,7 @@ msgstr "Hiba: Visszavonási esemény cella tartalmának változásához és cell
 
 #: ../../src/cells/EditorCell.cpp:4541
 msgid "Bug: Unknown type of text"
-msgstr ""
+msgstr "Hiba: Ismeretlen szövegtípus"
 
 #: ../../src/cells/EditorCell.cpp:3981 ../../src/cells/TextCell.cpp:479
 msgid "Bug: dc == NULL"
@@ -1515,11 +1515,11 @@ msgstr ""
 
 #: ../../src/cells/EditorCell.cpp:2637
 msgid "Bug: x position of cell is unknown!"
-msgstr ""
+msgstr "Hiba: a cella x pozíciója ismeretlen!"
 
 #: ../../src/cells/EditorCell.cpp:2638
 msgid "Bug: y position of cell is unknown!"
-msgstr ""
+msgstr "Hiba: a cella y pozíciója ismeretlen!"
 
 #: ../../src/wxMaximaFrame.cpp:1985
 msgid "Build &Info"
@@ -1532,7 +1532,7 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:54
 msgid "By default, Shift-Enter is used to evaluate commands, while Enter is used for multiline input. This behaviour can be changed in 'Edit->Configure' dialog by checking 'Enter evaluates cells'. This switches the roles of these two key commands."
-msgstr ""
+msgstr "A Shift+Enter billentyűkombinációval alapértelmezés szerint az aktuális parancs hajtódik végre, míg az Enter-t a többsoros bemenetre használjuk. Mindez megváltoztatható a 'Szerkesztés->Beállítás' ablakban, kipipálva 'A parancsok az Enter lenyomására hajtódnak végre' tulajdonságot, amely felcseréli a két billentyűparancs hatását."
 
 #: ../../src/MaximaCommandMenus.cpp:4087
 msgid "Byte:"
@@ -1557,7 +1557,7 @@ msgstr ""
 #: ../../src/cells/FontVariantCache.cpp:96
 #, c-format
 msgid "Caching font variant: %s"
-msgstr ""
+msgstr "Betűtípus-változat gyorsítótárazása: %s"
 
 #: ../../src/wxMaximaFrame.cpp:1519
 msgid "Calculate &Product..."
@@ -1702,7 +1702,7 @@ msgstr ""
 #: ../../src/cells/FontVariantCache.cpp:85
 #, c-format
 msgid "Cannot create a font based on %s. Falling back to a default font."
-msgstr ""
+msgstr "Nem lehet betűtípust létrehozni a %s alapján. Visszaállás az alapértelmezett betűtípusra."
 
 #: ../../src/MaximaProcessManager.cpp:368
 msgid "Cannot find a maxima binary and no binary chosen in the config dialogue."
@@ -1739,7 +1739,7 @@ msgstr ""
 #: ../../src/graphical_io/OutCommon.cpp:98
 #, c-format
 msgid "Cannot remove the file %s"
-msgstr ""
+msgstr "A(z) %s fájl nem távolítható el"
 
 #: ../../src/sidebars/History.cpp:258
 #, c-format
@@ -1770,11 +1770,11 @@ msgstr "A Maxima bináris nem tudott elindulni"
 
 #: ../../src/sidebars/MathSidebar.cpp:62
 msgid "Canonical (tr)"
-msgstr ""
+msgstr "Kanonikus (tr)"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:188
 msgid "Catalan"
-msgstr ""
+msgstr "Katalán"
 
 #: ../../src/MaximaCommandMenus.cpp:466
 msgid "Cauchy principal value of f(x)/(x-c), finite interval"
@@ -1831,7 +1831,7 @@ msgstr "Könyvtár módosítása..."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:859
 msgid "Change names of greek letters to greek letters"
-msgstr ""
+msgstr "A görög betűk nevei helyett görög betűk legyenek"
 
 #: ../../src/wxMaximaFrame.cpp:1073
 msgid "Change the 2d display algorithm used to display math output"
@@ -1839,7 +1839,7 @@ msgstr "Matematikai jelek 2d-s megjelenítési algoritmusának megváltoztatása
 
 #: ../../src/dialogs/ConfigDialogue.cpp:489
 msgid "Change the text \"alpha\" and \"beta\" to the corresponding greek letter?"
-msgstr ""
+msgstr "Az \"alfa\" és \"béta\" szöveg változzon a megfelelő görög betűre?"
 
 #: ../../src/MaximaCommandMenus.cpp:136
 msgid "Change variable"
@@ -1859,7 +1859,7 @@ msgstr "Módosítsa a változót integrálban vagy összegben, és értékelje k
 
 #: ../../src/dialogs/ChangeLogDialog.cpp:37
 msgid "ChangeLog"
-msgstr ""
+msgstr "Változási napló"
 
 #: ../../src/wxMaximaFrame.cpp:1060
 msgid "Changed option variables"
@@ -1920,15 +1920,15 @@ msgstr "A wxMaxima újabb verziójának keresése."
 
 #: ../../src/sidebars/GreekSidebar.cpp:199
 msgid "Chi"
-msgstr ""
+msgstr "Khí"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:189
 msgid "Chinese (Simplified)"
-msgstr ""
+msgstr "Kínai (egyszerűsített)"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:190
 msgid "Chinese (traditional)"
-msgstr ""
+msgstr "Kínai (hagyományos)"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1554
 msgid "Choose a Lisp Maxima was compiled with"
@@ -1940,11 +1940,11 @@ msgstr ""
 
 #: ../../src/sidebars/HelpBrowser.cpp:204
 msgid "Choose between the following help topics:"
-msgstr ""
+msgstr "Válasszon a következő súgótémák közül:"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2100
 msgid "Choose font"
-msgstr ""
+msgstr "Betűtípus választás"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:793
 msgid "Choose how mathematical output is formatted:\n"
@@ -1955,12 +1955,12 @@ msgstr ""
 
 #: ../../src/wizards/PlotFormatWiz.cpp:31
 msgid "Choose new plot format:"
-msgstr ""
+msgstr "Új ábrázolási mód választása:"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2432
 #, c-format
 msgid "Choose the %s Font"
-msgstr ""
+msgstr "%s betűtípus kiválasztása"
 
 #: ../../src/wxMaximaFrame.cpp:837
 msgid "Choose the parenthesis type for Matrices"
@@ -1996,7 +1996,7 @@ msgstr "Összes gradef-ek törlése"
 
 #: ../../src/sidebars/History.cpp:116
 msgid "Clear all history"
-msgstr ""
+msgstr "Memória törlése"
 
 #: ../../src/wxMaximaFrame.cpp:1034
 msgid "Clear all labels"
@@ -2028,16 +2028,16 @@ msgstr "Összes változók törlése"
 
 #: ../../src/sidebars/History.cpp:115
 msgid "Clear the selection"
-msgstr ""
+msgstr "Kiválasztás törlése"
 
 #: ../../src/cells/FontVariantCache.cpp:44
 #, c-format
 msgid "Cleared font cache for font %s"
-msgstr ""
+msgstr "A(z) %s betűtípus gyorsítótára törölve"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1926
 msgid "Clipboard format parameters"
-msgstr ""
+msgstr "Vágólap formátum paraméterei"
 
 #: ../../src/wxMaximaFrame.cpp:637
 msgid "Close\tCtrl+W"
@@ -2129,7 +2129,7 @@ msgstr "Oszlopok"
 
 #: ../../src/wizards/MatWiz.cpp:155
 msgid "Columns:"
-msgstr ""
+msgstr "Oszlopok:"
 
 #: ../../src/wxMaximaFrame.cpp:1621
 msgid "Combine factorials in an expression"
@@ -2145,11 +2145,11 @@ msgstr "A vesszőt közvetlenül egy bezáró zárójel követi"
 
 #: ../../src/wizards/Plot2dWiz.cpp:626
 msgid "Comma separated x coordinates"
-msgstr ""
+msgstr "Vesszővel válassza el az x koordinátákat"
 
 #: ../../src/wizards/Plot2dWiz.cpp:627
 msgid "Comma separated y coordinates"
-msgstr ""
+msgstr "Vesszővel válassza el az y koordinátákat"
 
 #: ../../src/MaximaCommandMenus.cpp:4071
 msgid "Comma-separated arguments"
@@ -2235,11 +2235,11 @@ msgstr "Parancs:"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1145
 msgid "Commands that are executed at every start of maxima."
-msgstr ""
+msgstr "Maxima parancsok végrehajtása a Maxima minden egyes indulásakor."
 
 #: ../../src/cells/EditorCell.cpp:4538
 msgid "Comment (ordinary worksheet text that isn't fed to maxima)"
-msgstr ""
+msgstr "Megjegyzés (szokásos munkalap-szöveg, amely a Maxima nem futtat)"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:465
 msgid "Comment Selection"
@@ -2375,16 +2375,16 @@ msgstr "Feltétel:"
 #: ../../src/dialogs/ConfigDialogue.cpp:2641
 #: ../../src/dialogs/ConfigDialogue.cpp:2647
 msgid "Config file (*.ini)|*.ini"
-msgstr ""
+msgstr "Konfigurációs fájl (*.ini)|*.ini"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2539
 #, c-format
 msgid "Config item \"%s\" was of an unknown type"
-msgstr ""
+msgstr "A(z) \"%s\" konfigurációs elem ismeretlen típusú volt"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2607
 msgid "Configuration warning"
-msgstr ""
+msgstr "Figyelmeztetés a beállításokkal kapcsolatban"
 
 #: ../../src/ToolBar.cpp:367 ../../src/ToolBar.cpp:369
 #: ../../src/wxMaximaFrame.cpp:722 ../../src/wxMaximaFrame.cpp:724
@@ -2393,7 +2393,7 @@ msgstr "A wxMaxima beállítása"
 
 #: ../../src/wizards/DrawWiz.cpp:829
 msgid "Connect the dots"
-msgstr ""
+msgstr "Pontok összekötése"
 
 #: ../../src/MaximaProcessManager.cpp:163
 msgid "Connection attempt, but connection failed."
@@ -2407,7 +2407,7 @@ msgstr "Megszakadt a kapcsolat a maximával."
 #: ../../src/wizards/IntegrateWiz.cpp:208 ../../src/wizards/LimitWiz.cpp:133
 #: ../../src/wizards/SeriesWiz.cpp:105
 msgid "Constant"
-msgstr ""
+msgstr "Állandó"
 
 #: ../../src/MaximaCommandMenus.cpp:1102
 msgid "Construct a fraction"
@@ -2419,7 +2419,7 @@ msgstr "Tört szerkesztése..."
 
 #: ../../src/sidebars/VariablesPane.cpp:58
 msgid "Contents"
-msgstr ""
+msgstr "Tartalmak"
 
 #: ../../src/MaximaCommandMenus.cpp:3970
 msgid "Contents:"
@@ -2435,27 +2435,27 @@ msgstr "Környezetfüggő &Súgó\tF1"
 
 #: ../../src/sidebars/DrawSidebar.cpp:80
 msgid "Contour"
-msgstr ""
+msgstr "Kontúr"
 
 #: ../../src/sidebars/DrawSidebar.cpp:101
 msgid "Contour lines for 3d plots"
-msgstr ""
+msgstr "Kontúrvonalak 3d-s ábrákhoz"
 
 #: ../../src/wizards/DrawWiz.cpp:648
 msgid "Contour lines on surface and Bottom"
-msgstr ""
+msgstr "Kontúrvonalak a felszínen és az alján"
 
 #: ../../src/wizards/DrawWiz.cpp:644
 msgid "Contour lines on the Bottom"
-msgstr ""
+msgstr "Kontúrvonalak az alján"
 
 #: ../../src/wizards/DrawWiz.cpp:641
 msgid "Contour lines on the Surface"
-msgstr ""
+msgstr "Kontúrvonalak a felszínen"
 
 #: ../../src/wizards/DrawWiz.cpp:629
 msgid "Contour lines settings for the following 3d plots"
-msgstr ""
+msgstr "Kontúrvonalak beállításai a következő 3d-s ábrákhoz"
 
 #: ../../src/wxMaximaFrame.cpp:1579
 msgid "Contract Logarithms"
@@ -2540,30 +2540,30 @@ msgstr "&Algebraivá alakítás"
 #: ../../src/sidebars/TableOfContents.cpp:522
 #: ../../src/sidebars/TableOfContents.cpp:543
 msgid "Convert to Heading 5"
-msgstr ""
+msgstr "Átalakítás 5. címmé"
 
 #: ../../src/sidebars/TableOfContents.cpp:519
 msgid "Convert to Heading 6"
-msgstr ""
+msgstr "Átalakítás 6. címmé"
 
 #: ../../src/sidebars/TableOfContents.cpp:531
 #: ../../src/sidebars/TableOfContents.cpp:552
 msgid "Convert to Section"
-msgstr ""
+msgstr "Fejezetté alakítás"
 
 #: ../../src/sidebars/TableOfContents.cpp:525
 #: ../../src/sidebars/TableOfContents.cpp:546
 msgid "Convert to Sub-Subsection"
-msgstr ""
+msgstr "Átalakítás Al-alfejezetté"
 
 #: ../../src/sidebars/TableOfContents.cpp:528
 #: ../../src/sidebars/TableOfContents.cpp:549
 msgid "Convert to Subsection"
-msgstr ""
+msgstr "Alfejezetté alakítás"
 
 #: ../../src/sidebars/TableOfContents.cpp:555
 msgid "Convert to Title"
-msgstr ""
+msgstr "Címmé alakítás"
 
 #: ../../src/wxMaximaFrame.cpp:1200
 msgid "Convert to downcase..."
@@ -2749,22 +2749,22 @@ msgstr "Másolás, Kivágás és Beillesztés gomb"
 #: ../../src/dialogs/ConfigDialogue.cpp:2523
 #, c-format
 msgid "Copying config bool \"%s\""
-msgstr ""
+msgstr "Konfiguráció másolása bool \"%s\""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2533
 #, c-format
 msgid "Copying config float \"%s\""
-msgstr ""
+msgstr "A float \"%s\" konfiguráció másolása"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2528
 #, c-format
 msgid "Copying config int \"%s\""
-msgstr ""
+msgstr "Konfiguráció másolása int \"%s\""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2518
 #, c-format
 msgid "Copying config string \"%s\""
-msgstr ""
+msgstr "Konfiguráció másolása string \"%s\""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:191
 msgid "Corsican"
@@ -2857,7 +2857,7 @@ msgstr "Lista létrehozása vesszővel elválasztott elemekből"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1389
 msgid "Create scalable plots."
-msgstr ""
+msgstr "Skálázható ábrák készítése."
 
 #: ../../src/wxMaximaFrame.cpp:1116
 msgid "Create struct..."
@@ -2881,7 +2881,7 @@ msgstr ""
 
 #: ../../src/worksheet/Worksheet.cpp:6115
 msgid "Cursor"
-msgstr ""
+msgstr "Kurzor"
 
 #: ../../src/Styles.cpp:126
 msgid "Cursor color"
@@ -2903,11 +2903,11 @@ msgstr "Kijelölt rész kivágása"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:193
 msgid "Czech"
-msgstr ""
+msgstr "Cseh"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:194
 msgid "Danish"
-msgstr ""
+msgstr "Dán"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2069
 msgid "Dark"
@@ -2923,7 +2923,7 @@ msgstr "Adat fájlok (*.csv, *.tab, *.txt)|*.csv;*.tab;*.txt"
 
 #: ../../src/wizards/DrawWiz.cpp:810
 msgid "Data format"
-msgstr ""
+msgstr "Adat formátum"
 
 #: ../../src/MaximaCommandMenus.cpp:1767 ../../src/MaximaCommandMenus.cpp:1772
 #: ../../src/MaximaCommandMenus.cpp:1777 ../../src/MaximaCommandMenus.cpp:1781
@@ -2977,15 +2977,15 @@ msgstr "Csökkenő f(x)<x függvény"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1336
 msgid "Default animation framerate:"
-msgstr ""
+msgstr "Az animáció alapértelmezett framerátája:"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:717
 msgid "Default plot size for new maxima sessions:"
-msgstr ""
+msgstr "Új Maxima munkalap alapértelmezett ábrázolási mérete:"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1534
 msgid "Default port for communication with wxMaxima:"
-msgstr ""
+msgstr "A Maxima és a wxMaxima közötti kommunikáció során használt alapértelmezett port:"
 
 #: ../../src/MaximaCommandMenus.cpp:3946
 msgid "Define a function"
@@ -3025,7 +3025,7 @@ msgstr "Struktúra meghatározása..."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:404
 msgid "Define the default speed (in frames per second) animations are played back with."
-msgstr ""
+msgstr "Az animációk lejátszásának alapértelmezett sebessége (képkocka per másodperc)."
 
 #: ../../src/wxMaximaFrame.cpp:1114
 msgid "Define variable..."
@@ -3098,7 +3098,7 @@ msgstr "Kiküszöbölés:"
 
 #: ../../src/sidebars/GreekSidebar.cpp:181
 msgid "Delta"
-msgstr ""
+msgstr "Delta"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:110
 #: ../../src/worksheet/WorksheetContextMenu.cpp:558
@@ -3124,7 +3124,7 @@ msgstr "Függőségek"
 
 #: ../../src/wizards/SeriesWiz.cpp:42
 msgid "Depth:"
-msgstr ""
+msgstr "Fokszám:"
 
 #: ../../src/MaximaCommandMenus.cpp:994
 msgid "Derivate of y at that point:"
@@ -3159,7 +3159,7 @@ msgstr ""
 
 #: ../../src/sidebars/StatSidebar.cpp:61
 msgid "Deviation..."
-msgstr ""
+msgstr "Szórás..."
 
 #: ../../src/wxMaximaFrame.cpp:1534
 msgid "Di&vide Polynomials..."
@@ -3171,11 +3171,11 @@ msgstr ""
 
 #: ../../src/sidebars/DrawSidebar.cpp:71
 msgid "Diagram title"
-msgstr ""
+msgstr "Diagram címe"
 
 #: ../../src/sidebars/HelpBrowser.cpp:51
 msgid "Didn't find an installed offline manual."
-msgstr ""
+msgstr "Nem található telepített offline kézikönyv."
 
 #: ../../src/MaximaManual.cpp:534
 msgid "Didn't find the maxima HTML manual."
@@ -3191,7 +3191,7 @@ msgstr ""
 
 #: ../../src/sidebars/MathSidebar.cpp:80
 msgid "Diff..."
-msgstr ""
+msgstr "Differenciál..."
 
 #: ../../src/dialogs/DiffFrame.cpp:308
 #, c-format
@@ -3220,7 +3220,7 @@ msgstr "A kifejezést n-szer differenciál"
 
 #: ../../src/wizards/LimitWiz.cpp:41
 msgid "Direction:"
-msgstr ""
+msgstr "Irány:"
 
 #: ../../src/wxMaximaFrame.cpp:1246
 msgid "Directory operations"
@@ -3232,11 +3232,11 @@ msgstr ""
 
 #: ../../src/wizards/Plot2dWiz.cpp:418 ../../src/wizards/Plot2dWiz.cpp:619
 msgid "Discrete plot"
-msgstr ""
+msgstr "Diszkrét ábrázolás"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:699
 msgid "Display"
-msgstr ""
+msgstr "Megjelenítés"
 
 #: ../../src/wxMaximaFrame.cpp:1075
 msgid "Display Te&X Form"
@@ -3248,11 +3248,11 @@ msgstr "Megjelenítő algoritmus"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:827
 msgid "Display all and allow linebreaks in long numbers"
-msgstr ""
+msgstr "Az összes megjelenítése és a sortörések engedélyezése hosszú számokban"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:820
 msgid "Display all digits"
-msgstr ""
+msgstr "Mindig megmutatja az összes számjegyet"
 
 #: ../../src/wxMaximaFrame.cpp:788
 msgid "Display an expression as maxima's internal lisp representation"
@@ -3280,7 +3280,7 @@ msgstr "Kifejezés megjelenítése TeX formátumban"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:804
 msgid "Display of long numbers"
-msgstr ""
+msgstr "Hosszú számok megjelenítése"
 
 #: ../../src/ToolBar.cpp:580
 #, c-format
@@ -3359,11 +3359,11 @@ msgstr "A dokumentum a wxMaxima újabb verziójával lett elmentve. Kérjük, fr
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1170
 msgid "Documentclass for TeX export:"
-msgstr ""
+msgstr "Dokumentum osztály TeX exportálásra:"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1178
 msgid "Documentclass options:"
-msgstr ""
+msgstr "Dokumentum osztály beállítása:"
 
 #: ../../src/wxMaximaFrame.cpp:807
 msgid "Don't autosubscript after an underscore"
@@ -3409,19 +3409,19 @@ msgstr "Nem használ zárójelet mátrixoknál"
 
 #: ../../src/dialogs/DiffFrame.cpp:428 ../../src/dialogs/FindReplacePane.cpp:83
 msgid "Down"
-msgstr ""
+msgstr "Le"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:185
 msgid "Drag-and-drop unicode symbols here"
-msgstr ""
+msgstr "Fogd és vidd az unicode szimbólumokat"
 
 #: ../../src/wizards/DrawWiz.cpp:155
 msgid "Draw all points where an equation is true."
-msgstr ""
+msgstr "Rajzoljon minden pontot, ahol az egyenlet igaz."
 
 #: ../../src/wizards/DrawWiz.cpp:802
 msgid "Draw points"
-msgstr ""
+msgstr "Pontok rajzolása"
 
 #: ../../src/MaximaCommandMenus.cpp:1536
 msgid "Drop the first n list elements"
@@ -3541,7 +3541,7 @@ msgstr "Ismeretlen socket esemény."
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:129
 msgid "End of proof"
-msgstr ""
+msgstr "Bizonyítás vége"
 
 #: ../../src/MaximaCommandMenus.cpp:1024
 msgid "End of t:"
@@ -3549,19 +3549,19 @@ msgstr "t vége:"
 
 #: ../../src/wizards/DrawWiz.cpp:71 ../../src/wizards/DrawWiz.cpp:176
 msgid "End of the x value"
-msgstr ""
+msgstr "Az x érték vége"
 
 #: ../../src/wizards/DrawWiz.cpp:88 ../../src/wizards/DrawWiz.cpp:191
 msgid "End of the y value"
-msgstr ""
+msgstr "Az y érték vége"
 
 #: ../../src/wizards/DrawWiz.cpp:208
 msgid "End of the z value"
-msgstr ""
+msgstr "A z érték vége"
 
 #: ../../src/wizards/DrawWiz.cpp:760
 msgid "End value of the parameter"
-msgstr ""
+msgstr "A paraméter értékének vége"
 
 #: ../../src/MaximaResponseReader.cpp:432
 #: ../../src/MaximaResponseReader.cpp:586
@@ -3574,19 +3574,19 @@ msgstr "Mérnöki formátum (12.1e6 stb.)"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:196
 msgid "English"
-msgstr ""
+msgstr "Angol"
 
 #: ../../src/wizards/DrawWiz.cpp:552
 msgid "Enhanced 3D settings:"
-msgstr ""
+msgstr "Továbbfejlesztett 3D beállítások:"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1919
 msgid "Enhanced meta file (emf)"
-msgstr ""
+msgstr "Továbbfejlesztett metafájl (emf)"
 
 #: ../../src/sidebars/StatSidebar.cpp:106
 msgid "Enter Matrix..."
-msgstr ""
+msgstr "Mátrix bevitele..."
 
 #: ../../src/MaximaCommandMenus.cpp:2255
 msgid "Enter UUID to jump to:"
@@ -3598,7 +3598,7 @@ msgstr "Mátrix bevitele"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:925
 msgid "Enter adds newlines, Ctrl+Enter evaluates cells"
-msgstr ""
+msgstr "Az Enter új sorokat ad hozzá, a Ctrl+Enter kiértékeli a cellákat"
 
 #: ../../src/MaximaCommandMenus.cpp:873
 msgid "Enter an equation for rational simplification:"
@@ -3606,11 +3606,11 @@ msgstr "Írja be a listába felvenni kívánt algebrai egyenletet:"
 
 #: ../../src/wizards/SystemWiz.cpp:50
 msgid "Enter comma separated list of variables."
-msgstr ""
+msgstr "A változókat vesszővel válassza el egymástól."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:921
 msgid "Enter evaluates cells, Ctrl+Enter adds newlines"
-msgstr ""
+msgstr "Az Enter kiértékeli a cellákat, a Ctrl+Enter új sorokat ad hozzá"
 
 #: ../../src/MaximaCommandMenus.cpp:1357
 msgid "Enter matrix"
@@ -3626,7 +3626,7 @@ msgstr "Új pontosság bevitele:"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:388
 msgid "Enter the path to the Maxima executable."
-msgstr ""
+msgstr "A Maxima elérési útjának beírása."
 
 #: ../../src/MaximaCommandMenus.cpp:1103
 msgid "Enumerator:"
@@ -3638,11 +3638,11 @@ msgstr "Környezeti változók"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1605
 msgid "Environment variables for maxima"
-msgstr ""
+msgstr "A maxima környezeti változói"
 
 #: ../../src/sidebars/GreekSidebar.cpp:182
 msgid "Epsilon"
-msgstr ""
+msgstr "Epszilon"
 
 #: ../../src/MaximaCommandMenus.cpp:299
 msgid "Epsilon:"
@@ -3681,7 +3681,7 @@ msgstr "Egyenlet:"
 
 #: ../../src/dialogs/TipOfTheDay.cpp:196
 msgid "Equations have several advantages over functions. For example they can be manipulated with factor(), expand() and similar functions. They can easily be introduced one into another. Also they are always printed out as 2D maths."
-msgstr ""
+msgstr "Az egyenleteknek számos előnyük van a függvényekkel szemben. Például módosíthatóak a factor(), expand() és hasonló függvényekkel. Könnyen behelyettesíthetőek egymásba, kirajzoltathatóak kétdimenziós matematikai alakzatokként."
 
 #: ../../src/MaximaFileIO.cpp:64 ../../src/MaximaFileIO.cpp:121
 #: ../../src/MaximaFileIO.cpp:130 ../../src/MaximaFileIO.cpp:399
@@ -3737,11 +3737,11 @@ msgstr "Egy karakterlánc összes speciális karakterét megszökteti. Az eredm�
 
 #: ../../src/sidebars/GreekSidebar.cpp:184
 msgid "Eta"
-msgstr ""
+msgstr "Éta"
 
 #: ../../src/sidebars/TableOfContents.cpp:513
 msgid "Evaluate"
-msgstr ""
+msgstr "Kiértékelés"
 
 #: ../../src/wxMaximaFrame.cpp:1689
 msgid "Evaluate &Noun Forms..."
@@ -3875,11 +3875,11 @@ msgstr "Páros szám"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2659
 msgid "Example text"
-msgstr ""
+msgstr "Példaszöveg"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1547
 msgid "Examples:"
-msgstr ""
+msgstr "Példák:"
 
 #: ../../src/wxMaximaFrame.cpp:1740
 msgid "Execute a command for each element of the list"
@@ -3891,11 +3891,11 @@ msgstr "Kilépés"
 
 #: ../../src/sidebars/MathSidebar.cpp:53
 msgid "Expand"
-msgstr ""
+msgstr "Felbont"
 
 #: ../../src/sidebars/MathSidebar.cpp:68
 msgid "Expand (tr)"
-msgstr ""
+msgstr "Felbont (tr)"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:356
 msgid "Expand Expression"
@@ -3940,7 +3940,7 @@ msgstr "Exportálás"
 
 #: ../../src/sidebars/History.cpp:152
 msgid "Export As"
-msgstr ""
+msgstr "Exportálás mint"
 
 #: ../../src/wxMaximaFrame.cpp:1742
 msgid "Export List to csv file..."
@@ -3956,15 +3956,15 @@ msgstr "Mátrix exportálása csv fájlba"
 
 #: ../../src/sidebars/History.cpp:102
 msgid "Export all history to a .mac file"
-msgstr ""
+msgstr "Az összes előzmény exportálása .mac fájlba"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1016
 msgid "Export all settings"
-msgstr ""
+msgstr "Minden beállítás exportálása"
 
 #: ../../src/sidebars/History.cpp:105
 msgid "Export commands from the current maxima session to a .mac file"
-msgstr ""
+msgstr "Parancsok exportálása az aktuális maxima munkamenetből .mac fájlba"
 
 #: ../../src/wxMaximaFrame.cpp:652
 msgid "Export document to a HTML or LaTeX file"
@@ -3972,7 +3972,7 @@ msgstr "Dokumentum exportálása HTML vagy LaTeX formátumba"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1218
 msgid "Export equations to HTML as:"
-msgstr ""
+msgstr "Egyenletek HTML-be való exportálása mint:"
 
 #: ../../src/wxMaximaFrame.cpp:600
 msgid "Export failed."
@@ -3988,7 +3988,7 @@ msgstr ""
 
 #: ../../src/sidebars/History.cpp:108
 msgid "Export selected commands to a .mac file"
-msgstr ""
+msgstr "Kiválasztott parancsok exportálása .mac fájlba"
 
 #: ../../src/wxMaximaFrame.cpp:588
 msgid "Export successful."
@@ -4000,11 +4000,11 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1022
 msgid "Export the style settings"
-msgstr ""
+msgstr "Exportálja a stílusbeállításokat"
 
 #: ../../src/sidebars/History.cpp:111
 msgid "Export visible commands to a .mac file"
-msgstr ""
+msgstr "Látható parancsok exportálása .mac fájlba"
 
 #: ../../src/MaximaCommandMenus.cpp:3417
 #, c-format
@@ -4018,7 +4018,7 @@ msgstr ""
 
 #: ../../src/sidebars/History.cpp:228
 msgid "Exporting to .mac file failed!"
-msgstr ""
+msgstr "A .mac fájlba való exportálás meghiúsult!"
 
 #: ../../src/MaximaCommandMenus.cpp:2343
 msgid "Exporting to HTML failed!"
@@ -4054,19 +4054,19 @@ msgstr "Kifejezés vagy vesszővel elválasztott kifejezések listája"
 
 #: ../../src/wizards/DrawWiz.cpp:733
 msgid "Expression that calculates the x value"
-msgstr ""
+msgstr "Az x értéket kiszámító kifejezés"
 
 #: ../../src/wizards/DrawWiz.cpp:738
 msgid "Expression that calculates the y value"
-msgstr ""
+msgstr "Az y értéket kiszámító kifejezés"
 
 #: ../../src/wizards/DrawWiz.cpp:744
 msgid "Expression that calculates the z value"
-msgstr ""
+msgstr "A z értéket kiszámító kifejezés"
 
 #: ../../src/wizards/DrawWiz.cpp:56
 msgid "Expression to plot"
-msgstr ""
+msgstr "Kifejezés ábrába"
 
 #: ../../src/wxMaximaFrame.cpp:1122
 msgid "Expression to string..."
@@ -4221,7 +4221,7 @@ msgstr "Kibont egy téglalapot egy 2D tömbből és mátrixszá alakítja"
 
 #: ../../src/sidebars/MathSidebar.cpp:50
 msgid "Factor"
-msgstr ""
+msgstr "Faktorizál"
 
 #: ../../src/wxMaximaFrame.cpp:1558
 msgid "Factor Complex"
@@ -4296,7 +4296,7 @@ msgstr "Mezők:"
 #: ../../src/cells/GroupCell.cpp:2115
 #, c-format
 msgid "Figure %d:"
-msgstr ""
+msgstr "%d. ábra:"
 
 #: ../../src/main.cpp:678
 msgid "File"
@@ -4348,7 +4348,7 @@ msgstr "Fájlnév vagy vesszővel elválasztott fájlnevek listája"
 
 #: ../../src/sidebars/DrawSidebar.cpp:93
 msgid "Fill color"
-msgstr ""
+msgstr "Kitöltőszín"
 
 #: ../../src/ToolBar.cpp:401 ../../src/ToolBar.cpp:403
 msgid "Find"
@@ -4469,7 +4469,7 @@ msgstr "Határozzuk meg egy mátrixsor abszolút értékeinek maximális összeg
 
 #: ../../src/dialogs/FindReplacePane.cpp:46
 msgid "Find:"
-msgstr ""
+msgstr "Keresés:"
 
 #: ../../src/wxMaximaFrame.cpp:1869
 msgid "Fine-tune the display of engineering-format numbers"
@@ -4477,7 +4477,7 @@ msgstr "A mérnöki formátumú számok megjelenítésének finomítása"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:197
 msgid "Finnish"
-msgstr ""
+msgstr "Finn"
 
 #: ../../src/wxMaximaFrame.cpp:1749
 msgid "First"
@@ -4490,11 +4490,11 @@ msgstr "Görbék illesztése a mérési adatokhoz"
 #: ../../src/dialogs/ConfigDialogue.cpp:1404
 #, c-format
 msgid "Fix reordered reference indices (of %i, %o) before saving"
-msgstr ""
+msgstr "Mentés előtt rögzíti a (%i, %o) indexek hivatkozását"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:873
 msgid "Fixed font in text controls"
-msgstr ""
+msgstr "Rögzített szélességű betűtípus a bemeneti sorban"
 
 #: ../../src/MaximaCommandMenus.cpp:4039
 msgid "Flush stream"
@@ -4522,11 +4522,11 @@ msgstr ""
 
 #: ../../src/wizards/DrawWiz.cpp:341
 msgid "Following plots use secondary x axis"
-msgstr ""
+msgstr "A következő diagramok másodlagos x tengelyt használnak"
 
 #: ../../src/wizards/DrawWiz.cpp:347
 msgid "Following plots use secondary y axis"
-msgstr ""
+msgstr "A következő diagramok másodlagos y tengelyt használnak"
 
 #: ../../src/sidebars/PerformanceSidebar.cpp:37
 msgid "Font cache hits:"
@@ -4538,11 +4538,11 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2047
 msgid "Fonts"
-msgstr ""
+msgstr "Betűkészletek"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:442
 msgid "For each Text-, Sectioning or code cell wxMaxima can display a bracket showing the extend of the cell and allowing to fold it. This setting now tells if this bracket is to be printed, as well."
-msgstr ""
+msgstr "Minden egyes szöveg-, fejezet- vagy kódcella esetén a wxMaxima egy olyan zárójelet jelenít meg, mellyel a cellatartalmat megjelenítheti és elrejtheti. Ez a beállítás azt jelzi, hogy ezt a zárójelet is ki szeretné-e nyomtatni."
 
 #: ../../src/ToolBar.cpp:495
 msgid "For faster creation of cells the following shortcuts exist:\n\n"
@@ -4574,7 +4574,7 @@ msgstr "A hurokhoz..."
 
 #: ../../src/wizards/Plot2dWiz.cpp:69 ../../src/wizards/Plot3dWiz.cpp:60
 msgid "Format:"
-msgstr ""
+msgstr "Formátum:"
 
 #: ../../src/worksheet/Worksheet.cpp:301 ../../src/wxMaxima.cpp:3521
 msgid "Forwarding the keyboard focus to a text control"
@@ -4619,15 +4619,15 @@ msgstr "Képkocka: %li / %li"
 
 #: ../../src/wizards/DrawWiz.cpp:488
 msgid "Frame counter"
-msgstr ""
+msgstr "Frame számláló"
 
 #: ../../src/wizards/DrawWiz.cpp:499
 msgid "Frame counter end"
-msgstr ""
+msgstr "Frame számláló vége"
 
 #: ../../src/wizards/DrawWiz.cpp:494
 msgid "Frame counter start"
-msgstr ""
+msgstr "Frame számláló kezdete"
 
 #: ../../src/MaximaCommandMenus.cpp:102
 msgid "Frame rate"
@@ -4639,7 +4639,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:198
 msgid "French"
-msgstr ""
+msgstr "Francia"
 
 #: ../../src/wxMaximaFrame.cpp:1447
 msgid "Frobenius Norm sqrt(sum((A(i,j))^2)) (complex)"
@@ -4722,11 +4722,11 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:199
 msgid "Galician"
-msgstr ""
+msgstr "Galíciai"
 
 #: ../../src/sidebars/GreekSidebar.cpp:180
 msgid "Gamma"
-msgstr ""
+msgstr "Gamma"
 
 #: ../../src/wxMaximaFrame.cpp:316
 msgid "General Math"
@@ -4778,7 +4778,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:201
 msgid "German"
-msgstr ""
+msgstr "Német"
 
 #: ../../src/wxMaximaFrame.cpp:1656
 msgid "Get &Imaginary Part"
@@ -4866,7 +4866,7 @@ msgstr "Nagyobb, figyelmen kívül hagyva az esetet?..."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:202
 msgid "Greek"
-msgstr ""
+msgstr "Görög"
 
 #: ../../src/wxMaximaFrame.cpp:281
 msgid "Greek Letters"
@@ -4878,11 +4878,11 @@ msgstr "Görög betűk\tAlt+Shift+G"
 
 #: ../../src/sidebars/DrawSidebar.cpp:97
 msgid "Grid"
-msgstr ""
+msgstr "Rács"
 
 #: ../../src/wizards/Plot3dWiz.cpp:52
 msgid "Grid:"
-msgstr ""
+msgstr "Rács:"
 
 #: ../../src/wxMaximaFrame.cpp:1852
 msgid "Guess an exact number that could be meant by this float"
@@ -4890,7 +4890,7 @@ msgstr "Találj ki egy pontos számot, amit ez az úszó jelenthet"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1215
 msgid "HTML"
-msgstr ""
+msgstr "HTML"
 
 #: ../../src/MaximaCommandMenus.cpp:2279
 msgid "HTML file (*.html)|*.html|maxima batch file (*.mac)|*.mac|LaTeX file (*.tex)|*.tex"
@@ -4938,7 +4938,7 @@ msgstr "Súgó"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1461
 msgid "Help browser:"
-msgstr ""
+msgstr "Súgó böngésző:"
 
 #: ../../src/ToolBar.cpp:835
 msgid "Help button"
@@ -4957,7 +4957,7 @@ msgstr ""
 
 #: ../../src/sidebars/TableOfContents.cpp:510
 msgid "Hide"
-msgstr ""
+msgstr "Elrejtés"
 
 #: ../../src/ToolBar.cpp:471 ../../src/ToolBar.cpp:473
 msgid "Hide Code"
@@ -4997,7 +4997,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:487
 msgid "Hide all multiplication signs that aren't really necessary for understanding the equation"
-msgstr ""
+msgstr "Rejtsen el minden szorzásjelet, amely nem igazán szükséges az egyenlet értelmezéséhez"
 
 #: ../../src/wxMaximaFrame.cpp:767
 msgid "Hide all panes"
@@ -5017,15 +5017,15 @@ msgstr "Szorzásjelek elrejtése"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:854
 msgid "Hide multiplication signs, if possible"
-msgstr ""
+msgstr "Ha lehetséges, rejtse el a szorzásjeleket"
 
 #: ../../src/wizards/DrawWiz.cpp:555
 msgid "Hide objects behind the surface"
-msgstr ""
+msgstr "Objektumok elrejtése a felszín mögé"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:502
 msgid "Hide the brackets that mark the extend of the worksheet cells at the worksheet's right side and that contain the \"hide\" button of the cell if the cells aren't active."
-msgstr ""
+msgstr "A munkalap jobb oldalán levő munkalapcellák kiterjesztését jelző zárójelek elrejtése, amelyek a cellák \"elrejtése\" gombját tartalmazzák, ha a cellák nem aktívak."
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:702
 #: ../../src/worksheet/WorksheetContextMenu.cpp:835
@@ -5043,11 +5043,11 @@ msgstr "Kiemelés (doboz)"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:869
 msgid "Highlight the matching parenthesis"
-msgstr ""
+msgstr "Zárójelek párjainak kiemelése"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:463
 msgid "Highlight the opening or closing parenthesis for the parenthesis the cursor is at."
-msgstr ""
+msgstr "A kezdő vagy záró zárójelek kijelölése a zárójeleknél, amelyeken a kurzor található."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:204
 msgid "Hindi"
@@ -5059,7 +5059,7 @@ msgstr "Hisztogram"
 
 #: ../../src/sidebars/StatSidebar.cpp:85
 msgid "Histogram..."
-msgstr ""
+msgstr "Hisztogram..."
 
 #: ../../src/wxMaximaFrame.cpp:246
 msgid "History"
@@ -5071,7 +5071,7 @@ msgstr "Előzmények\tAlt+Shift+I"
 
 #: ../../src/dialogs/TipOfTheDay.cpp:105
 msgid "Horizontal cursor works like a normal cursor, but it operates on cells: press up or down arrow to move it, holding down Shift while moving will select cells, pressing backspace or delete twice will delete a cell next to it."
-msgstr ""
+msgstr "A vízszintes kurzor normál kurzorként működik, csak éppen a hatása cellákon jelentkezik: nyomjuk meg a fel vagy le nyilat mozgatásához. Ha mindeközben a Shift gombot lenyomva tartjuk, kijelöljük az érintett részeket."
 
 #: ../../src/wxMaximaFrame.cpp:1563
 msgid "Horner's rule"
@@ -5079,7 +5079,7 @@ msgstr "Horner szabálya"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:918
 msgid "Hotkeys for sending commands to maxima"
-msgstr ""
+msgstr "Gyorsbillentyűk a parancsok végrehajtásához"
 
 #: ../../src/MaximaCommandMenus.cpp:398
 msgid "How many digits to show:"
@@ -5091,7 +5091,7 @@ msgstr "Új egyenletek hogyan legyenek megjelenítve"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:205
 msgid "Hungarian"
-msgstr ""
+msgstr "Magyar"
 
 #: ../../src/wxMaximaFrame.cpp:1147
 msgid "I/O"
@@ -5099,7 +5099,7 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:121
 msgid "Identical to"
-msgstr ""
+msgstr "Azonos"
 
 #: ../../src/MaximaCommandMenus.cpp:3874
 msgid "If a program doesn't need local variables, Maxima allows putting the commands between parentheses. The result of the last operation is the return value of the program."
@@ -5107,51 +5107,51 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:145
 msgid "If maxima versions compiled with different lisps are installed: The name of the lisp to use by default"
-msgstr ""
+msgstr "Ha a maxima verziók különböző lisp változatokkal vannak fordítva: Az alapértelmezés szerint használandó lisp neve"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:174
 msgid "If maxima was compiled by GCL: Garbage Collect at minimum allocation past this heapsize"
-msgstr ""
+msgstr "Ha a maxima GCL-lel lett fordítva: Garbage Collect at minimum allocation past this heapsize"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:171
 msgid "If maxima was compiled by GCL: Minimum allocation fraction between Garbage Collects"
-msgstr ""
+msgstr "Ha a maxima GCL-lel lett fordítva: Minimum allocation fraction between Garbage Collects"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:168
 msgid "If maxima was compiled by GCL: Only garbage collect past this heapsize fraction of working mem"
-msgstr ""
+msgstr "Ha a maxima GCL-lel lett fordítva: Only garbage collect past this heapsize fraction of working mem"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:180
 msgid "If maxima was compiled by GCL: Share the allocated memory between gcl processes. Allows more than one gcl-compiled maxima to run at the same time, but might provoke crashes."
-msgstr ""
+msgstr "Ha a maxima a GCL-lel lett fordítva: A kiosztott memória megosztása a GCL folyamatok között. Lehetővé teszi több GCL által összeállított maxima futását egyszerre, de ez összeomlásokat okozhat."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:177
 msgid "If maxima was compiled by GCL: The fraction of the total installed RAM to reserve for maxima"
-msgstr ""
+msgstr "Ha a maxima GCL-lel lett fordítva: A teljes beépített RAM töredéke van a maxima számára fenntartva"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:375
 msgid "If multiple cells are evaluated in one go: Abort evaluation if wxMaxima detects that maxima has encountered any error."
-msgstr ""
+msgstr "Ha egyszerre több cellát értékelük ki, a kiértékelés nem történik meg, amennyiben a wxMaxima bármilyen hibát észlel."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:727
 msgid "If not extremely long"
-msgstr ""
+msgstr "Ha nem túl hosszú"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:726
 msgid "If not very long"
-msgstr ""
+msgstr "Ha nem nagyon hosszú"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:418
 msgid "If numbers are getting longer than this number of digits they will be displayed abbreviated by an ellipsis."
-msgstr ""
+msgstr "Ha a számok nem jeleníthetőek meg a megadott számú számjeggyel, három ponttal rövidítve lesznek."
 
 #: ../../src/dialogs/TipOfTheDay.cpp:181
 msgid "If the \"Autosave\" functionality is enabled in the configuration dialogue wxMaxima acts like mobile apps that backup the file every few minutes and save it on closing."
-msgstr ""
+msgstr "Ha az \"Automatikus mentés\" engedélyezve van a wxMaxima beállításainál, a program rendszeresen, illetve bezáráskor menti a dokumentumot."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:396
 msgid "If the font provides big parenthesis symbols: Use them when big parenthesis are needed for maths display."
-msgstr ""
+msgstr "Ha a betűtípus nagy zárószimbólumokat tartalmaz: akkor használja őket, ha nagy méretű zárójelek szükségesek a matematikai megjelenítéshez."
 
 #: ../../src/cells/TextCell.cpp:327
 msgid "If the thing maxima complains about actually looks like a polynomial you can try running it through ratdisrep() in order to fix that problem."
@@ -5167,15 +5167,15 @@ msgstr "Ha egy függvényparaméter típusa ismert a függvény összeállítás
 
 #: ../../src/dialogs/ConfigDialogue.cpp:399
 msgid "If this checkbox is checked wxMaxima automatically saves the file closing and every few minutes giving wxMaxima a more cellphone-app-like feel as the file is virtually always saved. If this checkbox is unchecked from time to time a backup is made in the temp folder instead."
-msgstr ""
+msgstr "Ha ezt a jelölőnégyzetet bejelöli, a wxMaxima néhány percenként automatikusan menti a fájlt, és a wxMaxima számára mobiltelefon-alkalmazás-szerűbb érzetet ad. Ha ezt a jelölőnégyzetet nem jelöli be, helyette időről időre biztonsági másolat készül a fájlról az ideiglenes mappában."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:378
 msgid "If this checkbox is set a new code cell is opened as soon as maxima requests data. If it isn't set a new code cell is opened in this case as soon as the user starts typing in code."
-msgstr ""
+msgstr "Ha ez a jelölőnégyzet be van állítva, akkor egy új kódcellát nyit meg, amint a Maxima adatokat kér. Ha nincs beállítva, akkor új kódcellát nyit meg, amint a felhasználó elkezdi gépelni a kódot."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:372
 msgid "If this checkbox isn't checked the current command is sent to maxima only on pressing Ctrl+Enter"
-msgstr ""
+msgstr "Ha ez a jelölőnégyzet nincs bejelölve, akkor az aktuális parancsot csak a Ctrl+Enter billentyűkombinációra küldi el a maxima"
 
 #: ../../src/MathParser.cpp:945
 msgid "If this isn't a function returning a lambda() expression a multiplication sign (*) between closing and opening parenthesis is missing here."
@@ -5188,7 +5188,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:439
 msgid "If this option is set the .wxmx source of the current file is copied to a place a link to is put into the result of an export."
-msgstr ""
+msgstr "Ha ez az opció ki van jelölve, az aktuális fájl wxmx forrása egy linkre lesz másolva amely az eredmény exportjára mutat."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1873
 msgid "If unset, Maxima's output is announced to the screen reader as maths in a linear text form. Set this option if your screen reader can speak MathML properly."
@@ -5196,15 +5196,15 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:247
 msgid "If you have ideas, how to improve the design or functionality of wxMaxima, please share your ideas at the issue list or discussion forum at https://github.com/wxMaxima-developers/wxmaxima/."
-msgstr ""
+msgstr "Ha ötletei vannak a wxMaxima kialakításának vagy funkcionalitásának javítására, kérjük, ossza meg ötleteit a problémalistán vagy a vitafórumon a https://github.com/wxMaxima-developers/wxmaxima/ címen."
 
 #: ../../src/dialogs/TipOfTheDay.cpp:76
 msgid "If you type an operator (one of +*/^=,) as the first symbol in an input cell, % will be automatically inserted before the operator, as on a graphing calculator. You can disable this feature from the 'Edit->Configure' dialog."
-msgstr ""
+msgstr "Ha a bemeneti cella első karaktere valamelyik műveleti jel (a +*/^= karakterek egyike), egy % jel fog automatikusan beíródni elé. Ez a funkció kiiktatható a 'Szerkesztés->Beállítás' menüpont alatt."
 
 #: ../../src/dialogs/TipOfTheDay.cpp:122
 msgid "If your calculation is taking too long to evaluate, you can try 'Maxima->Interrupt' or 'Maxima->Restart Maxima' menu commands."
-msgstr ""
+msgstr "Ha egy számítás elvégzése túl sokáig tart, megpróbálhatjuk a 'Maxima->Megszakítás' vagy a 'Maxima->A Maxima újraindítása' menüparancsok használatát."
 
 #: ../../src/MaximaManual.cpp:420
 msgid "Ignoring the cache version for the manual anchors."
@@ -5212,7 +5212,7 @@ msgstr "A kézi horgonyok gyorsítótár verziójának figyelmen kívül hagyás
 
 #: ../../src/sidebars/FormatSidebar.cpp:66
 msgid "Image"
-msgstr ""
+msgstr "Kép"
 
 #: ../../src/Image.cpp:110
 msgid "Image data had zero length!"
@@ -5230,19 +5230,19 @@ msgstr ""
 
 #: ../../src/worksheet/WorksheetExport.cpp:1407
 msgid "ImageCell without image."
-msgstr ""
+msgstr "ImageCell without image."
 
 #: ../../src/sidebars/DrawSidebar.cpp:60
 msgid "Implicit Plot"
-msgstr ""
+msgstr "Implicit ábra"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1028
 msgid "Import settings"
-msgstr ""
+msgstr "Beállítások importálása"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1013
 msgid "Import+Export"
-msgstr ""
+msgstr "Importálás+Exportálás"
 
 #: ../../src/MathParser.cpp:395
 msgid "Importing compressed gnuplot sources for an animation"
@@ -5277,11 +5277,11 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:214
 msgid "In text cells bullet lists can be created by beginning a line with \" * \". The number of spaces in front of the \"*\" determines the indentation level; Indentation can be continued in the next line by indenting the line using spaces."
-msgstr ""
+msgstr "Ha szövegcellában egy sort \"*\"-gal kezdünk, abból felsorolás lista lesz. A \"*\" előtti szóközök száma határozza meg a behúzás mértékét. A behúzás a következő sorban szóközök használatával folytatható."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:421
 msgid "In the LaTeX output: Put exponents after an eventual subscript instead of above it. Might increase readability for some fonts and short subscripts."
-msgstr ""
+msgstr "A LaTeX kimenetben: a kitevőket egy esetleges index után rakja ahelyett, hogy a kifejezés fölé tenné. Ez javíthatja az olvashatóságot egyes betűtípusok és rövid indexek esetén."
 
 #: ../../src/MaximaCommandMenus.cpp:1869
 msgid "Include columns:"
@@ -5293,15 +5293,15 @@ msgstr "Növelő f(x)>x függvény"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:884
 msgid "Incremental Search"
-msgstr ""
+msgstr "Azonnali keresés"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:844
 msgid "Indent equations by the label width"
-msgstr ""
+msgstr "Egyenletek behúzás a címke szélességével"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:512
 msgid "Indent maths so all lines are in par with the first line that starts after the label."
-msgstr ""
+msgstr "A matematikái sorok ki vannak jelölve, így minden sor párban van a címke után kezdődő első sorral."
 
 #: ../../src/sidebars/TableOfContents.cpp:583
 msgid "Indentation"
@@ -5342,7 +5342,7 @@ msgstr ""
 #: ../../src/wizards/IntegrateWiz.cpp:215 ../../src/wizards/LimitWiz.cpp:132
 #: ../../src/wizards/LimitWiz.cpp:140
 msgid "Infinity"
-msgstr ""
+msgstr "Végtelen"
 
 #: ../../src/wxMaximaFrame.cpp:1986
 msgid "Info about Maxima build"
@@ -5400,7 +5400,7 @@ msgstr "Beszúrás"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:889
 msgid "Insert % before an operator at the beginning of a cell"
-msgstr ""
+msgstr "Beszúr egy %-jelet a cella elején található műveleti jel elé"
 
 #: ../../src/wxMaximaFrame.cpp:939
 msgid "Insert &Section Cell\tCtrl+3"
@@ -5536,7 +5536,7 @@ msgstr ""
 
 #: ../../src/sidebars/HelpBrowser.cpp:111
 msgid "Instantiating the HTML manual browser"
-msgstr ""
+msgstr "A HTML kézi böngésző példányosítása"
 
 #: ../../src/MaximaProcessManager.cpp:1066
 msgid "Instructed to prefer gnuplot over wgnuplot"
@@ -5548,11 +5548,11 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:749
 msgid "Integers and single letters"
-msgstr ""
+msgstr "Egészek és egyedi betűk"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:113
 msgid "Integral sign"
-msgstr ""
+msgstr "Integráljel"
 
 #: ../../src/MaximaCommandMenus.cpp:149 ../../src/MaximaCommandMenus.cpp:170
 msgid "Integral/Sum:"
@@ -5586,15 +5586,15 @@ msgstr "Integrál..."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:834
 msgid "Intelligently hide cell brackets"
-msgstr ""
+msgstr "A cella-zárójelek intelligens elrejtése"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:881
 msgid "Interaction"
-msgstr ""
+msgstr "Kölcsönhatás"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1349
 msgid "Interactive popup memory limit [MB/plot]:"
-msgstr ""
+msgstr "Interaktív felugró memóriakorlát [MB/plot]:"
 
 #: ../../src/wxMaximaFrame.cpp:1774
 msgid "Interleave"
@@ -5610,7 +5610,7 @@ msgstr "Két lista beillesztése"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1465
 msgid "Internal"
-msgstr ""
+msgstr "Integrál"
 
 #: ../../src/wxMaximaFrame.cpp:1121
 msgid "Interpret like input..."
@@ -5659,7 +5659,7 @@ msgstr "Egy vagy több hozzárendelést visz be egy kifejezésbe"
 
 #: ../../src/sidebars/RegexCtrl.cpp:40
 msgid "Invalid RegEx!"
-msgstr ""
+msgstr "Érvénytelen RegEx!"
 
 #: ../../src/MathParser.cpp:1338
 #, c-format
@@ -5676,7 +5676,7 @@ msgstr "I&nverz Laplace-transzformáció..."
 
 #: ../../src/sidebars/GreekSidebar.cpp:186
 msgid "Iota"
-msgstr ""
+msgstr "Ióta"
 
 #: ../../src/MaximaCommandMenus.cpp:4150
 msgid "Is Char 1 greater than Char2, if case is ignored?"
@@ -5792,7 +5792,7 @@ msgstr "Nagybetűk?..."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:498
 msgid "Issue a notification if maxima finishes calculating while the wxMaxima window isn't in focus."
-msgstr ""
+msgstr "Értesítés kiadása, ha a Maxima befejezi a számítást, miközben a wxMaxima ablak nincs fókuszban."
 
 #: ../../src/worksheet/Worksheet.cpp:4237
 msgid "Issuing the active cell's undo function"
@@ -5800,31 +5800,31 @@ msgstr "Issuing the active cella's undo function"
 
 #: ../../src/worksheet/Worksheet.cpp:4241
 msgid "Issuing the worksheet's undo function"
-msgstr ""
+msgstr "Issuing the worksheet's undo function"
 
 #: ../../src/dialogs/TipOfTheDay.cpp:185
 msgid "It is possible to add custom symbols to the \"symbols\" sidebar by copying them into the respective field in the configuration dialogue."
-msgstr ""
+msgstr "Saját szimbólumokat adhatunk a \"Szimbólumok\" oldalsávhoz a beállítások megfelelő mezőjébe másolva."
 
 #: ../../src/dialogs/TipOfTheDay.cpp:152
 msgid "It is possible to define reusable Maxima libraries with wxMaxima that can be later loaded by using the load() function. All that has to be done is to export a file in the .mac or to save it in the .wxm format. Note, though, that a few special characters like the \"not equal\" symbol for \"#\" are handled by wxMaxima, not by Maxima and therefore cannot be recognized on load()."
-msgstr ""
+msgstr "A wxMaxima lehetőséget nyújt Maxima könyvtárak (library-k) definiálására, azoknak a load() függvénnyel való betöltésére és felhasználására. E célból csak annyit kell tenni, hogy a fájlt mac vagy .wxm formátumban mentjük el. Néhány speciális karaktert, mint a \"nem egyenlő\" jelentésű \"#\"-ot a wxMaxima kezeli, viszont a maxima nem, így azokat a load() sem ismeri fel."
 
 #: ../../src/wizards/DrawWiz.cpp:476
 msgid "It needs to be filled with objects to draw afterwards."
-msgstr ""
+msgstr "A rajzoláshoz meg kell tölteni objektumokkal."
 
 #: ../../src/wizards/ActualValuesStorageWiz.cpp:38
 msgid "It therefore makes sense to apply the known values for variables as late as possible."
-msgstr ""
+msgstr "Ezért érdemes a változók ismert értékeit a lehető legrövidebb időn belül alkalmazni."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:207
 msgid "Italian"
-msgstr ""
+msgstr "Olasz"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2111
 msgid "Italic"
-msgstr ""
+msgstr "Dőlt"
 
 #: ../../src/MaximaCommandMenus.cpp:1617 ../../src/MaximaCommandMenus.cpp:1623
 msgid "Item"
@@ -5836,7 +5836,7 @@ msgstr "Az iterátor neve:"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:208
 msgid "Japanese"
-msgstr ""
+msgstr "Japán"
 
 #: ../../src/MaximaCommandMenus.cpp:2255
 msgid "Jump to UUID"
@@ -5864,16 +5864,16 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:210
 msgid "Kabyle"
-msgstr ""
+msgstr "Kabil"
 
 #: ../../src/sidebars/GreekSidebar.cpp:187
 msgid "Kappa"
-msgstr ""
+msgstr "Kappa"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:864
 #, c-format
 msgid "Keep percent sign with special symbols: %e, %i, etc."
-msgstr ""
+msgstr "Százalékjel használata speciális , mint például %e, %i, stb."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:212
 msgid "Korean"
@@ -5901,19 +5901,19 @@ msgstr "L[inf] Norm (valódi)"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1166
 msgid "LaTeX"
-msgstr ""
+msgstr "LaTeX"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1199
 msgid "LaTeX: Place exponents after, instead above subscripts"
-msgstr ""
+msgstr "LaTeX: kitevők nem az indexek fölé, hanem után"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1204
 msgid "LaTeX: Use the \"partial derivative\" symbol to represent diff()"
-msgstr ""
+msgstr "LaTeX: Használja a \"részleges derivált\" szimbólumot a diff()LaTeX: A \"parciális derivált\" szimbólumának megjelenítése a diff() használata során"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:758
 msgid "Label width:"
-msgstr ""
+msgstr "Címke szélesség:"
 
 #: ../../src/wxMaximaFrame.cpp:1059
 msgid "Labels"
@@ -5932,11 +5932,11 @@ msgstr "A lambda létrehoz egy függvényt, de nem ad neki nevet.\\n Ez akkor ha
 
 #: ../../src/dialogs/ConfigDialogue.cpp:470
 msgid "Language used for wxMaxima GUI."
-msgstr ""
+msgstr "A wxMaxima grafikus felület nyelve."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1311
 msgid "Language:"
-msgstr ""
+msgstr "Nyelv:"
 
 #: ../../src/MaximaCommandMenus.cpp:251
 msgid "Laplace"
@@ -5983,7 +5983,7 @@ msgstr "A rendszer alapértelmezett súgóböngészőjének elindítása nem sik
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:126
 msgid "Leads to"
-msgstr ""
+msgstr "Vezet"
 
 #: ../../src/wxMaximaFrame.cpp:1530
 msgid "Least Common Multiple..."
@@ -5995,7 +5995,7 @@ msgstr "Legkisebb négyzetes közelítés"
 
 #: ../../src/sidebars/StatSidebar.cpp:79
 msgid "Least Squares Fit..."
-msgstr ""
+msgstr "Legkisebb négyzetes közelítés..."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2007
 msgid "Left"
@@ -6032,12 +6032,12 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:163
 msgid "Libraries can be accessed by any wxMaxima process regardless of which directory it runs in, if they are placed in the user directory. This directory can be found by typing maxima_userdir;"
-msgstr ""
+msgstr "A könyvtárak (library-k) bármelyik wxMaxima eljárás számára hozzáférhetőek (függetlenül attól, hogy az eljárások mely könyvtárban futnak), ha a felhasználói könyvtárban helyeztük el azokat. A felhasználói könyvtár elérési útját a maxima_userdir parancs végrehajtásával tudhatjuk meg"
 
 #: ../../src/dialogs/LicenseDialog.cpp:63
 #: ../../src/dialogs/LicenseDialog.cpp:77
 msgid "License"
-msgstr ""
+msgstr "Licenc"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2068
 msgid "Light"
@@ -6053,15 +6053,15 @@ msgstr "Határérték"
 
 #: ../../src/sidebars/MathSidebar.cpp:86
 msgid "Limit..."
-msgstr ""
+msgstr "Határérték..."
 
 #: ../../src/sidebars/DrawSidebar.cpp:88
 msgid "Line color"
-msgstr ""
+msgstr "Sorszín"
 
 #: ../../src/sidebars/StatSidebar.cpp:76
 msgid "Linear Regression..."
-msgstr ""
+msgstr "Lineáris regresszió..."
 
 #: ../../src/MaximaCommandMenus.cpp:4068
 msgid "Lisp format string:"
@@ -6109,15 +6109,15 @@ msgstr "Lista könyvtár..."
 
 #: ../../src/wizards/ListSortWiz.cpp:34
 msgid "List name:"
-msgstr ""
+msgstr "Lista név:"
 
 #: ../../src/sidebars/VariablesPane.cpp:188
 msgid "List of arrays"
-msgstr ""
+msgstr "Vektorok listája"
 
 #: ../../src/sidebars/VariablesPane.cpp:191
 msgid "List of changed options"
-msgstr ""
+msgstr "Megváltozott beállítások listálja"
 
 #: ../../src/MaximaCommandMenus.cpp:4197
 msgid "List of char to String"
@@ -6133,47 +6133,47 @@ msgstr "Karakterek listája:"
 
 #: ../../src/sidebars/VariablesPane.cpp:179
 msgid "List of functional dependencies"
-msgstr ""
+msgstr "A funkcionális függőségek listája"
 
 #: ../../src/sidebars/VariablesPane.cpp:203
 msgid "List of labels"
-msgstr ""
+msgstr "Címkék listája"
 
 #: ../../src/sidebars/VariablesPane.cpp:200
 msgid "List of structs"
-msgstr ""
+msgstr "Struktúrák listája"
 
 #: ../../src/sidebars/VariablesPane.cpp:197
 msgid "List of user aliases"
-msgstr ""
+msgstr "A felhasználói álnevek listája"
 
 #: ../../src/sidebars/VariablesPane.cpp:185
 msgid "List of user functions"
-msgstr ""
+msgstr "A felhasználói függvények listája"
 
 #: ../../src/sidebars/VariablesPane.cpp:194
 msgid "List of user rules"
-msgstr ""
+msgstr "A felhasználói szabályok listája"
 
 #: ../../src/sidebars/VariablesPane.cpp:182
 msgid "List of user variables"
-msgstr ""
+msgstr "A felhasználói változók listája"
 
 #: ../../src/sidebars/VariablesPane.cpp:206
 msgid "List of user-defined derivatives"
-msgstr ""
+msgstr "A felhasználói derivatívák listája"
 
 #: ../../src/sidebars/VariablesPane.cpp:216
 msgid "List of user-defined let rule packages"
-msgstr ""
+msgstr "A felhasználó által megadott letiltási szabálycsomagok listája"
 
 #: ../../src/sidebars/VariablesPane.cpp:212
 msgid "List of user-defined macros"
-msgstr ""
+msgstr "A felhasználó által megadott makrók"
 
 #: ../../src/sidebars/VariablesPane.cpp:209
 msgid "List of user-defined properties"
-msgstr ""
+msgstr "A felhasználó által megadott tulajdonságok"
 
 #: ../../src/MaximaCommandMenus.cpp:1575
 msgid "List with values"
@@ -6194,7 +6194,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2162
 msgid "Load"
-msgstr ""
+msgstr "Betöltés"
 
 #: ../../src/MaximaCommandMenus.cpp:2356
 msgid "Load Package"
@@ -6234,7 +6234,7 @@ msgstr "Lisp betöltése..."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2645
 msgid "Load style from file"
-msgstr ""
+msgstr "Stílusfájl betöltése"
 
 #: ../../src/wxMaximaFrame.cpp:1232
 msgid "Load the file/dir operations (operatingsystem)"
@@ -6250,7 +6250,7 @@ msgstr "A fordításgenerátor betöltése (gentran)"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:128
 msgid "Long Right arrow"
-msgstr ""
+msgstr "Hosszú jobbra nyíl"
 
 #: ../../src/MaximaCommandMenus.cpp:1409
 msgid "Loop variable"
@@ -6270,7 +6270,7 @@ msgstr "M&átrix"
 
 #: ../../src/sidebars/XmlInspector.cpp:104
 msgid "MAXIMA RESPONSE:"
-msgstr ""
+msgstr "MAXIMA VÁLASZA:"
 
 #: ../../src/MaximaCommandMenus.cpp:3965
 msgid "Macro contents:"
@@ -6334,7 +6334,7 @@ msgstr "Függvény leképezése egy mátrixba, amely hatással van annak összes
 
 #: ../../src/dialogs/FindReplacePane.cpp:71
 msgid "Match Case"
-msgstr ""
+msgstr "Kisbetű-nagybetű érzékeny keresés"
 
 #: ../../src/Styles.cpp:139
 msgid "Math Default"
@@ -6346,7 +6346,7 @@ msgstr ""
 
 #: ../../src/cells/Cell.cpp:1490
 msgid "Math output"
-msgstr ""
+msgstr "Matematika kimenet"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1221
 msgid "MathML (rendered by the browser)"
@@ -6358,11 +6358,11 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1906
 msgid "MathML as HTML"
-msgstr ""
+msgstr "MathML HTML-ként"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1902
 msgid "MathML description"
-msgstr ""
+msgstr "MathML leírás"
 
 #: ../../src/wxMaximaFrame.cpp:307
 msgid "Mathematical Symbols"
@@ -6442,11 +6442,11 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:281
 msgid "Maxima"
-msgstr ""
+msgstr "Maxima"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1433
 msgid "Maxima Location"
-msgstr ""
+msgstr "Maxima helye"
 
 #: ../../src/MaximaCommandMenus.cpp:619
 msgid "Maxima allows making functions \"nouns\", which means that they aren't automatically evaluated as soon as Maxima encounters them.\n"
@@ -6479,19 +6479,19 @@ msgstr "A Maxima automatikusan egyszerűsíti a bemenetként kapott kifejezések
 
 #: ../../src/cells/EditorCell.cpp:4516
 msgid "Maxima code"
-msgstr ""
+msgstr "Maxima kód"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1110
 msgid "Maxima commands to be executed at every start of Maxima"
-msgstr ""
+msgstr "Maxima parancsok végrehajtása a Maxima minden egyes indulásakor"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1063
 msgid "Maxima commands to be executed every time wxMaxima starts Maxima"
-msgstr ""
+msgstr "Maxima parancsok végrehajtása a wxMaxima minden indításakor"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1507
 msgid "Maxima configuration"
-msgstr ""
+msgstr "A wxMaxima beállítása"
 
 #: ../../src/MaximaResponseReader.cpp:346
 msgid "Maxima didn't attempt to authenticate!"
@@ -6567,11 +6567,11 @@ msgstr "A maxima eljárásának futása váratlanul megszakadt."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1437
 msgid "Maxima program:"
-msgstr ""
+msgstr "Maxima program:"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:382
 msgid "Maxima provides no \"forget all\" command that flushes all settings a maxima session could make. wxMaxima therefore normally defaults to starting a fresh maxima process every time the worksheet is to be re-evaluated. As this needs a little bit of time this switch allows to disable this behavior."
-msgstr ""
+msgstr "A Maximában nincs \"felejts el mindent\" parancs, ami az összes eddig végrehajtott eljárás hatását törölné, ezért a wxMaxima alapértelmezés szerint új Maximát indít minden munkalap-újraértékelésnél. Mivel ez időigényes lehet, ez a kapcsoló lehetővé teszi az újraindítás kiiktatását."
 
 #: ../../src/Styles.cpp:108
 msgid "Maxima question labels"
@@ -6591,7 +6591,7 @@ msgstr "A Maxima új változót küld nekünk a figyelők listájához."
 
 #: ../../src/sidebars/History.cpp:153
 msgid "Maxima session (*.mac)|*.mac"
-msgstr ""
+msgstr "Maxima munkalap (*.mac)|*.mac|"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1518 ../../src/wxMaximaFrame.cpp:1981
 msgid "Maxima shows help in a browser"
@@ -6623,11 +6623,11 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1143
 msgid "Maxima startup file location: "
-msgstr ""
+msgstr "Maxima indító fájl helye: "
 
 #: ../../src/dialogs/TipOfTheDay.cpp:68
 msgid "Maxima supports three types of numbers: exact fractions (which can be generated for example by typing 1/10), IEEE floating-point numbers (0.2) and arbitrary precision big floats (1b-1). Note that, owing to their nature as binary (not decimal) numbers, there is for example no way to generate an IEEE floating-point number that exactly equals 0.1. If floating-point numbers are used instead of fractions, Maxima will therefore sometimes have to introduce a (very small) error and use things like 3602879701896397/36028797018963968 for 0.1."
-msgstr ""
+msgstr "A Maxima háromféle számtípust támogat: közönséges törteket (például ilyen jön létre, amikor az gépeljük be, hogy 1/10), az IEEE lebegőpontos számformátumot (0.2) és tetszőleges pontosságú hosszú tizedes törteket (1b-1). Vegyük azonban figyelembe, hogy bináris (nem decimális) számok természete miatt például nem tudunk pontosan 0.1-el egyenlő IEEE lebegőpontos számot előállítani. Ne feledje továbbá, hogy ha lebegőpontos számokat használunk közönséges törtek helyett, a kerekítés miatt pontatlan értéket kaphatunk. Például 3602879701896397/36028797018963968 helyett 0.1-et."
 
 #: ../../src/wxMaximaFrame.cpp:1265
 msgid "Maxima to other language"
@@ -6643,7 +6643,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1615
 msgid "Maxima usage"
-msgstr ""
+msgstr "Maxima használat"
 
 #: ../../src/MaximaResponseReader.cpp:776
 #, c-format
@@ -6739,7 +6739,7 @@ msgstr "A Maxima kézikönyve a(z) %s könyvtárban található"
 
 #: ../../src/wizards/ActualValuesStorageWiz.cpp:34
 msgid "Maxima's power lies in symbolic operations."
-msgstr ""
+msgstr "A Maxima ereje a szimbolikus műveletekben rejlik."
 
 #: ../../src/StatusBar.cpp:365
 msgid "Maxima's reader is in Lisp mode (after to_lisp()).\n"
@@ -6786,7 +6786,7 @@ msgstr "Maximális abszolút érték kitevő nélkül nyomtatva"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1931
 msgid "Maximum bitmap size on clipboard [Mb]:"
-msgstr ""
+msgstr "Maximális bitkép méret a vágólapon [Mb]:"
 
 #: ../../src/MaximaCommandMenus.cpp:488 ../../src/MaximaCommandMenus.cpp:501
 #: ../../src/MaximaCommandMenus.cpp:516 ../../src/MaximaCommandMenus.cpp:530
@@ -6799,19 +6799,19 @@ msgstr "Maximálisan megjelenített számjegyek száma:"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:811
 msgid "Maximum number of displayed digits:"
-msgstr ""
+msgstr "Maximálisan megjelenített számjegyek száma:"
 
 #: ../../src/sidebars/StatSidebar.cpp:70
 msgid "Mean Difference Test..."
-msgstr ""
+msgstr "Kétmintás t-próba..."
 
 #: ../../src/sidebars/StatSidebar.cpp:67
 msgid "Mean Test..."
-msgstr ""
+msgstr "Egymintás t-próba..."
 
 #: ../../src/sidebars/StatSidebar.cpp:52
 msgid "Mean..."
-msgstr ""
+msgstr "Átlag..."
 
 #: ../../src/MaximaCommandMenus.cpp:1806
 msgid "Mean:"
@@ -6819,7 +6819,7 @@ msgstr "Átlag:"
 
 #: ../../src/sidebars/StatSidebar.cpp:55
 msgid "Median..."
-msgstr ""
+msgstr "Medián..."
 
 #: ../../src/wxMaximaFrame.cpp:1961
 msgid "Memoizing"
@@ -6840,7 +6840,7 @@ msgstr "Üzenet a Maxima kimenetéről: "
 
 #: ../../src/wizards/IntegrateWiz.cpp:55
 msgid "Method:"
-msgstr ""
+msgstr "Eljárás:"
 
 #: ../../src/wxMaximaFrame.cpp:1360
 msgid "Methods of generating a matrix"
@@ -6866,7 +6866,7 @@ msgstr "Minimális abszolút érték kitevő nélkül nyomtatva:"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1270
 msgid "Misc"
-msgstr ""
+msgstr "Egyéb"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1963
 msgid "Misc settings"
@@ -6907,7 +6907,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:189
 msgid "Mu"
-msgstr ""
+msgstr "Mű"
 
 #: ../../src/wxMaximaFrame.cpp:1386
 msgid "Multiplication, exponent and similar"
@@ -6931,7 +6931,7 @@ msgstr "t neve:"
 
 #: ../../src/wizards/DrawWiz.cpp:750
 msgid "Name of the parameter"
-msgstr ""
+msgstr "A paraméter neve"
 
 #: ../../src/MaximaCommandMenus.cpp:1019
 msgid "Name of x:"
@@ -6939,7 +6939,7 @@ msgstr "x neve:"
 
 #: ../../src/wizards/MatWiz.cpp:163
 msgid "Name:"
-msgstr ""
+msgstr "Név:"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:216
 msgid "Nepali"
@@ -7002,7 +7002,7 @@ msgstr "Új dokumentum"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:901
 msgid "New lines: Jump to text"
-msgstr ""
+msgstr "Új sorok: Ugrás a szövegre"
 
 #: ../../src/MaximaResponseReader.cpp:1015
 #, c-format
@@ -7015,7 +7015,7 @@ msgstr "Új rész:"
 
 #: ../../src/wizards/SubstituteWiz.cpp:35
 msgid "New value:"
-msgstr ""
+msgstr "Új érték:"
 
 #: ../../src/MaximaCommandMenus.cpp:151 ../../src/MaximaCommandMenus.cpp:171
 #: ../../src/MaximaCommandMenus.cpp:254 ../../src/MaximaCommandMenus.cpp:259
@@ -7053,7 +7053,7 @@ msgstr ""
 
 #: ../../src/wizards/DrawWiz.cpp:636
 msgid "No contour lines"
-msgstr ""
+msgstr "Nincsenek kontúrvonalak"
 
 #: ../../src/dialogs/DiffFrame.cpp:304
 msgid "No differences"
@@ -7090,11 +7090,11 @@ msgstr "A kifejezés nem található!"
 
 #: ../../src/wizards/DrawWiz.cpp:651
 msgid "No plot, only contour lines"
-msgstr ""
+msgstr "Nincs ábra, csak kontúrvonalak"
 
 #: ../../src/wizards/DrawWiz.cpp:837
 msgid "No points"
-msgstr ""
+msgstr "Nincsenek pontok"
 
 #: ../../src/MaximaResponseReader.cpp:145
 msgid "No topics found in topic flag"
@@ -7110,7 +7110,7 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:179
 msgid "Non-builtin symbols"
-msgstr ""
+msgstr "Nem beépített szimbólumok"
 
 #: ../../src/wxMaximaFrame.cpp:834
 msgid "None"
@@ -7118,7 +7118,7 @@ msgstr "Egyik sem"
 
 #: ../../src/sidebars/StatSidebar.cpp:73
 msgid "Normality Test..."
-msgstr ""
+msgstr "Normalitás vizsgálat..."
 
 #: ../../src/cells/TextCell.cpp:271
 msgid "Normally computers use floating-point numbers that can be handled incredibly fast while being accurate to dozens of digits. They will, though, introduce a small error into some common numbers. For example 0.1 is represented as 3602879701896397/36028797018963968.\n"
@@ -7129,11 +7129,11 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:431
 msgid "Normally html expects images to be rather low-res but space saving. These images tend to look rather blurry when viewed on modern screens. Therefore this setting was introduces that selects the factor by which the HTML export increases the resolution in respect to the default value."
-msgstr ""
+msgstr "Helytakarékossági okok miatt HTML dokumentumban általában alacsony felbontású képeket szoktunk használni. Modern képernyőkön ezek a képek elmosódottak lehetnek. Ezzel a beállítással HTML export esetén az megnöveli a felbontás alapértelmezett értékét."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:217
 msgid "Norwegian"
-msgstr ""
+msgstr "Norvég"
 
 #: ../../src/MaximaCommandMenus.cpp:1351
 msgid "Not a valid matrix dimension!"
@@ -7169,7 +7169,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:190
 msgid "Nu"
-msgstr ""
+msgstr "Nű"
 
 #: ../../src/MaximaCommandMenus.cpp:177
 msgid "Num. deg:"
@@ -7312,7 +7312,7 @@ msgstr "Páratlan szám"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:910
 msgid "Offer answers for questions known from previous runs"
-msgstr ""
+msgstr "Választ ajánl a korábbi futásokból ismert kérdésekre"
 
 #: ../../src/cells/TextCell.cpp:332
 msgid "Often caused by recursive function calls. Some lisps allow increasing the control stack size using command-line arguments."
@@ -7320,7 +7320,7 @@ msgstr ""
 
 #: ../../src/wizards/SubstituteWiz.cpp:32
 msgid "Old value:"
-msgstr ""
+msgstr "Régi érték:"
 
 #: ../../src/MaximaCommandMenus.cpp:151 ../../src/MaximaCommandMenus.cpp:172
 #: ../../src/MaximaCommandMenus.cpp:253 ../../src/MaximaCommandMenus.cpp:259
@@ -7329,11 +7329,11 @@ msgstr "Régi változó:"
 
 #: ../../src/sidebars/GreekSidebar.cpp:201
 msgid "Omega"
-msgstr ""
+msgstr "Ómega"
 
 #: ../../src/sidebars/GreekSidebar.cpp:192
 msgid "Omicron"
-msgstr ""
+msgstr "Omikron"
 
 #: ../../src/wxMaximaFrame.cpp:1089
 msgid "On all errors"
@@ -7357,7 +7357,7 @@ msgstr "Csak egészek és egyedi betűk"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:771
 msgid "Only user-defined labels"
-msgstr ""
+msgstr "Csak a felhasználó által definiált címkék"
 
 #: ../../src/MaximaCommandMenus.cpp:2197 ../../src/ToolBar.cpp:330
 #: ../../src/ToolBar.cpp:333 ../../src/main.cpp:882
@@ -7366,7 +7366,7 @@ msgstr "Megnyitás"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:905
 msgid "Open a cell when Maxima expects input"
-msgstr ""
+msgstr "Nyit egy cellát, amikor a Maxima bemenetet vár"
 
 #: ../../src/wxMaximaFrame.cpp:629
 msgid "Open a document"
@@ -7440,7 +7440,7 @@ msgstr "Optimalizálja a memóriát"
 
 #: ../../src/wizards/DrawWiz.cpp:97
 msgid "Optional: A 2nd expression that defines a region to fill"
-msgstr ""
+msgstr "Opcionális: egy második kifejezés, amely egy kitöltött régiót határoz meg"
 
 #: ../../src/ToolBar.cpp:367 ../../src/ToolBar.cpp:369
 #: ../../src/dialogs/ConfigDialogue.cpp:284
@@ -7449,7 +7449,7 @@ msgstr "Beállítások"
 
 #: ../../src/wizards/Plot2dWiz.cpp:75 ../../src/wizards/Plot3dWiz.cpp:66
 msgid "Options:"
-msgstr ""
+msgstr "Beállítások:"
 
 #: ../../src/dialogs/FindReplacePane.cpp:109
 msgid "Output"
@@ -7510,7 +7510,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:458
 msgid "PNG images can be read by old wxMaxima versions - but aren't really scalable."
-msgstr ""
+msgstr "A PNG -képeket a régi wxMaxima verziók is olvashatják - de nem igazán méretezhetők."
 
 #: ../../src/MaximaCommandMenus.cpp:175
 msgid "Pade approximation"
@@ -7522,7 +7522,7 @@ msgstr "Taylor-sor Padé-approximációja"
 
 #: ../../src/sidebars/FormatSidebar.cpp:69
 msgid "Pagebreak"
-msgstr ""
+msgstr "Laptörés"
 
 #: ../../src/wxMaximaFrame.cpp:1674
 msgid "Parallel Substitute..."
@@ -7534,7 +7534,7 @@ msgstr "Párhuzamos behelyettesítés"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:124
 msgid "Parallel to"
-msgstr ""
+msgstr "Párhuzamos"
 
 #: ../../src/MaximaCommandMenus.cpp:3991
 msgid "Parameter name:"
@@ -7546,11 +7546,11 @@ msgstr "Paraméter(ek):"
 
 #: ../../src/sidebars/DrawSidebar.cpp:64
 msgid "Parametric Plot"
-msgstr ""
+msgstr "Paraméteres ábrázolás"
 
 #: ../../src/wizards/Plot2dWiz.cpp:417 ../../src/wizards/Plot2dWiz.cpp:523
 msgid "Parametric plot"
-msgstr ""
+msgstr "Paraméteres ábrázolás"
 
 #: ../../src/MaximaCommandMenus.cpp:4211
 msgid "Parse string"
@@ -7604,7 +7604,7 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:125
 msgid "Perpendicular to"
-msgstr ""
+msgstr "Merőleges"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:218
 msgid "Persian"
@@ -7612,15 +7612,15 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:198
 msgid "Phi"
-msgstr ""
+msgstr "Fí"
 
 #: ../../src/sidebars/GreekSidebar.cpp:193
 msgid "Pi"
-msgstr ""
+msgstr "Pí"
 
 #: ../../src/sidebars/StatSidebar.cpp:94
 msgid "Piechart..."
-msgstr ""
+msgstr "Tortadiagram..."
 
 #: ../../src/wxMaxima.cpp:1585
 msgid "Please configure wxMaxima with 'Edit->Configure'."
@@ -7628,7 +7628,7 @@ msgstr "Kérem állítsa be a wxMaximát a 'Szerkesztés->Beállítás' menüpon
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2606
 msgid "Please restart wxMaxima for changes to take effect!"
-msgstr ""
+msgstr "A változások életbe lépéséhez indítsa újra a wxMaximát!"
 
 #: ../../src/MaximaCommandMenus.cpp:2250
 msgid "Please select exactly 2 or 3 files."
@@ -7669,16 +7669,16 @@ msgstr "3D..."
 
 #: ../../src/wizards/DrawWiz.cpp:713
 msgid "Plot a parametric curve"
-msgstr ""
+msgstr "Paraméteres görbe ábrázolása"
 
 #: ../../src/wizards/DrawWiz.cpp:45 ../../src/wizards/DrawWiz.cpp:148
 #: ../../src/wizards/DrawWiz.cpp:255
 msgid "Plot an explicit expression"
-msgstr ""
+msgstr "Egy explicit kifejezés ábrázolása"
 
 #: ../../src/wizards/DrawWiz.cpp:53
 msgid "Plot an expression, for example sin(x) or (x+1)^2."
-msgstr ""
+msgstr "Kifejezés ábrázolása, mint például sin(x) vagy (x+1)^2."
 
 #: ../../src/MaximaCommandMenus.cpp:1776
 msgid "Plot as bars"
@@ -7702,11 +7702,11 @@ msgstr "Ábrázolás három dimenzióban"
 
 #: ../../src/sidebars/DrawSidebar.cpp:83
 msgid "Plot name"
-msgstr ""
+msgstr "Ábrázolandó neve"
 
 #: ../../src/wizards/Plot2dWiz.cpp:84 ../../src/wizards/Plot3dWiz.cpp:80
 msgid "Plot to file:"
-msgstr ""
+msgstr "Ábrázolás fájlba:"
 
 #: ../../src/wxMaximaFrame.cpp:341 ../../src/wxMaximaFrame.cpp:749
 msgid "Plot using Draw"
@@ -7726,7 +7726,7 @@ msgstr "Pont az érték ismert:"
 
 #: ../../src/wizards/DrawWiz.cpp:842
 msgid "Point type:"
-msgstr ""
+msgstr "Pont típusa:"
 
 #: ../../src/MaximaCommandMenus.cpp:186 ../../src/MaximaCommandMenus.cpp:1090
 #: ../../src/wizards/BC2Wiz.cpp:33 ../../src/wizards/BC2Wiz.cpp:39
@@ -7736,11 +7736,11 @@ msgstr "Hely:"
 
 #: ../../src/sidebars/DrawSidebar.cpp:67
 msgid "Points"
-msgstr ""
+msgstr "Pontok"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:219
 msgid "Polish"
-msgstr ""
+msgstr "Lengyel"
 
 #: ../../src/MaximaCommandMenus.cpp:215 ../../src/MaximaCommandMenus.cpp:220
 #: ../../src/MaximaCommandMenus.cpp:225
@@ -7776,7 +7776,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:221
 msgid "Portuguese (Brazilian)"
-msgstr ""
+msgstr "Portugál (Brazil)"
 
 #: ../../src/wxMaximaFrame.cpp:1223
 msgid "Position of a match"
@@ -7792,7 +7792,7 @@ msgstr ""
 
 #: ../../src/wizards/Plot2dWiz.cpp:474 ../../src/wizards/Plot3dWiz.cpp:422
 msgid "Postscript file (*.eps)|*.eps|All|*"
-msgstr ""
+msgstr "Postscript fájl (*.eps)|*.eps|Minden fájl|*"
 
 #: ../../src/MaximaCommandMenus.cpp:190
 msgid "Power series"
@@ -7812,7 +7812,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1492
 msgid "Prefer the all-in-one-file >1000 page manual"
-msgstr ""
+msgstr "Inkább a több mint 1000 oldalas kézikönyvet"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:389
 msgid "Prefer user labels"
@@ -7840,7 +7840,7 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:146
 msgid "Pressing Ctrl+Space or Ctrl+Tab starts an autocomplete function that can not only complete all functions that are integrated into the Maxima core and their parameters: It also knows about parameters from currently loaded packages and from functions that are defined in the current file."
-msgstr ""
+msgstr "A Ctrl+Space vagy a Ctrl+Tab megnyomására elindul egy automatikus kiegészítési eljárás, mely nem csak a Maxima alapvető függvényeit és azok paramétereit ismeri, hanem a betöltött csomagokéit és az aktuális fájlon belül definiáltakéit is."
 
 #: ../../src/wxMaximaFrame.cpp:961
 msgid "Previous Command\tAlt+Up"
@@ -7877,11 +7877,11 @@ msgstr "3-mal osztható kitevőjű lebegőpontos számok kiírása"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1968
 msgid "Print scale:"
-msgstr ""
+msgstr "Nyomtatási skála:"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1981
 msgid "Print the cell brackets [drawn to their left]"
-msgstr ""
+msgstr "Cellazárójelek nyomtatása [balra helyezve]"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:287
 msgid "Printout settings"
@@ -7931,7 +7931,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:936
 msgid "Privacy settings"
-msgstr ""
+msgstr "Adatvédelmi beállítások"
 
 #: ../../src/WXMXformat.cpp:256
 msgid "Produced invalid XML. The erroneous XML data has therefore not been saved but has been put on the clipboard in order to allow debugging it.\n"
@@ -7944,7 +7944,7 @@ msgstr "Szorzat"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:123
 msgid "Product sign"
-msgstr ""
+msgstr "Szorzás jele"
 
 #: ../../src/wxMaximaFrame.cpp:1129
 msgid "Program"
@@ -7968,7 +7968,7 @@ msgstr "Programblokk, nincsenek helyi változók..."
 
 #: ../../src/sidebars/GreekSidebar.cpp:200
 msgid "Psi"
-msgstr ""
+msgstr "Pszí"
 
 #: ../../src/wxMaximaFrame.cpp:1788
 msgid "Push"
@@ -7992,7 +7992,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1910
 msgid "RTF with OMML maths"
-msgstr ""
+msgstr "RTF OMML matematikával"
 
 #: ../../src/MaximaCommandMenus.cpp:207
 msgid "Range radius:"
@@ -8054,7 +8054,7 @@ msgstr "Olvassa el a címtárat"
 
 #: ../../src/sidebars/StatSidebar.cpp:103
 msgid "Read Matrix..."
-msgstr ""
+msgstr "Mátrix beolvasása..."
 
 #: ../../src/MaximaCommandMenus.cpp:4008
 msgid "Read a structure field"
@@ -8070,7 +8070,7 @@ msgstr "Karakter beolvasása"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2488
 msgid "Read config to file"
-msgstr ""
+msgstr "Konfiguráció beolvasása fájlból"
 
 #: ../../src/MaximaCommandMenus.cpp:4405
 msgid "Read environment variable"
@@ -8183,7 +8183,7 @@ msgstr "A Maxima első promptja : %s"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1327
 msgid "Recent files list length:"
-msgstr ""
+msgstr "Jelenlegi fájllista hossza:"
 
 #: ../../src/wxMaximaFrame.cpp:634
 msgid "Recover unsaved"
@@ -8191,7 +8191,7 @@ msgstr "Mentetlen visszaállítása"
 
 #: ../../src/sidebars/MathSidebar.cpp:56
 msgid "Rectform"
-msgstr ""
+msgstr "Alg.-i alak"
 
 #: ../../src/wxMaximaFrame.cpp:1677
 msgid "Recursive Substitute..."
@@ -8215,7 +8215,7 @@ msgstr "Utolsó változtatás visszavonása"
 
 #: ../../src/sidebars/MathSidebar.cpp:71
 msgid "Reduce (tr)"
-msgstr ""
+msgstr "Redukál (tr)"
 
 #: ../../src/wxMaximaFrame.cpp:1632
 msgid "Reduce trigonometric expression"
@@ -8265,11 +8265,11 @@ msgstr "\"%s\" kép újratöltése"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:997
 msgid "Reload all GUI settings from disc"
-msgstr ""
+msgstr "Az összes GUI -beállítás újbóli betöltése a lemezről"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1004
 msgid "Reload the style settings from disc"
-msgstr ""
+msgstr "A stílusbeállítások újbóli betöltése a lemezről"
 
 #: ../../src/MaximaCommandMenus.cpp:3212
 #, c-format
@@ -8278,15 +8278,15 @@ msgstr "%s képfájl újratöltése."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2573
 msgid "Reloading the configuration from disc"
-msgstr ""
+msgstr "A konfiguráció újbóli betöltése lemezről"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2581
 msgid "Reloading the styles from disc"
-msgstr ""
+msgstr "A stílusok újbóli betöltése lemezről"
 
 #: ../../src/sidebars/VariablesPane.cpp:220
 msgid "Remove"
-msgstr ""
+msgstr "Eltávolítás"
 
 #: ../../src/wxMaximaFrame.cpp:917
 msgid "Remove All Output"
@@ -8302,7 +8302,7 @@ msgstr ""
 
 #: ../../src/sidebars/VariablesPane.cpp:225
 msgid "Remove all"
-msgstr ""
+msgstr "Az összes eltávolítása"
 
 #: ../../src/wxMaximaFrame.cpp:1785
 msgid "Remove all list elements that appear twice in a row. Normally used in conjunction with sort."
@@ -8382,7 +8382,7 @@ msgstr "Ismétlődő elemenkénti szorzás"
 
 #: ../../src/dialogs/FindReplacePane.cpp:117
 msgid "Replace All"
-msgstr ""
+msgstr "Mindet cseréli"
 
 #: ../../src/MaximaCommandMenus.cpp:4350
 msgid "Replace all regex matches"
@@ -8411,7 +8411,7 @@ msgstr "%li előfordulás lecserélve."
 
 #: ../../src/dialogs/FindReplacePane.cpp:62
 msgid "Replacement:"
-msgstr ""
+msgstr "Csere:"
 
 #: ../../src/MaximaCommandMenus.cpp:768
 msgid "Replaces the subexpression that part(expr, n_1, n_2, ...) would select by a new value. The part numbers form a path: n_1 selects a part of the expression, n_2 a part of that, and so on."
@@ -8423,7 +8423,7 @@ msgstr "Hibajelentés"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:983
 msgid "Reset all GUI settings"
-msgstr ""
+msgstr "Az összes GUI-beállítás visszaállítása"
 
 #: ../../src/wxMaximaFrame.cpp:1030
 msgid "Reset option variables"
@@ -8431,12 +8431,12 @@ msgstr "Beállításváltozók alaphelyzetbe állítása"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:990
 msgid "Reset the Style settings"
-msgstr ""
+msgstr "A Stílusbeállítások visszaállítása"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2557
 #: ../../src/dialogs/ConfigDialogue.cpp:2565
 msgid "Resetting all configuration settings"
-msgstr ""
+msgstr "Minden konfigurációs beállítás visszaállítása"
 
 #: ../../src/ToolBar.cpp:411 ../../src/ToolBar.cpp:417
 #: ../../src/wxMaximaFrame.cpp:1008
@@ -8526,7 +8526,7 @@ msgstr ""
 
 #: ../../src/wizards/DrawWiz.cpp:836
 msgid "Reuse last"
-msgstr ""
+msgstr "Utolsó újrahasználata"
 
 #: ../../src/wxMaximaFrame.cpp:1780
 msgid "Reverse"
@@ -8542,15 +8542,15 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:295
 msgid "Revert all to defaults"
-msgstr ""
+msgstr "Minden visszaállítása az alapértelmezett értékekre"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:980
 msgid "Revert changes"
-msgstr ""
+msgstr "Utolsó változtatás visszavonása"
 
 #: ../../src/sidebars/GreekSidebar.cpp:194
 msgid "Rho"
-msgstr ""
+msgstr "Ró"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2015
 msgid "Right"
@@ -8563,7 +8563,7 @@ msgstr "Jobb mátrix:"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:127
 msgid "Right arrow"
-msgstr ""
+msgstr "Jobbra nyíl"
 
 #: ../../src/MaximaCommandMenus.cpp:1380
 msgid "Right end"
@@ -8603,7 +8603,7 @@ msgstr "Sorok"
 
 #: ../../src/wizards/MatWiz.cpp:152
 msgid "Rows:"
-msgstr ""
+msgstr "Sorok:"
 
 #: ../../src/MaximaCommandMenus.cpp:1391
 msgid "Rule"
@@ -8673,7 +8673,7 @@ msgstr "Minden egyes elemet egy kifejezésen keresztül futtat"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:223
 msgid "Russian"
-msgstr ""
+msgstr "Orosz"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1578
 msgid "SBCL: use <int>Mbytes of heap"
@@ -8685,11 +8685,11 @@ msgstr ""
 
 #: ../../src/sidebars/XmlInspector.cpp:78
 msgid "SENT TO MAXIMA:"
-msgstr ""
+msgstr "MAXIMÁHOZ KÜLDVE:"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1224
 msgid "SVG graphics"
-msgstr ""
+msgstr "SVG grafika"
 
 #: ../../src/MaximaCommandMenus.cpp:1810
 msgid "Sample 1:"
@@ -8705,19 +8705,19 @@ msgstr "Minta:"
 
 #: ../../src/wizards/DrawWiz.cpp:956
 msgid "Samples for explicit and parametric plots:"
-msgstr ""
+msgstr "Példák explicit és paraméteres ábrákra:"
 
 #: ../../src/wizards/DrawWiz.cpp:969
 msgid "Samples for implicit plots and regions:"
-msgstr ""
+msgstr "Példák implicit ábrákra és tartományokra:"
 
 #: ../../src/wizards/DrawWiz.cpp:937
 msgid "Samples for implicit plots:"
-msgstr ""
+msgstr "Példák implicit ábrákra :"
 
 #: ../../src/wizards/DrawWiz.cpp:924
 msgid "Samples on a line:"
-msgstr ""
+msgstr "Példák egy sorban:"
 
 #: ../../src/ToolBar.cpp:331 ../../src/ToolBar.cpp:334
 #: ../../src/dialogs/ConfigDialogue.cpp:2163 ../../src/wxMaxima.cpp:3507
@@ -8762,7 +8762,7 @@ msgstr "Mentés lisp kódként..."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2478
 msgid "Save config to file"
-msgstr ""
+msgstr "Konfiguráció mentése fájlba"
 
 #: ../../src/ToolBar.cpp:331 ../../src/ToolBar.cpp:334
 #: ../../src/wxMaximaFrame.cpp:639
@@ -8775,7 +8775,7 @@ msgstr "Mentés másként"
 
 #: ../../src/wizards/Plot2dWiz.cpp:473 ../../src/wizards/Plot3dWiz.cpp:421
 msgid "Save plot to file"
-msgstr ""
+msgstr "Kép mentése fájlba"
 
 #: ../../src/wxMaximaFrame.cpp:713
 msgid "Save selection from document to an image file"
@@ -8787,11 +8787,11 @@ msgstr "Kijelölt rész mentése fájlba"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2640
 msgid "Save style to file"
-msgstr ""
+msgstr "Stílus mentése fájlba"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1384
 msgid "Save the worksheet automatically"
-msgstr ""
+msgstr "A munkalapot automatikus mentése"
 
 #: ../../src/MaximaFileIO.cpp:873
 msgid "Saving failed!"
@@ -8807,7 +8807,7 @@ msgstr "A mentés sikerült, de a kapott fájlok eltűntek ?!?."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1914
 msgid "Scalable Vector Graphics (svg)"
-msgstr ""
+msgstr "Skálázható Vektor Grafika (svg)"
 
 #: ../../src/MaximaCommandMenus.cpp:3536
 msgid "Scalable Vector image (*.svg)|*.svg|Compressed Scalable Vector Image (*.svgz)|*.svgz|PNG image (*.png)|*.png|JPEG image (*.jpg)|*.jpg|GIF image (*.gif)|*.gif|Windows bitmap (*.bmp)|*.bmp|"
@@ -8819,7 +8819,7 @@ msgstr "Szóródási pont"
 
 #: ../../src/sidebars/StatSidebar.cpp:88
 msgid "Scatterplot..."
-msgstr ""
+msgstr "Szóródási pont..."
 
 #: ../../src/Autocomplete.cpp:157
 msgid "Scheduling a background task that compiles a new list of autocompletable maxima commands."
@@ -8867,7 +8867,7 @@ msgstr ""
 
 #: ../../src/wizards/DrawWiz.cpp:158
 msgid "See also the speed <-> accuracy button."
-msgstr ""
+msgstr "Lásd még a sebesség <-> pontosság gombot."
 
 #: ../../src/MaximaCommandMenus.cpp:4030
 msgid "Seek to position"
@@ -8883,7 +8883,7 @@ msgstr "Úgy tűnik, hogy a maxima megosztott fájljait tartalmazó csomag nincs
 
 #: ../../src/sidebars/TableOfContents.cpp:511
 msgid "Select"
-msgstr ""
+msgstr "Kijelölés"
 
 #: ../../src/MaximaCommandMenus.cpp:2239
 msgid "Select 2 or 3 files to compare"
@@ -8910,7 +8910,7 @@ msgstr "Részminta kiválasztása"
 #: ../../src/wizards/IntegrateWiz.cpp:208 ../../src/wizards/LimitWiz.cpp:133
 #: ../../src/wizards/SeriesWiz.cpp:105
 msgid "Select a constant"
-msgstr ""
+msgstr "Állandó kiválasztása"
 
 #: ../../src/ToolBar.cpp:390 ../../src/ToolBar.cpp:392
 #: ../../src/wxMaximaFrame.cpp:710
@@ -8931,7 +8931,7 @@ msgstr "Matematikai megjelenítés algoritmusának kiválasztása"
 
 #: ../../src/dialogs/TipOfTheDay.cpp:109
 msgid "Selecting a part of an output and right-clicking on the selection will bring up a menu with convenient functions that will operate on the selection."
-msgstr ""
+msgstr "A kimenetet egy részét kijelölve az egérrel és arra a jobb egérgombbal kattintva egy menüt kapunk a kijelölt részen való lehetséges műveletekkel."
 
 #: ../../src/Styles.cpp:127
 msgid "Selection color"
@@ -9019,7 +9019,7 @@ msgstr "Hosszú lebegőpontos műveletek &pontosságának állítása..."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:479
 msgid "Set fixed font in text controls."
-msgstr ""
+msgstr "Rögzített szélességű betűtípus beállítása a bemeneti sorban."
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:68
 #: ../../src/worksheet/WorksheetContextMenu.cpp:250
@@ -9028,7 +9028,7 @@ msgstr "Állítsa be a képfelbontást"
 
 #: ../../src/dialogs/ResolutionChooser.cpp:29
 msgid "Set image resolution [in ppi]"
-msgstr ""
+msgstr "Képfelbontás beállítása [ppi-ben]"
 
 #: ../../src/wxMaximaFrame.cpp:1547
 msgid "Set main variable..."
@@ -9036,7 +9036,7 @@ msgstr "Fő változó megadása..."
 
 #: ../../src/dialogs/MaxSizeChooser.cpp:29
 msgid "Set maximum image size [in mm]"
-msgstr ""
+msgstr "A maximális képméret beállítása [mm-ben]"
 
 #: ../../src/wxMaximaFrame.cpp:1810
 msgid "Set plot format"
@@ -9096,7 +9096,7 @@ msgstr "Nagyítás beállítása 80%-ra"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:163
 msgid "Sets the language, line ending type and charset encoding programs will use"
-msgstr ""
+msgstr "Beállítja a nyelvet, a sorvégződés típusát és a karakterkészlet-kódolást"
 
 #: ../../src/MaximaEvaluator.cpp:574
 #, c-format
@@ -9109,24 +9109,24 @@ msgstr "A prompt és a súgó formátumának beállítása"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:165
 msgid "Setting this to \"cat\" causes gnuplot not to halt if there is much output"
-msgstr ""
+msgstr "Ha ezt \"cat\" -re állítja, a gnuplot nem áll le, ha sok kimenet van"
 
 #: ../../src/wizards/DrawWiz.cpp:546
 msgid "Settings for the following 3d plots"
-msgstr ""
+msgstr "A következő 3d-s ábrák beállításai"
 
 #: ../../src/wizards/DrawWiz.cpp:462
 #, c-format
 msgid "Setup a %iD scene"
-msgstr ""
+msgstr "A%iD jelenet beállítása"
 
 #: ../../src/sidebars/DrawSidebar.cpp:48
 msgid "Setup a 2D plot"
-msgstr ""
+msgstr "2D-s diagram készítése"
 
 #: ../../src/sidebars/DrawSidebar.cpp:52
 msgid "Setup a 3D plot"
-msgstr ""
+msgstr "3D-s diagram készítése"
 
 #: ../../src/wxMaximaFrame.cpp:1326
 msgid "Setup atvalues for solving ODE with Laplace transformation"
@@ -9138,11 +9138,11 @@ msgstr "Modulus értékének beállítása"
 
 #: ../../src/sidebars/DrawSidebar.cpp:78
 msgid "Setup the axis"
-msgstr ""
+msgstr "A tengely beállítása"
 
 #: ../../src/wizards/DrawWiz.cpp:263
 msgid "Setup the axis for the current plot."
-msgstr ""
+msgstr "A tengely beállítása az aktuális ábrából."
 
 #: ../../src/MaximaCommandMenus.cpp:411
 msgid "Setup the engineering format"
@@ -9190,7 +9190,7 @@ msgstr "Megmutat minden parancsot, ami hasonlít erre:"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:206
 msgid "Show all unicode symbols"
-msgstr ""
+msgstr "Az összes unicode szimbólum megjelenítése"
 
 #: ../../src/MaximaCommandMenus.cpp:2111
 msgid "Show an example for the command:"
@@ -9202,7 +9202,7 @@ msgstr "Példa a parancs használatára"
 
 #: ../../src/sidebars/History.cpp:121
 msgid "Show commands from current session only"
-msgstr ""
+msgstr "Csak az aktuális munkamenet parancsainak megjelenítése"
 
 #: ../../src/wxMaximaFrame.cpp:1921
 msgid "Show commands similar to"
@@ -9238,7 +9238,7 @@ msgstr "Bemeneti címkék megjelenítése"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:766
 msgid "Show labels:"
-msgstr ""
+msgstr "&Címkék megjelenítése:"
 
 #: ../../src/wxMaximaFrame.cpp:787
 msgid "Show lisp representation"
@@ -9246,11 +9246,11 @@ msgstr "Lisp-reprezentáció megjelenítése"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:465
 msgid "Show long expressions in wxMaxima document."
-msgstr ""
+msgstr "A wxMaxima konzolja megjeleníti a hosszú kifejezéseket."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:722
 msgid "Show long expressions:"
-msgstr ""
+msgstr "Hosszú kifejezések megjelenítése:"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:377
 msgid "Show max. 100 digits"
@@ -9314,7 +9314,7 @@ msgstr "Mutassa a visszavonás és ismétlés gombot?"
 
 #: ../../src/dialogs/TipOfTheDay.cpp:288
 msgid "Show tips at Startup"
-msgstr ""
+msgstr "Mutasson tippeket induláskor"
 
 #: ../../src/wxMaximaFrame.cpp:1040 ../../src/wxMaximaFrame.cpp:1045
 msgid "Show used + to-be-freed memory"
@@ -9339,7 +9339,7 @@ msgstr "Oldalsávok"
 
 #: ../../src/sidebars/GreekSidebar.cpp:195
 msgid "Sigma"
-msgstr ""
+msgstr "Szigma"
 
 #: ../../src/dialogs/FindReplacePane.cpp:88
 msgid "Simple"
@@ -9351,7 +9351,7 @@ msgstr ""
 
 #: ../../src/sidebars/MathSidebar.cpp:44
 msgid "Simplify"
-msgstr ""
+msgstr "Egyszerűsít"
 
 #: ../../src/wxMaximaFrame.cpp:1550
 msgid "Simplify &Radicals..."
@@ -9359,11 +9359,11 @@ msgstr "&Gyökös egyszerűsítés..."
 
 #: ../../src/sidebars/MathSidebar.cpp:47
 msgid "Simplify (r)"
-msgstr ""
+msgstr "Egysz. (r)"
 
 #: ../../src/sidebars/MathSidebar.cpp:65
 msgid "Simplify (tr)"
-msgstr ""
+msgstr "Egysz. (tr)"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:352
 msgid "Simplify Expression"
@@ -9403,7 +9403,7 @@ msgstr "Összeg egyszerűsítése"
 
 #: ../../src/wizards/SumWiz.cpp:68
 msgid "Simplify the sum"
-msgstr ""
+msgstr "Egyszerűsíti az összeget"
 
 #: ../../src/wxMaximaFrame.cpp:1629
 msgid "Simplify trigonometric expression"
@@ -9411,7 +9411,7 @@ msgstr "Trigonometrikus kifejezést egyszerűbb alakra hoz"
 
 #: ../../src/dialogs/TipOfTheDay.cpp:139
 msgid "Since wxMaxima 0.8.2 you can also insert images into your documents. Use 'Cell->Insert Image...' menu command."
-msgstr ""
+msgstr "A wxMaxima 0.8.2-es változatától már képeket is be lehet illeszteni a dokumentumba. Ehhez használja a 'Cella->Kép beszúrása...' menüparancsot."
 
 #: ../../src/wxMaximaFrame.cpp:1433
 msgid "Singular Values"
@@ -9443,7 +9443,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2113
 msgid "Slanted"
-msgstr ""
+msgstr "Ferde"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:225
 msgid "Slovak"
@@ -9468,7 +9468,7 @@ msgstr "Az ODE megoldása:"
 
 #: ../../src/wizards/BC2Wiz.cpp:30
 msgid "Solution:"
-msgstr ""
+msgstr "Megoldás:"
 
 #: ../../src/MaximaCommandMenus.cpp:3446
 msgid "Solve"
@@ -9508,7 +9508,7 @@ msgstr "D&ifferenciálegyenlet megoldása (Laplace)..."
 
 #: ../../src/sidebars/MathSidebar.cpp:77
 msgid "Solve ODE..."
-msgstr ""
+msgstr "Differenciálegyenletek megoldása...."
 
 #: ../../src/wxMaximaFrame.cpp:1432
 msgid "Solve a linear equation system using dgesv"
@@ -9615,7 +9615,7 @@ msgstr "Rendezés"
 
 #: ../../src/wizards/ListSortWiz.cpp:41
 msgid "Sort Criterion:"
-msgstr ""
+msgstr "Rendezési feltétel:"
 
 #: ../../src/MaximaCommandMenus.cpp:1500
 msgid "Sort a list"
@@ -9635,16 +9635,16 @@ msgstr "Forrás lista:"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:227
 msgid "Spanish"
-msgstr ""
+msgstr "Spanyol"
 
 #: ../../src/wizards/IntegrateWiz.cpp:44 ../../src/wizards/IntegrateWiz.cpp:50
 #: ../../src/wizards/LimitWiz.cpp:38 ../../src/wizards/SeriesWiz.cpp:39
 msgid "Special"
-msgstr ""
+msgstr "Különleges"
 
 #: ../../src/wizards/DrawWiz.cpp:918
 msgid "Speed versus accuracy"
-msgstr ""
+msgstr "Sebesség vs. pontosság"
 
 #: ../../src/MaximaCommandMenus.cpp:4241
 msgid "Split"
@@ -9672,7 +9672,7 @@ msgstr "Szögletes"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1300
 msgid "Standard Options"
-msgstr ""
+msgstr "Alapértelmezett Beállítások"
 
 #: ../../src/Styles.cpp:115
 msgid "Standard Text"
@@ -9684,7 +9684,7 @@ msgstr "Animáció indítása"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1622
 msgid "Start a new maxima for each re-evaluation"
-msgstr ""
+msgstr "Új Maxima indítása minden újraértékeléshez"
 
 #: ../../src/MaximaCommandMenus.cpp:1023
 msgid "Start of t:"
@@ -9692,15 +9692,15 @@ msgstr "t kezdete"
 
 #: ../../src/wizards/DrawWiz.cpp:66 ../../src/wizards/DrawWiz.cpp:171
 msgid "Start of the x value"
-msgstr ""
+msgstr "Az x érték kezdete"
 
 #: ../../src/wizards/DrawWiz.cpp:83 ../../src/wizards/DrawWiz.cpp:186
 msgid "Start of the y value"
-msgstr ""
+msgstr "Az y érték kezdete"
 
 #: ../../src/wizards/DrawWiz.cpp:203
 msgid "Start of the z value"
-msgstr ""
+msgstr "A z érték kezdete"
 
 #: ../../src/ToolBar.cpp:507 ../../src/ToolBar.cpp:519
 msgid "Start or Stop animation"
@@ -9712,11 +9712,11 @@ msgstr "A kiválasztott, with_slider paranccsal létrehozott animáció indítá
 
 #: ../../src/dialogs/ConfigDialogue.cpp:496
 msgid "Start searching while the phrase to search for is still being typed."
-msgstr ""
+msgstr "Már a keresendő kifejezés gépelése közben elindítja a keresést."
 
 #: ../../src/wizards/DrawWiz.cpp:755
 msgid "Start value of the parameter"
-msgstr ""
+msgstr "A paraméter értékének kezdete"
 
 #: ../../src/wxMaxima.cpp:403
 msgid "Starting Maxima process failed"
@@ -9741,7 +9741,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:286
 msgid "Startup commands"
-msgstr ""
+msgstr "Indítási parancsok"
 
 #: ../../src/wxMaximaFrame.cpp:266
 msgid "Statistics"
@@ -9757,7 +9757,7 @@ msgstr "Lépésszélesség:"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:939
 msgid "Store filenames in image cells to enable image reloading after re-opening the worksheet"
-msgstr ""
+msgstr "A fájlnevek tárolása a képcellákban, hogy lehetővé tegye a kép újratöltését a munkalap újbóli megnyitása után"
 
 #: ../../src/wxMaximaFrame.cpp:831
 msgid "Straight lines"
@@ -9783,7 +9783,7 @@ msgstr "Adatfolyam:"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2117
 msgid "Strike Through"
-msgstr ""
+msgstr "Átütés"
 
 #: ../../src/wxMaximaFrame.cpp:1219
 msgid "String"
@@ -9851,15 +9851,15 @@ msgstr "Struktúrák"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:282
 msgid "Style"
-msgstr ""
+msgstr "Stílus"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2082
 msgid "Styles"
-msgstr ""
+msgstr "Stílusok"
 
 #: ../../src/sidebars/StatSidebar.cpp:112
 msgid "Subsample..."
-msgstr ""
+msgstr "Részminta..."
 
 #: ../../src/ToolBar.cpp:484 ../../src/sidebars/FormatSidebar.cpp:54
 msgid "Subsection"
@@ -9879,7 +9879,7 @@ msgstr "A Subst egy jobb string-keresés-helyettesítés a kifejezésekhez."
 
 #: ../../src/sidebars/MathSidebar.cpp:59
 msgid "Subst..."
-msgstr ""
+msgstr "Behelyet...."
 
 #: ../../src/MaximaCommandMenus.cpp:715 ../../src/MaximaCommandMenus.cpp:3490
 #: ../../src/MaximaCommandMenus.cpp:4500 ../../src/wizards/SubstituteWiz.cpp:53
@@ -9955,7 +9955,7 @@ msgstr "Összeg"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:122
 msgid "Sum sign"
-msgstr ""
+msgstr "Szummajel"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:228
 msgid "Swedish"
@@ -9984,7 +9984,7 @@ msgstr "Szimbólumok\tAlt+Shift+Y"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:472
 msgid "Symbols that are entered or copied here will appear in the symbols sidebar so they can be entered into the worksheet easily."
-msgstr ""
+msgstr "Az ide másolt vagy gépelt szimbólumok meg fognak jelenni a szimbólumok oldalpanelen, így azokat könnyen beilleszthetjük a munkalapokba."
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:778
 msgid "Symmetric function: f(x)=f(-x)"
@@ -10012,7 +10012,7 @@ msgstr "Tartalomjegyzék\tAlt+Shift+T"
 
 #: ../../src/wizards/DrawWiz.cpp:561
 msgid "Take surface color from steepness"
-msgstr ""
+msgstr "A felület színét a meredekségből veszi"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:229
 msgid "Tamil"
@@ -10020,7 +10020,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:196
 msgid "Tau"
-msgstr ""
+msgstr "Tau"
 
 #: ../../src/MaximaCommandMenus.cpp:181
 msgid "Taylor series"
@@ -10056,7 +10056,7 @@ msgstr "Megmondja a maximának, hogy mutassa meg súgót a ?, ?? és a descripti
 
 #: ../../src/dialogs/ConfigDialogue.cpp:148
 msgid "Tells maxima where to store the result of compiling libraries"
-msgstr ""
+msgstr "Megmondja a maximumot, hogy hol tárolja a könyvtárak fordításának eredményétMegmondja a maximának, hogy hol tárolja a könyvtárak fordításának eredményét"
 
 #: ../../src/ToolBar.cpp:481 ../../src/sidebars/FormatSidebar.cpp:45
 msgid "Text"
@@ -10068,7 +10068,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:738
 msgid "Text Only"
-msgstr ""
+msgstr "Csak szöveg"
 
 #: ../../src/Styles.cpp:122
 msgid "Text cell background"
@@ -10076,7 +10076,7 @@ msgstr "Szöveg háttere"
 
 #: ../../src/dialogs/TipOfTheDay.cpp:219
 msgid "Text cells can hold citations that as marked as such by beginning a line with \" > \". The number of spaces in front of the \">\" determines the indentation level, as it does with bullet lists."
-msgstr ""
+msgstr "Ha egy szövegcella a \" > \" jellel kezdődik, az idézetet fog jelenteni. A \">\" jel előtti szóközök száma határozza meg a behúzás mértékét, ahogyan az a felsorolás lista esetében is történt."
 
 #: ../../src/MaximaCommandMenus.cpp:3001
 msgid "Text snippet"
@@ -10099,7 +10099,7 @@ msgstr "A Maxima folyamat nem kínál megosztott memória szegmenst, így küldh
 
 #: ../../src/dialogs/ConfigDialogue.cpp:392
 msgid "The URL MathJaX.js should be downloaded from by our HTML export."
-msgstr ""
+msgstr "Az MathJaX.js URL-t HTML exportálással kell letölteni."
 
 #: ../../src/cells/TextCell.cpp:336
 msgid "The [] or the part() command tried to access a list or matrix element that doesn't exist."
@@ -10107,7 +10107,7 @@ msgstr ""
 
 #: ../../src/sidebars/DrawSidebar.cpp:106
 msgid "The accuracy versus speed tradeoff"
-msgstr ""
+msgstr "Pontosság vs. sebesség"
 
 #: ../../src/cells/TextCell.cpp:357
 msgid "The argument of a function was of the wrong type. Most probably an equation was expected but was lacking an \"=\"."
@@ -10131,7 +10131,7 @@ msgstr "A klasszikus műveletek, amelyekhez általában mátrixokat használunk"
 
 #: ../../src/sidebars/DrawSidebar.cpp:91
 msgid "The color of the next line to draw"
-msgstr ""
+msgstr "A következő vonal színe a rajzoláshoz"
 
 #: ../../src/MaximaCommandMenus.cpp:4005
 msgid "The comma-separated contents of the struct fields"
@@ -10151,48 +10151,48 @@ msgstr "A jelenlegi varázsló"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:415
 msgid "The default height for embedded plots. Can be read out or overridden by the maxima variable wxplot_size."
-msgstr ""
+msgstr "A beágyazott pontok alapértelmezett magassága. A Maxima wxplot_size nevű változója olvashatja vagy átírhatja."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:492
 msgid "The default port used for communication between Maxima and wxMaxima."
-msgstr ""
+msgstr "A Maxima és a wxMaxima közötti kommunikációhoz használt alapértelmezett port.A Maxima és a wxMaxima közötti kommunikáció során használt alapértelmezett port."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:412
 msgid "The default width for embedded plots. Can be read out or overridden by the maxima variable wxplot_size"
-msgstr ""
+msgstr "A beágyazott pontok alapértelmezett szélessége. A Maxima wxplot_size nevű változója olvashatja vagy átírhatja"
 
 #: ../../src/sidebars/DrawSidebar.cpp:74
 msgid "The diagram title"
-msgstr ""
+msgstr "Diagram címe"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2401
 #, c-format
 msgid "The directory %s with maxima's startup file doesn't exist. Trying to create it..."
-msgstr ""
+msgstr "A(z) %s könyvtár a Maxima indítófájljával nem létezik. Megpróbáljuk létrehozni ..."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:150
 msgid "The directory containing the startup files, any user libraries and, if MAXIMA_OBJDIR isn't set the subdirectory with the results from compiling maxima libraries."
-msgstr ""
+msgstr "A könyvtár tartalmazza az indítófájlokat, a felhasználói könyvtárakat, és ha a MAXIMA_OBJDIR nincs beállítva, a maxima könyvtárak fordításának eredményeit tartalmazó alkönyvtárat is."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:154
 msgid "The directory maxima places temporary files in, for example plots that are to be included in the worksheet."
-msgstr ""
+msgstr "A maxima ideiglenes fájlokat helyez el a könyvtárba, például a munkalapon szerepelő ábrákat."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:157
 msgid "The directory the compiled versions of maxima are placed in"
-msgstr ""
+msgstr "A könyvtár, amelyben a maxima lefordított verziói találhatóak"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:159
 msgid "The directory the maxima manual can be found in"
-msgstr ""
+msgstr "A könyvtár, amelyben a maxima kézikönyv található"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:160
 msgid "The directory the user's home directory is in"
-msgstr ""
+msgstr "A könyvtár, amelyben a felhasználó könyvtára található"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:475
 msgid "The document class LaTeX is instructed to use for our documents."
-msgstr ""
+msgstr "Dokumentumjainkhoz a LaTeX dokumentum osztályt használjuk."
 
 #: ../../src/MaximaCommandMenus.cpp:1832
 msgid "The equation to fit the data to"
@@ -10209,7 +10209,7 @@ msgstr ""
 
 #: ../../src/sidebars/DrawSidebar.cpp:96
 msgid "The fill color for the next objects"
-msgstr ""
+msgstr "A következő objektum kitöltőszíne"
 
 #: ../../src/cells/TextCell.cpp:354
 msgid "The first argument of subst() isn't an equation or a list of equations. Most probably it was lacking an \"=\"."
@@ -10221,7 +10221,7 @@ msgstr "Függvényhívás, mely argumentumait ki kell csomagolni"
 
 #: ../../src/sidebars/DrawSidebar.cpp:100
 msgid "The grid in the background of the diagram"
-msgstr ""
+msgstr "A rács a diagram hátterében"
 
 #: ../../src/wxMaximaFrame.cpp:1332
 msgid "The half of the equation that is to the left of the \"=\""
@@ -10255,11 +10255,11 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:223
 msgid "The key combination Shift+Space results in a non-breakable space."
-msgstr ""
+msgstr "A Shift+Space billentyűkombináció eredménye egy el nem törhető szóköz."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:162
 msgid "The list of directories the operating system looks for programs in"
-msgstr ""
+msgstr "Azon könyvtárak listája, amelyekben az operációs rendszer programokat keresA könyvtárak listája, amelyekben az operációs rendszer programokat keres"
 
 #: ../../src/cells/TextCell.cpp:293
 msgid "The list of time-dependent variables to solve to doesn't match the time-dependent variables the list of dgls contains."
@@ -10271,7 +10271,7 @@ msgstr "Az egyes mátrixsorokban található változók listája"
 
 #: ../../src/dialogs/TipOfTheDay.cpp:166
 msgid "The load() command of Maxima versions >5.38 is able to load .wxm files as library of Maxima's commands."
-msgstr ""
+msgstr "Az 5.38-asnál nagyobb verziószámú maxima load() parancsa képes a .wxm fájloknak maxima parancskönyvtárakként való betöltésére."
 
 #: ../../src/wxMaximaFrame.cpp:228
 msgid "The main toolbar"
@@ -10287,7 +10287,7 @@ msgstr "A maxima kézikönyve"
 
 #: ../../src/dialogs/MaxSizeChooser.cpp:59
 msgid "The maximum size for this image. Values <= 0 mean: Unspecified."
-msgstr ""
+msgstr "A kép maximális mérete. Értékek <= 0 jelentés: Meghatározatlan."
 
 #: ../../src/MaximaCommandMenus.cpp:3937
 msgid "The name of a function we don't want to be evaluated here"
@@ -10319,11 +10319,11 @@ msgstr "Az aktuális elemet tartalmazó változó neve"
 
 #: ../../src/sidebars/DrawSidebar.cpp:86
 msgid "The next plot's title"
-msgstr ""
+msgstr "A következő ábra címe"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:494
 msgid "The number of recently opened files that is to be remembered."
-msgstr ""
+msgstr "A jelenleg megnyitott fájlok száma lesz megjegyezve."
 
 #: ../../src/MaximaCommandMenus.cpp:1471
 msgid "The number of the item which is stepped from \"Index Start\" to \"Index End\"."
@@ -10331,16 +10331,16 @@ msgstr "Az \"Index kezdete\"-ről az \"Index vége\"-ig tett lépések száma."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:477
 msgid "The options the document class LaTeX is instructed to use for our documents gets."
-msgstr ""
+msgstr "Dokumentumjainkhoz használható LaTeX dokumentum osztály opciók."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1065
 #: ../../src/dialogs/ConfigDialogue.cpp:1112
 msgid "The part of the output of these commands that isn't declared as \"math\" might be suppressed by wxMaxima. As always maxima commands are required to end in a \";\" or a \"$\""
-msgstr ""
+msgstr "Ezen parancsoknak a kimenetelének azt a részét, melyet nem \"matematikaiként\" deklarálnak, a wxMaxima elhagyhatja, mivel a Maxima parancsoknak a \";\" vagy a \"$\" jelre kell végződniük"
 
 #: ../../src/dialogs/ResolutionChooser.cpp:51
 msgid "The resolution for this image."
-msgstr ""
+msgstr "A kép felbontása."
 
 #: ../../src/cells/TextCell.cpp:182
 msgid "The result was indefinite, which might be infinity, both plus or minus infinity or something additionally potentially involving a complex infinity."
@@ -10402,7 +10402,7 @@ msgstr "A megoldásváltozónak a \n"
 
 #: ../../src/sidebars/DrawSidebar.cpp:58
 msgid "The standard plot command: Plot an equation as a curve"
-msgstr ""
+msgstr "A szokásos plot parancs: egyenletet ábrázolása görbe formájában"
 
 #: ../../src/cells/TextCell.cpp:267
 msgid "The value of few special variables is assigned by Maxima and cannot be changed by the user. Also a few constructs aren't variable names and therefore cannot be written to."
@@ -10438,7 +10438,7 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:95
 msgid "There are many resources about Maxima and wxMaxima on the internet. Visit https://wxMaxima-developers.github.io/wxmaxima/help.html for more information and to find tutorials on using wxMaxima and Maxima."
-msgstr ""
+msgstr "Az Interneten számtalan Maximával és wxMaximával foglalkozó leírás található. További információkért látogassa meg a https://wxMaxima-developers.github.io/wxMaxima/help.html honlapot!"
 
 #: ../../src/dialogs/TipOfTheDay.cpp:251
 msgid "There is a discussion forum for wxMaxima at https://github.com/wxMaxima-developers/wxmaxima/discussions.\n"
@@ -10484,7 +10484,7 @@ msgstr "Hiba volt az XML-ben, amelynek az állapotsor üzenetét kellene leírni
 
 #: ../../src/sidebars/GreekSidebar.cpp:185
 msgid "Theta"
-msgstr ""
+msgstr "Théta"
 
 #: ../../src/dialogs/LicenseDialog.cpp:85
 msgid "Third-party notices"
@@ -10506,7 +10506,7 @@ msgstr "Ezt a fájlt a wxMaxima állítja elő\n"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1097
 msgid "This file won't be read by maxima if maxima is used without wxMaxima. In order to add startup commands that are executed in this case, too, please add them to maxima-init.mac, instead."
-msgstr ""
+msgstr "Ez a fájl nem olvasható a Maxima által, ha a Maximát a wxMaxima nélkül használja. Az ebben az esetben végrehajtott indítási parancsok hozzáadásához kérjük, adja hozzá azokat a Maxima-init.mac fájlhoz."
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:764
 msgid "This function will return even integers"
@@ -10539,7 +10539,7 @@ msgstr ""
 #: ../../src/wizards/DrawWiz.cpp:471
 #, c-format
 msgid "This wizard setups a %iD scene."
-msgstr ""
+msgstr "Ez a varázsló létrehoz egy %iD jelenetet."
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:752
 msgid "Throw an error if this symbol is used before assigning it any contents"
@@ -10547,11 +10547,11 @@ msgstr "Ha ezt a szimbólumot használja, adjon meg egy hibát, mielőtt bármil
 
 #: ../../src/wizards/Plot2dWiz.cpp:65 ../../src/wizards/Plot2dWiz.cpp:505
 msgid "Ticks:"
-msgstr ""
+msgstr "Törésvonalak:"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1359
 msgid "Time [in Minutes] between autosaves"
-msgstr ""
+msgstr "Idő [percben] az automatikus mentések között"
 
 #: ../../src/MaximaCommandMenus.cpp:267 ../../src/MaximaCommandMenus.cpp:3487
 msgid "Times:"
@@ -10559,7 +10559,7 @@ msgstr "Ennyiszer:"
 
 #: ../../src/dialogs/TipOfTheDay.cpp:49 ../../src/dialogs/TipOfTheDay.cpp:267
 msgid "Tip of the day"
-msgstr ""
+msgstr "A nap tippje"
 
 #: ../../src/ToolBar.cpp:482 ../../src/sidebars/FormatSidebar.cpp:48
 msgid "Title"
@@ -10575,7 +10575,7 @@ msgstr "Címcella (1. fejléc)"
 
 #: ../../src/dialogs/TipOfTheDay.cpp:89
 msgid "Title, section and subsection cells can be folded to hide their contents. To fold or unfold, click in the square next to the cell. If you shift-click, all sublevels of that cell will also fold/unfold."
-msgstr ""
+msgstr "A cím- , fejezet- és alfejezetcellák tartalma elrejthető/megjeleníthető, ha rákattint a sor elején látható négyzetre. A Shift+kattintás kombinációval az adott cella alatti összes tartalom láthatóvá válik."
 
 #: ../../src/wxMaximaFrame.cpp:1831
 msgid "To &Bigfloat"
@@ -10603,19 +10603,19 @@ msgstr "Pontos számra"
 
 #: ../../src/dialogs/TipOfTheDay.cpp:124
 msgid "To plot in polar coordinates, select 'set polar' in the Options entry for Plot2d dialog. You can also plot in spherical and cylindrical coordinates in 3D."
-msgstr ""
+msgstr "Polár koordinátás ábrázolásmódhoz válasszuk a 'set polar' opciót a kétdimenziós ábrázolás 'Beállítások:' menüjében. 3D-ben szférikus (spherical) vagy cilindrikus (cylindrical) ábrázolásmódot is választhatunk."
 
 #: ../../src/dialogs/TipOfTheDay.cpp:131
 msgid "To put parentheses around an expression, select it, and press '(' or ')' depending on where you want the cursor to appear afterwards."
-msgstr ""
+msgstr "Ha egy kifejezést zárójelbe szeretnénk rakni, jelöljük ki azt, majd nyomjuk meg a '(' vagy ')' zárójelek egyikét, aszerint, hogy a művelet végrehajtása után a kifejezés előtt, vagy után szeretnénk a kurzort megjeleníteni."
 
 #: ../../src/dialogs/TipOfTheDay.cpp:137
 msgid "To save the size and position of wxMaxima windows between session, use 'Edit->Configure' dialog."
-msgstr ""
+msgstr "A wxMaxima ablak méretének és pozíciójának mentéséhez jelölje ki a megfelelő opciót a 'Szerkesztés->Beállítás' ablakban."
 
 #: ../../src/dialogs/TipOfTheDay.cpp:51
 msgid "To start using wxMaxima right away, start typing your command. An input cell should appear. Then press Shift-Enter to evaluate your command."
-msgstr ""
+msgstr "A wxMaxima használatához csak el kell kezdeni gépelni a végrehajtani kívánt parancsot. Az első billentyű leütésekor egy bemeneti cella fog megjelenni. A parancs végrehajtásához nyomjunk Shift+Enter-t."
 
 #: ../../src/MaximaCommandMenus.cpp:318 ../../src/wizards/IntegrateWiz.cpp:47
 #: ../../src/wizards/Plot2dWiz.cpp:51 ../../src/wizards/Plot2dWiz.cpp:61
@@ -10626,7 +10626,7 @@ msgstr "Meddig:"
 
 #: ../../src/sidebars/TableOfContents.cpp:579
 msgid "Toc levels shown here"
-msgstr ""
+msgstr "Toc szintek láthatók itt"
 
 #: ../../src/wxMaximaFrame.cpp:862 ../../src/wxMaximaFrame.cpp:865
 msgid "Toggle full screen editing"
@@ -10799,7 +10799,7 @@ msgstr "Kísérlet a socket elindítására, amelyhez a helyi gépen futó Maxim
 
 #: ../../src/dialogs/ConfigDialogue.cpp:230
 msgid "Turkish"
-msgstr ""
+msgstr "Török"
 
 #: ../../src/wxMaximaFrame.cpp:1965
 msgid "Tutorials"
@@ -10815,7 +10815,7 @@ msgstr "Típus"
 
 #: ../../src/cells/EditorCell.cpp:4550
 msgid "Type in text"
-msgstr ""
+msgstr "Gépelés szövegbe"
 
 #: ../../src/MaximaCommandMenus.cpp:3992 ../../src/wizards/MatWiz.cpp:158
 msgid "Type:"
@@ -10835,7 +10835,7 @@ msgstr "UTF8 to Unicode kódpont..."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:231
 msgid "Ukrainian"
-msgstr ""
+msgstr "Ukrán"
 
 #: ../../src/wxMaxima.cpp:3164
 msgid "Un-closed parenthesis"
@@ -10862,15 +10862,15 @@ msgstr "Definíció megszüntetése"
 #: ../../src/sidebars/VariablesPane.cpp:303
 #: ../../src/sidebars/VariablesPane.cpp:386
 msgid "Undefined"
-msgstr ""
+msgstr "Nem definiált"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2115
 msgid "Underlined"
-msgstr ""
+msgstr "Aláhúzott"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:745
 msgid "Underscore converts to subscripts:"
-msgstr ""
+msgstr "Aláhúzást indexszé alakítja:"
 
 #: ../../src/ToolBar.cpp:354 ../../src/ToolBar.cpp:357
 msgid "Undo"
@@ -10903,7 +10903,7 @@ msgstr "Minden fejezet megjelenítése"
 
 #: ../../src/sidebars/TableOfContents.cpp:507
 msgid "Unhide"
-msgstr ""
+msgstr "Megmutat"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:665
 msgid "Unhide Heading 5"
@@ -10959,7 +10959,7 @@ msgstr "Unicode kódpont utf8 számokra"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:180
 msgid "Unicode symbols:"
-msgstr ""
+msgstr "Unicode szimbólumok:"
 
 #: ../../src/MaximaCommandMenus.cpp:3890
 msgid "Unlike in other programming language return() only exits from the current loop or block(), not from the whole function."
@@ -10975,11 +10975,11 @@ msgstr "Befejezetlen szöveg."
 
 #: ../../src/wizards/ActualValuesStorageWiz.cpp:43
 msgid "Until then the actual values for all variables can be kept in a list."
-msgstr ""
+msgstr "Amíg az összes változó tényleges értékeit meg lehet tartani egy listában."
 
 #: ../../src/dialogs/DiffFrame.cpp:429 ../../src/dialogs/FindReplacePane.cpp:80
 msgid "Up"
-msgstr ""
+msgstr "Fel"
 
 #: ../../src/MaximaEvaluator.cpp:629
 msgid "Updating maxima's configuration"
@@ -11002,7 +11002,7 @@ msgstr "Felső végpont:"
 
 #: ../../src/sidebars/GreekSidebar.cpp:197
 msgid "Upsilon"
-msgstr ""
+msgstr "Üpszilon"
 
 #: ../../src/wxMaximaFrame.cpp:829
 msgid "Use \"<\" and \">\" as parenthesis for matrices"
@@ -11014,7 +11014,7 @@ msgstr ""
 
 #: ../../src/wizards/SumWiz.cpp:69
 msgid "Use Gosper algorithm"
-msgstr ""
+msgstr "Gosper algoritmus használata"
 
 #: ../../src/sidebars/RegexCtrl.cpp:133
 msgid "Use RegEx filtering"
@@ -11038,11 +11038,11 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:485
 msgid "Use centered dot and Minus, not Star and Hyphen"
-msgstr ""
+msgstr "Középre helyezett pont és mínuszjel használata csillag és kötőjel helyett"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:849
 msgid "Use centered dot character for multiplication"
-msgstr ""
+msgstr "Középre helyezett pont használata szorzásjelként"
 
 #: ../../src/wxMaximaFrame.cpp:1745
 msgid "Use list"
@@ -11066,11 +11066,11 @@ msgstr "Struktúra mező használata..."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:425
 msgid "Use the \"partial derivative\" symbol to represent the fraction that represents a diff() when exporting LaTeX"
-msgstr ""
+msgstr "A \"parciális derivált\" szimbólumának megjelenítése a diff() használata során, amikor LaTeX-be mentünk"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2052
 msgid "Use unicode Math Symbols, if available"
-msgstr ""
+msgstr "Unicode matematikai szimbólumok használata, amit az lehetséges"
 
 #: ../../src/wxMaximaFrame.cpp:832
 msgid "Use vertical lines instead of parenthesis for matrices"
@@ -11085,7 +11085,7 @@ msgstr "Csak a felhasználó által definiált címkék"
 #: ../../src/dialogs/ConfigDialogue.cpp:1480
 #: ../../src/dialogs/MaximaNotStartingDialog.cpp:54
 msgid "User specified"
-msgstr ""
+msgstr "Felhasználó által meghatározott"
 
 #: ../../src/Styles.cpp:110
 msgid "User-defined labels"
@@ -11093,7 +11093,7 @@ msgstr "Felhasználó által definiált címkék"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:770
 msgid "User-defined labels if available"
-msgstr ""
+msgstr "Felhasználó által definiált címkék, amennyiben elérhetőek"
 
 #: ../../src/MaximaManual.cpp:500
 msgid "Using Maxima help file from wxMaxima configuration file (helpFile=...))"
@@ -11131,7 +11131,7 @@ msgstr "Ellenőrzi, hogy a dokumentum XML-reprezentációja valóban érvényes 
 #: ../../src/dialogs/ConfigDialogue.cpp:542
 #: ../../src/wizards/ActualValuesStorageWiz.cpp:49
 msgid "Value"
-msgstr ""
+msgstr "Érték"
 
 #: ../../src/MaximaCommandMenus.cpp:756
 msgid "Value at a given point"
@@ -11171,15 +11171,15 @@ msgstr "Változó"
 
 #: ../../src/wizards/DrawWiz.cpp:61 ../../src/wizards/DrawWiz.cpp:166
 msgid "Variable for the x value"
-msgstr ""
+msgstr "Változó az x értékhez"
 
 #: ../../src/wizards/DrawWiz.cpp:78 ../../src/wizards/DrawWiz.cpp:181
 msgid "Variable for the y value"
-msgstr ""
+msgstr "Változó az y értékhez"
 
 #: ../../src/wizards/DrawWiz.cpp:198
 msgid "Variable for the z value"
-msgstr ""
+msgstr "Változó a z értékhez"
 
 #: ../../src/MaximaCommandMenus.cpp:1586 ../../src/MaximaCommandMenus.cpp:2990
 #: ../../src/MaximaCommandMenus.cpp:2996
@@ -11227,7 +11227,7 @@ msgstr "Változók:"
 
 #: ../../src/sidebars/StatSidebar.cpp:58
 msgid "Variance..."
-msgstr ""
+msgstr "Szórásnégyzet..."
 
 #: ../../src/WXMXformat.cpp:339
 msgid "Verified that we are able to read the whole .zip archive we produced."
@@ -11255,7 +11255,7 @@ msgstr "Várakozás a maxima kézikönyvet elemző szál befejezésére"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1410
 msgid "Warn if an inactive window is idle"
-msgstr ""
+msgstr "Figyelmeztetés, ha egy inaktív ablak tétlen"
 
 #: ../../src/MathParser.cpp:1343 ../../src/MaximaFileIO.cpp:536
 #: ../../src/MaximaResponseReader.cpp:361 ../../src/wxMaxima.cpp:1583
@@ -11275,7 +11275,7 @@ msgstr "Figyelmeztetés: A(z) %s nem hozható létre, a könyvtár maxima megőr
 
 #: ../../src/cells/GroupCell.cpp:400 ../../src/cells/GroupCell.cpp:406
 msgid "Warning: Lookalike chars: "
-msgstr ""
+msgstr "Figyelmeztetés: Hasonmás karakterek:"
 
 #: ../../src/wxMaximaFrame.cpp:1583
 msgid "Warning: No test if the argument of the log is complex, positive or negative"
@@ -11300,7 +11300,7 @@ msgstr "Mit kell tenni:"
 
 #: ../../src/dialogs/TipOfTheDay.cpp:134
 msgid "When applying functions with one argument from menus, the default argument is '%'. To apply the function to some other value, select it in the document before executing a menu command."
-msgstr ""
+msgstr "Ha egy egy bemeneti értékkel működő függvényt választunk ki a menük közül, annak argumentuma a '%' lesz. Ha mást szeretnénk bemeneti értékként, jelöljük ki azt a parancs végrehajtása előtt."
 
 #: ../../src/wxMaximaFrame.cpp:1092
 msgid "When to invoke the lisp compiler's debugger"
@@ -11316,7 +11316,7 @@ msgstr "Míg a hurok..."
 
 #: ../../src/dialogs/TipOfTheDay.cpp:243
 msgid "While wxMaxima is programmed mostly in C++, it also uses some Lisp code. You can help to improve wxMaxima, if you have knowledge of Common Lisp."
-msgstr ""
+msgstr "Bár a wxMaxima többnyire C++ nyelven van programozva, némi Lisp kódot is használ. Segíthet a wxMaxima fejlesztésében, ha ismeri a Common Lisp-et."
 
 #: ../../src/MaximaFileIO.cpp:780
 msgid "Whole document (*.wxmx)|*.wxmx|The input, readable by load() (maxima > 5.38) (*.wxm)|*.wxm|All Files (*.*)|*"
@@ -11328,7 +11328,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:280
 msgid "Worksheet"
-msgstr ""
+msgstr "Munkalap"
 
 #: ../../src/MaximaResponseReader.cpp:117
 #, c-format
@@ -11349,7 +11349,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:428
 msgid "Wrap equations exported by the \"copy as LaTeX\" feature between \\[ and \\] as equation markers"
-msgstr ""
+msgstr "A \"LaTeX másolás\" \\[ és \\] jelek közé rakja a kifejezéseket"
 
 #: ../../src/worksheet/Worksheet.cpp:5190
 msgid "Wrapped search"
@@ -11371,7 +11371,7 @@ msgstr "Megírta a MIME-típus adatait"
 #: ../../src/wizards/DrawWiz.cpp:961 ../../src/wizards/DrawWiz.cpp:974
 #: ../../src/wizards/DrawWiz.cpp:977
 msgid "X"
-msgstr ""
+msgstr "X"
 
 #: ../../src/MathParser.cpp:1279
 msgid "XML nesting limit exceeded"
@@ -11379,35 +11379,35 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:191
 msgid "Xi"
-msgstr ""
+msgstr "Kszí"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:728
 msgid "Yes"
-msgstr ""
+msgstr "Igen"
 
 #: ../../src/dialogs/TipOfTheDay.cpp:64
 msgid "You can access the last output using the variable '%'. You can access the output of previous commands using variables '%on' where n is the number of output."
-msgstr ""
+msgstr "Az előző parancs kimenetére a '%' jellel, valamely korábbi kimenetre pedig a '%on' változó használatával hivatkozhatunk, ahol n annak száma."
 
 #: ../../src/dialogs/TipOfTheDay.cpp:118
 msgid "You can evaluate your whole document by using 'Cell->Evaluate All Cells' menu command or the appropriate key shortcut. The cells will be evaluated in the order they appear in the document."
-msgstr ""
+msgstr "A dokumentum összes parancsának végrehajtása a 'Cellák->Minden cella újraszámolása' menü parancs vagy a megfelelő gyorsbillentyű kombináció segítségével történhet. A cellák parancsainak végrehajtása a dokumentumban való elhelyezkedésük sorrendjében fog megtörténni."
 
 #: ../../src/dialogs/TipOfTheDay.cpp:98
 msgid "You can get help on a Maxima function by selecting or clicking on the function name and pressing F1. wxMaxima will search the help index for the selection or the word under the cursor."
-msgstr ""
+msgstr "A Maxima egy függvényéről segítséget kaphatunk, ha kijelöljük vagy rákattintunk a nevére, majd megnyomjuk az F1-et. A wxMaxima meg fogja keresni a kijelölt, vagy a kurzor alatti szöveg 'Tartalom mutató'-ját a Súgóban."
 
 #: ../../src/dialogs/TipOfTheDay.cpp:92
 msgid "You can hide output part of cells by clicking in the triangle on the left side of cells. This works on text cells also."
-msgstr ""
+msgstr "Elrejthetjük a cellák kimeneti részét, ha bal oldalukon lévő háromszögre kattintunk. Ez az eljárás szövegcellák esetén is működik."
 
 #: ../../src/dialogs/TipOfTheDay.cpp:81
 msgid "You can insert different types of 'cells' in wxMaxima documents using the 'Cell' menu. Note that only 'input cells' can be evaluated, while others are used for commenting and structuring your calculations."
-msgstr ""
+msgstr "A 'Cellák' menü használatával különböző típusú cellákat illeszthetünk be. Fontos tudni, hogy csak az 'Új bemeneti cella' használatával jutunk parancs végrehajtására alkalmas cellához, a többi segítségével megjegyzéseket szúrhatunk be, illetve tagolhatjuk dokumentumunkat."
 
 #: ../../src/dialogs/TipOfTheDay.cpp:112
 msgid "You can select multiple cells either with a mouse - click'n'drag from between cells or from a cell bracket on the left - or with a keyboard - hold down Shift while moving the horizontal cursor - and then operate on selection. This comes in handy when you want to delete or evaluate multiple cells."
-msgstr ""
+msgstr "Egy cellán belül akár több sort is kiválaszthatunk egérrel - kattintva, majd a bal egérgombot lenyomva tartva az egeret mozgatva, vagy a cella bal oldalán lévő cellazárójelre kattintva - vagy a billentyűzet segítségével - a Shift gombot lenyomva tartva a vízszintes kurzort mozgatva. Ez nagyon hasznos, ha többsoros cellák parancsait akarjuk végrehajtani vagy tartalmukat törölni."
 
 #: ../../src/dialogs/TipOfTheDay.cpp:232
 msgid "You found a bug in wxMaxima? Please report it at https://github.com/wxMaxima-developers/wxmaxima/issues\n"
@@ -11417,7 +11417,7 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:238
 msgid "You got an idea for an improvement of wxMaxima? Great! Please submit your idea at https://github.com/wxMaxima-developers/wxmaxima/issues. "
-msgstr ""
+msgstr "Van ötlete a wxMaxima fejlesztésére? Nagyszerű! Kérjük, mutassa be a https://github.com/wxMaxima-developers/wxmaxima/issues címen. "
 
 #: ../../src/wxMaxima.cpp:3402 ../../src/wxMaxima.cpp:3456
 #, c-format
@@ -11435,7 +11435,7 @@ msgstr "A wxMaxima verzió a lehető legfrissebb."
 
 #: ../../src/sidebars/GreekSidebar.cpp:183
 msgid "Zeta"
-msgstr ""
+msgstr "Dzéta"
 
 #: ../../src/wxMaximaFrame.cpp:842
 msgid "Zoom &In\tCtrl++"
@@ -11463,11 +11463,11 @@ msgstr "[ mentetlen* ]"
 
 #: ../../src/wizards/DrawWiz.cpp:819 ../../src/wizards/DrawWiz.cpp:825
 msgid "[[x_1,x_2,...],[y_1,y_2,...]]"
-msgstr ""
+msgstr "[[x_1,x_2,...],[y_1,y_2,...]]"
 
 #: ../../src/wizards/DrawWiz.cpp:814
 msgid "[x_1, x_2,...] or [x_1, x_2,...],[y_1, y_2,...] or matrix([x_1,y_1],[x_2,y_2],...)"
-msgstr ""
+msgstr "[x_1, x_2,...] vagy [x_1, x_2,...],[y_1, y_2,...] vagy matrix([x_1,y_1],[x_2,y_2],...)"
 
 #: ../../src/wizards/ListSortWiz.cpp:46
 msgid "a<b (Maxima default)"
@@ -11475,15 +11475,15 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:151
 msgid "alpha"
-msgstr ""
+msgstr "alfa"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:95
 msgid "and"
-msgstr ""
+msgstr "és"
 
 #: ../../src/wizards/MatWiz.cpp:160
 msgid "antisymmetric"
-msgstr ""
+msgstr "antiszimmetrikus"
 
 #: ../../src/wxMaximaFrame.cpp:1727
 msgid "apply function to each element"
@@ -11507,11 +11507,11 @@ msgstr "a változók tényleges értékeinek tárolása"
 
 #: ../../src/sidebars/GreekSidebar.cpp:152
 msgid "beta"
-msgstr ""
+msgstr "béta"
 
 #: ../../src/wizards/LimitWiz.cpp:42
 msgid "both sides"
-msgstr ""
+msgstr "két oldalról"
 
 #: ../../src/wxMaximaFrame.cpp:1173
 msgid "char to Ascii code..."
@@ -11519,7 +11519,7 @@ msgstr "char - Ascii kód..."
 
 #: ../../src/sidebars/GreekSidebar.cpp:172
 msgid "chi"
-msgstr ""
+msgstr "khí"
 
 #: ../../src/MaximaFileIO.cpp:318
 #, c-format
@@ -11529,15 +11529,15 @@ msgstr ""
 #: ../../src/wizards/Plot2dWiz.cpp:70 ../../src/wizards/Plot2dWiz.cpp:372
 #: ../../src/wizards/Plot3dWiz.cpp:61 ../../src/wizards/Plot3dWiz.cpp:358
 msgid "default"
-msgstr ""
+msgstr "alapértelmezett"
 
 #: ../../src/sidebars/GreekSidebar.cpp:154
 msgid "delta"
-msgstr ""
+msgstr "delta"
 
 #: ../../src/wizards/MatWiz.cpp:159
 msgid "diagonal"
-msgstr ""
+msgstr "átlós"
 
 #: ../../src/cells/FracCell.cpp:73
 msgid "diff(): Cannot find the multiplication sign I should hide"
@@ -11553,19 +11553,19 @@ msgstr "végrehajt egy parancsot a lista egyes elemeihez"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:92
 msgid "empty"
-msgstr ""
+msgstr "üres"
 
 #: ../../src/sidebars/GreekSidebar.cpp:155
 msgid "epsilon"
-msgstr ""
+msgstr "epszilon"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:100
 msgid "equivalent"
-msgstr ""
+msgstr "ekvivalens"
 
 #: ../../src/sidebars/GreekSidebar.cpp:157
 msgid "eta"
-msgstr ""
+msgstr "éta"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:799
 msgid "ev() shall evaluate this automatically"
@@ -11573,7 +11573,7 @@ msgstr "Az ev() ezt automatikusan kiértékeli"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:88
 msgid "exists"
-msgstr ""
+msgstr "létezik"
 
 #: ../../src/MaximaCommandMenus.cpp:3942
 msgid "expression:"
@@ -11615,11 +11615,11 @@ msgstr "függvény"
 
 #: ../../src/sidebars/GreekSidebar.cpp:153
 msgid "gamma"
-msgstr ""
+msgstr "gamma"
 
 #: ../../src/wizards/MatWiz.cpp:159
 msgid "general"
-msgstr ""
+msgstr "általános"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1630
 msgid "gnuplot: Without command console"
@@ -11627,11 +11627,11 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:118
 msgid "greater than or equal"
-msgstr ""
+msgstr "nagyobb vagy egyenlő"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:87
 msgid "in"
-msgstr ""
+msgstr "ban"
 
 #: ../../src/wxMaximaFrame.cpp:784
 msgid "in 2D"
@@ -11642,31 +11642,31 @@ msgstr "2D-sen"
 #: ../../src/wizards/Plot3dWiz.cpp:61 ../../src/wizards/Plot3dWiz.cpp:194
 #: ../../src/wizards/Plot3dWiz.cpp:358 ../../src/wizards/Plot3dWiz.cpp:386
 msgid "inline"
-msgstr ""
+msgstr "sorok között"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:104
 msgid "intersection"
-msgstr ""
+msgstr "metszet"
 
 #: ../../src/sidebars/GreekSidebar.cpp:159
 msgid "iota"
-msgstr ""
+msgstr "ióta"
 
 #: ../../src/sidebars/GreekSidebar.cpp:160
 msgid "kappa"
-msgstr ""
+msgstr "kappa"
 
 #: ../../src/sidebars/GreekSidebar.cpp:161
 msgid "lambda"
-msgstr ""
+msgstr "lambda"
 
 #: ../../src/wizards/LimitWiz.cpp:42
 msgid "left"
-msgstr ""
+msgstr "balról"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:117
 msgid "less or equal"
-msgstr ""
+msgstr "kisebb vagy egyenlő"
 
 #: ../../src/MaximaCommandMenus.cpp:1567
 msgid "list"
@@ -11674,11 +11674,11 @@ msgstr "lista"
 
 #: ../../src/wizards/Plot2dWiz.cpp:54 ../../src/wizards/Plot2dWiz.cpp:64
 msgid "logscale"
-msgstr ""
+msgstr "logaritmikus skála"
 
 #: ../../src/wizards/DrawWiz.cpp:822
 msgid "matrix([x_1,x_2,...],[y_1,y_2,...])"
-msgstr ""
+msgstr "matrix([x_1,x_2,...],[y_1,y_2,...])"
 
 #: ../../src/wxMaximaFrame.cpp:1439
 msgid "max(abs(A(i,j))) (complex)"
@@ -11690,15 +11690,15 @@ msgstr "max(abs(A(i,j))) (valós)"
 
 #: ../../src/sidebars/GreekSidebar.cpp:162
 msgid "mu"
-msgstr ""
+msgstr "mű"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:120
 msgid "much greater than"
-msgstr ""
+msgstr "sokkal nagyobb"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:119
 msgid "much less than"
-msgstr ""
+msgstr "sokkal kevesebb"
 
 #: ../../src/MaximaCommandMenus.cpp:1232
 msgid "m×n Matrix A:"
@@ -11711,35 +11711,35 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:112
 msgid "nabla sign"
-msgstr ""
+msgstr "nabla jel"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:98
 msgid "nand"
-msgstr ""
+msgstr "negált és"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:772
 msgid "nary: f(x, f(y,z)) = foo(x,y,z)"
-msgstr ""
+msgstr "nary: f(x, f(y,z)) = foo(x,y,z)"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:99
 msgid "nor"
-msgstr ""
+msgstr "negált vagy"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:102
 msgid "not"
-msgstr ""
+msgstr "nem"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:116
 msgid "not bytewise identical"
-msgstr ""
+msgstr "nem bájtonként azonos"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:108
 msgid "not subset"
-msgstr ""
+msgstr "nem részhalmaza"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:107
 msgid "not subset or equal"
-msgstr ""
+msgstr "nem részhalmaza vagy egyenlő"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:796
 msgid "noun: Not evaluated by default"
@@ -11751,7 +11751,7 @@ msgstr "n-edik"
 
 #: ../../src/sidebars/GreekSidebar.cpp:163
 msgid "nu"
-msgstr ""
+msgstr "nű"
 
 #: ../../src/MaximaCommandMenus.cpp:1233
 msgid "n×1 Matrix b:"
@@ -11759,15 +11759,15 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:174
 msgid "omega"
-msgstr ""
+msgstr "ómega"
 
 #: ../../src/sidebars/GreekSidebar.cpp:165
 msgid "omicron"
-msgstr ""
+msgstr "omikron"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:96
 msgid "or"
-msgstr ""
+msgstr "vagy"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:793
 msgid "outative: f(2*x) = 2*f(x)"
@@ -11784,19 +11784,19 @@ msgstr "rész:"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:111
 msgid "partial sign"
-msgstr ""
+msgstr "parciális jele"
 
 #: ../../src/sidebars/GreekSidebar.cpp:171
 msgid "phi"
-msgstr ""
+msgstr "fí"
 
 #: ../../src/sidebars/GreekSidebar.cpp:166
 msgid "pi"
-msgstr ""
+msgstr "pí"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:101
 msgid "plus or minus"
-msgstr ""
+msgstr "plusz vagy mínusz"
 
 #: ../../src/MaximaCommandMenus.cpp:196
 msgid "point:"
@@ -11821,11 +11821,11 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:115
 msgid "proportional to"
-msgstr ""
+msgstr "aránylik"
 
 #: ../../src/sidebars/GreekSidebar.cpp:173
 msgid "psi"
-msgstr ""
+msgstr "pszí"
 
 #: ../../src/MaximaCommandMenus.cpp:642
 msgid "radcan() is a powerful tools for simplification trigonometric functions but needs to be taken with care: If a function has more than one branch radcan uses the one that looks like it would fit best, not necessarily the one that makes sense for the problem that resulted in the Expression that is to be simplified."
@@ -11853,31 +11853,31 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:167
 msgid "rho"
-msgstr ""
+msgstr "ró"
 
 #: ../../src/wizards/LimitWiz.cpp:42
 msgid "right"
-msgstr ""
+msgstr "jobbról"
 
 #: ../../src/wizards/DrawWiz.cpp:310
 msgid "secondary x axis label"
-msgstr ""
+msgstr "másodlagos x tengely címkéje"
 
 #: ../../src/wizards/DrawWiz.cpp:315
 msgid "secondary x range (automatic if incomplete)"
-msgstr ""
+msgstr "másodlagos x tartomány (automatikus, ha nem teljes)"
 
 #: ../../src/wizards/DrawWiz.cpp:325
 msgid "secondary y axis label"
-msgstr ""
+msgstr "másodlagos y tengely címkéje"
 
 #: ../../src/wizards/DrawWiz.cpp:330
 msgid "secondary y range (automatic if incomplete)"
-msgstr ""
+msgstr "másodlagos y tartomány (automatikus, ha nem teljes)"
 
 #: ../../src/sidebars/GreekSidebar.cpp:168
 msgid "sigma"
-msgstr ""
+msgstr "szigma"
 
 #: ../../src/MaximaCommandMenus.cpp:3447
 msgid "solve() will solve a list of equations only if for n independent equations there are n variables to solve to.\n"
@@ -11900,19 +11900,19 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:81
 msgid "sqrt (needs parenthesis for its argument to work as a Maxima command)"
-msgstr ""
+msgstr "sqrt (zárójelre van szüksége ahhoz, hogy az argumentum Maxima parancsként működjön)sqrt (hogy maxima parancsként működjön, az argumentumát zárójelbe kell rakni)"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:106
 msgid "subset"
-msgstr ""
+msgstr "részhalmaz"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:105
 msgid "subset or equal"
-msgstr ""
+msgstr "részhalmaz vagy egyenlő"
 
 #: ../../src/wizards/MatWiz.cpp:160
 msgid "symmetric"
-msgstr ""
+msgstr "szimmetrikus"
 
 #: ../../src/MaximaCommandMenus.cpp:970
 msgid "t:"
@@ -11920,7 +11920,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:169
 msgid "tau"
-msgstr ""
+msgstr "tau"
 
 #: ../../src/cells/TextCell.cpp:340
 msgid "the [] operator tried to extract an element of a list, a matrix, an equation or an array. But instead of an integer number something was used whose numerical value is unknown or not an integer.\n"
@@ -11929,31 +11929,31 @@ msgstr ""
 
 #: ../../src/wizards/DrawWiz.cpp:725
 msgid "the x and the y coordinate."
-msgstr ""
+msgstr "x és y koordináta."
 
 #: ../../src/wizards/DrawWiz.cpp:729
 msgid "the x, the y and the z coordinate."
-msgstr ""
+msgstr "x, y és z koordináta."
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:89
 msgid "there is no"
-msgstr ""
+msgstr "nincs"
 
 #: ../../src/sidebars/GreekSidebar.cpp:158
 msgid "theta"
-msgstr ""
+msgstr "théta"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:78
 msgid "to the power of 2"
-msgstr ""
+msgstr "négyzetre emel"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:79
 msgid "to the power of 3"
-msgstr ""
+msgstr "köbre emel"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:103
 msgid "union"
-msgstr ""
+msgstr "unió"
 
 #: ../../src/wxMaximaFrame.cpp:1109
 msgid "unnamed function (lambda)..."
@@ -11970,7 +11970,7 @@ msgstr "névtelen"
 
 #: ../../src/sidebars/GreekSidebar.cpp:170
 msgid "upsilon"
-msgstr ""
+msgstr "üpszilon"
 
 #: ../../src/wxMaximaFrame.cpp:1737
 msgid "use as function arguments"
@@ -12008,7 +12008,7 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:159
 msgid "wxMaxima can be made to execute commands at every start-up by placing them in a text file with the name wxmaxima.rc in the user directory. This directory can be found by typing maxima_userdir;"
-msgstr ""
+msgstr "A wxMaxima minden induláskor végrehajtja a felhasználói könyvtárban elhelyezett wxmaxima.rc szövegfájlban elhelyezett parancsokat. A könyvtár elérési útját a maxima_userdir parancs végrehajtásával tudhatjuk meg"
 
 #: ../../src/MaximaFileIO.cpp:398
 msgid "wxMaxima cannot read the xml contents of "
@@ -12017,7 +12017,7 @@ msgstr "A wxMaxima nem képes az xml tartalom olvasására itt: "
 #: ../../src/dialogs/ConfigDialogue.cpp:142
 #: ../../src/dialogs/ConfigDialogue.cpp:311
 msgid "wxMaxima configuration"
-msgstr ""
+msgstr "A wxMaxima beállítása"
 
 #: ../../src/MaximaProcessManager.cpp:209
 msgid "wxMaxima could not start a server.\n\n"
@@ -12029,7 +12029,7 @@ msgstr "A wxMaxima nem tudott elindítani egy szervert.\n\n"
 
 #: ../../src/dialogs/TipOfTheDay.cpp:127
 msgid "wxMaxima dialogs set default values for inputs entries, one of which is '%'. If you have made a selection in your document, the selection will be used instead of '%'."
-msgstr ""
+msgstr "A wxMaxima menüparancsai bemenetekkel hajtódnak végre, ezek egyike a '%'. Ha kijelölünk egy részt a dokumentumunkban, a menüparancs ezt fogja argumentumként használni a '%' helyett."
 
 #: ../../src/MaximaCommandMenus.cpp:4544
 msgid "wxMaxima document"
@@ -12060,19 +12060,19 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:240
 msgid "wxMaxima is programmed in C++ using the wxWidgets toolkit and uses CMake as build system. You can contribute to wxMaxima, if you have some knowledge with this environment."
-msgstr ""
+msgstr "A wxMaxima programozása C++ nyelven történik a wxWidgets eszköztár használatával, és CMake-et használ fordítási rendszerként. Hozzájárulhat a wxMaxima fejlesztéséhez, ha van némi ismerete ezzel a környezettel."
 
 #: ../../src/dialogs/TipOfTheDay.cpp:228
 msgid "wxMaxima needs more developers. It is an open source project where you can contribute. Join the wxMaxima development at: https://github.com/wxMaxima-developers/wxmaxima"
-msgstr ""
+msgstr "A wxMaxima-nak további fejlesztőkre van szüksége. Ez egy nyílt forráskódú projekt, melyhez Ön is hozzájárulhat. Csatlakozzon a wxMaxima fejlesztéséhez: https://github.com/wxMaxima-developers/wxmaxima"
 
 #: ../../src/dialogs/TipOfTheDay.cpp:224
 msgid "wxMaxima needs more translators. We do not speak every language. Help us to translate wxMaxima and the manual to your language. Join the wxMaxima development at: https://github.com/wxMaxima-developers/wxmaxima"
-msgstr ""
+msgstr "A wxMaxima-nak további fordítókra van szüksége. Nem beszélünk minden nyelven. Segítsen nekünk a wxMaximának és a kézikönyvnek az Ön nyelvére való lefordításában . Csatlakozzon a wxMaxima fejlesztéséhez: https://github.com/wxMaxima-developers/wxmaxima"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:407
 msgid "wxMaxima normally stores the gnuplot sources for every plot made using draw() in order to be able to open plots interactively in gnuplot later. This setting defines the limit [in Megabytes per plot] for this feature."
-msgstr ""
+msgstr "A wxMaxima rendszerint minden rajzhoz tárolja a gnuplot forrásait a draw() használatával, hogy később interaktívan megnyithassa a grafikonokat a gnuplotban. Ez a beállítás határozza meg ennek a funkciónak a korlátját [megabájt/képenként]."
 
 #: ../../src/dialogs/TipOfTheDay.cpp:172
 msgid "wxMaxima provides the \"table_form\" command that shows lists in an alternative form. One example would be:\n\n"
@@ -12091,7 +12091,7 @@ msgstr "A wxMaxima megjegyzi az utolsó futtatásnál adott válaszokat, és aut
 
 #: ../../src/dialogs/ConfigDialogue.cpp:481
 msgid "wxMaxima remembers the answers to maxima's questions. If this checkbox is set it automatically offers to enter the last answer to this question the user has input."
-msgstr ""
+msgstr "A wxMaxima megjegyzi a Maxima kérdéseire adott válaszokat. Ha ez a jelölőnégyzet be van állítva, akkor automatikusan megadja az utolsó választ a felhasználó által bevitt kérdésre."
 
 #: ../../src/wxMaximaFrame.cpp:1933
 msgid "wxMaxima shows help in a browser"
@@ -12103,7 +12103,7 @@ msgstr "A wxMaxima az oldalsávban jeleníti meg a súgót"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1095
 msgid "wxMaxima startup file location: "
-msgstr ""
+msgstr "wxMaxima indító fájl helye: "
 
 #: ../../src/wxMaximaFrame.cpp:119
 #, c-format
@@ -12155,11 +12155,11 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:709
 msgid "x"
-msgstr ""
+msgstr "x"
 
 #: ../../src/wizards/DrawWiz.cpp:266
 msgid "x axis label"
-msgstr ""
+msgstr "x tengely címkéje"
 
 #: ../../src/MaximaCommandMenus.cpp:2021
 msgid "x direction [in multiples of the tick frequency]"
@@ -12167,11 +12167,11 @@ msgstr ""
 
 #: ../../src/wizards/DrawWiz.cpp:269
 msgid "x range (automatic if incomplete)"
-msgstr ""
+msgstr "x tartomány (automatikus, ha nem teljes)"
 
 #: ../../src/sidebars/GreekSidebar.cpp:164
 msgid "xi"
-msgstr ""
+msgstr "kszí"
 
 #: ../../src/MaximaFileIO.cpp:408 ../../src/MaximaFileIO.cpp:566
 msgid "xml contained in the file claims not to be a wxMaxima worksheet. "
@@ -12179,11 +12179,11 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:97
 msgid "xor"
-msgstr ""
+msgstr "kizáró vagy"
 
 #: ../../src/wizards/DrawWiz.cpp:279
 msgid "y axis label"
-msgstr ""
+msgstr "y tengely címkéje"
 
 #: ../../src/MaximaCommandMenus.cpp:2022
 msgid "y direction [in multiples of the tick frequency]"
@@ -12191,7 +12191,7 @@ msgstr ""
 
 #: ../../src/wizards/DrawWiz.cpp:282
 msgid "y range (automatic if incomplete)"
-msgstr ""
+msgstr "y tartomány (automatikus, ha nem teljes)"
 
 #: ../../src/MaximaCommandMenus.cpp:970
 msgid "y:"
@@ -12199,15 +12199,15 @@ msgstr ""
 
 #: ../../src/wizards/DrawWiz.cpp:294
 msgid "z axis label"
-msgstr ""
+msgstr "z tengely címkéje"
 
 #: ../../src/wizards/DrawWiz.cpp:298
 msgid "z range (automatic if incomplete)"
-msgstr ""
+msgstr "z tartomány (automatikus, ha nem teljes)"
 
 #: ../../src/sidebars/GreekSidebar.cpp:156
 msgid "zeta"
-msgstr ""
+msgstr "dzéta"
 
 #. type: Title #
 #: ../../info/wxmaxima.md:1

--- a/locales/wxMaxima/it.po
+++ b/locales/wxMaxima/it.po
@@ -53,23 +53,23 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1569
 msgid "      -X \"--control-stack-size <int>\""
-msgstr ""
+msgstr "      -X \"--control-stack-size <int>\""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1568
 msgid "      -X \"--dynamic-space-size <int>\""
-msgstr ""
+msgstr "      -X \"--dynamic-space-size <int>\""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1572
 msgid "      -X '--control-stack-size <int>'"
-msgstr ""
+msgstr "      -X '--control-stack-size <int>'"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1571
 msgid "      -X '--dynamic-space-size <int>'"
-msgstr ""
+msgstr "      -X '--dynamic-space-size <int>'"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1551
 msgid "      -l <name>"
-msgstr ""
+msgstr "      -l <nome>"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1557
 msgid "      -u <versionnumber>"
@@ -167,7 +167,7 @@ msgstr ""
 #: ../../src/cells/ImgCell.cpp:212 ../../src/cells/ImgCell.cpp:214
 #: ../../src/cells/ImgCell.cpp:216
 msgid " (Graphics) "
-msgstr ""
+msgstr " (grafiche) "
 
 #: ../../src/cells/EditorCell.cpp:3551 ../../src/cells/EditorCell.cpp:3820
 #: ../../src/cells/EditorCell.cpp:3945
@@ -177,7 +177,7 @@ msgstr ""
 
 #: ../../src/cells/EditorCell.cpp:3553
 msgid " ... + 1 hidden line"
-msgstr ""
+msgstr " ... + 1 riga nascosta"
 
 #: ../../src/dialogs/TipOfTheDay.cpp:273
 msgid " Did you know? "
@@ -193,15 +193,15 @@ msgstr "Sbagliato, se a è complessa"
 
 #: ../../src/wizards/DrawWiz.cpp:964 ../../src/wizards/DrawWiz.cpp:980
 msgid " samples"
-msgstr ""
+msgstr " campioni"
 
 #: ../../src/wizards/DrawWiz.cpp:929 ../../src/wizards/DrawWiz.cpp:945
 msgid " samples, on demand split "
-msgstr ""
+msgstr " campioni, separati su richiesta"
 
 #: ../../src/wizards/DrawWiz.cpp:933 ../../src/wizards/DrawWiz.cpp:952
 msgid " times"
-msgstr ""
+msgstr " volte"
 
 #: ../../src/MaximaCommandMenus.cpp:4413
 msgid "\".\" = \"The current directory\"\n"
@@ -216,7 +216,7 @@ msgstr "\"..\" significa \"una cartella su\"."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1208
 msgid "\"Copy LaTeX\" adds equation markers"
-msgstr ""
+msgstr "\"Copia LaTeX\" aggiunge marcatori di equazione"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:446
 msgid "\"MathML (rendered by the browser)\" is the recommended choice: every current browser renders MathML natively and instantly, and the exported page needs no JavaScript and makes no requests to any external server.\n"
@@ -226,11 +226,11 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:930
 msgid "\"Numpad Enter\" always evaluates cells"
-msgstr ""
+msgstr "\"Invio numerico\" elabora sempre le celle"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:90
 msgid "\"implies\" symbol"
-msgstr ""
+msgstr "\"implica\" simbolo"
 
 #: ../../src/dialogs/DiffFrame.cpp:306
 #, c-format
@@ -245,7 +245,7 @@ msgstr ""
 #: ../../src/sidebars/TableOfContents.cpp:570
 #, c-format
 msgid "%li Levels"
-msgstr ""
+msgstr "%li livelli"
 
 #: ../../src/worksheet/Worksheet.cpp:423
 #, c-format
@@ -317,7 +317,7 @@ msgstr "&Copia\tCtrl+C"
 
 #: ../../src/wizards/IntegrateWiz.cpp:39
 msgid "&Definite integration"
-msgstr ""
+msgstr "Integrazione &definita"
 
 #: ../../src/wxMaximaFrame.cpp:1658
 msgid "&Demoivre"
@@ -433,11 +433,11 @@ msgstr "Risultati &numerici"
 
 #: ../../src/wizards/IntegrateWiz.cpp:52
 msgid "&Numerical integration"
-msgstr ""
+msgstr "Integrazione &numerica"
 
 #: ../../src/wizards/SumWiz.cpp:44
 msgid "&Nusum"
-msgstr ""
+msgstr "Som&nu"
 
 #: ../../src/main.cpp:675
 msgid "&Open\tCtrl+O"
@@ -453,7 +453,7 @@ msgstr "&Disegno"
 
 #: ../../src/wizards/SeriesWiz.cpp:45
 msgid "&Power series"
-msgstr ""
+msgstr "Serie di &potenze"
 
 #: ../../src/wxMaximaFrame.cpp:655
 msgid "&Print...\tCtrl+P"
@@ -461,7 +461,7 @@ msgstr "Stam&pa...\tCtrl+P"
 
 #: ../../src/wizards/SubstituteWiz.cpp:38
 msgid "&Rational"
-msgstr ""
+msgstr "&Razionale"
 
 #: ../../src/wxMaximaFrame.cpp:1631
 msgid "&Reduce Trigonometric"
@@ -493,11 +493,11 @@ msgstr "Ris&olvi..."
 
 #: ../../src/wizards/Plot2dWiz.cpp:42
 msgid "&Special"
-msgstr ""
+msgstr "&Speciale"
 
 #: ../../src/wizards/LimitWiz.cpp:45
 msgid "&Taylor series"
-msgstr ""
+msgstr "Serie di &Taylor:"
 
 #: ../../src/wxMaximaFrame.cpp:1069
 msgid "&Time Display"
@@ -517,7 +517,7 @@ msgstr "&Variabili"
 
 #: ../../src/wizards/Plot3dWiz.cpp:79
 msgid "&pm3d"
-msgstr ""
+msgstr "&pm3d"
 
 #: ../../src/cells/AnimationCell.cpp:475
 msgid "(Animation)"
@@ -545,15 +545,15 @@ msgstr ""
 
 #: ../../src/sidebars/CharButton.cpp:211
 msgid "(Might not be displayed correctly in at least one of the worksheet fonts)"
-msgstr ""
+msgstr "(potrebbe non essere mostrato correttamente in almeno uno dei font del foglio di lavoro)"
 
 #: ../../src/sidebars/VariablesPane.cpp:254
 msgid "(Not a valid variable name)"
-msgstr ""
+msgstr "(nome di variabile non valido)"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:183
 msgid "(Use default language)"
-msgstr ""
+msgstr "(usa la lingua predefinita)"
 
 #: ../../src/MaximaCommandMenus.cpp:440
 msgid "(f(x),x,a,b)), Epsilon algorithm"
@@ -587,7 +587,7 @@ msgstr "(f(x),x,y) con singolarità+discontinuità"
 #: ../../src/wizards/DrawWiz.cpp:303 ../../src/wizards/DrawWiz.cpp:320
 #: ../../src/wizards/DrawWiz.cpp:335
 msgid "-"
-msgstr ""
+msgstr "-"
 
 #: ../../src/wizards/IntegrateWiz.cpp:192
 #: ../../src/wizards/IntegrateWiz.cpp:202
@@ -595,7 +595,7 @@ msgstr ""
 #: ../../src/wizards/IntegrateWiz.cpp:217 ../../src/wizards/LimitWiz.cpp:132
 #: ../../src/wizards/LimitWiz.cpp:142
 msgid "- Infinity"
-msgstr ""
+msgstr "- infinito"
 
 #: ../../src/MaximaOutputAppender.cpp:116
 msgid "... [suppressed additional lines as the output is longer than allowed in the wxMaxima configuration] "
@@ -607,15 +607,15 @@ msgstr ".wxm dati appunti con insolita intestazione"
 
 #: ../../src/sidebars/TableOfContents.cpp:567
 msgid "1 Level"
-msgstr ""
+msgstr "1 Livello"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:77
 msgid "1/2"
-msgstr ""
+msgstr "1/2"
 
 #: ../../src/sidebars/DrawSidebar.cpp:45
 msgid "2D"
-msgstr ""
+msgstr "2D"
 
 #: ../../src/wxMaximaFrame.cpp:1346
 msgid "2D Array to Matrix..."
@@ -639,7 +639,7 @@ msgstr ""
 
 #: ../../src/sidebars/DrawSidebar.cpp:49
 msgid "3D"
-msgstr ""
+msgstr "3D"
 
 #: ../../src/wxMaxima.cpp:1833
 #, c-format
@@ -652,7 +652,7 @@ msgstr "Un \":lisp\" come primo comando può impedire l'invio del segnale \"fini
 
 #: ../../src/dialogs/TipOfTheDay.cpp:102
 msgid "A 'horizontal cursor' was introduced in wxMaxima 0.8.0. It looks like a horizontal line between cells. It indicates where a new cell will appear if you type or paste text or execute a menu command."
-msgstr ""
+msgstr "Un \"cursore orizzontale\" è stato introdotto in wxMaxima dalla versione 0.8.0. Esso consiste in una linea orizzontale tra le celle. Esso indica dove una nuova cella apparirà se si digita o incolla del testo o si esegue in comando dai menu."
 
 #: ../../src/MaximaCommandMenus.cpp:3039
 msgid "A Ctrl-F event"
@@ -678,7 +678,7 @@ msgstr "Un evento trova, %s"
 
 #: ../../src/wizards/ListSortWiz.cpp:63
 msgid "A function f(a,b), named"
-msgstr ""
+msgstr "Una funzione f(a,b), con nome"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:784
 msgid "A function returning integers"
@@ -690,7 +690,7 @@ msgstr "Una funzione che restituisce numeri positivi"
 
 #: ../../src/wizards/DrawWiz.cpp:164
 msgid "A good example equation would be x^2+y^2=1"
-msgstr ""
+msgstr "Un buona equazione di esempio potrebbe essere x^2+y^2=1"
 
 #: ../../src/cells/GroupCell.cpp:2193 ../../src/cells/GroupCell.cpp:2196
 msgid "A heading"
@@ -714,15 +714,15 @@ msgstr "Una matrice nella quale ogni riga è un insieme di variabili"
 
 #: ../../src/dialogs/TipOfTheDay.cpp:84
 msgid "A new document format has been introduced in wxMaxima 0.8.2 that saves not only your input and text commentaries, but also the outputs of your calculations. When saving your document, select 'Whole document (*.wxmx)' format."
-msgstr ""
+msgstr "A partire da wxMaxima versione 0.8.2 è stato introdotto un nuovo formato di documenti che salva non solamente il testo immesso ed i commenti, ma anche i risultati del calcoli. Quando si salva il documento, selezionare il formato 'Documento intero (*.wxmx)'."
 
 #: ../../src/cells/GroupCell.cpp:2175
 msgid "A page break"
-msgstr ""
+msgstr "Un saltopagina"
 
 #: ../../src/dialogs/TipOfTheDay.cpp:168
 msgid "A plot to be embedded into the work sheet by preceding its name with a \"wx\". \"draw\" can be replaced by \"wxdraw\", plot by \"wxplot\" etc."
-msgstr ""
+msgstr "Un grafico da incorporare nel foglio di lavoro facendo precedere il suo nome con un \"wx\". \"draw\" può essere rimpiazzato da \"wxdraw\", plot da \"wxplot\" ecc."
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:735
 msgid "A rational variable"
@@ -734,7 +734,7 @@ msgstr "Una funzione associativa a destra"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:436
 msgid "A scale factor for the printout. Helpful for printing big equations on small pdf pages."
-msgstr ""
+msgstr "Un fattore di scala per la stampa. Utile per la stampa di grandi equazioni su piccole pagine pdf."
 
 #: ../../src/wxMaximaFrame.cpp:1671
 msgid "A search-and-replace for equations"
@@ -742,27 +742,27 @@ msgstr "Ricerca e sostituzione per equazioni"
 
 #: ../../src/cells/EditorCell.cpp:4522 ../../src/cells/GroupCell.cpp:2184
 msgid "A section heading"
-msgstr ""
+msgstr "Una intestazione di sezione"
 
 #: ../../src/wizards/DrawWiz.cpp:479
 msgid "A static plot"
-msgstr ""
+msgstr "Un grafico statico"
 
 #: ../../src/cells/EditorCell.cpp:4534
 msgid "A sub-sub-sub-subsection heading"
-msgstr ""
+msgstr "Una intestazione di sub-sub-sub-subsezione"
 
 #: ../../src/cells/EditorCell.cpp:4531
 msgid "A sub-sub-subsection heading"
-msgstr ""
+msgstr "Una intestazione di sub-sub-subsezione"
 
 #: ../../src/cells/EditorCell.cpp:4528 ../../src/cells/GroupCell.cpp:2190
 msgid "A sub-subsection heading"
-msgstr ""
+msgstr "Una intestazione di sub-subsezione"
 
 #: ../../src/cells/EditorCell.cpp:4525 ../../src/cells/GroupCell.cpp:2187
 msgid "A subsection heading"
-msgstr ""
+msgstr "Una intestazione di subsezione"
 
 #: ../../src/wxMaximaFrame.cpp:1673
 msgid "A subst with basic maths knowledge"
@@ -770,7 +770,7 @@ msgstr "Una subst con conoscenze di matematica di base"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:239
 msgid "A symbol from the configuration dialogue"
-msgstr ""
+msgstr "Un simbolo dalla finestra di configurazione"
 
 #: ../../src/cells/GroupCell.cpp:2181
 msgid "A text cell"
@@ -807,7 +807,7 @@ msgstr "Matem. ASCII"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1618
 msgid "Abort evaluation on error"
-msgstr ""
+msgstr "Interrompi elaborazione in caso di errore"
 
 #: ../../src/MaximaEvaluator.cpp:214
 #, c-format
@@ -840,7 +840,7 @@ msgstr ""
 
 #: ../../src/sidebars/DrawSidebar.cpp:103
 msgid "Accuracy"
-msgstr ""
+msgstr "Accuratezza"
 
 #: ../../src/wxMaximaFrame.cpp:1405
 msgid "Ad&joint Matrix"
@@ -860,7 +860,7 @@ msgstr "Aggiungi un nuovo elemento all'inizio della lista. Utile per creare pile
 
 #: ../../src/sidebars/VariablesPane.cpp:228
 msgid "Add all"
-msgstr ""
+msgstr "Aggiugi tutto"
 
 #: ../../src/MaximaCommandMenus.cpp:1621
 msgid "Add an element to the end of a list"
@@ -880,11 +880,11 @@ msgstr "Aggiungi uguaglianza al semplificatore razionale"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:204
 msgid "Add more symbols"
-msgstr ""
+msgstr "Aggiungi più simboli"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1262
 msgid "Add the .wxmx file to the HTML export"
-msgstr ""
+msgstr "Agiungi il file .wxmx all'esportazione HTML"
 
 #: ../../src/wxMaximaFrame.cpp:1049
 msgid "Add to &Path..."
@@ -892,7 +892,7 @@ msgstr "Aggiungi al &percorso..."
 
 #: ../../src/sidebars/UnicodeSidebar.cpp:105
 msgid "Add to symbols Sidebar"
-msgstr ""
+msgstr "Aggiungi alla barra laterale dei simboli"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:304
 #: ../../src/worksheet/WorksheetContextMenu.cpp:337
@@ -903,23 +903,23 @@ msgstr "Aggiungi alla alla watchlist"
 #: ../../src/sidebars/XmlInspector.cpp:147
 #, c-format
 msgid "Added much text (%li chars) to the XML inspector."
-msgstr ""
+msgstr "Aggiunto molto testo (%li caratteri) all'ispettore XML."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1896
 msgid "Additional clipboard formats to put on the clipboard on ordinary copy"
-msgstr ""
+msgstr "Formati appunti aggiuntivi da metter negli appunti con una copia normale"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:393
 msgid "Additional commands to be added to the preamble of LaTeX output for pdftex."
-msgstr ""
+msgstr "Comandi aggiuntivi da aggiungere al preambolo dell'uscita LaTeX per pdftex."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1187
 msgid "Additional lines for the TeX preamble:"
-msgstr ""
+msgstr "Righe aggiuntive per il preambolo TeX:"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:389
 msgid "Additional parameters for Maxima (e.g. -l clisp)."
-msgstr ""
+msgstr "Parametri aggiuntivi per maxima (per es. -l clisp)."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1543
 msgid "Additional parameters for Maxima (restart Maxima after changes)"
@@ -927,7 +927,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1318
 msgid "Additional symbols for the \"symbols\" sidebar:"
-msgstr ""
+msgstr "Simboli aggiuntivi per la barra laterale \"simboli\":"
 
 #: ../../src/wxMaximaFrame.cpp:1599
 msgid "Additionally: log(a*b)=log(a)+log(b)"
@@ -971,7 +971,7 @@ msgstr "Alias"
 
 #: ../../src/sidebars/TableOfContents.cpp:572
 msgid "All Levels"
-msgstr ""
+msgstr "Tutti i livelli"
 
 #: ../../src/wxMaximaFrame.cpp:1751
 msgid "All but the 1st n elements"
@@ -987,7 +987,7 @@ msgstr "Tutti i tipi apribili (*.wxm, *.wxmx, *.mac, *.out, *.xml)|*.wxm;*.wxmx;
 
 #: ../../src/dialogs/ConfigDialogue.cpp:750
 msgid "All variable names"
-msgstr ""
+msgstr "Tutti nomi di variabile"
 
 #: ../../src/wxMaximaFrame.cpp:770
 msgid "All visible sidebars"
@@ -1015,7 +1015,7 @@ msgstr ""
 
 #: ../../src/dialogs/BinaryNameCtrl.cpp:69
 msgid "All|*"
-msgstr ""
+msgstr "Tutti|*"
 
 #: ../../src/wxMaximaFrame.cpp:800
 msgid "Always after underscores"
@@ -1035,7 +1035,7 @@ msgstr "Mostra sempre tutte le cifre"
 
 #: ../../src/wizards/DrawWiz.cpp:484
 msgid "An animation with multiple frames"
-msgstr ""
+msgstr "Un'animazione con più quadri"
 
 #: ../../src/cells/GroupCell.cpp:2202
 msgid "An image cell"
@@ -1193,7 +1193,7 @@ msgstr "Codice ascii a char..."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1397
 msgid "Ask to save untitled documents"
-msgstr ""
+msgstr "Richiedi il salvataggio dei documenti senza nome"
 
 #: ../../src/dialogs/MaximaNotStartingDialog.cpp:36
 msgid "Asking the user for the location of a working maxima binary"
@@ -1217,21 +1217,21 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:897
 msgid "Auto-indent new lines"
-msgstr ""
+msgstr "Auto indenta a capo"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:893
 msgid "Auto-insert closing parenthesis"
-msgstr ""
+msgstr "Autoinserimento parentesi di chiusura"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1441
 #: ../../src/dialogs/ConfigDialogue.cpp:1472
 #: ../../src/dialogs/MaximaNotStartingDialog.cpp:43
 msgid "Autodetect"
-msgstr ""
+msgstr "Autorileva"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1236
 msgid "Automatic"
-msgstr ""
+msgstr "Automatico"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:391
 msgid "Automatic labels"
@@ -1240,7 +1240,7 @@ msgstr "Etichette automatiche"
 #: ../../src/dialogs/ConfigDialogue.cpp:769
 #, c-format
 msgid "Automatic labels (%i1, %o1,...)"
-msgstr ""
+msgstr "Etichette automatiche (%i1, %o1,...)"
 
 #: ../../src/wxMaximaFrame.cpp:986
 msgid "Automatically answer questions"
@@ -1287,15 +1287,15 @@ msgstr "Auto-pedice questa variabile"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:734
 msgid "Autowrap long lines:"
-msgstr ""
+msgstr "Auto a capo righe lunghe:"
 
 #: ../../src/sidebars/DrawSidebar.cpp:75
 msgid "Axis"
-msgstr ""
+msgstr "Asse"
 
 #: ../../src/wizards/BC2Wiz.cpp:59
 msgid "BC2"
-msgstr ""
+msgstr "BC2"
 
 #: ../../src/MaximaManual.cpp:559
 msgid "Background task that compiles the Manual anchors scheduled."
@@ -1303,7 +1303,7 @@ msgstr ""
 
 #: ../../src/sidebars/StatSidebar.cpp:91
 msgid "Barsplot..."
-msgstr ""
+msgstr "Grafico a barre..."
 
 #: ../../src/wxMaximaFrame.cpp:1384
 msgid "Basic matrix operations"
@@ -1342,27 +1342,27 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:141
 msgid "Besides the global undo functionality that is active when the cursor is between cells, wxMaxima has a per-cell undo function that is active if the cursor is inside a cell. Pressing Ctrl+Z inside a cell can therefore been used for a fine-pitch undo that doesn't affect latter changes made in other cells."
-msgstr ""
+msgstr "Oltre alla funzionalità di annullamento globale che è attiva quando il cursore si trova tra le celle, wxMaxima ha una funzione di annullamento per-cella che è attiva se il cursore si trova all'interno di una cella. La pressione di Ctrl+Z all'interno di una cella può quindi essere usata per un annullamento a passo fine che non pregiudica le ultime modifiche apportate in altre celle."
 
 #: ../../src/sidebars/GreekSidebar.cpp:179
 msgid "Beta"
-msgstr ""
+msgstr "Beta"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1898
 msgid "Bitmap"
-msgstr ""
+msgstr "Bitmap"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1273
 msgid "Bitmap scale for export:"
-msgstr ""
+msgstr "Scala bitmap per esportazione:"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1223
 msgid "Bitmaps"
-msgstr ""
+msgstr "Bitmap"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2109
 msgid "Bold"
-msgstr ""
+msgstr "Grassetto"
 
 #: ../../src/wxMaxima.cpp:2259
 msgid "Both horizontal and vertical cursor active at the same time"
@@ -1386,13 +1386,13 @@ msgstr ""
 
 #: ../../src/sidebars/StatSidebar.cpp:97
 msgid "Boxplot..."
-msgstr ""
+msgstr "Grafico a blocchi..."
 
 #: ../../src/dialogs/BinaryNameCtrl.cpp:42 ../../src/wizards/CsvWiz.cpp:57
 #: ../../src/wizards/CsvWiz.cpp:131 ../../src/wizards/Plot2dWiz.cpp:114
 #: ../../src/wizards/Plot3dWiz.cpp:109
 msgid "Browse"
-msgstr ""
+msgstr "Naviga"
 
 #: ../../src/wxMathml.cpp:101
 msgid "Bug: After removing the whitespace wxMathml.lisp is shorter than expected!"
@@ -1441,7 +1441,7 @@ msgstr "Bug: il risultato HTML non è XML valido"
 
 #: ../../src/cells/Cell.cpp:289
 msgid "Bug: Math Cell that claims to have no group Cell it belongs to"
-msgstr ""
+msgstr "Bug: cella di formule che dichiara di non avere gruppi di celle a cui appartenere"
 
 #: ../../src/Configuration.h:741
 msgid "Bug: Maximum number of digits that is to be displayed is too low!"
@@ -1453,7 +1453,7 @@ msgstr "Bug: contenuti mancanti"
 
 #: ../../src/cells/GroupCell.cpp:1498
 msgid "Bug: No image counter to write to!"
-msgstr ""
+msgstr "Bug: nessun contatore immagine su cui scrivere!"
 
 #: ../../src/cells/AnimationCell.cpp:543 ../../src/cells/EditorCell.cpp:2968
 #: ../../src/cells/ImgCell.cpp:353 ../../src/graphical_io/BitmapOut.cpp:161
@@ -1472,7 +1472,7 @@ msgstr "Bug: gli appunti sono già aperti"
 
 #: ../../src/cells/EditorCell.cpp:3051
 msgid "Bug: The clipboard isn't open on pasting into an editor cell"
-msgstr ""
+msgstr "Bug: gli appunti non sono aperti sull'incollamento in una cella dell'editor"
 
 #: ../../src/cells/GroupCell.cpp:2288
 msgid "Bug: The predecessor to a GroupCell is not a GroupCell."
@@ -1484,7 +1484,7 @@ msgstr ""
 
 #: ../../src/cells/GroupCell.cpp:340
 msgid "Bug: Trying to append NULL to a group cell."
-msgstr ""
+msgstr "Bug: tentativo di accodare NULL ad un gruppo di celle."
 
 #: ../../src/worksheet/Worksheet.cpp:5939
 msgid "Bug: Trying to move a title out by one sectioning unit"
@@ -1508,7 +1508,7 @@ msgstr "Bug: azione di annullamento con sia cambiamento contenuti cella che aggi
 
 #: ../../src/cells/EditorCell.cpp:4541
 msgid "Bug: Unknown type of text"
-msgstr ""
+msgstr "Bug: tipo di testo sconosciuto"
 
 #: ../../src/cells/EditorCell.cpp:3981 ../../src/cells/TextCell.cpp:479
 msgid "Bug: dc == NULL"
@@ -1516,11 +1516,11 @@ msgstr ""
 
 #: ../../src/cells/EditorCell.cpp:2637
 msgid "Bug: x position of cell is unknown!"
-msgstr ""
+msgstr "Bug: posizione x della cella sconosciuta!"
 
 #: ../../src/cells/EditorCell.cpp:2638
 msgid "Bug: y position of cell is unknown!"
-msgstr ""
+msgstr "Bug: posizione y della cella sconosciuta!"
 
 #: ../../src/wxMaximaFrame.cpp:1985
 msgid "Build &Info"
@@ -1533,7 +1533,7 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:54
 msgid "By default, Shift-Enter is used to evaluate commands, while Enter is used for multiline input. This behaviour can be changed in 'Edit->Configure' dialog by checking 'Enter evaluates cells'. This switches the roles of these two key commands."
-msgstr ""
+msgstr "Come impostazione predefinita la combinazione di tasti Maiusc-Invio viene usata per segnalare la richiesta di valutazione dei comandi, mentre Invio da solo viene usato per l'immissione di testo su più righe. Questo comportamento può essere modificato nella finestra di dialogo 'Modifica->Configura' selezionando 'Invio elabora le celle'. Questa impostazione scambia il comportamento di queste due combinazioni di tasti."
 
 #: ../../src/MaximaCommandMenus.cpp:4087
 msgid "Byte:"
@@ -1727,20 +1727,20 @@ msgstr "Impossibile interpretare il componente numero di versione %s"
 
 #: ../../src/cells/EditorCell.cpp:2991
 msgid "Cannot put the copied text on the clipboard"
-msgstr ""
+msgstr "Impossibile mettere il testo copiato negli appunti"
 
 #: ../../src/cells/EditorCell.cpp:2984
 msgid "Cannot put the copied text on the clipboard (1st try)"
-msgstr ""
+msgstr "Impossibile mettere il testo copiato negli appunti (1° tentativo)"
 
 #: ../../src/cells/EditorCell.cpp:2988
 msgid "Cannot put the copied text on the clipboard (2nd try)"
-msgstr ""
+msgstr "Impossibile mettere il testo copiato negli appunti (2° tentativo)"
 
 #: ../../src/graphical_io/OutCommon.cpp:98
 #, c-format
 msgid "Cannot remove the file %s"
-msgstr ""
+msgstr "Impossibile rimuovere il file %s"
 
 #: ../../src/sidebars/History.cpp:258
 #, c-format
@@ -1771,11 +1771,11 @@ msgstr "Impossibile avviare maxima"
 
 #: ../../src/sidebars/MathSidebar.cpp:62
 msgid "Canonical (tr)"
-msgstr ""
+msgstr "Canonica (tr)"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:188
 msgid "Catalan"
-msgstr ""
+msgstr "Catalano"
 
 #: ../../src/MaximaCommandMenus.cpp:466
 msgid "Cauchy principal value of f(x)/(x-c), finite interval"
@@ -1832,7 +1832,7 @@ msgstr "Cambia cartella..."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:859
 msgid "Change names of greek letters to greek letters"
-msgstr ""
+msgstr "Cambia i nomi delle lettere greche in lettere greche"
 
 #: ../../src/wxMaximaFrame.cpp:1073
 msgid "Change the 2d display algorithm used to display math output"
@@ -1840,7 +1840,7 @@ msgstr "Cambia l'algoritmo della finestra 2d usato per visualizzare il risultato
 
 #: ../../src/dialogs/ConfigDialogue.cpp:489
 msgid "Change the text \"alpha\" and \"beta\" to the corresponding greek letter?"
-msgstr ""
+msgstr "Cambiare il testo \"alfa\" e \"beta\" nelle lettere greche corrispondenti?"
 
 #: ../../src/MaximaCommandMenus.cpp:136
 msgid "Change variable"
@@ -1860,7 +1860,7 @@ msgstr "Cambia variabile nell'integrale o nella somma ed elabora il risultato"
 
 #: ../../src/dialogs/ChangeLogDialog.cpp:37
 msgid "ChangeLog"
-msgstr ""
+msgstr "ChangeLog"
 
 #: ../../src/wxMaximaFrame.cpp:1060
 msgid "Changed option variables"
@@ -1921,15 +1921,15 @@ msgstr "Controlla se esiste una versione più recente di wxMaxima"
 
 #: ../../src/sidebars/GreekSidebar.cpp:199
 msgid "Chi"
-msgstr ""
+msgstr "Chi"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:189
 msgid "Chinese (Simplified)"
-msgstr ""
+msgstr "Cinese (semplificato)"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:190
 msgid "Chinese (traditional)"
-msgstr ""
+msgstr "Cinese (tradizionale)"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1554
 msgid "Choose a Lisp Maxima was compiled with"
@@ -1945,7 +1945,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2100
 msgid "Choose font"
-msgstr ""
+msgstr "Scegli font"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:793
 msgid "Choose how mathematical output is formatted:\n"
@@ -1956,12 +1956,12 @@ msgstr ""
 
 #: ../../src/wizards/PlotFormatWiz.cpp:31
 msgid "Choose new plot format:"
-msgstr ""
+msgstr "Scegliere un nuovo formato per il grafico:"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2432
 #, c-format
 msgid "Choose the %s Font"
-msgstr ""
+msgstr "Scegli il font %s"
 
 #: ../../src/wxMaximaFrame.cpp:837
 msgid "Choose the parenthesis type for Matrices"
@@ -1997,7 +1997,7 @@ msgstr "Cancella tutte le grafdefs"
 
 #: ../../src/sidebars/History.cpp:116
 msgid "Clear all history"
-msgstr ""
+msgstr "Cancella la cronologia"
 
 #: ../../src/wxMaximaFrame.cpp:1034
 msgid "Clear all labels"
@@ -2029,7 +2029,7 @@ msgstr "Cancella tutte le variabili"
 
 #: ../../src/sidebars/History.cpp:115
 msgid "Clear the selection"
-msgstr ""
+msgstr "Cancella la selezione"
 
 #: ../../src/cells/FontVariantCache.cpp:44
 #, c-format
@@ -2038,7 +2038,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1926
 msgid "Clipboard format parameters"
-msgstr ""
+msgstr "Parametri formato appunti"
 
 #: ../../src/wxMaximaFrame.cpp:637
 msgid "Close\tCtrl+W"
@@ -2130,7 +2130,7 @@ msgstr ""
 
 #: ../../src/wizards/MatWiz.cpp:155
 msgid "Columns:"
-msgstr ""
+msgstr "Colonne:"
 
 #: ../../src/wxMaximaFrame.cpp:1621
 msgid "Combine factorials in an expression"
@@ -2146,11 +2146,11 @@ msgstr "Virgola direttamente seguita da una parentesi chiusa"
 
 #: ../../src/wizards/Plot2dWiz.cpp:626
 msgid "Comma separated x coordinates"
-msgstr ""
+msgstr "Coordinate x separate da virgole"
 
 #: ../../src/wizards/Plot2dWiz.cpp:627
 msgid "Comma separated y coordinates"
-msgstr ""
+msgstr "Coordinate y separate da virgole"
 
 #: ../../src/MaximaCommandMenus.cpp:4071
 msgid "Comma-separated arguments"
@@ -2236,11 +2236,11 @@ msgstr "Comando:"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1145
 msgid "Commands that are executed at every start of maxima."
-msgstr ""
+msgstr "Comandi che vengono eseguiti ad ogni avvio di maxima."
 
 #: ../../src/cells/EditorCell.cpp:4538
 msgid "Comment (ordinary worksheet text that isn't fed to maxima)"
-msgstr ""
+msgstr "Commento (testo di foglio di lavoro normale che non viene inviato a maxima)"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:465
 msgid "Comment Selection"
@@ -2376,16 +2376,16 @@ msgstr "Condizione:"
 #: ../../src/dialogs/ConfigDialogue.cpp:2641
 #: ../../src/dialogs/ConfigDialogue.cpp:2647
 msgid "Config file (*.ini)|*.ini"
-msgstr ""
+msgstr "File di configurazione (*.ini)|*.ini"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2539
 #, c-format
 msgid "Config item \"%s\" was of an unknown type"
-msgstr ""
+msgstr "L'elemento di configurazione \"%s\" era di tipo sconosciuto"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2607
 msgid "Configuration warning"
-msgstr ""
+msgstr "Avvertimenti di configurazione"
 
 #: ../../src/ToolBar.cpp:367 ../../src/ToolBar.cpp:369
 #: ../../src/wxMaximaFrame.cpp:722 ../../src/wxMaximaFrame.cpp:724
@@ -2394,7 +2394,7 @@ msgstr "Configura wxMaxima"
 
 #: ../../src/wizards/DrawWiz.cpp:829
 msgid "Connect the dots"
-msgstr ""
+msgstr "Connetti i punti"
 
 #: ../../src/MaximaProcessManager.cpp:163
 msgid "Connection attempt, but connection failed."
@@ -2408,7 +2408,7 @@ msgstr "Connessione a Maxima persa."
 #: ../../src/wizards/IntegrateWiz.cpp:208 ../../src/wizards/LimitWiz.cpp:133
 #: ../../src/wizards/SeriesWiz.cpp:105
 msgid "Constant"
-msgstr ""
+msgstr "Costante"
 
 #: ../../src/MaximaCommandMenus.cpp:1102
 msgid "Construct a fraction"
@@ -2420,7 +2420,7 @@ msgstr "Costruisci frazione..."
 
 #: ../../src/sidebars/VariablesPane.cpp:58
 msgid "Contents"
-msgstr ""
+msgstr "Contenuti"
 
 #: ../../src/MaximaCommandMenus.cpp:3970
 msgid "Contents:"
@@ -2436,27 +2436,27 @@ msgstr "Aiuto sensibile al contesto (&h)\tF1"
 
 #: ../../src/sidebars/DrawSidebar.cpp:80
 msgid "Contour"
-msgstr ""
+msgstr "Contorno"
 
 #: ../../src/sidebars/DrawSidebar.cpp:101
 msgid "Contour lines for 3d plots"
-msgstr ""
+msgstr "Linee di contorno per grafici 3D"
 
 #: ../../src/wizards/DrawWiz.cpp:648
 msgid "Contour lines on surface and Bottom"
-msgstr ""
+msgstr "Linee di contorno sulla superficie e sul fondo"
 
 #: ../../src/wizards/DrawWiz.cpp:644
 msgid "Contour lines on the Bottom"
-msgstr ""
+msgstr "Linee di contorno sul fondo"
 
 #: ../../src/wizards/DrawWiz.cpp:641
 msgid "Contour lines on the Surface"
-msgstr ""
+msgstr "Linee di contorno sulla superficie"
 
 #: ../../src/wizards/DrawWiz.cpp:629
 msgid "Contour lines settings for the following 3d plots"
-msgstr ""
+msgstr "Impostazioni delle linee di contorno per i seguenti grafici 3D"
 
 #: ../../src/wxMaximaFrame.cpp:1579
 msgid "Contract Logarithms"
@@ -2541,30 +2541,30 @@ msgstr "Converti in forma no&rmale"
 #: ../../src/sidebars/TableOfContents.cpp:522
 #: ../../src/sidebars/TableOfContents.cpp:543
 msgid "Convert to Heading 5"
-msgstr ""
+msgstr "Converti a intestazione 5"
 
 #: ../../src/sidebars/TableOfContents.cpp:519
 msgid "Convert to Heading 6"
-msgstr ""
+msgstr "Converti a intestazione 6"
 
 #: ../../src/sidebars/TableOfContents.cpp:531
 #: ../../src/sidebars/TableOfContents.cpp:552
 msgid "Convert to Section"
-msgstr ""
+msgstr "Converti a sezione"
 
 #: ../../src/sidebars/TableOfContents.cpp:525
 #: ../../src/sidebars/TableOfContents.cpp:546
 msgid "Convert to Sub-Subsection"
-msgstr ""
+msgstr "Converti a sottosezione"
 
 #: ../../src/sidebars/TableOfContents.cpp:528
 #: ../../src/sidebars/TableOfContents.cpp:549
 msgid "Convert to Subsection"
-msgstr ""
+msgstr "Converti a sottosezione"
 
 #: ../../src/sidebars/TableOfContents.cpp:555
 msgid "Convert to Title"
-msgstr ""
+msgstr "Converti a titolo"
 
 #: ../../src/wxMaximaFrame.cpp:1200
 msgid "Convert to downcase..."
@@ -2750,22 +2750,22 @@ msgstr "Pulsante copia, taglia e incolla"
 #: ../../src/dialogs/ConfigDialogue.cpp:2523
 #, c-format
 msgid "Copying config bool \"%s\""
-msgstr ""
+msgstr "Copia booleano di configurazione \"%s\""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2533
 #, c-format
 msgid "Copying config float \"%s\""
-msgstr ""
+msgstr "Copia virgola mobile di configurazione \"%s\""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2528
 #, c-format
 msgid "Copying config int \"%s\""
-msgstr ""
+msgstr "Copia intero di configurazione \"%s\""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2518
 #, c-format
 msgid "Copying config string \"%s\""
-msgstr ""
+msgstr "Copia stringa di configurazione \"%s\""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:191
 msgid "Corsican"
@@ -2858,7 +2858,7 @@ msgstr "Crea una lista da elementi separati da virgole"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1389
 msgid "Create scalable plots."
-msgstr ""
+msgstr "Crea grafici scalabili."
 
 #: ../../src/wxMaximaFrame.cpp:1116
 msgid "Create struct..."
@@ -2882,7 +2882,7 @@ msgstr ""
 
 #: ../../src/worksheet/Worksheet.cpp:6115
 msgid "Cursor"
-msgstr ""
+msgstr "Cursore"
 
 #: ../../src/Styles.cpp:126
 msgid "Cursor color"
@@ -2904,11 +2904,11 @@ msgstr "Taglia la selezione"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:193
 msgid "Czech"
-msgstr ""
+msgstr "Ceco"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:194
 msgid "Danish"
-msgstr ""
+msgstr "Danese"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2069
 msgid "Dark"
@@ -2924,7 +2924,7 @@ msgstr "File dati (*.csv, *.tab, *.txt)|*.csv;*.tab;*.txt"
 
 #: ../../src/wizards/DrawWiz.cpp:810
 msgid "Data format"
-msgstr ""
+msgstr "Formato dati"
 
 #: ../../src/MaximaCommandMenus.cpp:1767 ../../src/MaximaCommandMenus.cpp:1772
 #: ../../src/MaximaCommandMenus.cpp:1777 ../../src/MaximaCommandMenus.cpp:1781
@@ -2978,15 +2978,15 @@ msgstr "Funzione decremento f(x)<x"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1336
 msgid "Default animation framerate:"
-msgstr ""
+msgstr "Frequenza di quadro predefinita animazioni:"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:717
 msgid "Default plot size for new maxima sessions:"
-msgstr ""
+msgstr "Dimensione grafici predefinita per le nuove sessioni maxima:"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1534
 msgid "Default port for communication with wxMaxima:"
-msgstr ""
+msgstr "La porta predefinita per la comunicazione con wxMaxima:"
 
 #: ../../src/MaximaCommandMenus.cpp:3946
 msgid "Define a function"
@@ -3026,7 +3026,7 @@ msgstr "Definisci struttura..."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:404
 msgid "Define the default speed (in frames per second) animations are played back with."
-msgstr ""
+msgstr "Definisce la velocità predefinita (in quadri al secondo) alla quale sono eseguite le animazioni."
 
 #: ../../src/wxMaximaFrame.cpp:1114
 msgid "Define variable..."
@@ -3099,7 +3099,7 @@ msgstr "Delimitatore:"
 
 #: ../../src/sidebars/GreekSidebar.cpp:181
 msgid "Delta"
-msgstr ""
+msgstr "Delta"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:110
 #: ../../src/worksheet/WorksheetContextMenu.cpp:558
@@ -3125,7 +3125,7 @@ msgstr "Dipendenze"
 
 #: ../../src/wizards/SeriesWiz.cpp:42
 msgid "Depth:"
-msgstr ""
+msgstr "profondità:"
 
 #: ../../src/MaximaCommandMenus.cpp:994
 msgid "Derivate of y at that point:"
@@ -3160,7 +3160,7 @@ msgstr ""
 
 #: ../../src/sidebars/StatSidebar.cpp:61
 msgid "Deviation..."
-msgstr ""
+msgstr "Deviazione..."
 
 #: ../../src/wxMaximaFrame.cpp:1534
 msgid "Di&vide Polynomials..."
@@ -3172,11 +3172,11 @@ msgstr ""
 
 #: ../../src/sidebars/DrawSidebar.cpp:71
 msgid "Diagram title"
-msgstr ""
+msgstr "Titolo diagramma"
 
 #: ../../src/sidebars/HelpBrowser.cpp:51
 msgid "Didn't find an installed offline manual."
-msgstr ""
+msgstr "Non ho trovato il manuale installato localmente."
 
 #: ../../src/MaximaManual.cpp:534
 msgid "Didn't find the maxima HTML manual."
@@ -3192,7 +3192,7 @@ msgstr ""
 
 #: ../../src/sidebars/MathSidebar.cpp:80
 msgid "Diff..."
-msgstr ""
+msgstr "Diff..."
 
 #: ../../src/dialogs/DiffFrame.cpp:308
 #, c-format
@@ -3221,7 +3221,7 @@ msgstr "Deriva l'espressione n volte"
 
 #: ../../src/wizards/LimitWiz.cpp:41
 msgid "Direction:"
-msgstr ""
+msgstr "Direzione:"
 
 #: ../../src/wxMaximaFrame.cpp:1246
 msgid "Directory operations"
@@ -3233,11 +3233,11 @@ msgstr ""
 
 #: ../../src/wizards/Plot2dWiz.cpp:418 ../../src/wizards/Plot2dWiz.cpp:619
 msgid "Discrete plot"
-msgstr ""
+msgstr "Grafico discreto"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:699
 msgid "Display"
-msgstr ""
+msgstr "Mostra"
 
 #: ../../src/wxMaximaFrame.cpp:1075
 msgid "Display Te&X Form"
@@ -3249,11 +3249,11 @@ msgstr "Mostra l'algoritmo"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:827
 msgid "Display all and allow linebreaks in long numbers"
-msgstr ""
+msgstr "Mostra tutto e permetti interruzioni di riga nei numeri linghi"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:820
 msgid "Display all digits"
-msgstr ""
+msgstr "Mostra tutte le cifre"
 
 #: ../../src/wxMaximaFrame.cpp:788
 msgid "Display an expression as maxima's internal lisp representation"
@@ -3281,7 +3281,7 @@ msgstr "Mostra l'espressione precedente in TeX"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:804
 msgid "Display of long numbers"
-msgstr ""
+msgstr "Visualizzazione di numeri lunghi"
 
 #: ../../src/ToolBar.cpp:580
 #, c-format
@@ -3360,11 +3360,11 @@ msgstr "Il documento è stato salvato usando una versione più recente di wxMaxi
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1170
 msgid "Documentclass for TeX export:"
-msgstr ""
+msgstr "Documentclass per l'esportazione TeX:"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1178
 msgid "Documentclass options:"
-msgstr ""
+msgstr "Opzioni documentclass:"
 
 #: ../../src/wxMaximaFrame.cpp:807
 msgid "Don't autosubscript after an underscore"
@@ -3410,19 +3410,19 @@ msgstr "Non usare le parentesi per le matrici"
 
 #: ../../src/dialogs/DiffFrame.cpp:428 ../../src/dialogs/FindReplacePane.cpp:83
 msgid "Down"
-msgstr ""
+msgstr "Giù"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:185
 msgid "Drag-and-drop unicode symbols here"
-msgstr ""
+msgstr "Trascina-e-rilascia i simboli unicode qui"
 
 #: ../../src/wizards/DrawWiz.cpp:155
 msgid "Draw all points where an equation is true."
-msgstr ""
+msgstr "Disegna tutti i punti dove un'equazione è vera."
 
 #: ../../src/wizards/DrawWiz.cpp:802
 msgid "Draw points"
-msgstr ""
+msgstr "Disegna punti"
 
 #: ../../src/MaximaCommandMenus.cpp:1536
 msgid "Drop the first n list elements"
@@ -3542,7 +3542,7 @@ msgstr "Incontrato un evento socket sconosciuto."
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:129
 msgid "End of proof"
-msgstr ""
+msgstr "Fine dimostrazione"
 
 #: ../../src/MaximaCommandMenus.cpp:1024
 msgid "End of t:"
@@ -3550,19 +3550,19 @@ msgstr "Fine di t:"
 
 #: ../../src/wizards/DrawWiz.cpp:71 ../../src/wizards/DrawWiz.cpp:176
 msgid "End of the x value"
-msgstr ""
+msgstr "Fine del valore x"
 
 #: ../../src/wizards/DrawWiz.cpp:88 ../../src/wizards/DrawWiz.cpp:191
 msgid "End of the y value"
-msgstr ""
+msgstr "Fine del valore y"
 
 #: ../../src/wizards/DrawWiz.cpp:208
 msgid "End of the z value"
-msgstr ""
+msgstr "Fine del valore z"
 
 #: ../../src/wizards/DrawWiz.cpp:760
 msgid "End value of the parameter"
-msgstr ""
+msgstr "Fine del valore del parametro"
 
 #: ../../src/MaximaResponseReader.cpp:432
 #: ../../src/MaximaResponseReader.cpp:586
@@ -3575,19 +3575,19 @@ msgstr "Formato ingegneristico (12.1e6 ecc.)"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:196
 msgid "English"
-msgstr ""
+msgstr "Inglese"
 
 #: ../../src/wizards/DrawWiz.cpp:552
 msgid "Enhanced 3D settings:"
-msgstr ""
+msgstr "Impostazioni del 3D avanzato:"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1919
 msgid "Enhanced meta file (emf)"
-msgstr ""
+msgstr "Metafile avanzato (emf)"
 
 #: ../../src/sidebars/StatSidebar.cpp:106
 msgid "Enter Matrix..."
-msgstr ""
+msgstr "Inserire la matrice..."
 
 #: ../../src/MaximaCommandMenus.cpp:2255
 msgid "Enter UUID to jump to:"
@@ -3599,7 +3599,7 @@ msgstr "Inserisci una matrice"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:925
 msgid "Enter adds newlines, Ctrl+Enter evaluates cells"
-msgstr ""
+msgstr "Invio aggiunge ritorni a capo, Ctrl+Invio elabora le celle"
 
 #: ../../src/MaximaCommandMenus.cpp:873
 msgid "Enter an equation for rational simplification:"
@@ -3607,11 +3607,11 @@ msgstr "Inserire un'equazione per la semplificazione razionale:"
 
 #: ../../src/wizards/SystemWiz.cpp:50
 msgid "Enter comma separated list of variables."
-msgstr ""
+msgstr "Inserire la lista di variabili separate dalla virgola."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:921
 msgid "Enter evaluates cells, Ctrl+Enter adds newlines"
-msgstr ""
+msgstr "Invio elabora le celle, Ctrl+Invio aggiunge ritorni a capo"
 
 #: ../../src/MaximaCommandMenus.cpp:1357
 msgid "Enter matrix"
@@ -3627,7 +3627,7 @@ msgstr "Inserire la nuova precisione per i bigfloat:"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:388
 msgid "Enter the path to the Maxima executable."
-msgstr ""
+msgstr "Inserire il percorso dell'eseguibile Maxima."
 
 #: ../../src/MaximaCommandMenus.cpp:1103
 msgid "Enumerator:"
@@ -3639,11 +3639,11 @@ msgstr "Variabili ambiente"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1605
 msgid "Environment variables for maxima"
-msgstr ""
+msgstr "Variabili ambiente per maxima"
 
 #: ../../src/sidebars/GreekSidebar.cpp:182
 msgid "Epsilon"
-msgstr ""
+msgstr "Epsilon"
 
 #: ../../src/MaximaCommandMenus.cpp:299
 msgid "Epsilon:"
@@ -3682,7 +3682,7 @@ msgstr "Equazione:"
 
 #: ../../src/dialogs/TipOfTheDay.cpp:196
 msgid "Equations have several advantages over functions. For example they can be manipulated with factor(), expand() and similar functions. They can easily be introduced one into another. Also they are always printed out as 2D maths."
-msgstr ""
+msgstr "Le equazioni hanno diversi vantaggi rispetto alle funzioni. Per esempio possono essere elaborate con factor(), expand() e funzioni simili. Possono facilmente essere inserite una nell'altra. Inoltre sono sempre stampate come grafici 2D."
 
 #: ../../src/MaximaFileIO.cpp:64 ../../src/MaximaFileIO.cpp:121
 #: ../../src/MaximaFileIO.cpp:130 ../../src/MaximaFileIO.cpp:399
@@ -3739,11 +3739,11 @@ msgstr "Escapes all special characters in a string. The result is a regex that m
 
 #: ../../src/sidebars/GreekSidebar.cpp:184
 msgid "Eta"
-msgstr ""
+msgstr "Eta"
 
 #: ../../src/sidebars/TableOfContents.cpp:513
 msgid "Evaluate"
-msgstr ""
+msgstr "Elabora"
 
 #: ../../src/wxMaximaFrame.cpp:1689
 msgid "Evaluate &Noun Forms..."
@@ -3877,11 +3877,11 @@ msgstr "Numero pari"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2659
 msgid "Example text"
-msgstr ""
+msgstr "Esempio di testo"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1547
 msgid "Examples:"
-msgstr ""
+msgstr "Esempi:"
 
 #: ../../src/wxMaximaFrame.cpp:1740
 msgid "Execute a command for each element of the list"
@@ -3893,11 +3893,11 @@ msgstr "Uscita"
 
 #: ../../src/sidebars/MathSidebar.cpp:53
 msgid "Expand"
-msgstr ""
+msgstr "Espandi"
 
 #: ../../src/sidebars/MathSidebar.cpp:68
 msgid "Expand (tr)"
-msgstr ""
+msgstr "Espandi (tr)"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:356
 msgid "Expand Expression"
@@ -3942,7 +3942,7 @@ msgstr "Esporta"
 
 #: ../../src/sidebars/History.cpp:152
 msgid "Export As"
-msgstr ""
+msgstr "Esporta come"
 
 #: ../../src/wxMaximaFrame.cpp:1742
 msgid "Export List to csv file..."
@@ -3958,15 +3958,15 @@ msgstr "Esporta una matrice in un file csv"
 
 #: ../../src/sidebars/History.cpp:102
 msgid "Export all history to a .mac file"
-msgstr ""
+msgstr "Esporta tutta la cronologia in un file .mac"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1016
 msgid "Export all settings"
-msgstr ""
+msgstr "Esporta tutte le impostazioni"
 
 #: ../../src/sidebars/History.cpp:105
 msgid "Export commands from the current maxima session to a .mac file"
-msgstr ""
+msgstr "Esporta i comandi dalla sessione maxima corrente in un file .mac"
 
 #: ../../src/wxMaximaFrame.cpp:652
 msgid "Export document to a HTML or LaTeX file"
@@ -3974,7 +3974,7 @@ msgstr "Esporta il documento in un file HTML o LaTeX"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1218
 msgid "Export equations to HTML as:"
-msgstr ""
+msgstr "Esporta le equazioni su HTML come:"
 
 #: ../../src/wxMaximaFrame.cpp:600
 msgid "Export failed."
@@ -3990,7 +3990,7 @@ msgstr ""
 
 #: ../../src/sidebars/History.cpp:108
 msgid "Export selected commands to a .mac file"
-msgstr ""
+msgstr "Esporta i comandi selezionati in un file .mac"
 
 #: ../../src/wxMaximaFrame.cpp:588
 msgid "Export successful."
@@ -4002,11 +4002,11 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1022
 msgid "Export the style settings"
-msgstr ""
+msgstr "Esporta le impostazioni di stile"
 
 #: ../../src/sidebars/History.cpp:111
 msgid "Export visible commands to a .mac file"
-msgstr ""
+msgstr "Esporta i comandi visibili in un file .mac"
 
 #: ../../src/MaximaCommandMenus.cpp:3417
 #, c-format
@@ -4020,7 +4020,7 @@ msgstr ""
 
 #: ../../src/sidebars/History.cpp:228
 msgid "Exporting to .mac file failed!"
-msgstr ""
+msgstr "Esportazione su file .mac fallita!"
 
 #: ../../src/MaximaCommandMenus.cpp:2343
 msgid "Exporting to HTML failed!"
@@ -4056,19 +4056,19 @@ msgstr "Espressione o lista di elementi separati da virgole"
 
 #: ../../src/wizards/DrawWiz.cpp:733
 msgid "Expression that calculates the x value"
-msgstr ""
+msgstr "Espressione che calcola il valore x"
 
 #: ../../src/wizards/DrawWiz.cpp:738
 msgid "Expression that calculates the y value"
-msgstr ""
+msgstr "Espressione che calcola il valore y"
 
 #: ../../src/wizards/DrawWiz.cpp:744
 msgid "Expression that calculates the z value"
-msgstr ""
+msgstr "Espressione che calcola il valore z"
 
 #: ../../src/wizards/DrawWiz.cpp:56
 msgid "Expression to plot"
-msgstr ""
+msgstr "Espressione da tracciare"
 
 #: ../../src/wxMaximaFrame.cpp:1122
 msgid "Expression to string..."
@@ -4223,7 +4223,7 @@ msgstr "Estrai un rettangolo da un array 2D e convertilo in una matrice"
 
 #: ../../src/sidebars/MathSidebar.cpp:50
 msgid "Factor"
-msgstr ""
+msgstr "Fattorizza"
 
 #: ../../src/wxMaximaFrame.cpp:1558
 msgid "Factor Complex"
@@ -4298,7 +4298,7 @@ msgstr "Campi:"
 #: ../../src/cells/GroupCell.cpp:2115
 #, c-format
 msgid "Figure %d:"
-msgstr ""
+msgstr "Figura %d:"
 
 #: ../../src/main.cpp:678
 msgid "File"
@@ -4350,7 +4350,7 @@ msgstr "Nomefile o una lista di nomi di file separati da virgole"
 
 #: ../../src/sidebars/DrawSidebar.cpp:93
 msgid "Fill color"
-msgstr ""
+msgstr "Colore riempimento"
 
 #: ../../src/ToolBar.cpp:401 ../../src/ToolBar.cpp:403
 msgid "Find"
@@ -4471,7 +4471,7 @@ msgstr "Trova la somma massima dei valori assoluti di una riga di matrice"
 
 #: ../../src/dialogs/FindReplacePane.cpp:46
 msgid "Find:"
-msgstr ""
+msgstr "Trova:"
 
 #: ../../src/wxMaximaFrame.cpp:1869
 msgid "Fine-tune the display of engineering-format numbers"
@@ -4479,7 +4479,7 @@ msgstr "Regola finemente la visualizzazione dei numeri in formato ingegneristico
 
 #: ../../src/dialogs/ConfigDialogue.cpp:197
 msgid "Finnish"
-msgstr ""
+msgstr "Finlandese"
 
 #: ../../src/wxMaximaFrame.cpp:1749
 msgid "First"
@@ -4492,11 +4492,11 @@ msgstr "Fit delle curve dei dati di misura"
 #: ../../src/dialogs/ConfigDialogue.cpp:1404
 #, c-format
 msgid "Fix reordered reference indices (of %i, %o) before saving"
-msgstr ""
+msgstr "Aggiusta gli indici di riferimento riordinati (di %i, %o) prima di salvare"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:873
 msgid "Fixed font in text controls"
-msgstr ""
+msgstr "Carattere di ampiezza fissa nei controlli di testo."
 
 #: ../../src/MaximaCommandMenus.cpp:4039
 msgid "Flush stream"
@@ -4524,11 +4524,11 @@ msgstr ""
 
 #: ../../src/wizards/DrawWiz.cpp:341
 msgid "Following plots use secondary x axis"
-msgstr ""
+msgstr "I grafici seguenti usano l'asse x secondario"
 
 #: ../../src/wizards/DrawWiz.cpp:347
 msgid "Following plots use secondary y axis"
-msgstr ""
+msgstr "I grafici seguenti usano l'asse y secondario"
 
 #: ../../src/sidebars/PerformanceSidebar.cpp:37
 msgid "Font cache hits:"
@@ -4540,11 +4540,11 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2047
 msgid "Fonts"
-msgstr ""
+msgstr "Font"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:442
 msgid "For each Text-, Sectioning or code cell wxMaxima can display a bracket showing the extend of the cell and allowing to fold it. This setting now tells if this bracket is to be printed, as well."
-msgstr ""
+msgstr "Per ogni testo, sezionamento o cella di codice wxMaxima può mostrare una parentesi che mostra l'estensione della cella permettendo di ripiegarla. Questa impostazione indica se anche questa parentesi deve essere stampata."
 
 #: ../../src/ToolBar.cpp:495
 msgid "For faster creation of cells the following shortcuts exist:\n\n"
@@ -4576,7 +4576,7 @@ msgstr ""
 
 #: ../../src/wizards/Plot2dWiz.cpp:69 ../../src/wizards/Plot3dWiz.cpp:60
 msgid "Format:"
-msgstr ""
+msgstr "Formato:"
 
 #: ../../src/worksheet/Worksheet.cpp:301 ../../src/wxMaxima.cpp:3521
 msgid "Forwarding the keyboard focus to a text control"
@@ -4621,15 +4621,15 @@ msgstr "Quadro %li di %li"
 
 #: ../../src/wizards/DrawWiz.cpp:488
 msgid "Frame counter"
-msgstr ""
+msgstr "Contatore di quadro"
 
 #: ../../src/wizards/DrawWiz.cpp:499
 msgid "Frame counter end"
-msgstr ""
+msgstr "Fine contatore di quadro"
 
 #: ../../src/wizards/DrawWiz.cpp:494
 msgid "Frame counter start"
-msgstr ""
+msgstr "Inizio contatore di quadro"
 
 #: ../../src/MaximaCommandMenus.cpp:102
 msgid "Frame rate"
@@ -4641,7 +4641,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:198
 msgid "French"
-msgstr ""
+msgstr "Francese"
 
 #: ../../src/wxMaximaFrame.cpp:1447
 msgid "Frobenius Norm sqrt(sum((A(i,j))^2)) (complex)"
@@ -4724,11 +4724,11 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:199
 msgid "Galician"
-msgstr ""
+msgstr "Galiziano"
 
 #: ../../src/sidebars/GreekSidebar.cpp:180
 msgid "Gamma"
-msgstr ""
+msgstr "Gamma"
 
 #: ../../src/wxMaximaFrame.cpp:316
 msgid "General Math"
@@ -4780,7 +4780,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:201
 msgid "German"
-msgstr ""
+msgstr "Tedesco"
 
 #: ../../src/wxMaximaFrame.cpp:1656
 msgid "Get &Imaginary Part"
@@ -4868,7 +4868,7 @@ msgstr "Maggiore, ignorare le maiuscole?..."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:202
 msgid "Greek"
-msgstr ""
+msgstr "Greco"
 
 #: ../../src/wxMaximaFrame.cpp:281
 msgid "Greek Letters"
@@ -4880,11 +4880,11 @@ msgstr "Lettere greche\tAlt+Shift+G"
 
 #: ../../src/sidebars/DrawSidebar.cpp:97
 msgid "Grid"
-msgstr ""
+msgstr "Griglia"
 
 #: ../../src/wizards/Plot3dWiz.cpp:52
 msgid "Grid:"
-msgstr ""
+msgstr "Griglia:"
 
 #: ../../src/wxMaximaFrame.cpp:1852
 msgid "Guess an exact number that could be meant by this float"
@@ -4892,7 +4892,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1215
 msgid "HTML"
-msgstr ""
+msgstr "HTML"
 
 #: ../../src/MaximaCommandMenus.cpp:2279
 msgid "HTML file (*.html)|*.html|maxima batch file (*.mac)|*.mac|LaTeX file (*.tex)|*.tex"
@@ -4940,7 +4940,7 @@ msgstr "Aiuto"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1461
 msgid "Help browser:"
-msgstr ""
+msgstr "Browser dell'aiuto:"
 
 #: ../../src/ToolBar.cpp:835
 msgid "Help button"
@@ -4959,7 +4959,7 @@ msgstr ""
 
 #: ../../src/sidebars/TableOfContents.cpp:510
 msgid "Hide"
-msgstr ""
+msgstr "Nascondi"
 
 #: ../../src/ToolBar.cpp:471 ../../src/ToolBar.cpp:473
 msgid "Hide Code"
@@ -4999,7 +4999,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:487
 msgid "Hide all multiplication signs that aren't really necessary for understanding the equation"
-msgstr ""
+msgstr "Nascondi tutti i segni delle moltiplicazioni che non sono strettamente necessari per la comprensione dell'equazione"
 
 #: ../../src/wxMaximaFrame.cpp:767
 msgid "Hide all panes"
@@ -5019,15 +5019,15 @@ msgstr "Nascondi punti moltiplicazioni"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:854
 msgid "Hide multiplication signs, if possible"
-msgstr ""
+msgstr "Nascondi segni delle moltiplicazioni, se possibile"
 
 #: ../../src/wizards/DrawWiz.cpp:555
 msgid "Hide objects behind the surface"
-msgstr ""
+msgstr "Nascondi gli oggetti dietro la superficie"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:502
 msgid "Hide the brackets that mark the extend of the worksheet cells at the worksheet's right side and that contain the \"hide\" button of the cell if the cells aren't active."
-msgstr ""
+msgstr "Nascondi le parentesi che marcano l'estensione delle celle del foglio di lavoro sul lato destro del foglio di lavoro e ciò contiene il pulsante \"nascondi\" della cella se le celle non sono attive."
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:702
 #: ../../src/worksheet/WorksheetContextMenu.cpp:835
@@ -5045,11 +5045,11 @@ msgstr "Evidenzia (riquadro)"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:869
 msgid "Highlight the matching parenthesis"
-msgstr ""
+msgstr "Evidenzia la parentesi corrispondente"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:463
 msgid "Highlight the opening or closing parenthesis for the parenthesis the cursor is at."
-msgstr ""
+msgstr "Evidenzia la parentesi di apertura o chiusura per la parentesi al cursore."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:204
 msgid "Hindi"
@@ -5061,7 +5061,7 @@ msgstr "Istogramma"
 
 #: ../../src/sidebars/StatSidebar.cpp:85
 msgid "Histogram..."
-msgstr ""
+msgstr "Istogramma..."
 
 #: ../../src/wxMaximaFrame.cpp:246
 msgid "History"
@@ -5073,7 +5073,7 @@ msgstr "Cronologia\tAlt+Shift+I"
 
 #: ../../src/dialogs/TipOfTheDay.cpp:105
 msgid "Horizontal cursor works like a normal cursor, but it operates on cells: press up or down arrow to move it, holding down Shift while moving will select cells, pressing backspace or delete twice will delete a cell next to it."
-msgstr ""
+msgstr "Il cursore orizzontale lavora come un normale cursore, anche se opera sulle celle: premere le frecce in su e in giù per spostarlo, mantenendo premuto il tasto Maiusc durante questo movimento selezionerà le celle, premendo backspace o Canc due volte si cancellerà la cella vicina ad esso."
 
 #: ../../src/wxMaximaFrame.cpp:1563
 msgid "Horner's rule"
@@ -5081,7 +5081,7 @@ msgstr "Regola di Horner"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:918
 msgid "Hotkeys for sending commands to maxima"
-msgstr ""
+msgstr "Tasti acceleratori per inviare comandi a maxima"
 
 #: ../../src/MaximaCommandMenus.cpp:398
 msgid "How many digits to show:"
@@ -5093,7 +5093,7 @@ msgstr "Come mostrare le nuove equazioni"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:205
 msgid "Hungarian"
-msgstr ""
+msgstr "Ungherese"
 
 #: ../../src/wxMaximaFrame.cpp:1147
 msgid "I/O"
@@ -5101,7 +5101,7 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:121
 msgid "Identical to"
-msgstr ""
+msgstr "Identico a"
 
 #: ../../src/MaximaCommandMenus.cpp:3874
 msgid "If a program doesn't need local variables, Maxima allows putting the commands between parentheses. The result of the last operation is the return value of the program."
@@ -5109,51 +5109,51 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:145
 msgid "If maxima versions compiled with different lisps are installed: The name of the lisp to use by default"
-msgstr ""
+msgstr "Se sono state installate diverse versioni di maxima compilate con lisp differenti: il nome del lisp da usare come impostazione predefinita"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:174
 msgid "If maxima was compiled by GCL: Garbage Collect at minimum allocation past this heapsize"
-msgstr ""
+msgstr "Se maxima è stato compilato con GCL: Garbage Collect alla minima allocazione oltre il suo heapsize"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:171
 msgid "If maxima was compiled by GCL: Minimum allocation fraction between Garbage Collects"
-msgstr ""
+msgstr "Se maxima è stato compilato con GCL: frazione di allocazione minima tra le operazioni di Garbage Collection"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:168
 msgid "If maxima was compiled by GCL: Only garbage collect past this heapsize fraction of working mem"
-msgstr ""
+msgstr "Se maxima è stato compilato con GCL: fa la garbage collection oltre questa frazione di heapsize di memoria di lavoro"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:180
 msgid "If maxima was compiled by GCL: Share the allocated memory between gcl processes. Allows more than one gcl-compiled maxima to run at the same time, but might provoke crashes."
-msgstr ""
+msgstr "Se maxima è stato compilato con GCL: condividi la memoria allocata tra tutti i processi gcl. Permette a più di un solo maxima compilato con gcl di venir eseguito contemporaneamente; può provocare dei malfunzionamenti."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:177
 msgid "If maxima was compiled by GCL: The fraction of the total installed RAM to reserve for maxima"
-msgstr ""
+msgstr "Se maxima è stato compilato con GCL: la frazione della RAM totale installata da riservare a maxima"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:375
 msgid "If multiple cells are evaluated in one go: Abort evaluation if wxMaxima detects that maxima has encountered any error."
-msgstr ""
+msgstr "Se più celle vengono elaborate in una volta: blocca l'elaborazione se wxMaxima rileva che maxima ha incontrato qualche errore."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:727
 msgid "If not extremely long"
-msgstr ""
+msgstr "Se non estremamente lunga"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:726
 msgid "If not very long"
-msgstr ""
+msgstr "Se non molto lunga"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:418
 msgid "If numbers are getting longer than this number of digits they will be displayed abbreviated by an ellipsis."
-msgstr ""
+msgstr "Se i numeri verranno più lunghi di questo numero di cifre verranno mostrati abbreviati con dei puntini di sospensione."
 
 #: ../../src/dialogs/TipOfTheDay.cpp:181
 msgid "If the \"Autosave\" functionality is enabled in the configuration dialogue wxMaxima acts like mobile apps that backup the file every few minutes and save it on closing."
-msgstr ""
+msgstr "Se la funzionalità \"Autosalva\" è abilitata nella finestra di dialogo, wxMaxima agisce come le applicazioni per cellulari che fanno il salvataggio del file ogni pochi minuti e lo salvano alla chiusura."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:396
 msgid "If the font provides big parenthesis symbols: Use them when big parenthesis are needed for maths display."
-msgstr ""
+msgstr "Se il font fornisce simboli di grandi parentesi: usali se servono per visualualizzare le formule matematiche."
 
 #: ../../src/cells/TextCell.cpp:327
 msgid "If the thing maxima complains about actually looks like a polynomial you can try running it through ratdisrep() in order to fix that problem."
@@ -5167,15 +5167,15 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:399
 msgid "If this checkbox is checked wxMaxima automatically saves the file closing and every few minutes giving wxMaxima a more cellphone-app-like feel as the file is virtually always saved. If this checkbox is unchecked from time to time a backup is made in the temp folder instead."
-msgstr ""
+msgstr "Se questa casella viene selezionata wxMaxima salva automaticamente il file alla chiusura e ad ogni intervallo di qualche minuto, dando un comportamento a wxMaxima più simile ad un'app per cellulare dato che il file viene quasi sempre salvato. Se questa casella non viene selezionata il backup periodico viene effettuato invece nella cartella dei file temporanei."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:378
 msgid "If this checkbox is set a new code cell is opened as soon as maxima requests data. If it isn't set a new code cell is opened in this case as soon as the user starts typing in code."
-msgstr ""
+msgstr "Se questa casella viene selezionata, viene aperta una nuova cella di codice non appena maxima richiede dei dati. Altrimenti una nuova cella di codice viene aperta non appena l'utente comincia ad inserire del codice."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:372
 msgid "If this checkbox isn't checked the current command is sent to maxima only on pressing Ctrl+Enter"
-msgstr ""
+msgstr "Se questa opzione non è selezionata il comando corrente viene mandato a maxima solo premendo Ctrl+Invio"
 
 #: ../../src/MathParser.cpp:945
 msgid "If this isn't a function returning a lambda() expression a multiplication sign (*) between closing and opening parenthesis is missing here."
@@ -5188,7 +5188,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:439
 msgid "If this option is set the .wxmx source of the current file is copied to a place a link to is put into the result of an export."
-msgstr ""
+msgstr "Se quest'opzione è impostata, i sorgenti .wxmx del file corrente vengono copiati in una posizione dove un collegamento a questa viene messo nel risultato di un'esportazione."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1873
 msgid "If unset, Maxima's output is announced to the screen reader as maths in a linear text form. Set this option if your screen reader can speak MathML properly."
@@ -5196,15 +5196,15 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:247
 msgid "If you have ideas, how to improve the design or functionality of wxMaxima, please share your ideas at the issue list or discussion forum at https://github.com/wxMaxima-developers/wxmaxima/."
-msgstr ""
+msgstr "Avete un'idea su come si può migliorare wxMaxima? Ottimo! Sottoponetecela nel forum https://github.com/wxMaxima-developers/wxmaxima/."
 
 #: ../../src/dialogs/TipOfTheDay.cpp:76
 msgid "If you type an operator (one of +*/^=,) as the first symbol in an input cell, % will be automatically inserted before the operator, as on a graphing calculator. You can disable this feature from the 'Edit->Configure' dialog."
-msgstr ""
+msgstr "Se si batte un operatore (uno fra +*/^=,) come primo simbolo in una cella di ingresso, % verrà automaticamente inserito prima dell'operatore, come su un calcolatore grafico. È possibile disabilitare questa caratteristica tramite la finestra di dialogo 'Modifica->Configura'."
 
 #: ../../src/dialogs/TipOfTheDay.cpp:122
 msgid "If your calculation is taking too long to evaluate, you can try 'Maxima->Interrupt' or 'Maxima->Restart Maxima' menu commands."
-msgstr ""
+msgstr "Se l'elaborazione di calcolo dura troppo tempo, si può provare ad arrestarla con i comandi da menu \"Maxima->Interruzione\" o \"Maxima->Riavvia Maxima\"."
 
 #: ../../src/MaximaManual.cpp:420
 msgid "Ignoring the cache version for the manual anchors."
@@ -5212,7 +5212,7 @@ msgstr "Ignorata la versione in cache delle ancore del manuale."
 
 #: ../../src/sidebars/FormatSidebar.cpp:66
 msgid "Image"
-msgstr ""
+msgstr "Immagine"
 
 #: ../../src/Image.cpp:110
 msgid "Image data had zero length!"
@@ -5234,15 +5234,15 @@ msgstr "ImageCell senza immagine."
 
 #: ../../src/sidebars/DrawSidebar.cpp:60
 msgid "Implicit Plot"
-msgstr ""
+msgstr "Grafico implicito"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1028
 msgid "Import settings"
-msgstr ""
+msgstr "Importa impostazioni"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1013
 msgid "Import+Export"
-msgstr ""
+msgstr "Importa+Esporta"
 
 #: ../../src/MathParser.cpp:395
 msgid "Importing compressed gnuplot sources for an animation"
@@ -5276,11 +5276,11 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:214
 msgid "In text cells bullet lists can be created by beginning a line with \" * \". The number of spaces in front of the \"*\" determines the indentation level; Indentation can be continued in the next line by indenting the line using spaces."
-msgstr ""
+msgstr "Nelle celle di testo gli elenchi puntati possono essere creati iniziando una riga con \" * \". Il numero di spazi di fronte al \"*\" determina il livello di indenzazione; l'indentazione può continuare nella riga seguente indentando la linea usando gli spazi."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:421
 msgid "In the LaTeX output: Put exponents after an eventual subscript instead of above it. Might increase readability for some fonts and short subscripts."
-msgstr ""
+msgstr "Nel risultato LaTeX: metti gli esponenti dopo un eventuale pedice invece di metterli sopra di esso. Può migliorare la leggibilità con alcuni font e con alcuni pedici corti."
 
 #: ../../src/MaximaCommandMenus.cpp:1869
 msgid "Include columns:"
@@ -5292,15 +5292,15 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:884
 msgid "Incremental Search"
-msgstr ""
+msgstr "Ricerca incrementale"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:844
 msgid "Indent equations by the label width"
-msgstr ""
+msgstr "Indenta equazioni alla larghezza etichetta"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:512
 msgid "Indent maths so all lines are in par with the first line that starts after the label."
-msgstr ""
+msgstr "Indenta le formule in modo tale che tutte le righe siano allineate alla prima riga che inizia dopo l'etichetta."
 
 #: ../../src/sidebars/TableOfContents.cpp:583
 msgid "Indentation"
@@ -5341,7 +5341,7 @@ msgstr ""
 #: ../../src/wizards/IntegrateWiz.cpp:215 ../../src/wizards/LimitWiz.cpp:132
 #: ../../src/wizards/LimitWiz.cpp:140
 msgid "Infinity"
-msgstr ""
+msgstr "Infinito"
 
 #: ../../src/wxMaximaFrame.cpp:1986
 msgid "Info about Maxima build"
@@ -5399,7 +5399,7 @@ msgstr "Inserisci"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:889
 msgid "Insert % before an operator at the beginning of a cell"
-msgstr ""
+msgstr "Inserire % prima di un operatore all'inizio di una cella"
 
 #: ../../src/wxMaximaFrame.cpp:939
 msgid "Insert &Section Cell\tCtrl+3"
@@ -5535,7 +5535,7 @@ msgstr ""
 
 #: ../../src/sidebars/HelpBrowser.cpp:111
 msgid "Instantiating the HTML manual browser"
-msgstr ""
+msgstr "Istanziazione del browser del manuale HTML"
 
 #: ../../src/MaximaProcessManager.cpp:1066
 msgid "Instructed to prefer gnuplot over wgnuplot"
@@ -5547,11 +5547,11 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:749
 msgid "Integers and single letters"
-msgstr ""
+msgstr "Interi e lettere singole"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:113
 msgid "Integral sign"
-msgstr ""
+msgstr "Segno integrale"
 
 #: ../../src/MaximaCommandMenus.cpp:149 ../../src/MaximaCommandMenus.cpp:170
 msgid "Integral/Sum:"
@@ -5585,15 +5585,15 @@ msgstr "Integra..."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:834
 msgid "Intelligently hide cell brackets"
-msgstr ""
+msgstr "Nascondi intelligentemente le parentesi della cella"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:881
 msgid "Interaction"
-msgstr ""
+msgstr "Interazione"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1349
 msgid "Interactive popup memory limit [MB/plot]:"
-msgstr ""
+msgstr "Limite memoria popup interattiva [MB/grafico]:"
 
 #: ../../src/wxMaximaFrame.cpp:1774
 msgid "Interleave"
@@ -5609,7 +5609,7 @@ msgstr "Alterna due liste"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1465
 msgid "Internal"
-msgstr ""
+msgstr "Interno"
 
 #: ../../src/wxMaximaFrame.cpp:1121
 msgid "Interpret like input..."
@@ -5658,7 +5658,7 @@ msgstr ""
 
 #: ../../src/sidebars/RegexCtrl.cpp:40
 msgid "Invalid RegEx!"
-msgstr ""
+msgstr "Espr. reg. non valida!"
 
 #: ../../src/MathParser.cpp:1338
 #, c-format
@@ -5675,7 +5675,7 @@ msgstr "T&rasformata inversa di Laplace..."
 
 #: ../../src/sidebars/GreekSidebar.cpp:186
 msgid "Iota"
-msgstr ""
+msgstr "Iota"
 
 #: ../../src/MaximaCommandMenus.cpp:4150
 msgid "Is Char 1 greater than Char2, if case is ignored?"
@@ -5791,7 +5791,7 @@ msgstr "È maiuscolo?..."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:498
 msgid "Issue a notification if maxima finishes calculating while the wxMaxima window isn't in focus."
-msgstr ""
+msgstr "Produce una notifica se maxima finisce di calcolare mentre la finestra di wxMaxima non ha il fuoco."
 
 #: ../../src/worksheet/Worksheet.cpp:4237
 msgid "Issuing the active cell's undo function"
@@ -5803,27 +5803,27 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:185
 msgid "It is possible to add custom symbols to the \"symbols\" sidebar by copying them into the respective field in the configuration dialogue."
-msgstr ""
+msgstr "È possibile aggiungere simboli personalizzati alla barra laterale \"simboli\" copiandoli nel campo corrispondente nella finestra di dialogo di configurazione."
 
 #: ../../src/dialogs/TipOfTheDay.cpp:152
 msgid "It is possible to define reusable Maxima libraries with wxMaxima that can be later loaded by using the load() function. All that has to be done is to export a file in the .mac or to save it in the .wxm format. Note, though, that a few special characters like the \"not equal\" symbol for \"#\" are handled by wxMaxima, not by Maxima and therefore cannot be recognized on load()."
-msgstr ""
+msgstr "È possibile definire librerie Maxima riutilizzabili con wxMaxima che possono essere in seguito caricate usando la funzione load(). Non si deve fare altro che esportare un file nel .mac o salvarlo nel formato .wxm . Si noti però che, qualche carattere speciale come il simbolo di \"non uguale\" per \"#\" sono gestiti da wxMaxima, non da maxima e perciò non possono essere riconosciuti da load()."
 
 #: ../../src/wizards/DrawWiz.cpp:476
 msgid "It needs to be filled with objects to draw afterwards."
-msgstr ""
+msgstr "Necessita di essere riempito con oggetti da disegnare in seguito."
 
 #: ../../src/wizards/ActualValuesStorageWiz.cpp:38
 msgid "It therefore makes sense to apply the known values for variables as late as possible."
-msgstr ""
+msgstr "Perciò ha senso applicare i valori conosciuti delle variabili il più tardi possibile."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:207
 msgid "Italian"
-msgstr ""
+msgstr "Italiano"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2111
 msgid "Italic"
-msgstr ""
+msgstr "Corsivo"
 
 #: ../../src/MaximaCommandMenus.cpp:1617 ../../src/MaximaCommandMenus.cpp:1623
 msgid "Item"
@@ -5835,7 +5835,7 @@ msgstr "Nome iteratore:"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:208
 msgid "Japanese"
-msgstr ""
+msgstr "Giapponese"
 
 #: ../../src/MaximaCommandMenus.cpp:2255
 msgid "Jump to UUID"
@@ -5863,16 +5863,16 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:210
 msgid "Kabyle"
-msgstr ""
+msgstr "Cabile"
 
 #: ../../src/sidebars/GreekSidebar.cpp:187
 msgid "Kappa"
-msgstr ""
+msgstr "Kappa"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:864
 #, c-format
 msgid "Keep percent sign with special symbols: %e, %i, etc."
-msgstr ""
+msgstr "Mantieni il simbolo di percentuale con i simboli speciali: %e, %i, ecc."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:212
 msgid "Korean"
@@ -5900,19 +5900,19 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1166
 msgid "LaTeX"
-msgstr ""
+msgstr "LaTeX"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1199
 msgid "LaTeX: Place exponents after, instead above subscripts"
-msgstr ""
+msgstr "LaTeX: metti gli esponenti dopo, invece che sopra i pedici"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1204
 msgid "LaTeX: Use the \"partial derivative\" symbol to represent diff()"
-msgstr ""
+msgstr "LaTeX: Usa il simbolo di \"derivata parziale\" per rappresentare diff()"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:758
 msgid "Label width:"
-msgstr ""
+msgstr "Larghezza etichetta:"
 
 #: ../../src/wxMaximaFrame.cpp:1059
 msgid "Labels"
@@ -5931,11 +5931,11 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:470
 msgid "Language used for wxMaxima GUI."
-msgstr ""
+msgstr "Lingua usata per wxMaxima."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1311
 msgid "Language:"
-msgstr ""
+msgstr "Lingua:"
 
 #: ../../src/MaximaCommandMenus.cpp:251
 msgid "Laplace"
@@ -5982,7 +5982,7 @@ msgstr "Avvio del browser dell'aiuto di sistema predefinito fallito."
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:126
 msgid "Leads to"
-msgstr ""
+msgstr "Porta a"
 
 #: ../../src/wxMaximaFrame.cpp:1530
 msgid "Least Common Multiple..."
@@ -5994,7 +5994,7 @@ msgstr "Metodo dei minimi quadrati"
 
 #: ../../src/sidebars/StatSidebar.cpp:79
 msgid "Least Squares Fit..."
-msgstr ""
+msgstr "Metodo dei minimi quadrati..."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2007
 msgid "Left"
@@ -6031,12 +6031,12 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:163
 msgid "Libraries can be accessed by any wxMaxima process regardless of which directory it runs in, if they are placed in the user directory. This directory can be found by typing maxima_userdir;"
-msgstr ""
+msgstr "Le librerie sono accessibili da qualsiasi processo wxMaxima, indipendentemente dalla cartella da cui questo viene eseguito, se piazzato nella cartella utente. La posizione di questa cartella può essere verificata battendo il comando maxima_userdir;"
 
 #: ../../src/dialogs/LicenseDialog.cpp:63
 #: ../../src/dialogs/LicenseDialog.cpp:77
 msgid "License"
-msgstr ""
+msgstr "Licenza"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2068
 msgid "Light"
@@ -6052,15 +6052,15 @@ msgstr "Limite"
 
 #: ../../src/sidebars/MathSidebar.cpp:86
 msgid "Limit..."
-msgstr ""
+msgstr "Limite..."
 
 #: ../../src/sidebars/DrawSidebar.cpp:88
 msgid "Line color"
-msgstr ""
+msgstr "Colore linea"
 
 #: ../../src/sidebars/StatSidebar.cpp:76
 msgid "Linear Regression..."
-msgstr ""
+msgstr "Regressione lineare..."
 
 #: ../../src/MaximaCommandMenus.cpp:4068
 msgid "Lisp format string:"
@@ -6108,15 +6108,15 @@ msgstr "Lista cartelle..."
 
 #: ../../src/wizards/ListSortWiz.cpp:34
 msgid "List name:"
-msgstr ""
+msgstr "Nome lista:"
 
 #: ../../src/sidebars/VariablesPane.cpp:188
 msgid "List of arrays"
-msgstr ""
+msgstr "Elenco di array"
 
 #: ../../src/sidebars/VariablesPane.cpp:191
 msgid "List of changed options"
-msgstr ""
+msgstr "Elenco di opzioni cambiate"
 
 #: ../../src/MaximaCommandMenus.cpp:4197
 msgid "List of char to String"
@@ -6132,47 +6132,47 @@ msgstr "Lista di caratteri:"
 
 #: ../../src/sidebars/VariablesPane.cpp:179
 msgid "List of functional dependencies"
-msgstr ""
+msgstr "Lista di dipendenze funzionali"
 
 #: ../../src/sidebars/VariablesPane.cpp:203
 msgid "List of labels"
-msgstr ""
+msgstr "Elenco di etichette"
 
 #: ../../src/sidebars/VariablesPane.cpp:200
 msgid "List of structs"
-msgstr ""
+msgstr "Elenco di strutture"
 
 #: ../../src/sidebars/VariablesPane.cpp:197
 msgid "List of user aliases"
-msgstr ""
+msgstr "Elenco di alias utente"
 
 #: ../../src/sidebars/VariablesPane.cpp:185
 msgid "List of user functions"
-msgstr ""
+msgstr "Elenco di funzioni utente"
 
 #: ../../src/sidebars/VariablesPane.cpp:194
 msgid "List of user rules"
-msgstr ""
+msgstr "Elenco di regole utente"
 
 #: ../../src/sidebars/VariablesPane.cpp:182
 msgid "List of user variables"
-msgstr ""
+msgstr "Elenco di variabili utente"
 
 #: ../../src/sidebars/VariablesPane.cpp:206
 msgid "List of user-defined derivatives"
-msgstr ""
+msgstr "Elenco di derivate definite dall'utente"
 
 #: ../../src/sidebars/VariablesPane.cpp:216
 msgid "List of user-defined let rule packages"
-msgstr ""
+msgstr "Elenco di pacchetti di regole definiti dall'utente"
 
 #: ../../src/sidebars/VariablesPane.cpp:212
 msgid "List of user-defined macros"
-msgstr ""
+msgstr "Elenco di macro definite dall'utente"
 
 #: ../../src/sidebars/VariablesPane.cpp:209
 msgid "List of user-defined properties"
-msgstr ""
+msgstr "Elenco di proprietà definite dall'utente"
 
 #: ../../src/MaximaCommandMenus.cpp:1575
 msgid "List with values"
@@ -6193,7 +6193,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2162
 msgid "Load"
-msgstr ""
+msgstr "Carica"
 
 #: ../../src/MaximaCommandMenus.cpp:2356
 msgid "Load Package"
@@ -6233,7 +6233,7 @@ msgstr "Carica lisp..."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2645
 msgid "Load style from file"
-msgstr ""
+msgstr "Carica lo stile da file"
 
 #: ../../src/wxMaximaFrame.cpp:1232
 msgid "Load the file/dir operations (operatingsystem)"
@@ -6249,7 +6249,7 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:128
 msgid "Long Right arrow"
-msgstr ""
+msgstr "Freccia destra lunga"
 
 #: ../../src/MaximaCommandMenus.cpp:1409
 msgid "Loop variable"
@@ -6269,7 +6269,7 @@ msgstr "M&atrice"
 
 #: ../../src/sidebars/XmlInspector.cpp:104
 msgid "MAXIMA RESPONSE:"
-msgstr ""
+msgstr "RISPOSTA DI MAXIMA:"
 
 #: ../../src/MaximaCommandMenus.cpp:3965
 msgid "Macro contents:"
@@ -6333,7 +6333,7 @@ msgstr "Mappa la funzione su di una matrice, influenza tutti i suoi cloni"
 
 #: ../../src/dialogs/FindReplacePane.cpp:71
 msgid "Match Case"
-msgstr ""
+msgstr "Controllo maiuscole"
 
 #: ../../src/Styles.cpp:139
 msgid "Math Default"
@@ -6345,7 +6345,7 @@ msgstr ""
 
 #: ../../src/cells/Cell.cpp:1490
 msgid "Math output"
-msgstr ""
+msgstr "Uscita matematica"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1221
 msgid "MathML (rendered by the browser)"
@@ -6357,11 +6357,11 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1906
 msgid "MathML as HTML"
-msgstr ""
+msgstr "MathML come HTML"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1902
 msgid "MathML description"
-msgstr ""
+msgstr "Descrizione MathML"
 
 #: ../../src/wxMaximaFrame.cpp:307
 msgid "Mathematical Symbols"
@@ -6441,11 +6441,11 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:281
 msgid "Maxima"
-msgstr ""
+msgstr "Maxima"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1433
 msgid "Maxima Location"
-msgstr ""
+msgstr "Posizione di Maxima"
 
 #: ../../src/MaximaCommandMenus.cpp:619
 msgid "Maxima allows making functions \"nouns\", which means that they aren't automatically evaluated as soon as Maxima encounters them.\n"
@@ -6478,19 +6478,19 @@ msgstr ""
 
 #: ../../src/cells/EditorCell.cpp:4516
 msgid "Maxima code"
-msgstr ""
+msgstr "Codice Maxima"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1110
 msgid "Maxima commands to be executed at every start of Maxima"
-msgstr ""
+msgstr "Comandi Maxima che devono essere eseguiti ad ogni avvio di Maxima"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1063
 msgid "Maxima commands to be executed every time wxMaxima starts Maxima"
-msgstr ""
+msgstr "Comandi Maxima da eseguire ogni volta che wxMaxima avvia Maxima"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1507
 msgid "Maxima configuration"
-msgstr ""
+msgstr "Configurazione di Maxima"
 
 #: ../../src/MaximaResponseReader.cpp:346
 msgid "Maxima didn't attempt to authenticate!"
@@ -6566,11 +6566,11 @@ msgstr "Il processo Maxima è terminato inaspettatamente."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1437
 msgid "Maxima program:"
-msgstr ""
+msgstr "Programma maxima:"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:382
 msgid "Maxima provides no \"forget all\" command that flushes all settings a maxima session could make. wxMaxima therefore normally defaults to starting a fresh maxima process every time the worksheet is to be re-evaluated. As this needs a little bit of time this switch allows to disable this behavior."
-msgstr ""
+msgstr "Maxima non fornisce un comando \"dimentica tutto\" che pulisce tutte le impostazioni che una sessione maxima può fare. wxMaxima perciò è normalmente impostato per far partire un nuovo processo maxima ogni volta che il foglio di lavoro deve essere ri-elaborato. Visto che questo necessita di un po' di tempo in più, questa impostazione permette di disabilitare questo comportamento."
 
 #: ../../src/Styles.cpp:108
 msgid "Maxima question labels"
@@ -6590,7 +6590,7 @@ msgstr "Maxima ci spedisce un nuovo insieme di variabili per la watch list."
 
 #: ../../src/sidebars/History.cpp:153
 msgid "Maxima session (*.mac)|*.mac"
-msgstr ""
+msgstr "Sessione Maxima (*.mac)|*.mac"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1518 ../../src/wxMaximaFrame.cpp:1981
 msgid "Maxima shows help in a browser"
@@ -6622,11 +6622,11 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1143
 msgid "Maxima startup file location: "
-msgstr ""
+msgstr "Posizione file di avvio di Maxima: "
 
 #: ../../src/dialogs/TipOfTheDay.cpp:68
 msgid "Maxima supports three types of numbers: exact fractions (which can be generated for example by typing 1/10), IEEE floating-point numbers (0.2) and arbitrary precision big floats (1b-1). Note that, owing to their nature as binary (not decimal) numbers, there is for example no way to generate an IEEE floating-point number that exactly equals 0.1. If floating-point numbers are used instead of fractions, Maxima will therefore sometimes have to introduce a (very small) error and use things like 3602879701896397/36028797018963968 for 0.1."
-msgstr ""
+msgstr "Maxima supporta tre tipi di numeri: frazioni esatte (che possono essere generate per esempio battendo 1/10), numeri in virgola mobile secondo lo standard IEEE (0.2) e numeri in virgola mobile a precisione arbitraria \"big floats\" (1b-1). Si noti che, a causa della natura binaria (non decimale) dei numeri, non c'è per esempio modo di generare un numero in virgola mobile IEEE esattamente uguale a 0.1. Per questo motivo, se numeri in virgola mobile vengono usati invece di frazioni, Maxima introdurrà alle volte un (piccolissimo) errore, e userà cose come 3602879701896397/36028797018963968 per il valore 0.1."
 
 #: ../../src/wxMaximaFrame.cpp:1265
 msgid "Maxima to other language"
@@ -6642,7 +6642,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1615
 msgid "Maxima usage"
-msgstr ""
+msgstr "Uso di Maxima"
 
 #: ../../src/MaximaResponseReader.cpp:776
 #, c-format
@@ -6738,7 +6738,7 @@ msgstr ""
 
 #: ../../src/wizards/ActualValuesStorageWiz.cpp:34
 msgid "Maxima's power lies in symbolic operations."
-msgstr ""
+msgstr "La potenza di Maxima è nelle operazioni simboliche."
 
 #: ../../src/StatusBar.cpp:365
 msgid "Maxima's reader is in Lisp mode (after to_lisp()).\n"
@@ -6785,7 +6785,7 @@ msgstr "Valore assoluto massimo stampato senza esponente"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1931
 msgid "Maximum bitmap size on clipboard [Mb]:"
-msgstr ""
+msgstr "Dimensione massima bitmap negli appunti [Mb]:"
 
 #: ../../src/MaximaCommandMenus.cpp:488 ../../src/MaximaCommandMenus.cpp:501
 #: ../../src/MaximaCommandMenus.cpp:516 ../../src/MaximaCommandMenus.cpp:530
@@ -6798,19 +6798,19 @@ msgstr "Numero massimo di cifre da visualizzare:"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:811
 msgid "Maximum number of displayed digits:"
-msgstr ""
+msgstr "Numero massimo di cifre visualizzate:"
 
 #: ../../src/sidebars/StatSidebar.cpp:70
 msgid "Mean Difference Test..."
-msgstr ""
+msgstr "Test della differenza della media..."
 
 #: ../../src/sidebars/StatSidebar.cpp:67
 msgid "Mean Test..."
-msgstr ""
+msgstr "Test della media..."
 
 #: ../../src/sidebars/StatSidebar.cpp:52
 msgid "Mean..."
-msgstr ""
+msgstr "Media..."
 
 #: ../../src/MaximaCommandMenus.cpp:1806
 msgid "Mean:"
@@ -6818,7 +6818,7 @@ msgstr "Media:"
 
 #: ../../src/sidebars/StatSidebar.cpp:55
 msgid "Median..."
-msgstr ""
+msgstr "Mediana..."
 
 #: ../../src/wxMaximaFrame.cpp:1961
 msgid "Memoizing"
@@ -6839,7 +6839,7 @@ msgstr "Messaggio dallo stdout di Maxima: "
 
 #: ../../src/wizards/IntegrateWiz.cpp:55
 msgid "Method:"
-msgstr ""
+msgstr "Metodo:"
 
 #: ../../src/wxMaximaFrame.cpp:1360
 msgid "Methods of generating a matrix"
@@ -6865,7 +6865,7 @@ msgstr "Valore assoluto minimo stampato senza esponente:"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1270
 msgid "Misc"
-msgstr ""
+msgstr "Varie"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1963
 msgid "Misc settings"
@@ -6906,7 +6906,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:189
 msgid "Mu"
-msgstr ""
+msgstr "Mu"
 
 #: ../../src/wxMaximaFrame.cpp:1386
 msgid "Multiplication, exponent and similar"
@@ -6930,7 +6930,7 @@ msgstr "Nome di t:"
 
 #: ../../src/wizards/DrawWiz.cpp:750
 msgid "Name of the parameter"
-msgstr ""
+msgstr "Nome del parametro"
 
 #: ../../src/MaximaCommandMenus.cpp:1019
 msgid "Name of x:"
@@ -6938,7 +6938,7 @@ msgstr "Nome di x:"
 
 #: ../../src/wizards/MatWiz.cpp:163
 msgid "Name:"
-msgstr ""
+msgstr "Nome:"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:216
 msgid "Nepali"
@@ -7001,7 +7001,7 @@ msgstr "Nuovo documento"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:901
 msgid "New lines: Jump to text"
-msgstr ""
+msgstr "Nuove righe: salta al testo"
 
 #: ../../src/MaximaResponseReader.cpp:1015
 #, c-format
@@ -7014,7 +7014,7 @@ msgstr "Nuova parte:"
 
 #: ../../src/wizards/SubstituteWiz.cpp:35
 msgid "New value:"
-msgstr ""
+msgstr "Nuovo valore:"
 
 #: ../../src/MaximaCommandMenus.cpp:151 ../../src/MaximaCommandMenus.cpp:171
 #: ../../src/MaximaCommandMenus.cpp:254 ../../src/MaximaCommandMenus.cpp:259
@@ -7052,7 +7052,7 @@ msgstr ""
 
 #: ../../src/wizards/DrawWiz.cpp:636
 msgid "No contour lines"
-msgstr ""
+msgstr "No linee di bordo"
 
 #: ../../src/dialogs/DiffFrame.cpp:304
 msgid "No differences"
@@ -7089,11 +7089,11 @@ msgstr "Nessuna corrispondenza trovata!"
 
 #: ../../src/wizards/DrawWiz.cpp:651
 msgid "No plot, only contour lines"
-msgstr ""
+msgstr "No grafico, solo linee di bordo"
 
 #: ../../src/wizards/DrawWiz.cpp:837
 msgid "No points"
-msgstr ""
+msgstr "No punti"
 
 #: ../../src/MaximaResponseReader.cpp:145
 msgid "No topics found in topic flag"
@@ -7109,7 +7109,7 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:179
 msgid "Non-builtin symbols"
-msgstr ""
+msgstr "Nessun simbolo incorporato"
 
 #: ../../src/wxMaximaFrame.cpp:834
 msgid "None"
@@ -7117,7 +7117,7 @@ msgstr "Nulla"
 
 #: ../../src/sidebars/StatSidebar.cpp:73
 msgid "Normality Test..."
-msgstr ""
+msgstr "Test di normalità..."
 
 #: ../../src/cells/TextCell.cpp:271
 msgid "Normally computers use floating-point numbers that can be handled incredibly fast while being accurate to dozens of digits. They will, though, introduce a small error into some common numbers. For example 0.1 is represented as 3602879701896397/36028797018963968.\n"
@@ -7128,11 +7128,11 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:431
 msgid "Normally html expects images to be rather low-res but space saving. These images tend to look rather blurry when viewed on modern screens. Therefore this setting was introduces that selects the factor by which the HTML export increases the resolution in respect to the default value."
-msgstr ""
+msgstr "Normalmente i documenti HTML usano immagini a bassa risoluzione ma che occupano poco spazio. Queste immagini tendono ad apparire molto sfocate se visualizzate su uno schermo moderno. Perciò questa impostazione è stato introdotta per selezionare il fattore col quale l'esportazione HTML aumenterà la risoluzione rispetto ai valori predefiniti."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:217
 msgid "Norwegian"
-msgstr ""
+msgstr "Norvegese"
 
 #: ../../src/MaximaCommandMenus.cpp:1351
 msgid "Not a valid matrix dimension!"
@@ -7168,7 +7168,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:190
 msgid "Nu"
-msgstr ""
+msgstr "Nu"
 
 #: ../../src/MaximaCommandMenus.cpp:177
 msgid "Num. deg:"
@@ -7311,7 +7311,7 @@ msgstr "Numero dispari"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:910
 msgid "Offer answers for questions known from previous runs"
-msgstr ""
+msgstr "Offre risposte a domande prese dalle esecuzioni precedenti"
 
 #: ../../src/cells/TextCell.cpp:332
 msgid "Often caused by recursive function calls. Some lisps allow increasing the control stack size using command-line arguments."
@@ -7319,7 +7319,7 @@ msgstr ""
 
 #: ../../src/wizards/SubstituteWiz.cpp:32
 msgid "Old value:"
-msgstr ""
+msgstr "Vecchio valore:"
 
 #: ../../src/MaximaCommandMenus.cpp:151 ../../src/MaximaCommandMenus.cpp:172
 #: ../../src/MaximaCommandMenus.cpp:253 ../../src/MaximaCommandMenus.cpp:259
@@ -7328,11 +7328,11 @@ msgstr "Vecchia variabile:"
 
 #: ../../src/sidebars/GreekSidebar.cpp:201
 msgid "Omega"
-msgstr ""
+msgstr "Omega"
 
 #: ../../src/sidebars/GreekSidebar.cpp:192
 msgid "Omicron"
-msgstr ""
+msgstr "Omicron"
 
 #: ../../src/wxMaximaFrame.cpp:1089
 msgid "On all errors"
@@ -7356,7 +7356,7 @@ msgstr "Solo interi e lettere singole"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:771
 msgid "Only user-defined labels"
-msgstr ""
+msgstr "Solo etichette definite dall'utente"
 
 #: ../../src/MaximaCommandMenus.cpp:2197 ../../src/ToolBar.cpp:330
 #: ../../src/ToolBar.cpp:333 ../../src/main.cpp:882
@@ -7365,7 +7365,7 @@ msgstr "Apri"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:905
 msgid "Open a cell when Maxima expects input"
-msgstr ""
+msgstr "Apri una cella mentre Maxima aspetta l'ingresso"
 
 #: ../../src/wxMaximaFrame.cpp:629
 msgid "Open a document"
@@ -7439,7 +7439,7 @@ msgstr "Ottimizza per la memoria"
 
 #: ../../src/wizards/DrawWiz.cpp:97
 msgid "Optional: A 2nd expression that defines a region to fill"
-msgstr ""
+msgstr "Opzionale: una seconda espressione che definisce una regione da riempire"
 
 #: ../../src/ToolBar.cpp:367 ../../src/ToolBar.cpp:369
 #: ../../src/dialogs/ConfigDialogue.cpp:284
@@ -7448,7 +7448,7 @@ msgstr "Opzioni"
 
 #: ../../src/wizards/Plot2dWiz.cpp:75 ../../src/wizards/Plot3dWiz.cpp:66
 msgid "Options:"
-msgstr ""
+msgstr "Opzioni:"
 
 #: ../../src/dialogs/FindReplacePane.cpp:109
 msgid "Output"
@@ -7509,7 +7509,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:458
 msgid "PNG images can be read by old wxMaxima versions - but aren't really scalable."
-msgstr ""
+msgstr "Le immagini PNG si possono leggere con le vecchie versioni di wxMaxima - ma non sono scalabili."
 
 #: ../../src/MaximaCommandMenus.cpp:175
 msgid "Pade approximation"
@@ -7521,7 +7521,7 @@ msgstr "Approssimazione Pade di una serie di Taylor"
 
 #: ../../src/sidebars/FormatSidebar.cpp:69
 msgid "Pagebreak"
-msgstr ""
+msgstr "Saltopagina"
 
 #: ../../src/wxMaximaFrame.cpp:1674
 msgid "Parallel Substitute..."
@@ -7533,7 +7533,7 @@ msgstr "Sosituzione parallela"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:124
 msgid "Parallel to"
-msgstr ""
+msgstr "Parallelo a"
 
 #: ../../src/MaximaCommandMenus.cpp:3991
 msgid "Parameter name:"
@@ -7545,11 +7545,11 @@ msgstr "Parametro(i):"
 
 #: ../../src/sidebars/DrawSidebar.cpp:64
 msgid "Parametric Plot"
-msgstr ""
+msgstr "Grafico parametrico"
 
 #: ../../src/wizards/Plot2dWiz.cpp:417 ../../src/wizards/Plot2dWiz.cpp:523
 msgid "Parametric plot"
-msgstr ""
+msgstr "Grafico parametrico"
 
 #: ../../src/MaximaCommandMenus.cpp:4211
 msgid "Parse string"
@@ -7603,7 +7603,7 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:125
 msgid "Perpendicular to"
-msgstr ""
+msgstr "Perpendicolare a"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:218
 msgid "Persian"
@@ -7611,15 +7611,15 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:198
 msgid "Phi"
-msgstr ""
+msgstr "Phi"
 
 #: ../../src/sidebars/GreekSidebar.cpp:193
 msgid "Pi"
-msgstr ""
+msgstr "Pi"
 
 #: ../../src/sidebars/StatSidebar.cpp:94
 msgid "Piechart..."
-msgstr ""
+msgstr "Diagramma a torta..."
 
 #: ../../src/wxMaxima.cpp:1585
 msgid "Please configure wxMaxima with 'Edit->Configure'."
@@ -7627,7 +7627,7 @@ msgstr "Configurare wxMaxima con \"Modifica->Configura\"."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2606
 msgid "Please restart wxMaxima for changes to take effect!"
-msgstr ""
+msgstr "Riavviare wxMaxima perché i cambiamenti abbiano effetto!"
 
 #: ../../src/MaximaCommandMenus.cpp:2250
 msgid "Please select exactly 2 or 3 files."
@@ -7668,16 +7668,16 @@ msgstr "Grafico 3D..."
 
 #: ../../src/wizards/DrawWiz.cpp:713
 msgid "Plot a parametric curve"
-msgstr ""
+msgstr "Grafico di una curva parametrica"
 
 #: ../../src/wizards/DrawWiz.cpp:45 ../../src/wizards/DrawWiz.cpp:148
 #: ../../src/wizards/DrawWiz.cpp:255
 msgid "Plot an explicit expression"
-msgstr ""
+msgstr "Fa il grafico di un'espressione"
 
 #: ../../src/wizards/DrawWiz.cpp:53
 msgid "Plot an expression, for example sin(x) or (x+1)^2."
-msgstr ""
+msgstr "Fa il grafico di una espressione, per esempio sin(x) o (x+1)^2."
 
 #: ../../src/MaximaCommandMenus.cpp:1776
 msgid "Plot as bars"
@@ -7701,11 +7701,11 @@ msgstr "Grafico in 3 dimensioni"
 
 #: ../../src/sidebars/DrawSidebar.cpp:83
 msgid "Plot name"
-msgstr ""
+msgstr "Nome grafico"
 
 #: ../../src/wizards/Plot2dWiz.cpp:84 ../../src/wizards/Plot3dWiz.cpp:80
 msgid "Plot to file:"
-msgstr ""
+msgstr "Grafico su file:"
 
 #: ../../src/wxMaximaFrame.cpp:341 ../../src/wxMaximaFrame.cpp:749
 msgid "Plot using Draw"
@@ -7725,7 +7725,7 @@ msgstr "Punto in cui è noto il valore:"
 
 #: ../../src/wizards/DrawWiz.cpp:842
 msgid "Point type:"
-msgstr ""
+msgstr "Tipo di punto:"
 
 #: ../../src/MaximaCommandMenus.cpp:186 ../../src/MaximaCommandMenus.cpp:1090
 #: ../../src/wizards/BC2Wiz.cpp:33 ../../src/wizards/BC2Wiz.cpp:39
@@ -7735,11 +7735,11 @@ msgstr "Punto:"
 
 #: ../../src/sidebars/DrawSidebar.cpp:67
 msgid "Points"
-msgstr ""
+msgstr "Punti"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:219
 msgid "Polish"
-msgstr ""
+msgstr "Polacco"
 
 #: ../../src/MaximaCommandMenus.cpp:215 ../../src/MaximaCommandMenus.cpp:220
 #: ../../src/MaximaCommandMenus.cpp:225
@@ -7775,7 +7775,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:221
 msgid "Portuguese (Brazilian)"
-msgstr ""
+msgstr "Portoghese (Brasiliano)"
 
 #: ../../src/wxMaximaFrame.cpp:1223
 msgid "Position of a match"
@@ -7791,7 +7791,7 @@ msgstr ""
 
 #: ../../src/wizards/Plot2dWiz.cpp:474 ../../src/wizards/Plot3dWiz.cpp:422
 msgid "Postscript file (*.eps)|*.eps|All|*"
-msgstr ""
+msgstr "File postscript (*.eps)|*.eps|Tutti|"
 
 #: ../../src/MaximaCommandMenus.cpp:190
 msgid "Power series"
@@ -7839,7 +7839,7 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:146
 msgid "Pressing Ctrl+Space or Ctrl+Tab starts an autocomplete function that can not only complete all functions that are integrated into the Maxima core and their parameters: It also knows about parameters from currently loaded packages and from functions that are defined in the current file."
-msgstr ""
+msgstr "Premendo Ctrl+Spazio o Ctrl+Tab si innesca una funzione di autocompletamento che può completare non solo tutte le funzioni integrate nel nucleo di Maxima ed il loro parametri, ma questa è in grado di completare anche i parametri dei pacchetti attualmente caricati e da funzioni definite nel file corrente."
 
 #: ../../src/wxMaximaFrame.cpp:961
 msgid "Previous Command\tAlt+Up"
@@ -7876,11 +7876,11 @@ msgstr "Stampa i numeri in virgola mobile con esponenti divisibili per 3"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1968
 msgid "Print scale:"
-msgstr ""
+msgstr "Scala stampa:"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1981
 msgid "Print the cell brackets [drawn to their left]"
-msgstr ""
+msgstr "Stampa le parentesi delle celle [disegna alla loro sinistra]"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:287
 msgid "Printout settings"
@@ -7930,7 +7930,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:936
 msgid "Privacy settings"
-msgstr ""
+msgstr "Impostazioni di riservatezza"
 
 #: ../../src/WXMXformat.cpp:256
 msgid "Produced invalid XML. The erroneous XML data has therefore not been saved but has been put on the clipboard in order to allow debugging it.\n"
@@ -7943,7 +7943,7 @@ msgstr "Prodotto"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:123
 msgid "Product sign"
-msgstr ""
+msgstr "Segno del prodotto"
 
 #: ../../src/wxMaximaFrame.cpp:1129
 msgid "Program"
@@ -7967,7 +7967,7 @@ msgstr "Blocco programma, senza variabili locali..."
 
 #: ../../src/sidebars/GreekSidebar.cpp:200
 msgid "Psi"
-msgstr ""
+msgstr "Psi"
 
 #: ../../src/wxMaximaFrame.cpp:1788
 msgid "Push"
@@ -7991,7 +7991,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1910
 msgid "RTF with OMML maths"
-msgstr ""
+msgstr "RTF con formule OMML"
 
 #: ../../src/MaximaCommandMenus.cpp:207
 msgid "Range radius:"
@@ -8053,7 +8053,7 @@ msgstr "Leggi cartella"
 
 #: ../../src/sidebars/StatSidebar.cpp:103
 msgid "Read Matrix..."
-msgstr ""
+msgstr "Leggi la matrice..."
 
 #: ../../src/MaximaCommandMenus.cpp:4008
 msgid "Read a structure field"
@@ -8069,7 +8069,7 @@ msgstr "Leggi carattere"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2488
 msgid "Read config to file"
-msgstr ""
+msgstr "Leggi configurazione su file"
 
 #: ../../src/MaximaCommandMenus.cpp:4405
 msgid "Read environment variable"
@@ -8182,7 +8182,7 @@ msgstr "Ricevuto il primo prompt di maxima: %s"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1327
 msgid "Recent files list length:"
-msgstr ""
+msgstr "Lunghezza elenco file recenti:"
 
 #: ../../src/wxMaximaFrame.cpp:634
 msgid "Recover unsaved"
@@ -8190,7 +8190,7 @@ msgstr "Recupero non salvato"
 
 #: ../../src/sidebars/MathSidebar.cpp:56
 msgid "Rectform"
-msgstr ""
+msgstr "Formanorm"
 
 #: ../../src/wxMaximaFrame.cpp:1677
 msgid "Recursive Substitute..."
@@ -8214,7 +8214,7 @@ msgstr "Ripeti l'ultima modifica"
 
 #: ../../src/sidebars/MathSidebar.cpp:71
 msgid "Reduce (tr)"
-msgstr ""
+msgstr "Riduci (tr)"
 
 #: ../../src/wxMaximaFrame.cpp:1632
 msgid "Reduce trigonometric expression"
@@ -8264,11 +8264,11 @@ msgstr "Ricarica immagine \"%s\""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:997
 msgid "Reload all GUI settings from disc"
-msgstr ""
+msgstr "Ricarica tutte le impostazioni GUI da disco"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1004
 msgid "Reload the style settings from disc"
-msgstr ""
+msgstr "Ricarica le impostazioni di stile da disco"
 
 #: ../../src/MaximaCommandMenus.cpp:3212
 #, c-format
@@ -8277,15 +8277,15 @@ msgstr "Ricaricamento file immagine %s."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2573
 msgid "Reloading the configuration from disc"
-msgstr ""
+msgstr "Ricaricamento configurazione da disco"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2581
 msgid "Reloading the styles from disc"
-msgstr ""
+msgstr "Ricaricamento stili da disco"
 
 #: ../../src/sidebars/VariablesPane.cpp:220
 msgid "Remove"
-msgstr ""
+msgstr "Rimuovi"
 
 #: ../../src/wxMaximaFrame.cpp:917
 msgid "Remove All Output"
@@ -8301,7 +8301,7 @@ msgstr ""
 
 #: ../../src/sidebars/VariablesPane.cpp:225
 msgid "Remove all"
-msgstr ""
+msgstr "Rimuovi tutto"
 
 #: ../../src/wxMaximaFrame.cpp:1785
 msgid "Remove all list elements that appear twice in a row. Normally used in conjunction with sort."
@@ -8381,7 +8381,7 @@ msgstr "Moltiplicazione ripetitiva elemento-per-elemento"
 
 #: ../../src/dialogs/FindReplacePane.cpp:117
 msgid "Replace All"
-msgstr ""
+msgstr "Rimpiazza tutto"
 
 #: ../../src/MaximaCommandMenus.cpp:4350
 msgid "Replace all regex matches"
@@ -8410,7 +8410,7 @@ msgstr "Rimpiazzate %li occorrenze."
 
 #: ../../src/dialogs/FindReplacePane.cpp:62
 msgid "Replacement:"
-msgstr ""
+msgstr "Sostituzioni:"
 
 #: ../../src/MaximaCommandMenus.cpp:768
 msgid "Replaces the subexpression that part(expr, n_1, n_2, ...) would select by a new value. The part numbers form a path: n_1 selects a part of the expression, n_2 a part of that, and so on."
@@ -8422,7 +8422,7 @@ msgstr "Riporta un bug"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:983
 msgid "Reset all GUI settings"
-msgstr ""
+msgstr "Reimposta la GUI"
 
 #: ../../src/wxMaximaFrame.cpp:1030
 msgid "Reset option variables"
@@ -8430,12 +8430,12 @@ msgstr "Reimposta variabili opzionali"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:990
 msgid "Reset the Style settings"
-msgstr ""
+msgstr "Reimposta tutte le impostazioni di stile"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2557
 #: ../../src/dialogs/ConfigDialogue.cpp:2565
 msgid "Resetting all configuration settings"
-msgstr ""
+msgstr "Reimpostazione di tutta la configurazione"
 
 #: ../../src/ToolBar.cpp:411 ../../src/ToolBar.cpp:417
 #: ../../src/wxMaximaFrame.cpp:1008
@@ -8525,7 +8525,7 @@ msgstr ""
 
 #: ../../src/wizards/DrawWiz.cpp:836
 msgid "Reuse last"
-msgstr ""
+msgstr "Riutilizza l'ultima"
 
 #: ../../src/wxMaximaFrame.cpp:1780
 msgid "Reverse"
@@ -8541,15 +8541,15 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:295
 msgid "Revert all to defaults"
-msgstr ""
+msgstr "Reimposta tutto ai predefiniti"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:980
 msgid "Revert changes"
-msgstr ""
+msgstr "Annulla modifiche"
 
 #: ../../src/sidebars/GreekSidebar.cpp:194
 msgid "Rho"
-msgstr ""
+msgstr "Rho"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2015
 msgid "Right"
@@ -8562,7 +8562,7 @@ msgstr "Matrice destra:"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:127
 msgid "Right arrow"
-msgstr ""
+msgstr "Freccia destra"
 
 #: ../../src/MaximaCommandMenus.cpp:1380
 msgid "Right end"
@@ -8602,7 +8602,7 @@ msgstr ""
 
 #: ../../src/wizards/MatWiz.cpp:152
 msgid "Rows:"
-msgstr ""
+msgstr "Righe:"
 
 #: ../../src/MaximaCommandMenus.cpp:1391
 msgid "Rule"
@@ -8672,7 +8672,7 @@ msgstr "Passa ogni elemento attraverso una espressione"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:223
 msgid "Russian"
-msgstr ""
+msgstr "Russo"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1578
 msgid "SBCL: use <int>Mbytes of heap"
@@ -8684,11 +8684,11 @@ msgstr ""
 
 #: ../../src/sidebars/XmlInspector.cpp:78
 msgid "SENT TO MAXIMA:"
-msgstr ""
+msgstr "INVIATO A MAXIMA:"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1224
 msgid "SVG graphics"
-msgstr ""
+msgstr "Grafiche SVG"
 
 #: ../../src/MaximaCommandMenus.cpp:1810
 msgid "Sample 1:"
@@ -8704,19 +8704,19 @@ msgstr "Esempio:"
 
 #: ../../src/wizards/DrawWiz.cpp:956
 msgid "Samples for explicit and parametric plots:"
-msgstr ""
+msgstr "Campioni per grafici espliciti e parametrici:"
 
 #: ../../src/wizards/DrawWiz.cpp:969
 msgid "Samples for implicit plots and regions:"
-msgstr ""
+msgstr "Campioni per grafici e regioni impliciti:"
 
 #: ../../src/wizards/DrawWiz.cpp:937
 msgid "Samples for implicit plots:"
-msgstr ""
+msgstr "Campioni per grafici impliciti:"
 
 #: ../../src/wizards/DrawWiz.cpp:924
 msgid "Samples on a line:"
-msgstr ""
+msgstr "Campioni su una linea:"
 
 #: ../../src/ToolBar.cpp:331 ../../src/ToolBar.cpp:334
 #: ../../src/dialogs/ConfigDialogue.cpp:2163 ../../src/wxMaxima.cpp:3507
@@ -8761,7 +8761,7 @@ msgstr "Salva come lisp..."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2478
 msgid "Save config to file"
-msgstr ""
+msgstr "Salva config su file"
 
 #: ../../src/ToolBar.cpp:331 ../../src/ToolBar.cpp:334
 #: ../../src/wxMaximaFrame.cpp:639
@@ -8774,7 +8774,7 @@ msgstr "Salva documento come"
 
 #: ../../src/wizards/Plot2dWiz.cpp:473 ../../src/wizards/Plot3dWiz.cpp:421
 msgid "Save plot to file"
-msgstr ""
+msgstr "Salva il grafico su file"
 
 #: ../../src/wxMaximaFrame.cpp:713
 msgid "Save selection from document to an image file"
@@ -8786,11 +8786,11 @@ msgstr "Salva la selezione su file"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2640
 msgid "Save style to file"
-msgstr ""
+msgstr "Salva lo stile su file"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1384
 msgid "Save the worksheet automatically"
-msgstr ""
+msgstr "Salva il foglio di lavoro automaticamente"
 
 #: ../../src/MaximaFileIO.cpp:873
 msgid "Saving failed!"
@@ -8806,7 +8806,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1914
 msgid "Scalable Vector Graphics (svg)"
-msgstr ""
+msgstr "Scalable Vector Graphics (svg)"
 
 #: ../../src/MaximaCommandMenus.cpp:3536
 msgid "Scalable Vector image (*.svg)|*.svg|Compressed Scalable Vector Image (*.svgz)|*.svgz|PNG image (*.png)|*.png|JPEG image (*.jpg)|*.jpg|GIF image (*.gif)|*.gif|Windows bitmap (*.bmp)|*.bmp|"
@@ -8818,7 +8818,7 @@ msgstr "Grafico a dispersione"
 
 #: ../../src/sidebars/StatSidebar.cpp:88
 msgid "Scatterplot..."
-msgstr ""
+msgstr "Grafico a dispersione..."
 
 #: ../../src/Autocomplete.cpp:157
 msgid "Scheduling a background task that compiles a new list of autocompletable maxima commands."
@@ -8866,7 +8866,7 @@ msgstr ""
 
 #: ../../src/wizards/DrawWiz.cpp:158
 msgid "See also the speed <-> accuracy button."
-msgstr ""
+msgstr "Vedere anche il pulsante velocità <-> accuratezza."
 
 #: ../../src/MaximaCommandMenus.cpp:4030
 msgid "Seek to position"
@@ -8882,7 +8882,7 @@ msgstr "Sembra che il pacchetto con i file condivisi di maxima non sia installat
 
 #: ../../src/sidebars/TableOfContents.cpp:511
 msgid "Select"
-msgstr ""
+msgstr "Seleziona"
 
 #: ../../src/MaximaCommandMenus.cpp:2239
 msgid "Select 2 or 3 files to compare"
@@ -8909,7 +8909,7 @@ msgstr "Seleziona il sottocampione"
 #: ../../src/wizards/IntegrateWiz.cpp:208 ../../src/wizards/LimitWiz.cpp:133
 #: ../../src/wizards/SeriesWiz.cpp:105
 msgid "Select a constant"
-msgstr ""
+msgstr "Seleziona una costante"
 
 #: ../../src/ToolBar.cpp:390 ../../src/ToolBar.cpp:392
 #: ../../src/wxMaximaFrame.cpp:710
@@ -8930,7 +8930,7 @@ msgstr "Seleziona l'algoritmo di visualizzazione matematica"
 
 #: ../../src/dialogs/TipOfTheDay.cpp:109
 msgid "Selecting a part of an output and right-clicking on the selection will bring up a menu with convenient functions that will operate on the selection."
-msgstr ""
+msgstr "Selezionando una parte del risultato e facendo clic destro sulla selezione si porterà in primo piano un menu con comode funzioni che opereranno sulla selezione."
 
 #: ../../src/Styles.cpp:127
 msgid "Selection color"
@@ -9018,7 +9018,7 @@ msgstr "Imposta la &precisione bigfloat..."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:479
 msgid "Set fixed font in text controls."
-msgstr ""
+msgstr "Imposta carattere ad ampiezza fissa nei controlli di testo."
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:68
 #: ../../src/worksheet/WorksheetContextMenu.cpp:250
@@ -9027,7 +9027,7 @@ msgstr ""
 
 #: ../../src/dialogs/ResolutionChooser.cpp:29
 msgid "Set image resolution [in ppi]"
-msgstr ""
+msgstr "Imposta risoluzione immagine [in ppi]"
 
 #: ../../src/wxMaximaFrame.cpp:1547
 msgid "Set main variable..."
@@ -9035,7 +9035,7 @@ msgstr "Imposta variabile principale..."
 
 #: ../../src/dialogs/MaxSizeChooser.cpp:29
 msgid "Set maximum image size [in mm]"
-msgstr ""
+msgstr "Imposta la dimensione massima dell'immagine [in mm]"
 
 #: ../../src/wxMaximaFrame.cpp:1810
 msgid "Set plot format"
@@ -9095,7 +9095,7 @@ msgstr "Imposta lo zoom al 80%"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:163
 msgid "Sets the language, line ending type and charset encoding programs will use"
-msgstr ""
+msgstr "Imposta la lingua, il tipo di ritorno a capo e la codifica dei caratteri che i programmi useranno"
 
 #: ../../src/MaximaEvaluator.cpp:574
 #, c-format
@@ -9108,24 +9108,24 @@ msgstr "Impostazione formati di prompt e aiuto"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:165
 msgid "Setting this to \"cat\" causes gnuplot not to halt if there is much output"
-msgstr ""
+msgstr "Impostando questo a \"cat\" fa in modo che gnuplot non si blocchi se non ci sono molti dati in uscita"
 
 #: ../../src/wizards/DrawWiz.cpp:546
 msgid "Settings for the following 3d plots"
-msgstr ""
+msgstr "Impostazioni per i seguenti grafici 3D"
 
 #: ../../src/wizards/DrawWiz.cpp:462
 #, c-format
 msgid "Setup a %iD scene"
-msgstr ""
+msgstr "Imposta una scena %iD"
 
 #: ../../src/sidebars/DrawSidebar.cpp:48
 msgid "Setup a 2D plot"
-msgstr ""
+msgstr "Imposta un grafico 2D"
 
 #: ../../src/sidebars/DrawSidebar.cpp:52
 msgid "Setup a 3D plot"
-msgstr ""
+msgstr "Imposta un grafico 3D"
 
 #: ../../src/wxMaximaFrame.cpp:1326
 msgid "Setup atvalues for solving ODE with Laplace transformation"
@@ -9137,11 +9137,11 @@ msgstr "Imposta il calcolo del modulo"
 
 #: ../../src/sidebars/DrawSidebar.cpp:78
 msgid "Setup the axis"
-msgstr ""
+msgstr "Imposta l'asse"
 
 #: ../../src/wizards/DrawWiz.cpp:263
 msgid "Setup the axis for the current plot."
-msgstr ""
+msgstr "Imposta l'asse per il grafico corrente."
 
 #: ../../src/MaximaCommandMenus.cpp:411
 msgid "Setup the engineering format"
@@ -9189,7 +9189,7 @@ msgstr "Mostra tutti i comandi simili a:"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:206
 msgid "Show all unicode symbols"
-msgstr ""
+msgstr "Mostra tutti i simboli unicode"
 
 #: ../../src/MaximaCommandMenus.cpp:2111
 msgid "Show an example for the command:"
@@ -9201,7 +9201,7 @@ msgstr "Mostra un esempio di uso"
 
 #: ../../src/sidebars/History.cpp:121
 msgid "Show commands from current session only"
-msgstr ""
+msgstr "Mostra i comandi solo dalla sessione corrente"
 
 #: ../../src/wxMaximaFrame.cpp:1921
 msgid "Show commands similar to"
@@ -9237,7 +9237,7 @@ msgstr "Mostra etichette d'ingresso"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:766
 msgid "Show labels:"
-msgstr ""
+msgstr "Mostra etichette:"
 
 #: ../../src/wxMaximaFrame.cpp:787
 msgid "Show lisp representation"
@@ -9245,11 +9245,11 @@ msgstr "Mostra rappresentazione lisp"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:465
 msgid "Show long expressions in wxMaxima document."
-msgstr ""
+msgstr "Mostra le espressione lunghe nei documenti di wxMaxima."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:722
 msgid "Show long expressions:"
-msgstr ""
+msgstr "Mostra espressioni lunghe:"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:377
 msgid "Show max. 100 digits"
@@ -9313,7 +9313,7 @@ msgstr "Mostrare i pulsanti Annulla e Rifai?"
 
 #: ../../src/dialogs/TipOfTheDay.cpp:288
 msgid "Show tips at Startup"
-msgstr ""
+msgstr "Mostra suggerimenti all'avvio"
 
 #: ../../src/wxMaximaFrame.cpp:1040 ../../src/wxMaximaFrame.cpp:1045
 msgid "Show used + to-be-freed memory"
@@ -9338,7 +9338,7 @@ msgstr "Barre laterali"
 
 #: ../../src/sidebars/GreekSidebar.cpp:195
 msgid "Sigma"
-msgstr ""
+msgstr "Sigma"
 
 #: ../../src/dialogs/FindReplacePane.cpp:88
 msgid "Simple"
@@ -9350,7 +9350,7 @@ msgstr ""
 
 #: ../../src/sidebars/MathSidebar.cpp:44
 msgid "Simplify"
-msgstr ""
+msgstr "Semplifica"
 
 #: ../../src/wxMaximaFrame.cpp:1550
 msgid "Simplify &Radicals..."
@@ -9358,11 +9358,11 @@ msgstr "Semplifica i &radicali..."
 
 #: ../../src/sidebars/MathSidebar.cpp:47
 msgid "Simplify (r)"
-msgstr ""
+msgstr "Semplifica (r)"
 
 #: ../../src/sidebars/MathSidebar.cpp:65
 msgid "Simplify (tr)"
-msgstr ""
+msgstr "Semplifica (tr)"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:352
 msgid "Simplify Expression"
@@ -9402,7 +9402,7 @@ msgstr "Semplifica le somme"
 
 #: ../../src/wizards/SumWiz.cpp:68
 msgid "Simplify the sum"
-msgstr ""
+msgstr "Semplifica la somma"
 
 #: ../../src/wxMaximaFrame.cpp:1629
 msgid "Simplify trigonometric expression"
@@ -9410,7 +9410,7 @@ msgstr "Semplifica espressione trigonometrica"
 
 #: ../../src/dialogs/TipOfTheDay.cpp:139
 msgid "Since wxMaxima 0.8.2 you can also insert images into your documents. Use 'Cell->Insert Image...' menu command."
-msgstr ""
+msgstr "Dalla versione 0.8.2 di wxMaxima è possibile inserire immagini nei documenti. Usare il comando da menu \"Cella->Inserisci immagine...\"."
 
 #: ../../src/wxMaximaFrame.cpp:1433
 msgid "Singular Values"
@@ -9467,7 +9467,7 @@ msgstr "Soluzione dell'ODE:"
 
 #: ../../src/wizards/BC2Wiz.cpp:30
 msgid "Solution:"
-msgstr ""
+msgstr "Soluzione:"
 
 #: ../../src/MaximaCommandMenus.cpp:3446
 msgid "Solve"
@@ -9507,7 +9507,7 @@ msgstr "Risolvi ODE con Lapla&ce..."
 
 #: ../../src/sidebars/MathSidebar.cpp:77
 msgid "Solve ODE..."
-msgstr ""
+msgstr "Risolvi ODE..."
 
 #: ../../src/wxMaximaFrame.cpp:1432
 msgid "Solve a linear equation system using dgesv"
@@ -9614,7 +9614,7 @@ msgstr "Ordina"
 
 #: ../../src/wizards/ListSortWiz.cpp:41
 msgid "Sort Criterion:"
-msgstr ""
+msgstr "Criterio di ordinamento:"
 
 #: ../../src/MaximaCommandMenus.cpp:1500
 msgid "Sort a list"
@@ -9634,16 +9634,16 @@ msgstr "Lista sorgente:"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:227
 msgid "Spanish"
-msgstr ""
+msgstr "Spagnolo"
 
 #: ../../src/wizards/IntegrateWiz.cpp:44 ../../src/wizards/IntegrateWiz.cpp:50
 #: ../../src/wizards/LimitWiz.cpp:38 ../../src/wizards/SeriesWiz.cpp:39
 msgid "Special"
-msgstr ""
+msgstr "Speciale"
 
 #: ../../src/wizards/DrawWiz.cpp:918
 msgid "Speed versus accuracy"
-msgstr ""
+msgstr "Velocità contro accuratezza"
 
 #: ../../src/MaximaCommandMenus.cpp:4241
 msgid "Split"
@@ -9671,7 +9671,7 @@ msgstr "Quadrato"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1300
 msgid "Standard Options"
-msgstr ""
+msgstr "Opzioni standard"
 
 #: ../../src/Styles.cpp:115
 msgid "Standard Text"
@@ -9683,7 +9683,7 @@ msgstr "Avvia animazione"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1622
 msgid "Start a new maxima for each re-evaluation"
-msgstr ""
+msgstr "Esegui un nuovo maxima per ogni ri-elaborazione"
 
 #: ../../src/MaximaCommandMenus.cpp:1023
 msgid "Start of t:"
@@ -9691,15 +9691,15 @@ msgstr "Inizio di t:"
 
 #: ../../src/wizards/DrawWiz.cpp:66 ../../src/wizards/DrawWiz.cpp:171
 msgid "Start of the x value"
-msgstr ""
+msgstr "Inizio del valore x"
 
 #: ../../src/wizards/DrawWiz.cpp:83 ../../src/wizards/DrawWiz.cpp:186
 msgid "Start of the y value"
-msgstr ""
+msgstr "Inizio del valore y"
 
 #: ../../src/wizards/DrawWiz.cpp:203
 msgid "Start of the z value"
-msgstr ""
+msgstr "Inizio del valore z"
 
 #: ../../src/ToolBar.cpp:507 ../../src/ToolBar.cpp:519
 msgid "Start or Stop animation"
@@ -9711,11 +9711,11 @@ msgstr "Avvia o blocca l'animazione attualmente selezionata creata con la classe
 
 #: ../../src/dialogs/ConfigDialogue.cpp:496
 msgid "Start searching while the phrase to search for is still being typed."
-msgstr ""
+msgstr "Comincia la ricerca mentre la frase da cercare viene battuta."
 
 #: ../../src/wizards/DrawWiz.cpp:755
 msgid "Start value of the parameter"
-msgstr ""
+msgstr "Valore iniziale del parametro"
 
 #: ../../src/wxMaxima.cpp:403
 msgid "Starting Maxima process failed"
@@ -9740,7 +9740,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:286
 msgid "Startup commands"
-msgstr ""
+msgstr "Comandi d'avvio"
 
 #: ../../src/wxMaximaFrame.cpp:266
 msgid "Statistics"
@@ -9850,15 +9850,15 @@ msgstr "Strutture"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:282
 msgid "Style"
-msgstr ""
+msgstr "Stile"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2082
 msgid "Styles"
-msgstr ""
+msgstr "Stili"
 
 #: ../../src/sidebars/StatSidebar.cpp:112
 msgid "Subsample..."
-msgstr ""
+msgstr "Sottocampione..."
 
 #: ../../src/ToolBar.cpp:484 ../../src/sidebars/FormatSidebar.cpp:54
 msgid "Subsection"
@@ -9878,7 +9878,7 @@ msgstr "Subst è un buon sistema di ricerca e sostituzione per le espressioni."
 
 #: ../../src/sidebars/MathSidebar.cpp:59
 msgid "Subst..."
-msgstr ""
+msgstr "Sostit..."
 
 #: ../../src/MaximaCommandMenus.cpp:715 ../../src/MaximaCommandMenus.cpp:3490
 #: ../../src/MaximaCommandMenus.cpp:4500 ../../src/wizards/SubstituteWiz.cpp:53
@@ -9954,7 +9954,7 @@ msgstr "Somma"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:122
 msgid "Sum sign"
-msgstr ""
+msgstr "Segno somma"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:228
 msgid "Swedish"
@@ -9983,7 +9983,7 @@ msgstr "Simboli\tAlt+Shift+Y"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:472
 msgid "Symbols that are entered or copied here will appear in the symbols sidebar so they can be entered into the worksheet easily."
-msgstr ""
+msgstr "I simboli immessi o copiati qui appariranno nella barra simboli laterale in modo che possano essere inseriti facilmente nel foglio di lavoro."
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:778
 msgid "Symmetric function: f(x)=f(-x)"
@@ -10011,7 +10011,7 @@ msgstr "Sommario\tAlt+Shift+T"
 
 #: ../../src/wizards/DrawWiz.cpp:561
 msgid "Take surface color from steepness"
-msgstr ""
+msgstr "Prendi il colore della superficie dalla pendenza"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:229
 msgid "Tamil"
@@ -10019,7 +10019,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:196
 msgid "Tau"
-msgstr ""
+msgstr "Tau"
 
 #: ../../src/MaximaCommandMenus.cpp:181
 msgid "Taylor series"
@@ -10055,7 +10055,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:148
 msgid "Tells maxima where to store the result of compiling libraries"
-msgstr ""
+msgstr "Dice a maxima dove memorizzare il risultato delle librerie di compilazione"
 
 #: ../../src/ToolBar.cpp:481 ../../src/sidebars/FormatSidebar.cpp:45
 msgid "Text"
@@ -10067,7 +10067,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:738
 msgid "Text Only"
-msgstr ""
+msgstr "Solo testo"
 
 #: ../../src/Styles.cpp:122
 msgid "Text cell background"
@@ -10075,7 +10075,7 @@ msgstr "Sfondo della cella di testo"
 
 #: ../../src/dialogs/TipOfTheDay.cpp:219
 msgid "Text cells can hold citations that as marked as such by beginning a line with \" > \". The number of spaces in front of the \">\" determines the indentation level, as it does with bullet lists."
-msgstr ""
+msgstr "Le celle di testo possono contenere citazioni marcate come tali dall'inizio riga con \" > \". Il numero di spazi davanti al carattere \">\" determina il livello di indentazione, come accade con gli elenchi puntati."
 
 #: ../../src/MaximaCommandMenus.cpp:3001
 msgid "Text snippet"
@@ -10098,7 +10098,7 @@ msgstr "Il processo Maxima non offre un segmento di memoria condivisa a cui poss
 
 #: ../../src/dialogs/ConfigDialogue.cpp:392
 msgid "The URL MathJaX.js should be downloaded from by our HTML export."
-msgstr ""
+msgstr "L'URL da cui dovrebbe essere scaricato MathJaX.js dalla nostra esportazione HTML."
 
 #: ../../src/cells/TextCell.cpp:336
 msgid "The [] or the part() command tried to access a list or matrix element that doesn't exist."
@@ -10106,7 +10106,7 @@ msgstr ""
 
 #: ../../src/sidebars/DrawSidebar.cpp:106
 msgid "The accuracy versus speed tradeoff"
-msgstr ""
+msgstr "Compromesso tra velocità e accuratezza"
 
 #: ../../src/cells/TextCell.cpp:357
 msgid "The argument of a function was of the wrong type. Most probably an equation was expected but was lacking an \"=\"."
@@ -10130,7 +10130,7 @@ msgstr ""
 
 #: ../../src/sidebars/DrawSidebar.cpp:91
 msgid "The color of the next line to draw"
-msgstr ""
+msgstr "Il colore della prossima linea da disegnare"
 
 #: ../../src/MaximaCommandMenus.cpp:4005
 msgid "The comma-separated contents of the struct fields"
@@ -10150,48 +10150,48 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:415
 msgid "The default height for embedded plots. Can be read out or overridden by the maxima variable wxplot_size."
-msgstr ""
+msgstr "Altezza predefinita per grafici incorporati. Può essere letta o sovrascritta dalla variabile maxima wxplot_size."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:492
 msgid "The default port used for communication between Maxima and wxMaxima."
-msgstr ""
+msgstr "La porta predefinita usata per la comunicazione tra Maxima e wxMaxima."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:412
 msgid "The default width for embedded plots. Can be read out or overridden by the maxima variable wxplot_size"
-msgstr ""
+msgstr "Larghezza predefinita per grafici incorporati. Può essere letta o sovrascritta dalla variabile maxima wxplot_size"
 
 #: ../../src/sidebars/DrawSidebar.cpp:74
 msgid "The diagram title"
-msgstr ""
+msgstr "Il titolo del diagramma"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2401
 #, c-format
 msgid "The directory %s with maxima's startup file doesn't exist. Trying to create it..."
-msgstr ""
+msgstr "La cartella %s con il file di avvio di maxima non esiste. Tentativo di crearla..."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:150
 msgid "The directory containing the startup files, any user libraries and, if MAXIMA_OBJDIR isn't set the subdirectory with the results from compiling maxima libraries."
-msgstr ""
+msgstr "La cartella contenente i file di avvio, qualunque libreria utente e, se MAXIMA_OBJDIR non è impostata, la sottocartella con il risultati dalla compilazione delle librerie maxima."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:154
 msgid "The directory maxima places temporary files in, for example plots that are to be included in the worksheet."
-msgstr ""
+msgstr "La cartella dove maxima mette i file temporanei, per esempio grafici da includere nel foglio di lavoro."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:157
 msgid "The directory the compiled versions of maxima are placed in"
-msgstr ""
+msgstr "La cartella dove vengono messe le versioni compilate di maxima"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:159
 msgid "The directory the maxima manual can be found in"
-msgstr ""
+msgstr "La cartella dove si può trovare il manuale di maxima"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:160
 msgid "The directory the user's home directory is in"
-msgstr ""
+msgstr "La cartella dove si trova la cartella utente"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:475
 msgid "The document class LaTeX is instructed to use for our documents."
-msgstr ""
+msgstr "La classe di documento LaTeX è impostata per l'uso dei nostri documenti."
 
 #: ../../src/MaximaCommandMenus.cpp:1832
 msgid "The equation to fit the data to"
@@ -10208,7 +10208,7 @@ msgstr ""
 
 #: ../../src/sidebars/DrawSidebar.cpp:96
 msgid "The fill color for the next objects"
-msgstr ""
+msgstr "Il colore di riempimento per i prossimi oggetti"
 
 #: ../../src/cells/TextCell.cpp:354
 msgid "The first argument of subst() isn't an equation or a list of equations. Most probably it was lacking an \"=\"."
@@ -10220,7 +10220,7 @@ msgstr "La chiamata a funzione i cui argomenti sono da estrarre"
 
 #: ../../src/sidebars/DrawSidebar.cpp:100
 msgid "The grid in the background of the diagram"
-msgstr ""
+msgstr "La griglia nello sfondo del diagramma"
 
 #: ../../src/wxMaximaFrame.cpp:1332
 msgid "The half of the equation that is to the left of the \"=\""
@@ -10254,11 +10254,11 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:223
 msgid "The key combination Shift+Space results in a non-breakable space."
-msgstr ""
+msgstr "La combinazione di tasti Maiusc+Spazio crea uno spazio non divisibile."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:162
 msgid "The list of directories the operating system looks for programs in"
-msgstr ""
+msgstr "L'elenco di cartelle che il sistema operativo controlla per la presenza di programmi eseguibili"
 
 #: ../../src/cells/TextCell.cpp:293
 msgid "The list of time-dependent variables to solve to doesn't match the time-dependent variables the list of dgls contains."
@@ -10270,7 +10270,7 @@ msgstr "La lista delle variabili contenute in ogni riga della matrice"
 
 #: ../../src/dialogs/TipOfTheDay.cpp:166
 msgid "The load() command of Maxima versions >5.38 is able to load .wxm files as library of Maxima's commands."
-msgstr ""
+msgstr "Il comando load() di Maxima versione >5.38 è in grado di caricare file .wxm come librerie di comandi Maxima."
 
 #: ../../src/wxMaximaFrame.cpp:228
 msgid "The main toolbar"
@@ -10286,7 +10286,7 @@ msgstr "Il manuale di wxMaxima"
 
 #: ../../src/dialogs/MaxSizeChooser.cpp:59
 msgid "The maximum size for this image. Values <= 0 mean: Unspecified."
-msgstr ""
+msgstr "La dimensione massima per questa immagine. Valori <= 0 significano: non specificata."
 
 #: ../../src/MaximaCommandMenus.cpp:3937
 msgid "The name of a function we don't want to be evaluated here"
@@ -10318,11 +10318,11 @@ msgstr "Il nome della variabile che conterrà l'elemento corrente"
 
 #: ../../src/sidebars/DrawSidebar.cpp:86
 msgid "The next plot's title"
-msgstr ""
+msgstr "Il titolo del prossimo grafico"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:494
 msgid "The number of recently opened files that is to be remembered."
-msgstr ""
+msgstr "Il numero di file aperti recentemente che è necessario ricordare."
 
 #: ../../src/MaximaCommandMenus.cpp:1471
 msgid "The number of the item which is stepped from \"Index Start\" to \"Index End\"."
@@ -10330,12 +10330,12 @@ msgstr "Il numero dell'elemento al passo da \"Inizio indice\" a \"Fine indice\".
 
 #: ../../src/dialogs/ConfigDialogue.cpp:477
 msgid "The options the document class LaTeX is instructed to use for our documents gets."
-msgstr ""
+msgstr "Le opzioni che la classe di documenti LaTeX deve usare per i nostri documenti."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1065
 #: ../../src/dialogs/ConfigDialogue.cpp:1112
 msgid "The part of the output of these commands that isn't declared as \"math\" might be suppressed by wxMaxima. As always maxima commands are required to end in a \";\" or a \"$\""
-msgstr ""
+msgstr "La parte del risultato di questi comandi che non è stata dichiarata come \"calcoli\" può essere soppressa da wxMaxima. Come sempre i comandi di maxima devono terminare con un \";\" o un \"$\""
 
 #: ../../src/dialogs/ResolutionChooser.cpp:51
 msgid "The resolution for this image."
@@ -10398,7 +10398,7 @@ msgstr ""
 
 #: ../../src/sidebars/DrawSidebar.cpp:58
 msgid "The standard plot command: Plot an equation as a curve"
-msgstr ""
+msgstr "Il comando standard plot: disegna la curva di un'equazione"
 
 #: ../../src/cells/TextCell.cpp:267
 msgid "The value of few special variables is assigned by Maxima and cannot be changed by the user. Also a few constructs aren't variable names and therefore cannot be written to."
@@ -10433,7 +10433,7 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:95
 msgid "There are many resources about Maxima and wxMaxima on the internet. Visit https://wxMaxima-developers.github.io/wxmaxima/help.html for more information and to find tutorials on using wxMaxima and Maxima."
-msgstr ""
+msgstr "Ci sono molte risorse su Maxima e wxMaxima su internet. Visitare https://wxMaxima-developers.github.io/wxmaxima/help.html per ulteriori informazioni e per trovare guide sull'uso di wxMaxima e Maxima."
 
 #: ../../src/dialogs/TipOfTheDay.cpp:251
 msgid "There is a discussion forum for wxMaxima at https://github.com/wxMaxima-developers/wxmaxima/discussions.\n"
@@ -10483,7 +10483,7 @@ msgstr "C'è stato un errore nell'XML che doveva descrivere il messaggio della b
 
 #: ../../src/sidebars/GreekSidebar.cpp:185
 msgid "Theta"
-msgstr ""
+msgstr "Theta"
 
 #: ../../src/dialogs/LicenseDialog.cpp:85
 msgid "Third-party notices"
@@ -10504,7 +10504,7 @@ msgstr "Questo file è stato generato da wxMaxima\n"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1097
 msgid "This file won't be read by maxima if maxima is used without wxMaxima. In order to add startup commands that are executed in this case, too, please add them to maxima-init.mac, instead."
-msgstr ""
+msgstr "Il file non verrà letto da maxima se maxima viene usato senza wxMaxima. Per aggiungere comandi di avvio che vengano eseguiti in questo frangente, inserirli invece nel file maxima-init.mac."
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:764
 msgid "This function will return even integers"
@@ -10537,7 +10537,7 @@ msgstr ""
 #: ../../src/wizards/DrawWiz.cpp:471
 #, c-format
 msgid "This wizard setups a %iD scene."
-msgstr ""
+msgstr "Questo assistente imposta una scena %iD."
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:752
 msgid "Throw an error if this symbol is used before assigning it any contents"
@@ -10545,11 +10545,11 @@ msgstr ""
 
 #: ../../src/wizards/Plot2dWiz.cpp:65 ../../src/wizards/Plot2dWiz.cpp:505
 msgid "Ticks:"
-msgstr ""
+msgstr "Tacche:"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1359
 msgid "Time [in Minutes] between autosaves"
-msgstr ""
+msgstr "Tempo [in minuti] tra autosalvataggi"
 
 #: ../../src/MaximaCommandMenus.cpp:267 ../../src/MaximaCommandMenus.cpp:3487
 msgid "Times:"
@@ -10557,7 +10557,7 @@ msgstr "Volte:"
 
 #: ../../src/dialogs/TipOfTheDay.cpp:49 ../../src/dialogs/TipOfTheDay.cpp:267
 msgid "Tip of the day"
-msgstr ""
+msgstr "Suggerimento del giorno"
 
 #: ../../src/ToolBar.cpp:482 ../../src/sidebars/FormatSidebar.cpp:48
 msgid "Title"
@@ -10573,7 +10573,7 @@ msgstr "Cella titolo (Intestazione 1)"
 
 #: ../../src/dialogs/TipOfTheDay.cpp:89
 msgid "Title, section and subsection cells can be folded to hide their contents. To fold or unfold, click in the square next to the cell. If you shift-click, all sublevels of that cell will also fold/unfold."
-msgstr ""
+msgstr "Le celle titolo, sezione e subsezione possono essere chiuse per nascondere i propri contenuti. Per chiudere o aprire le celle, fare clic sul riquadro presso la cella. Se si preme la combinazione Maiusc-clic, anche tutti i sublivelli delle celle verranno chiusi o aperti."
 
 #: ../../src/wxMaximaFrame.cpp:1831
 msgid "To &Bigfloat"
@@ -10601,19 +10601,19 @@ msgstr "In numero esatto"
 
 #: ../../src/dialogs/TipOfTheDay.cpp:124
 msgid "To plot in polar coordinates, select 'set polar' in the Options entry for Plot2d dialog. You can also plot in spherical and cylindrical coordinates in 3D."
-msgstr ""
+msgstr "Per disegnare un grafico in coordinate polari, selezionare \"imposta polari\" nella voce Opzioni nella finestra di dialogo Plot2d. È possibile avere grafici anche in sistemi di coordinate 3D sferiche e cilindriche."
 
 #: ../../src/dialogs/TipOfTheDay.cpp:131
 msgid "To put parentheses around an expression, select it, and press '(' or ')' depending on where you want the cursor to appear afterwards."
-msgstr ""
+msgstr "Per mettere le parentesi attorno ad un'espressione, selezionarla e premere \"(\" o \")\" a seconda di dove si desidera che in seguito appaia il cursore."
 
 #: ../../src/dialogs/TipOfTheDay.cpp:137
 msgid "To save the size and position of wxMaxima windows between session, use 'Edit->Configure' dialog."
-msgstr ""
+msgstr "Per salvare la dimensione e posizione delle finestre di wxMaxima tra le sessioni, usare la finestra di dialogo \"Modifica->Configura\"."
 
 #: ../../src/dialogs/TipOfTheDay.cpp:51
 msgid "To start using wxMaxima right away, start typing your command. An input cell should appear. Then press Shift-Enter to evaluate your command."
-msgstr ""
+msgstr "Per cominciare subito a usare wxMaxima, si batta un comando. Dovrebbe apparire subito una cella. Poi premere Maiusc-Invio per farlo elaborare."
 
 #: ../../src/MaximaCommandMenus.cpp:318 ../../src/wizards/IntegrateWiz.cpp:47
 #: ../../src/wizards/Plot2dWiz.cpp:51 ../../src/wizards/Plot2dWiz.cpp:61
@@ -10624,7 +10624,7 @@ msgstr "A:"
 
 #: ../../src/sidebars/TableOfContents.cpp:579
 msgid "Toc levels shown here"
-msgstr ""
+msgstr "Livello indice mostrato qui"
 
 #: ../../src/wxMaximaFrame.cpp:862 ../../src/wxMaximaFrame.cpp:865
 msgid "Toggle full screen editing"
@@ -10793,7 +10793,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:230
 msgid "Turkish"
-msgstr ""
+msgstr "Turco"
 
 #: ../../src/wxMaximaFrame.cpp:1965
 msgid "Tutorials"
@@ -10809,7 +10809,7 @@ msgstr "Tipo"
 
 #: ../../src/cells/EditorCell.cpp:4550
 msgid "Type in text"
-msgstr ""
+msgstr "Tipo nel testo"
 
 #: ../../src/MaximaCommandMenus.cpp:3992 ../../src/wizards/MatWiz.cpp:158
 msgid "Type:"
@@ -10829,7 +10829,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:231
 msgid "Ukrainian"
-msgstr ""
+msgstr "Ucraino"
 
 #: ../../src/wxMaxima.cpp:3164
 msgid "Un-closed parenthesis"
@@ -10856,15 +10856,15 @@ msgstr "Indefinito"
 #: ../../src/sidebars/VariablesPane.cpp:303
 #: ../../src/sidebars/VariablesPane.cpp:386
 msgid "Undefined"
-msgstr ""
+msgstr "Indefinito"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2115
 msgid "Underlined"
-msgstr ""
+msgstr "Sottolineato"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:745
 msgid "Underscore converts to subscripts:"
-msgstr ""
+msgstr "Il sottolineato converte in pedice:"
 
 #: ../../src/ToolBar.cpp:354 ../../src/ToolBar.cpp:357
 msgid "Undo"
@@ -10897,7 +10897,7 @@ msgstr "Spiega tutte le sezioni ripiegate"
 
 #: ../../src/sidebars/TableOfContents.cpp:507
 msgid "Unhide"
-msgstr ""
+msgstr "Rivela"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:665
 msgid "Unhide Heading 5"
@@ -10953,7 +10953,7 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:180
 msgid "Unicode symbols:"
-msgstr ""
+msgstr "Simboli unicode:"
 
 #: ../../src/MaximaCommandMenus.cpp:3890
 msgid "Unlike in other programming language return() only exits from the current loop or block(), not from the whole function."
@@ -10969,11 +10969,11 @@ msgstr "Stringa non terminata."
 
 #: ../../src/wizards/ActualValuesStorageWiz.cpp:43
 msgid "Until then the actual values for all variables can be kept in a list."
-msgstr ""
+msgstr "Fino ad allora i valori correnti per tutte le variabili possono essere mantenuti in una lista."
 
 #: ../../src/dialogs/DiffFrame.cpp:429 ../../src/dialogs/FindReplacePane.cpp:80
 msgid "Up"
-msgstr ""
+msgstr "Su"
 
 #: ../../src/MaximaEvaluator.cpp:629
 msgid "Updating maxima's configuration"
@@ -10996,7 +10996,7 @@ msgstr "Intorno alto:"
 
 #: ../../src/sidebars/GreekSidebar.cpp:197
 msgid "Upsilon"
-msgstr ""
+msgstr "Upsilon"
 
 #: ../../src/wxMaximaFrame.cpp:829
 msgid "Use \"<\" and \">\" as parenthesis for matrices"
@@ -11008,7 +11008,7 @@ msgstr ""
 
 #: ../../src/wizards/SumWiz.cpp:69
 msgid "Use Gosper algorithm"
-msgstr ""
+msgstr "Usa l'algoritmo di Gosper"
 
 #: ../../src/sidebars/RegexCtrl.cpp:133
 msgid "Use RegEx filtering"
@@ -11032,11 +11032,11 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:485
 msgid "Use centered dot and Minus, not Star and Hyphen"
-msgstr ""
+msgstr "Usa il punto centrato e il segno meno, non l'asterisco e il trattino"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:849
 msgid "Use centered dot character for multiplication"
-msgstr ""
+msgstr "Usa il carattere punto centrato per la moltiplicazione"
 
 #: ../../src/wxMaximaFrame.cpp:1745
 msgid "Use list"
@@ -11060,11 +11060,11 @@ msgstr "Usa campo struct..."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:425
 msgid "Use the \"partial derivative\" symbol to represent the fraction that represents a diff() when exporting LaTeX"
-msgstr ""
+msgstr "Usa il simbolo di \"derivata parziale\" per rappresentare la frazione che rappresenta una diff() nell'esportazione in LaTeX"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2052
 msgid "Use unicode Math Symbols, if available"
-msgstr ""
+msgstr "Usa simboli matematici unicode se disponibili"
 
 #: ../../src/wxMaximaFrame.cpp:832
 msgid "Use vertical lines instead of parenthesis for matrices"
@@ -11079,7 +11079,7 @@ msgstr "Solo etichette utente"
 #: ../../src/dialogs/ConfigDialogue.cpp:1480
 #: ../../src/dialogs/MaximaNotStartingDialog.cpp:54
 msgid "User specified"
-msgstr ""
+msgstr "Specificato dall'utente"
 
 #: ../../src/Styles.cpp:110
 msgid "User-defined labels"
@@ -11087,7 +11087,7 @@ msgstr "Etichette definite dall'utente"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:770
 msgid "User-defined labels if available"
-msgstr ""
+msgstr "Etichette definite dall'utente se disponibili"
 
 #: ../../src/MaximaManual.cpp:500
 msgid "Using Maxima help file from wxMaxima configuration file (helpFile=...))"
@@ -11125,7 +11125,7 @@ msgstr ""
 #: ../../src/dialogs/ConfigDialogue.cpp:542
 #: ../../src/wizards/ActualValuesStorageWiz.cpp:49
 msgid "Value"
-msgstr ""
+msgstr "Valore"
 
 #: ../../src/MaximaCommandMenus.cpp:756
 msgid "Value at a given point"
@@ -11165,15 +11165,15 @@ msgstr "Variabile"
 
 #: ../../src/wizards/DrawWiz.cpp:61 ../../src/wizards/DrawWiz.cpp:166
 msgid "Variable for the x value"
-msgstr ""
+msgstr "Variabile per il valore x"
 
 #: ../../src/wizards/DrawWiz.cpp:78 ../../src/wizards/DrawWiz.cpp:181
 msgid "Variable for the y value"
-msgstr ""
+msgstr "Variabile per il valore y"
 
 #: ../../src/wizards/DrawWiz.cpp:198
 msgid "Variable for the z value"
-msgstr ""
+msgstr "Variabile per il valore z"
 
 #: ../../src/MaximaCommandMenus.cpp:1586 ../../src/MaximaCommandMenus.cpp:2990
 #: ../../src/MaximaCommandMenus.cpp:2996
@@ -11221,7 +11221,7 @@ msgstr "Variabili:"
 
 #: ../../src/sidebars/StatSidebar.cpp:58
 msgid "Variance..."
-msgstr ""
+msgstr "Varianza..."
 
 #: ../../src/WXMXformat.cpp:339
 msgid "Verified that we are able to read the whole .zip archive we produced."
@@ -11249,7 +11249,7 @@ msgstr "In attesa che il thread che analizza il manuale di maxima finisca"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1410
 msgid "Warn if an inactive window is idle"
-msgstr ""
+msgstr "Avverti se una finestra inattiva è in attesa"
 
 #: ../../src/MathParser.cpp:1343 ../../src/MaximaFileIO.cpp:536
 #: ../../src/MaximaResponseReader.cpp:361 ../../src/wxMaxima.cpp:1583
@@ -11269,7 +11269,7 @@ msgstr "Attenzione: impossibile creare %s, la cartella nella quale maxima tiene 
 
 #: ../../src/cells/GroupCell.cpp:400 ../../src/cells/GroupCell.cpp:406
 msgid "Warning: Lookalike chars: "
-msgstr ""
+msgstr "Attenzione: caratteri confondibili:"
 
 #: ../../src/wxMaximaFrame.cpp:1583
 msgid "Warning: No test if the argument of the log is complex, positive or negative"
@@ -11294,7 +11294,7 @@ msgstr "Cosa fare:"
 
 #: ../../src/dialogs/TipOfTheDay.cpp:134
 msgid "When applying functions with one argument from menus, the default argument is '%'. To apply the function to some other value, select it in the document before executing a menu command."
-msgstr ""
+msgstr "Quando si applicano funzioni con un argomento dai menu, l'argomento predefinito è \"%\". Per applicare la funzione a qualche altro valore, selezionarlo nel documento prima di eseguirlo."
 
 #: ../../src/wxMaximaFrame.cpp:1092
 msgid "When to invoke the lisp compiler's debugger"
@@ -11310,7 +11310,7 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:243
 msgid "While wxMaxima is programmed mostly in C++, it also uses some Lisp code. You can help to improve wxMaxima, if you have knowledge of Common Lisp."
-msgstr ""
+msgstr "Sebbene wxMaxima sia programmato principalmente in C++, utilizza anche del codice Lisp. Puoi aiutare a migliorare wxMaxima, se conosci Common Lisp."
 
 #: ../../src/MaximaFileIO.cpp:780
 msgid "Whole document (*.wxmx)|*.wxmx|The input, readable by load() (maxima > 5.38) (*.wxm)|*.wxm|All Files (*.*)|*"
@@ -11322,7 +11322,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:280
 msgid "Worksheet"
-msgstr ""
+msgstr "Foglio di lavoro"
 
 #: ../../src/MaximaResponseReader.cpp:117
 #, c-format
@@ -11343,7 +11343,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:428
 msgid "Wrap equations exported by the \"copy as LaTeX\" feature between \\[ and \\] as equation markers"
-msgstr ""
+msgstr "Incapsula le equazioni esportate dal comando \"copia come LaTeX\" tra i caratteri \\[ e \\] come marcatori di equazione"
 
 #: ../../src/worksheet/Worksheet.cpp:5190
 msgid "Wrapped search"
@@ -11365,7 +11365,7 @@ msgstr "Scritte le informazioni sul tipo mime"
 #: ../../src/wizards/DrawWiz.cpp:961 ../../src/wizards/DrawWiz.cpp:974
 #: ../../src/wizards/DrawWiz.cpp:977
 msgid "X"
-msgstr ""
+msgstr "X"
 
 #: ../../src/MathParser.cpp:1279
 msgid "XML nesting limit exceeded"
@@ -11373,35 +11373,35 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:191
 msgid "Xi"
-msgstr ""
+msgstr "Xi"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:728
 msgid "Yes"
-msgstr ""
+msgstr "Sì"
 
 #: ../../src/dialogs/TipOfTheDay.cpp:64
 msgid "You can access the last output using the variable '%'. You can access the output of previous commands using variables '%on' where n is the number of output."
-msgstr ""
+msgstr "Si può accedere all'ultimo risultato usando la variabile \"%\". È possibile accedere al risultato di comandi precedenti usando le variabili \"%on\" dove n è il numero del risultato."
 
 #: ../../src/dialogs/TipOfTheDay.cpp:118
 msgid "You can evaluate your whole document by using 'Cell->Evaluate All Cells' menu command or the appropriate key shortcut. The cells will be evaluated in the order they appear in the document."
-msgstr ""
+msgstr "Si può elaborare l'intero documento usando il comando da menu \"Celle->Elabora tutte le celle\" o tramite l'appropriata scorciatoia da tastiera. Le celle saranno valutate nell'ordine di apparizione nel documento."
 
 #: ../../src/dialogs/TipOfTheDay.cpp:98
 msgid "You can get help on a Maxima function by selecting or clicking on the function name and pressing F1. wxMaxima will search the help index for the selection or the word under the cursor."
-msgstr ""
+msgstr "Si può ottenere aiuto su una funzione di Maxima selezionandola o facendo clic sul nome della funzione e premendo F1. wxMaxima cercherà nell'indice dell'aiuto la parola o la selezione di parole sutto il cursore."
 
 #: ../../src/dialogs/TipOfTheDay.cpp:92
 msgid "You can hide output part of cells by clicking in the triangle on the left side of cells. This works on text cells also."
-msgstr ""
+msgstr "Si può nascondere i risultati delle celle facendo clic sul triangolo presente nel bordo sinistro delle celle. L'operazione funziona anche sulle celle di testo."
 
 #: ../../src/dialogs/TipOfTheDay.cpp:81
 msgid "You can insert different types of 'cells' in wxMaxima documents using the 'Cell' menu. Note that only 'input cells' can be evaluated, while others are used for commenting and structuring your calculations."
-msgstr ""
+msgstr "Nei documenti di wxMaxima si può inserire differenti tipi di \"celle\" usando il menu \"Cella\". Da notare che solo le \"celle d'ingresso\" possono essere elaborate, mentre le altre vengono usate per commentare e strutturare i propri calcoli."
 
 #: ../../src/dialogs/TipOfTheDay.cpp:112
 msgid "You can select multiple cells either with a mouse - click'n'drag from between cells or from a cell bracket on the left - or with a keyboard - hold down Shift while moving the horizontal cursor - and then operate on selection. This comes in handy when you want to delete or evaluate multiple cells."
-msgstr ""
+msgstr "Celle multiple possono essere selezionate, con il mouse facendo clic e trascinando tra le celle o da una parentesi di cella a sinistra, oppure tramite tastiera mantenendo premuto il tasto Maiusc mentre viene spostato il cursore orizzontale, per poi operare su di esse tramite la selezione. Ciò torna comodo quando si vuole cancellare o valutare celle multiple."
 
 #: ../../src/dialogs/TipOfTheDay.cpp:232
 msgid "You found a bug in wxMaxima? Please report it at https://github.com/wxMaxima-developers/wxmaxima/issues\n"
@@ -11411,7 +11411,7 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:238
 msgid "You got an idea for an improvement of wxMaxima? Great! Please submit your idea at https://github.com/wxMaxima-developers/wxmaxima/issues. "
-msgstr ""
+msgstr "Avete un'idea su come si può migliorare wxMaxima? Ottimo! Sottoponeteci la vostra idea su https://github.com/wxMaxima-developers/wxmaxima/issues."
 
 #: ../../src/wxMaxima.cpp:3402 ../../src/wxMaxima.cpp:3456
 #, c-format
@@ -11429,7 +11429,7 @@ msgstr "L'attuale versione di wxMaxima è aggiornata."
 
 #: ../../src/sidebars/GreekSidebar.cpp:183
 msgid "Zeta"
-msgstr ""
+msgstr "Zeta"
 
 #: ../../src/wxMaximaFrame.cpp:842
 msgid "Zoom &In\tCtrl++"
@@ -11457,11 +11457,11 @@ msgstr "[ non salvato* ]"
 
 #: ../../src/wizards/DrawWiz.cpp:819 ../../src/wizards/DrawWiz.cpp:825
 msgid "[[x_1,x_2,...],[y_1,y_2,...]]"
-msgstr ""
+msgstr "[[x_1,x_2,...],[y_1,y_2,...]]"
 
 #: ../../src/wizards/DrawWiz.cpp:814
 msgid "[x_1, x_2,...] or [x_1, x_2,...],[y_1, y_2,...] or matrix([x_1,y_1],[x_2,y_2],...)"
-msgstr ""
+msgstr "[x_1, x_2,...] o [x_1, x_2,...],[y_1, y_2,...] o matrice([x_1,y_1],[x_2,y_2],...)"
 
 #: ../../src/wizards/ListSortWiz.cpp:46
 msgid "a<b (Maxima default)"
@@ -11469,15 +11469,15 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:151
 msgid "alpha"
-msgstr ""
+msgstr "alfa"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:95
 msgid "and"
-msgstr ""
+msgstr "and"
 
 #: ../../src/wizards/MatWiz.cpp:160
 msgid "antisymmetric"
-msgstr ""
+msgstr "antimmetrica"
 
 #: ../../src/wxMaximaFrame.cpp:1727
 msgid "apply function to each element"
@@ -11501,11 +11501,11 @@ msgstr "come contenitore dei valori correnti delle variabili"
 
 #: ../../src/sidebars/GreekSidebar.cpp:152
 msgid "beta"
-msgstr ""
+msgstr "beta"
 
 #: ../../src/wizards/LimitWiz.cpp:42
 msgid "both sides"
-msgstr ""
+msgstr "entrambi i lati"
 
 #: ../../src/wxMaximaFrame.cpp:1173
 msgid "char to Ascii code..."
@@ -11513,7 +11513,7 @@ msgstr "da carattere a codice ASCII.."
 
 #: ../../src/sidebars/GreekSidebar.cpp:172
 msgid "chi"
-msgstr ""
+msgstr "chi"
 
 #: ../../src/MaximaFileIO.cpp:318
 #, c-format
@@ -11523,15 +11523,15 @@ msgstr ""
 #: ../../src/wizards/Plot2dWiz.cpp:70 ../../src/wizards/Plot2dWiz.cpp:372
 #: ../../src/wizards/Plot3dWiz.cpp:61 ../../src/wizards/Plot3dWiz.cpp:358
 msgid "default"
-msgstr ""
+msgstr "predefinito"
 
 #: ../../src/sidebars/GreekSidebar.cpp:154
 msgid "delta"
-msgstr ""
+msgstr "delta"
 
 #: ../../src/wizards/MatWiz.cpp:159
 msgid "diagonal"
-msgstr ""
+msgstr "diagonale"
 
 #: ../../src/cells/FracCell.cpp:73
 msgid "diff(): Cannot find the multiplication sign I should hide"
@@ -11547,19 +11547,19 @@ msgstr "fai per ogni elemento"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:92
 msgid "empty"
-msgstr ""
+msgstr "vuoto"
 
 #: ../../src/sidebars/GreekSidebar.cpp:155
 msgid "epsilon"
-msgstr ""
+msgstr "epsilon"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:100
 msgid "equivalent"
-msgstr ""
+msgstr "equivalente"
 
 #: ../../src/sidebars/GreekSidebar.cpp:157
 msgid "eta"
-msgstr ""
+msgstr "eta"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:799
 msgid "ev() shall evaluate this automatically"
@@ -11567,7 +11567,7 @@ msgstr "ev() lo valuterà automaticamente"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:88
 msgid "exists"
-msgstr ""
+msgstr "esiste"
 
 #: ../../src/MaximaCommandMenus.cpp:3942
 msgid "expression:"
@@ -11609,11 +11609,11 @@ msgstr "funzione"
 
 #: ../../src/sidebars/GreekSidebar.cpp:153
 msgid "gamma"
-msgstr ""
+msgstr "gamma"
 
 #: ../../src/wizards/MatWiz.cpp:159
 msgid "general"
-msgstr ""
+msgstr "generale"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1630
 msgid "gnuplot: Without command console"
@@ -11621,11 +11621,11 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:118
 msgid "greater than or equal"
-msgstr ""
+msgstr "maggiore o uguale"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:87
 msgid "in"
-msgstr ""
+msgstr "in"
 
 #: ../../src/wxMaximaFrame.cpp:784
 msgid "in 2D"
@@ -11636,31 +11636,31 @@ msgstr ""
 #: ../../src/wizards/Plot3dWiz.cpp:61 ../../src/wizards/Plot3dWiz.cpp:194
 #: ../../src/wizards/Plot3dWiz.cpp:358 ../../src/wizards/Plot3dWiz.cpp:386
 msgid "inline"
-msgstr ""
+msgstr "inlinea"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:104
 msgid "intersection"
-msgstr ""
+msgstr "intersezione"
 
 #: ../../src/sidebars/GreekSidebar.cpp:159
 msgid "iota"
-msgstr ""
+msgstr "iota"
 
 #: ../../src/sidebars/GreekSidebar.cpp:160
 msgid "kappa"
-msgstr ""
+msgstr "kappa"
 
 #: ../../src/sidebars/GreekSidebar.cpp:161
 msgid "lambda"
-msgstr ""
+msgstr "lambda"
 
 #: ../../src/wizards/LimitWiz.cpp:42
 msgid "left"
-msgstr ""
+msgstr "sinistro"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:117
 msgid "less or equal"
-msgstr ""
+msgstr "minore o uguale"
 
 #: ../../src/MaximaCommandMenus.cpp:1567
 msgid "list"
@@ -11668,11 +11668,11 @@ msgstr "lista"
 
 #: ../../src/wizards/Plot2dWiz.cpp:54 ../../src/wizards/Plot2dWiz.cpp:64
 msgid "logscale"
-msgstr ""
+msgstr "scala log"
 
 #: ../../src/wizards/DrawWiz.cpp:822
 msgid "matrix([x_1,x_2,...],[y_1,y_2,...])"
-msgstr ""
+msgstr "matrice([x_1,x_2,...],[y_1,y_2,...])"
 
 #: ../../src/wxMaximaFrame.cpp:1439
 msgid "max(abs(A(i,j))) (complex)"
@@ -11684,15 +11684,15 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:162
 msgid "mu"
-msgstr ""
+msgstr "mu"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:120
 msgid "much greater than"
-msgstr ""
+msgstr "molto maggiore di"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:119
 msgid "much less than"
-msgstr ""
+msgstr "molto minore di"
 
 #: ../../src/MaximaCommandMenus.cpp:1232
 msgid "m×n Matrix A:"
@@ -11705,11 +11705,11 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:112
 msgid "nabla sign"
-msgstr ""
+msgstr "simbolo nabla"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:98
 msgid "nand"
-msgstr ""
+msgstr "nand"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:772
 msgid "nary: f(x, f(y,z)) = foo(x,y,z)"
@@ -11717,23 +11717,23 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:99
 msgid "nor"
-msgstr ""
+msgstr "nor"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:102
 msgid "not"
-msgstr ""
+msgstr "not"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:116
 msgid "not bytewise identical"
-msgstr ""
+msgstr "non identico bit per bit"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:108
 msgid "not subset"
-msgstr ""
+msgstr "non sottoinsieme"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:107
 msgid "not subset or equal"
-msgstr ""
+msgstr "non sottoinsieme o uguale"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:796
 msgid "noun: Not evaluated by default"
@@ -11745,7 +11745,7 @@ msgstr "n-esimo"
 
 #: ../../src/sidebars/GreekSidebar.cpp:163
 msgid "nu"
-msgstr ""
+msgstr "nu"
 
 #: ../../src/MaximaCommandMenus.cpp:1233
 msgid "n×1 Matrix b:"
@@ -11753,15 +11753,15 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:174
 msgid "omega"
-msgstr ""
+msgstr "omega"
 
 #: ../../src/sidebars/GreekSidebar.cpp:165
 msgid "omicron"
-msgstr ""
+msgstr "omicron"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:96
 msgid "or"
-msgstr ""
+msgstr "or"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:793
 msgid "outative: f(2*x) = 2*f(x)"
@@ -11778,19 +11778,19 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:111
 msgid "partial sign"
-msgstr ""
+msgstr "segno parziale"
 
 #: ../../src/sidebars/GreekSidebar.cpp:171
 msgid "phi"
-msgstr ""
+msgstr "phi"
 
 #: ../../src/sidebars/GreekSidebar.cpp:166
 msgid "pi"
-msgstr ""
+msgstr "pi"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:101
 msgid "plus or minus"
-msgstr ""
+msgstr "più o meno"
 
 #: ../../src/MaximaCommandMenus.cpp:196
 msgid "point:"
@@ -11815,11 +11815,11 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:115
 msgid "proportional to"
-msgstr ""
+msgstr "proporzionale a"
 
 #: ../../src/sidebars/GreekSidebar.cpp:173
 msgid "psi"
-msgstr ""
+msgstr "psi"
 
 #: ../../src/MaximaCommandMenus.cpp:642
 msgid "radcan() is a powerful tools for simplification trigonometric functions but needs to be taken with care: If a function has more than one branch radcan uses the one that looks like it would fit best, not necessarily the one that makes sense for the problem that resulted in the Expression that is to be simplified."
@@ -11847,31 +11847,31 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:167
 msgid "rho"
-msgstr ""
+msgstr "rho"
 
 #: ../../src/wizards/LimitWiz.cpp:42
 msgid "right"
-msgstr ""
+msgstr "destro"
 
 #: ../../src/wizards/DrawWiz.cpp:310
 msgid "secondary x axis label"
-msgstr ""
+msgstr "etichetta asse x secondario"
 
 #: ../../src/wizards/DrawWiz.cpp:315
 msgid "secondary x range (automatic if incomplete)"
-msgstr ""
+msgstr "campo x secondario (automatico se incompleto)"
 
 #: ../../src/wizards/DrawWiz.cpp:325
 msgid "secondary y axis label"
-msgstr ""
+msgstr "etichetta asse y secondario"
 
 #: ../../src/wizards/DrawWiz.cpp:330
 msgid "secondary y range (automatic if incomplete)"
-msgstr ""
+msgstr "campo y secondario (automatico se incompleto)"
 
 #: ../../src/sidebars/GreekSidebar.cpp:168
 msgid "sigma"
-msgstr ""
+msgstr "sigma"
 
 #: ../../src/MaximaCommandMenus.cpp:3447
 msgid "solve() will solve a list of equations only if for n independent equations there are n variables to solve to.\n"
@@ -11894,19 +11894,19 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:81
 msgid "sqrt (needs parenthesis for its argument to work as a Maxima command)"
-msgstr ""
+msgstr "sqrt (ha bisogno di parentesi per il suo argomento per lavorare come comando Maxima)"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:106
 msgid "subset"
-msgstr ""
+msgstr "sottoinsieme"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:105
 msgid "subset or equal"
-msgstr ""
+msgstr "sottoinsieme o uguale"
 
 #: ../../src/wizards/MatWiz.cpp:160
 msgid "symmetric"
-msgstr ""
+msgstr "simmetrica"
 
 #: ../../src/MaximaCommandMenus.cpp:970
 msgid "t:"
@@ -11914,7 +11914,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:169
 msgid "tau"
-msgstr ""
+msgstr "tau"
 
 #: ../../src/cells/TextCell.cpp:340
 msgid "the [] operator tried to extract an element of a list, a matrix, an equation or an array. But instead of an integer number something was used whose numerical value is unknown or not an integer.\n"
@@ -11923,31 +11923,31 @@ msgstr ""
 
 #: ../../src/wizards/DrawWiz.cpp:725
 msgid "the x and the y coordinate."
-msgstr ""
+msgstr "le coordinate x e y."
 
 #: ../../src/wizards/DrawWiz.cpp:729
 msgid "the x, the y and the z coordinate."
-msgstr ""
+msgstr "le coordinate x, y e z."
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:89
 msgid "there is no"
-msgstr ""
+msgstr "non c'è"
 
 #: ../../src/sidebars/GreekSidebar.cpp:158
 msgid "theta"
-msgstr ""
+msgstr "theta"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:78
 msgid "to the power of 2"
-msgstr ""
+msgstr "alla potenza di 2"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:79
 msgid "to the power of 3"
-msgstr ""
+msgstr "alla potenza di 3"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:103
 msgid "union"
-msgstr ""
+msgstr "unione"
 
 #: ../../src/wxMaximaFrame.cpp:1109
 msgid "unnamed function (lambda)..."
@@ -11964,7 +11964,7 @@ msgstr "senzanome"
 
 #: ../../src/sidebars/GreekSidebar.cpp:170
 msgid "upsilon"
-msgstr ""
+msgstr "upsilon"
 
 #: ../../src/wxMaximaFrame.cpp:1737
 msgid "use as function arguments"
@@ -12002,7 +12002,7 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:159
 msgid "wxMaxima can be made to execute commands at every start-up by placing them in a text file with the name wxmaxima.rc in the user directory. This directory can be found by typing maxima_userdir;"
-msgstr ""
+msgstr "wxMaxima può essere impostato per eseguire dei comandi ad ogni avvio ponendoli in un file di testo di nome wxmaxima.rc nella cartella utente. La posizione di questa cartella può essere verificata battendo il comando maxima_userdir;"
 
 #: ../../src/MaximaFileIO.cpp:398
 msgid "wxMaxima cannot read the xml contents of "
@@ -12011,7 +12011,7 @@ msgstr "wxMaxima non può leggere il contenuto xml di "
 #: ../../src/dialogs/ConfigDialogue.cpp:142
 #: ../../src/dialogs/ConfigDialogue.cpp:311
 msgid "wxMaxima configuration"
-msgstr ""
+msgstr "Configurazione di wxMaxima"
 
 #: ../../src/MaximaProcessManager.cpp:209
 msgid "wxMaxima could not start a server.\n\n"
@@ -12021,7 +12021,7 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:127
 msgid "wxMaxima dialogs set default values for inputs entries, one of which is '%'. If you have made a selection in your document, the selection will be used instead of '%'."
-msgstr ""
+msgstr "Le finestre di dialogo di wxMaxima impostano valori predefiniti per le voci di ingresso, uno dei quali è \"%\". Se si è effettuata una selezione nel documento corrente, questa verrà utilizzata al posto di \"%\"."
 
 #: ../../src/MaximaCommandMenus.cpp:4544
 msgid "wxMaxima document"
@@ -12052,19 +12052,19 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:240
 msgid "wxMaxima is programmed in C++ using the wxWidgets toolkit and uses CMake as build system. You can contribute to wxMaxima, if you have some knowledge with this environment."
-msgstr ""
+msgstr "wxMaxima è programmato in C++ usando il toolkit wxWidgets e usa CMake come sistema di compilazione. Si può contribuire a wxMaxima, se si possiede qualche conoscenza su questo ambiente."
 
 #: ../../src/dialogs/TipOfTheDay.cpp:228
 msgid "wxMaxima needs more developers. It is an open source project where you can contribute. Join the wxMaxima development at: https://github.com/wxMaxima-developers/wxmaxima"
-msgstr ""
+msgstr "wxMaxima ha bisogno di più sviluppatori. È un progetto open source a cui puoi contribuire. Unisciti allo sviluppo di wxMaxima su: https://github.com/wxMaxima-developers/wxmaxima"
 
 #: ../../src/dialogs/TipOfTheDay.cpp:224
 msgid "wxMaxima needs more translators. We do not speak every language. Help us to translate wxMaxima and the manual to your language. Join the wxMaxima development at: https://github.com/wxMaxima-developers/wxmaxima"
-msgstr ""
+msgstr "wxMaxima ha bisogno di più traduttori. Non parliamo tutte le lingue. Aiutaci a tradurre wxMaxima e il manuale nella tua lingua. Unisciti allo sviluppo di wxMaxima su: https://github.com/wxMaxima-developers/wxmaxima "
 
 #: ../../src/dialogs/ConfigDialogue.cpp:407
 msgid "wxMaxima normally stores the gnuplot sources for every plot made using draw() in order to be able to open plots interactively in gnuplot later. This setting defines the limit [in Megabytes per plot] for this feature."
-msgstr ""
+msgstr "wxMaxima normalmente memorizza i sorgenti di gnuplot per ogni grafico creato usando draw() per essere in grado di aprire i grafici in modo interattivo in gnuplot in seguito. Questa impostazione definisce il limite [in Megabyte per grafico] per questa funzione. "
 
 #: ../../src/dialogs/TipOfTheDay.cpp:172
 msgid "wxMaxima provides the \"table_form\" command that shows lists in an alternative form. One example would be:\n\n"
@@ -12083,7 +12083,7 @@ msgstr "wxMaxima ricorda le risposte dall'ultima esecuzione ed è in grado di of
 
 #: ../../src/dialogs/ConfigDialogue.cpp:481
 msgid "wxMaxima remembers the answers to maxima's questions. If this checkbox is set it automatically offers to enter the last answer to this question the user has input."
-msgstr ""
+msgstr "wxMaxima ricorda le risposte alle domande di maxima. Se questa casella di controllo è impostata, offre automaticamente di inserire l'ultima risposta a questa domanda che l'utente ha inserito."
 
 #: ../../src/wxMaximaFrame.cpp:1933
 msgid "wxMaxima shows help in a browser"
@@ -12095,7 +12095,7 @@ msgstr "wxMaxima mostra la guida nella barra laterale"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1095
 msgid "wxMaxima startup file location: "
-msgstr ""
+msgstr "Posizione file di avvio wxMaxima: "
 
 #: ../../src/wxMaximaFrame.cpp:119
 #, c-format
@@ -12147,11 +12147,11 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:709
 msgid "x"
-msgstr ""
+msgstr "x"
 
 #: ../../src/wizards/DrawWiz.cpp:266
 msgid "x axis label"
-msgstr ""
+msgstr "etichetta asse x"
 
 #: ../../src/MaximaCommandMenus.cpp:2021
 msgid "x direction [in multiples of the tick frequency]"
@@ -12159,11 +12159,11 @@ msgstr "direzione x [in multipli della frequenza delle tacche]"
 
 #: ../../src/wizards/DrawWiz.cpp:269
 msgid "x range (automatic if incomplete)"
-msgstr ""
+msgstr "campo x (automatico se incompleto)"
 
 #: ../../src/sidebars/GreekSidebar.cpp:164
 msgid "xi"
-msgstr ""
+msgstr "xi"
 
 #: ../../src/MaximaFileIO.cpp:408 ../../src/MaximaFileIO.cpp:566
 msgid "xml contained in the file claims not to be a wxMaxima worksheet. "
@@ -12171,11 +12171,11 @@ msgstr "l'xml contenuto nel file dichiara di non essere un foglio di lavoro wxMa
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:97
 msgid "xor"
-msgstr ""
+msgstr "xor"
 
 #: ../../src/wizards/DrawWiz.cpp:279
 msgid "y axis label"
-msgstr ""
+msgstr "etichetta asse y"
 
 #: ../../src/MaximaCommandMenus.cpp:2022
 msgid "y direction [in multiples of the tick frequency]"
@@ -12183,7 +12183,7 @@ msgstr "direzione y [in multipli della frequenza delle tacche]"
 
 #: ../../src/wizards/DrawWiz.cpp:282
 msgid "y range (automatic if incomplete)"
-msgstr ""
+msgstr "campo y (automatico se incompleto)"
 
 #: ../../src/MaximaCommandMenus.cpp:970
 msgid "y:"
@@ -12191,15 +12191,15 @@ msgstr ""
 
 #: ../../src/wizards/DrawWiz.cpp:294
 msgid "z axis label"
-msgstr ""
+msgstr "etichetta asse z"
 
 #: ../../src/wizards/DrawWiz.cpp:298
 msgid "z range (automatic if incomplete)"
-msgstr ""
+msgstr "campo z (automatico se incompleto)"
 
 #: ../../src/sidebars/GreekSidebar.cpp:156
 msgid "zeta"
-msgstr ""
+msgstr "zeta"
 
 #. type: Title #
 #: ../../info/wxmaxima.md:1

--- a/locales/wxMaxima/ja.po
+++ b/locales/wxMaxima/ja.po
@@ -63,11 +63,11 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1571
 msgid "      -X '--dynamic-space-size <int>'"
-msgstr ""
+msgstr "      -X '--dynamic-space-size <整数>'"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1551
 msgid "      -l <name>"
-msgstr ""
+msgstr "      -l <名前>"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1557
 msgid "      -u <versionnumber>"
@@ -213,7 +213,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1208
 msgid "\"Copy LaTeX\" adds equation markers"
-msgstr ""
+msgstr "LaTeXとしてコピーする際に、別行立ての数式にする"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:446
 msgid "\"MathML (rendered by the browser)\" is the recommended choice: every current browser renders MathML natively and instantly, and the exported page needs no JavaScript and makes no requests to any external server.\n"
@@ -227,7 +227,7 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:90
 msgid "\"implies\" symbol"
-msgstr ""
+msgstr "含意"
 
 #: ../../src/dialogs/DiffFrame.cpp:306
 #, c-format
@@ -314,7 +314,7 @@ msgstr "コピー(&C)\tCtrl+C"
 
 #: ../../src/wizards/IntegrateWiz.cpp:39
 msgid "&Definite integration"
-msgstr ""
+msgstr "定積分(&D)"
 
 #: ../../src/wxMaximaFrame.cpp:1658
 msgid "&Demoivre"
@@ -430,11 +430,11 @@ msgstr ""
 
 #: ../../src/wizards/IntegrateWiz.cpp:52
 msgid "&Numerical integration"
-msgstr ""
+msgstr "結果を小数で出力(&N)"
 
 #: ../../src/wizards/SumWiz.cpp:44
 msgid "&Nusum"
-msgstr ""
+msgstr "数式で出力(&N)"
 
 #: ../../src/main.cpp:675
 msgid "&Open\tCtrl+O"
@@ -450,7 +450,7 @@ msgstr "プロット(&P)"
 
 #: ../../src/wizards/SeriesWiz.cpp:45
 msgid "&Power series"
-msgstr ""
+msgstr "ベキ級数で表示(&P)"
 
 #: ../../src/wxMaximaFrame.cpp:655
 msgid "&Print...\tCtrl+P"
@@ -458,7 +458,7 @@ msgstr "印刷(&P)...\tCtrl+P"
 
 #: ../../src/wizards/SubstituteWiz.cpp:38
 msgid "&Rational"
-msgstr ""
+msgstr "置換の代わりに代入を行う(&R)"
 
 #: ../../src/wxMaximaFrame.cpp:1631
 msgid "&Reduce Trigonometric"
@@ -490,11 +490,11 @@ msgstr "方程式を解く(&S)..."
 
 #: ../../src/wizards/Plot2dWiz.cpp:42
 msgid "&Special"
-msgstr ""
+msgstr "特殊プロット(&S)"
 
 #: ../../src/wizards/LimitWiz.cpp:45
 msgid "&Taylor series"
-msgstr ""
+msgstr "テイラー展開を用いる(&T)"
 
 #: ../../src/wxMaximaFrame.cpp:1069
 msgid "&Time Display"
@@ -514,7 +514,7 @@ msgstr ""
 
 #: ../../src/wizards/Plot3dWiz.cpp:79
 msgid "&pm3d"
-msgstr ""
+msgstr "&PM3Dを有効"
 
 #: ../../src/cells/AnimationCell.cpp:475
 msgid "(Animation)"
@@ -550,7 +550,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:183
 msgid "(Use default language)"
-msgstr ""
+msgstr "（デフォルトの言語を使用）"
 
 #: ../../src/MaximaCommandMenus.cpp:440
 msgid "(f(x),x,a,b)), Epsilon algorithm"
@@ -592,7 +592,7 @@ msgstr ""
 #: ../../src/wizards/IntegrateWiz.cpp:217 ../../src/wizards/LimitWiz.cpp:132
 #: ../../src/wizards/LimitWiz.cpp:142
 msgid "- Infinity"
-msgstr ""
+msgstr "－∞"
 
 #: ../../src/MaximaOutputAppender.cpp:116
 msgid "... [suppressed additional lines as the output is longer than allowed in the wxMaxima configuration] "
@@ -649,7 +649,7 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:102
 msgid "A 'horizontal cursor' was introduced in wxMaxima 0.8.0. It looks like a horizontal line between cells. It indicates where a new cell will appear if you type or paste text or execute a menu command."
-msgstr ""
+msgstr "wxMaxima 0.8.0 より「水平カーソル」が導入されました。これはセルとセルの間に現れる水平線のことです。「水平カーソル」はテキストの入力や貼り付け，メニューバーからコマンドを実行する時に，新しいセルが現れる位置を知らせます。"
 
 #: ../../src/MaximaCommandMenus.cpp:3039
 msgid "A Ctrl-F event"
@@ -767,7 +767,7 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:239
 msgid "A symbol from the configuration dialogue"
-msgstr ""
+msgstr "「設定」ダイアログで追加した記号"
 
 #: ../../src/cells/GroupCell.cpp:2181
 msgid "A text cell"
@@ -881,7 +881,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1262
 msgid "Add the .wxmx file to the HTML export"
-msgstr ""
+msgstr "HTMLへのエクスポート時に .wxmx ファイルを添付する"
 
 #: ../../src/wxMaximaFrame.cpp:1049
 msgid "Add to &Path..."
@@ -908,15 +908,15 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:393
 msgid "Additional commands to be added to the preamble of LaTeX output for pdftex."
-msgstr ""
+msgstr "pdftexに対してのLaTeX出力のプリアンブルに追加される追加コマンド"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1187
 msgid "Additional lines for the TeX preamble:"
-msgstr ""
+msgstr "TeXのプリアンブルに追加する行："
 
 #: ../../src/dialogs/ConfigDialogue.cpp:389
 msgid "Additional parameters for Maxima (e.g. -l clisp)."
-msgstr ""
+msgstr "Maximaにパラメーターを追加（例 -l clisp）"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1543
 msgid "Additional parameters for Maxima (restart Maxima after changes)"
@@ -924,7 +924,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1318
 msgid "Additional symbols for the \"symbols\" sidebar:"
-msgstr ""
+msgstr "「記号」サイドバーへの追加の記号："
 
 #: ../../src/wxMaximaFrame.cpp:1599
 msgid "Additionally: log(a*b)=log(a)+log(b)"
@@ -984,7 +984,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:750
 msgid "All variable names"
-msgstr ""
+msgstr "全ての変数名"
 
 #: ../../src/wxMaximaFrame.cpp:770
 msgid "All visible sidebars"
@@ -1012,7 +1012,7 @@ msgstr ""
 
 #: ../../src/dialogs/BinaryNameCtrl.cpp:69
 msgid "All|*"
-msgstr ""
+msgstr "すべてのファイル (*.*)|*"
 
 #: ../../src/wxMaximaFrame.cpp:800
 msgid "Always after underscores"
@@ -1189,7 +1189,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1397
 msgid "Ask to save untitled documents"
-msgstr ""
+msgstr "タイトルがないドキュメントを保存するかどうか確認する"
 
 #: ../../src/dialogs/MaximaNotStartingDialog.cpp:36
 msgid "Asking the user for the location of a working maxima binary"
@@ -1213,7 +1213,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:897
 msgid "Auto-indent new lines"
-msgstr ""
+msgstr "改行で自動インデント"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:893
 msgid "Auto-insert closing parenthesis"
@@ -1291,7 +1291,7 @@ msgstr ""
 
 #: ../../src/wizards/BC2Wiz.cpp:59
 msgid "BC2"
-msgstr ""
+msgstr "境界条件"
 
 #: ../../src/MaximaManual.cpp:559
 msgid "Background task that compiles the Manual anchors scheduled."
@@ -1299,7 +1299,7 @@ msgstr ""
 
 #: ../../src/sidebars/StatSidebar.cpp:91
 msgid "Barsplot..."
-msgstr ""
+msgstr "棒グラフ..."
 
 #: ../../src/wxMaximaFrame.cpp:1384
 msgid "Basic matrix operations"
@@ -1350,7 +1350,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1273
 msgid "Bitmap scale for export:"
-msgstr ""
+msgstr "ビットマップ画像として出力する際の倍率："
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1223
 msgid "Bitmaps"
@@ -1358,7 +1358,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2109
 msgid "Bold"
-msgstr ""
+msgstr "太字"
 
 #: ../../src/wxMaxima.cpp:2259
 msgid "Both horizontal and vertical cursor active at the same time"
@@ -1382,13 +1382,13 @@ msgstr ""
 
 #: ../../src/sidebars/StatSidebar.cpp:97
 msgid "Boxplot..."
-msgstr ""
+msgstr "箱ひげ図..."
 
 #: ../../src/dialogs/BinaryNameCtrl.cpp:42 ../../src/wizards/CsvWiz.cpp:57
 #: ../../src/wizards/CsvWiz.cpp:131 ../../src/wizards/Plot2dWiz.cpp:114
 #: ../../src/wizards/Plot3dWiz.cpp:109
 msgid "Browse"
-msgstr ""
+msgstr "参照"
 
 #: ../../src/wxMathml.cpp:101
 msgid "Bug: After removing the whitespace wxMathml.lisp is shorter than expected!"
@@ -1767,11 +1767,11 @@ msgstr ""
 
 #: ../../src/sidebars/MathSidebar.cpp:62
 msgid "Canonical (tr)"
-msgstr ""
+msgstr "整理 (tri)"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:188
 msgid "Catalan"
-msgstr ""
+msgstr "カタロニア語"
 
 #: ../../src/MaximaCommandMenus.cpp:466
 msgid "Cauchy principal value of f(x)/(x-c), finite interval"
@@ -1941,7 +1941,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2100
 msgid "Choose font"
-msgstr ""
+msgstr "フォントの選択"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:793
 msgid "Choose how mathematical output is formatted:\n"
@@ -1952,7 +1952,7 @@ msgstr ""
 
 #: ../../src/wizards/PlotFormatWiz.cpp:31
 msgid "Choose new plot format:"
-msgstr ""
+msgstr "グラフ表示に使用する描画形式を選択："
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2432
 #, c-format
@@ -2126,7 +2126,7 @@ msgstr ""
 
 #: ../../src/wizards/MatWiz.cpp:155
 msgid "Columns:"
-msgstr ""
+msgstr "列数："
 
 #: ../../src/wxMaximaFrame.cpp:1621
 msgid "Combine factorials in an expression"
@@ -2142,11 +2142,11 @@ msgstr ""
 
 #: ../../src/wizards/Plot2dWiz.cpp:626
 msgid "Comma separated x coordinates"
-msgstr ""
+msgstr "各x座標はカンマで区切ってください"
 
 #: ../../src/wizards/Plot2dWiz.cpp:627
 msgid "Comma separated y coordinates"
-msgstr ""
+msgstr "各y座標はカンマで区切ってください"
 
 #: ../../src/MaximaCommandMenus.cpp:4071
 msgid "Comma-separated arguments"
@@ -2374,7 +2374,7 @@ msgstr "抽出条件（複数指定可）：\n"
 #: ../../src/dialogs/ConfigDialogue.cpp:2641
 #: ../../src/dialogs/ConfigDialogue.cpp:2647
 msgid "Config file (*.ini)|*.ini"
-msgstr ""
+msgstr "設定ファイル (*.ini)|*.ini"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2539
 #, c-format
@@ -2406,7 +2406,7 @@ msgstr ""
 #: ../../src/wizards/IntegrateWiz.cpp:208 ../../src/wizards/LimitWiz.cpp:133
 #: ../../src/wizards/SeriesWiz.cpp:105
 msgid "Constant"
-msgstr ""
+msgstr "定数"
 
 #: ../../src/MaximaCommandMenus.cpp:1102
 msgid "Construct a fraction"
@@ -2880,7 +2880,7 @@ msgstr ""
 
 #: ../../src/worksheet/Worksheet.cpp:6115
 msgid "Cursor"
-msgstr ""
+msgstr "カーソル"
 
 #: ../../src/Styles.cpp:126
 msgid "Cursor color"
@@ -2902,11 +2902,11 @@ msgstr "切り取り"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:193
 msgid "Czech"
-msgstr ""
+msgstr "チェコ語"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:194
 msgid "Danish"
-msgstr ""
+msgstr "デンマーク語"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2069
 msgid "Dark"
@@ -2984,7 +2984,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1534
 msgid "Default port for communication with wxMaxima:"
-msgstr ""
+msgstr "wxMaximaとの通信に使用される既定のポート"
 
 #: ../../src/MaximaCommandMenus.cpp:3946
 msgid "Define a function"
@@ -3024,7 +3024,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:404
 msgid "Define the default speed (in frames per second) animations are played back with."
-msgstr ""
+msgstr "アニメーションを再生する際のデフォルトのスピード（一秒あたりのフレーム数）を定義。"
 
 #: ../../src/wxMaximaFrame.cpp:1114
 msgid "Define variable..."
@@ -3123,7 +3123,7 @@ msgstr ""
 
 #: ../../src/wizards/SeriesWiz.cpp:42
 msgid "Depth:"
-msgstr ""
+msgstr "次数の指定："
 
 #: ../../src/MaximaCommandMenus.cpp:994
 msgid "Derivate of y at that point:"
@@ -3158,7 +3158,7 @@ msgstr ""
 
 #: ../../src/sidebars/StatSidebar.cpp:61
 msgid "Deviation..."
-msgstr ""
+msgstr "標準偏差..."
 
 #: ../../src/wxMaximaFrame.cpp:1534
 msgid "Di&vide Polynomials..."
@@ -3190,7 +3190,7 @@ msgstr ""
 
 #: ../../src/sidebars/MathSidebar.cpp:80
 msgid "Diff..."
-msgstr ""
+msgstr "微分..."
 
 #: ../../src/dialogs/DiffFrame.cpp:308
 #, c-format
@@ -3219,7 +3219,7 @@ msgstr ""
 
 #: ../../src/wizards/LimitWiz.cpp:41
 msgid "Direction:"
-msgstr ""
+msgstr "近づき方："
 
 #: ../../src/wxMaximaFrame.cpp:1246
 msgid "Directory operations"
@@ -3231,7 +3231,7 @@ msgstr ""
 
 #: ../../src/wizards/Plot2dWiz.cpp:418 ../../src/wizards/Plot2dWiz.cpp:619
 msgid "Discrete plot"
-msgstr ""
+msgstr "座標データプロット"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:699
 msgid "Display"
@@ -3358,7 +3358,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1170
 msgid "Documentclass for TeX export:"
-msgstr ""
+msgstr "TeXエクスポート時の文書クラス："
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1178
 msgid "Documentclass options:"
@@ -3540,7 +3540,7 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:129
 msgid "End of proof"
-msgstr ""
+msgstr "証明終了"
 
 #: ../../src/MaximaCommandMenus.cpp:1024
 msgid "End of t:"
@@ -3573,7 +3573,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:196
 msgid "English"
-msgstr ""
+msgstr "英語"
 
 #: ../../src/wizards/DrawWiz.cpp:552
 msgid "Enhanced 3D settings:"
@@ -3585,7 +3585,7 @@ msgstr ""
 
 #: ../../src/sidebars/StatSidebar.cpp:106
 msgid "Enter Matrix..."
-msgstr ""
+msgstr "行列を手入力..."
 
 #: ../../src/MaximaCommandMenus.cpp:2255
 msgid "Enter UUID to jump to:"
@@ -3605,7 +3605,7 @@ msgstr "整数環に解を追加するための整数係数の多項式:"
 
 #: ../../src/wizards/SystemWiz.cpp:50
 msgid "Enter comma separated list of variables."
-msgstr ""
+msgstr "変数はカンマで区切ります（例：x,y,…）"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:921
 msgid "Enter evaluates cells, Ctrl+Enter adds newlines"
@@ -3625,7 +3625,7 @@ msgstr "多倍長浮動小数点数(bigfloat)の精度を入力してくださ�
 
 #: ../../src/dialogs/ConfigDialogue.cpp:388
 msgid "Enter the path to the Maxima executable."
-msgstr ""
+msgstr "Maximaの実行ファイルのパスを入力"
 
 #: ../../src/MaximaCommandMenus.cpp:1103
 msgid "Enumerator:"
@@ -3872,7 +3872,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2659
 msgid "Example text"
-msgstr ""
+msgstr "テキストの例"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1547
 msgid "Examples:"
@@ -3888,11 +3888,11 @@ msgstr ""
 
 #: ../../src/sidebars/MathSidebar.cpp:53
 msgid "Expand"
-msgstr ""
+msgstr "展開"
 
 #: ../../src/sidebars/MathSidebar.cpp:68
 msgid "Expand (tr)"
-msgstr ""
+msgstr "展開 (tri)"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:356
 msgid "Expand Expression"
@@ -4218,7 +4218,7 @@ msgstr ""
 
 #: ../../src/sidebars/MathSidebar.cpp:50
 msgid "Factor"
-msgstr ""
+msgstr "因数分解"
 
 #: ../../src/wxMaximaFrame.cpp:1558
 msgid "Factor Complex"
@@ -4293,7 +4293,7 @@ msgstr ""
 #: ../../src/cells/GroupCell.cpp:2115
 #, c-format
 msgid "Figure %d:"
-msgstr ""
+msgstr "図 %d:"
 
 #: ../../src/main.cpp:678
 msgid "File"
@@ -4467,7 +4467,7 @@ msgstr ""
 
 #: ../../src/dialogs/FindReplacePane.cpp:46
 msgid "Find:"
-msgstr ""
+msgstr "検索語："
 
 #: ../../src/wxMaximaFrame.cpp:1869
 msgid "Fine-tune the display of engineering-format numbers"
@@ -4475,7 +4475,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:197
 msgid "Finnish"
-msgstr ""
+msgstr "フィンランド語"
 
 #: ../../src/wxMaximaFrame.cpp:1749
 msgid "First"
@@ -4488,11 +4488,11 @@ msgstr ""
 #: ../../src/dialogs/ConfigDialogue.cpp:1404
 #, c-format
 msgid "Fix reordered reference indices (of %i, %o) before saving"
-msgstr ""
+msgstr "記録された参照インデックス（%i、%o）を保存前に固定"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:873
 msgid "Fixed font in text controls"
-msgstr ""
+msgstr "テキスト入力ボックスで固定幅フォントを使用"
 
 #: ../../src/MaximaCommandMenus.cpp:4039
 msgid "Flush stream"
@@ -4536,7 +4536,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2047
 msgid "Fonts"
-msgstr ""
+msgstr "フォント"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:442
 msgid "For each Text-, Sectioning or code cell wxMaxima can display a bracket showing the extend of the cell and allowing to fold it. This setting now tells if this bracket is to be printed, as well."
@@ -4564,7 +4564,7 @@ msgstr ""
 
 #: ../../src/wizards/Plot2dWiz.cpp:69 ../../src/wizards/Plot3dWiz.cpp:60
 msgid "Format:"
-msgstr ""
+msgstr "表示方法："
 
 #: ../../src/worksheet/Worksheet.cpp:301 ../../src/wxMaxima.cpp:3521
 msgid "Forwarding the keyboard focus to a text control"
@@ -4629,7 +4629,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:198
 msgid "French"
-msgstr ""
+msgstr "フランス語"
 
 #: ../../src/wxMaximaFrame.cpp:1447
 msgid "Frobenius Norm sqrt(sum((A(i,j))^2)) (complex)"
@@ -4712,7 +4712,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:199
 msgid "Galician"
-msgstr ""
+msgstr "ガリシア語"
 
 #: ../../src/sidebars/GreekSidebar.cpp:180
 msgid "Gamma"
@@ -4768,7 +4768,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:201
 msgid "German"
-msgstr ""
+msgstr "ドイツ語"
 
 #: ../../src/wxMaximaFrame.cpp:1656
 msgid "Get &Imaginary Part"
@@ -4856,7 +4856,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:202
 msgid "Greek"
-msgstr ""
+msgstr "ギリシャ語"
 
 #: ../../src/wxMaximaFrame.cpp:281
 msgid "Greek Letters"
@@ -4872,7 +4872,7 @@ msgstr ""
 
 #: ../../src/wizards/Plot3dWiz.cpp:52
 msgid "Grid:"
-msgstr ""
+msgstr "グラフの滑らかさ（y）："
 
 #: ../../src/wxMaximaFrame.cpp:1852
 msgid "Guess an exact number that could be meant by this float"
@@ -5049,7 +5049,7 @@ msgstr "ヒストグラム"
 
 #: ../../src/sidebars/StatSidebar.cpp:85
 msgid "Histogram..."
-msgstr ""
+msgstr "ヒストグラム..."
 
 #: ../../src/wxMaximaFrame.cpp:246
 msgid "History"
@@ -5061,7 +5061,7 @@ msgstr "入力履歴\tAlt+Shift+I"
 
 #: ../../src/dialogs/TipOfTheDay.cpp:105
 msgid "Horizontal cursor works like a normal cursor, but it operates on cells: press up or down arrow to move it, holding down Shift while moving will select cells, pressing backspace or delete twice will delete a cell next to it."
-msgstr ""
+msgstr "水平カーソルは上下方向にだけ動かせます。また，Shiftを押しながら動かすとセルを選択できます。水平カーソルを表示した状態でBackspace，またはDeleteキーを二回押すと，それぞれ水平カーソルの上または下のセルを削除します。"
 
 #: ../../src/wxMaximaFrame.cpp:1563
 msgid "Horner's rule"
@@ -5081,7 +5081,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:205
 msgid "Hungarian"
-msgstr ""
+msgstr "ハンガリー語"
 
 #: ../../src/wxMaximaFrame.cpp:1147
 msgid "I/O"
@@ -5089,7 +5089,7 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:121
 msgid "Identical to"
-msgstr ""
+msgstr "同一"
 
 #: ../../src/MaximaCommandMenus.cpp:3874
 msgid "If a program doesn't need local variables, Maxima allows putting the commands between parentheses. The result of the last operation is the return value of the program."
@@ -5125,15 +5125,15 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:727
 msgid "If not extremely long"
-msgstr ""
+msgstr "極端に長くない場合"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:726
 msgid "If not very long"
-msgstr ""
+msgstr "それほど長くない場合"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:418
 msgid "If numbers are getting longer than this number of digits they will be displayed abbreviated by an ellipsis."
-msgstr ""
+msgstr "もし数値がこの桁数より長ければ、 数値は省略記号によって省略表示されます。"
 
 #: ../../src/dialogs/TipOfTheDay.cpp:181
 msgid "If the \"Autosave\" functionality is enabled in the configuration dialogue wxMaxima acts like mobile apps that backup the file every few minutes and save it on closing."
@@ -5188,11 +5188,11 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:76
 msgid "If you type an operator (one of +*/^=,) as the first symbol in an input cell, % will be automatically inserted before the operator, as on a graphing calculator. You can disable this feature from the 'Edit->Configure' dialog."
-msgstr ""
+msgstr "入力時に最初の記号として演算子（「+*/^=」のうち一つ）を入力した際、%が自動的に演算子の前に挿入されます。なお、グラフ計算でも同様です。 この機能はメニューバーの「編集」から「設定」ダイアログを開くことで無効化できます。"
 
 #: ../../src/dialogs/TipOfTheDay.cpp:122
 msgid "If your calculation is taking too long to evaluate, you can try 'Maxima->Interrupt' or 'Maxima->Restart Maxima' menu commands."
-msgstr ""
+msgstr "もし入力セルの評価に時間がかかるようであれば、メニューバーの「Maxima」より「処理を強制終了」または「ラベル番号をリセット」を実行して下さい。"
 
 #: ../../src/MaximaManual.cpp:420
 msgid "Ignoring the cache version for the manual anchors."
@@ -5200,7 +5200,7 @@ msgstr ""
 
 #: ../../src/sidebars/FormatSidebar.cpp:66
 msgid "Image"
-msgstr ""
+msgstr "画像"
 
 #: ../../src/Image.cpp:110
 msgid "Image data had zero length!"
@@ -5268,7 +5268,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:421
 msgid "In the LaTeX output: Put exponents after an eventual subscript instead of above it. Might increase readability for some fonts and short subscripts."
-msgstr ""
+msgstr "LaTeXへの出力において、指数を最後の下付き文字の上部ではなく、後方に配置。 いくつかのフォントや短い下付き文字の読みやすさを向上させる可能性があります。"
 
 #: ../../src/MaximaCommandMenus.cpp:1869
 msgid "Include columns:"
@@ -5280,7 +5280,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:884
 msgid "Incremental Search"
-msgstr ""
+msgstr "インクリメンタルサーチ"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:844
 msgid "Indent equations by the label width"
@@ -5329,7 +5329,7 @@ msgstr ""
 #: ../../src/wizards/IntegrateWiz.cpp:215 ../../src/wizards/LimitWiz.cpp:132
 #: ../../src/wizards/LimitWiz.cpp:140
 msgid "Infinity"
-msgstr ""
+msgstr "∞"
 
 #: ../../src/wxMaximaFrame.cpp:1986
 msgid "Info about Maxima build"
@@ -5387,7 +5387,7 @@ msgstr "挿入"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:889
 msgid "Insert % before an operator at the beginning of a cell"
-msgstr ""
+msgstr "セルの最初で演算子の前に「%」を挿入"
 
 #: ../../src/wxMaximaFrame.cpp:939
 msgid "Insert &Section Cell\tCtrl+3"
@@ -5539,7 +5539,7 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:113
 msgid "Integral sign"
-msgstr ""
+msgstr "積分記号"
 
 #: ../../src/MaximaCommandMenus.cpp:149 ../../src/MaximaCommandMenus.cpp:170
 msgid "Integral/Sum:"
@@ -5807,11 +5807,11 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:207
 msgid "Italian"
-msgstr ""
+msgstr "イタリア語"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2111
 msgid "Italic"
-msgstr ""
+msgstr "斜体"
 
 #: ../../src/MaximaCommandMenus.cpp:1617 ../../src/MaximaCommandMenus.cpp:1623
 msgid "Item"
@@ -5823,7 +5823,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:208
 msgid "Japanese"
-msgstr ""
+msgstr "日本語"
 
 #: ../../src/MaximaCommandMenus.cpp:2255
 msgid "Jump to UUID"
@@ -5892,15 +5892,15 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1199
 msgid "LaTeX: Place exponents after, instead above subscripts"
-msgstr ""
+msgstr "LaTeX: 下付き文字の上部ではなく、後方に指数を置く"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1204
 msgid "LaTeX: Use the \"partial derivative\" symbol to represent diff()"
-msgstr ""
+msgstr "LaTeX: diff() 関数を表すのに偏微分記号を使う"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:758
 msgid "Label width:"
-msgstr ""
+msgstr "ラベル幅"
 
 #: ../../src/wxMaximaFrame.cpp:1059
 msgid "Labels"
@@ -5919,11 +5919,11 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:470
 msgid "Language used for wxMaxima GUI."
-msgstr ""
+msgstr "wxMaximaのGUIに使用される言語"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1311
 msgid "Language:"
-msgstr ""
+msgstr "使用言語："
 
 #: ../../src/MaximaCommandMenus.cpp:251
 msgid "Laplace"
@@ -5982,7 +5982,7 @@ msgstr "最小二乗法"
 
 #: ../../src/sidebars/StatSidebar.cpp:79
 msgid "Least Squares Fit..."
-msgstr ""
+msgstr "回帰式の係数と切片を求める..."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2007
 msgid "Left"
@@ -6040,7 +6040,7 @@ msgstr "極限値"
 
 #: ../../src/sidebars/MathSidebar.cpp:86
 msgid "Limit..."
-msgstr ""
+msgstr "極限値..."
 
 #: ../../src/sidebars/DrawSidebar.cpp:88
 msgid "Line color"
@@ -6048,7 +6048,7 @@ msgstr ""
 
 #: ../../src/sidebars/StatSidebar.cpp:76
 msgid "Linear Regression..."
-msgstr ""
+msgstr "単回帰分析..."
 
 #: ../../src/MaximaCommandMenus.cpp:4068
 msgid "Lisp format string:"
@@ -6181,7 +6181,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2162
 msgid "Load"
-msgstr ""
+msgstr "設定の読込み"
 
 #: ../../src/MaximaCommandMenus.cpp:2356
 msgid "Load Package"
@@ -6221,7 +6221,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2645
 msgid "Load style from file"
-msgstr ""
+msgstr "スタイルの読み込み"
 
 #: ../../src/wxMaximaFrame.cpp:1232
 msgid "Load the file/dir operations (operatingsystem)"
@@ -6237,7 +6237,7 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:128
 msgid "Long Right arrow"
-msgstr ""
+msgstr "長い右矢印"
 
 #: ../../src/MaximaCommandMenus.cpp:1409
 msgid "Loop variable"
@@ -6321,7 +6321,7 @@ msgstr ""
 
 #: ../../src/dialogs/FindReplacePane.cpp:71
 msgid "Match Case"
-msgstr ""
+msgstr "大文字と小文字を区別"
 
 #: ../../src/Styles.cpp:139
 msgid "Math Default"
@@ -6554,7 +6554,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1437
 msgid "Maxima program:"
-msgstr ""
+msgstr "Maxima本体のパス："
 
 #: ../../src/dialogs/ConfigDialogue.cpp:382
 msgid "Maxima provides no \"forget all\" command that flushes all settings a maxima session could make. wxMaxima therefore normally defaults to starting a fresh maxima process every time the worksheet is to be re-evaluated. As this needs a little bit of time this switch allows to disable this behavior."
@@ -6789,15 +6789,15 @@ msgstr ""
 
 #: ../../src/sidebars/StatSidebar.cpp:70
 msgid "Mean Difference Test..."
-msgstr ""
+msgstr "母平均の差の検定..."
 
 #: ../../src/sidebars/StatSidebar.cpp:67
 msgid "Mean Test..."
-msgstr ""
+msgstr "母平均の検定..."
 
 #: ../../src/sidebars/StatSidebar.cpp:52
 msgid "Mean..."
-msgstr ""
+msgstr "平均値..."
 
 #: ../../src/MaximaCommandMenus.cpp:1806
 msgid "Mean:"
@@ -6805,7 +6805,7 @@ msgstr "比較する値："
 
 #: ../../src/sidebars/StatSidebar.cpp:55
 msgid "Median..."
-msgstr ""
+msgstr "中央値..."
 
 #: ../../src/wxMaximaFrame.cpp:1961
 msgid "Memoizing"
@@ -6826,7 +6826,7 @@ msgstr ""
 
 #: ../../src/wizards/IntegrateWiz.cpp:55
 msgid "Method:"
-msgstr ""
+msgstr "数値積分法："
 
 #: ../../src/wxMaximaFrame.cpp:1360
 msgid "Methods of generating a matrix"
@@ -6925,7 +6925,7 @@ msgstr ""
 
 #: ../../src/wizards/MatWiz.cpp:163
 msgid "Name:"
-msgstr ""
+msgstr "変数名："
 
 #: ../../src/dialogs/ConfigDialogue.cpp:216
 msgid "Nepali"
@@ -7001,7 +7001,7 @@ msgstr ""
 
 #: ../../src/wizards/SubstituteWiz.cpp:35
 msgid "New value:"
-msgstr ""
+msgstr "新部分式："
 
 #: ../../src/MaximaCommandMenus.cpp:151 ../../src/MaximaCommandMenus.cpp:171
 #: ../../src/MaximaCommandMenus.cpp:254 ../../src/MaximaCommandMenus.cpp:259
@@ -7104,7 +7104,7 @@ msgstr ""
 
 #: ../../src/sidebars/StatSidebar.cpp:73
 msgid "Normality Test..."
-msgstr ""
+msgstr "正規性の検定..."
 
 #: ../../src/cells/TextCell.cpp:271
 msgid "Normally computers use floating-point numbers that can be handled incredibly fast while being accurate to dozens of digits. They will, though, introduce a small error into some common numbers. For example 0.1 is represented as 3602879701896397/36028797018963968.\n"
@@ -7119,7 +7119,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:217
 msgid "Norwegian"
-msgstr ""
+msgstr "ノルウェー語"
 
 #: ../../src/MaximaCommandMenus.cpp:1351
 msgid "Not a valid matrix dimension!"
@@ -7306,7 +7306,7 @@ msgstr ""
 
 #: ../../src/wizards/SubstituteWiz.cpp:32
 msgid "Old value:"
-msgstr ""
+msgstr "旧部分式："
 
 #: ../../src/MaximaCommandMenus.cpp:151 ../../src/MaximaCommandMenus.cpp:172
 #: ../../src/MaximaCommandMenus.cpp:253 ../../src/MaximaCommandMenus.cpp:259
@@ -7352,7 +7352,7 @@ msgstr "参照"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:905
 msgid "Open a cell when Maxima expects input"
-msgstr ""
+msgstr "Maximaが入力を待機しているときセルを開く"
 
 #: ../../src/wxMaximaFrame.cpp:629
 msgid "Open a document"
@@ -7435,7 +7435,7 @@ msgstr "オプション"
 
 #: ../../src/wizards/Plot2dWiz.cpp:75 ../../src/wizards/Plot3dWiz.cpp:66
 msgid "Options:"
-msgstr ""
+msgstr "オプション："
 
 #: ../../src/dialogs/FindReplacePane.cpp:109
 msgid "Output"
@@ -7508,7 +7508,7 @@ msgstr "テイラー級数を有理式で近似"
 
 #: ../../src/sidebars/FormatSidebar.cpp:69
 msgid "Pagebreak"
-msgstr ""
+msgstr "改ページ"
 
 #: ../../src/wxMaximaFrame.cpp:1674
 msgid "Parallel Substitute..."
@@ -7520,7 +7520,7 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:124
 msgid "Parallel to"
-msgstr ""
+msgstr "平行"
 
 #: ../../src/MaximaCommandMenus.cpp:3991
 msgid "Parameter name:"
@@ -7536,7 +7536,7 @@ msgstr ""
 
 #: ../../src/wizards/Plot2dWiz.cpp:417 ../../src/wizards/Plot2dWiz.cpp:523
 msgid "Parametric plot"
-msgstr ""
+msgstr "媒介変数プロット"
 
 #: ../../src/MaximaCommandMenus.cpp:4211
 msgid "Parse string"
@@ -7590,7 +7590,7 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:125
 msgid "Perpendicular to"
-msgstr ""
+msgstr "垂直"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:218
 msgid "Persian"
@@ -7606,7 +7606,7 @@ msgstr ""
 
 #: ../../src/sidebars/StatSidebar.cpp:94
 msgid "Piechart..."
-msgstr ""
+msgstr "円グラフ..."
 
 #: ../../src/wxMaxima.cpp:1585
 msgid "Please configure wxMaxima with 'Edit->Configure'."
@@ -7614,7 +7614,7 @@ msgstr "メニューバーの「編集」から「設定」ダイアログを開
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2606
 msgid "Please restart wxMaxima for changes to take effect!"
-msgstr ""
+msgstr "変更を有効にするにはwxMaximaを再起動する必要があります"
 
 #: ../../src/MaximaCommandMenus.cpp:2250
 msgid "Please select exactly 2 or 3 files."
@@ -7692,7 +7692,7 @@ msgstr ""
 
 #: ../../src/wizards/Plot2dWiz.cpp:84 ../../src/wizards/Plot3dWiz.cpp:80
 msgid "Plot to file:"
-msgstr ""
+msgstr "EPS形式で出力："
 
 #: ../../src/wxMaximaFrame.cpp:341 ../../src/wxMaximaFrame.cpp:749
 msgid "Plot using Draw"
@@ -7726,7 +7726,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:219
 msgid "Polish"
-msgstr ""
+msgstr "ポーランド語"
 
 #: ../../src/MaximaCommandMenus.cpp:215 ../../src/MaximaCommandMenus.cpp:220
 #: ../../src/MaximaCommandMenus.cpp:225
@@ -7762,7 +7762,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:221
 msgid "Portuguese (Brazilian)"
-msgstr ""
+msgstr "ポルトガル語（ブラジル）"
 
 #: ../../src/wxMaximaFrame.cpp:1223
 msgid "Position of a match"
@@ -7778,7 +7778,7 @@ msgstr ""
 
 #: ../../src/wizards/Plot2dWiz.cpp:474 ../../src/wizards/Plot3dWiz.cpp:422
 msgid "Postscript file (*.eps)|*.eps|All|*"
-msgstr ""
+msgstr "Postscript ファイル (*.eps)|*.eps|すべてのファイル (*.*)|*"
 
 #: ../../src/MaximaCommandMenus.cpp:190
 msgid "Power series"
@@ -7930,7 +7930,7 @@ msgstr "総乗"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:123
 msgid "Product sign"
-msgstr ""
+msgstr "総乗記号"
 
 #: ../../src/wxMaximaFrame.cpp:1129
 msgid "Program"
@@ -8040,7 +8040,7 @@ msgstr ""
 
 #: ../../src/sidebars/StatSidebar.cpp:103
 msgid "Read Matrix..."
-msgstr ""
+msgstr "行列のファイル..."
 
 #: ../../src/MaximaCommandMenus.cpp:4008
 msgid "Read a structure field"
@@ -8177,7 +8177,7 @@ msgstr ""
 
 #: ../../src/sidebars/MathSidebar.cpp:56
 msgid "Rectform"
-msgstr ""
+msgstr "複素関数展開"
 
 #: ../../src/wxMaximaFrame.cpp:1677
 msgid "Recursive Substitute..."
@@ -8201,7 +8201,7 @@ msgstr "一番新しい入力をやり直す"
 
 #: ../../src/sidebars/MathSidebar.cpp:71
 msgid "Reduce (tr)"
-msgstr ""
+msgstr "結合 (tri)"
 
 #: ../../src/wxMaximaFrame.cpp:1632
 msgid "Reduce trigonometric expression"
@@ -8368,7 +8368,7 @@ msgstr ""
 
 #: ../../src/dialogs/FindReplacePane.cpp:117
 msgid "Replace All"
-msgstr ""
+msgstr "全て置換"
 
 #: ../../src/MaximaCommandMenus.cpp:4350
 msgid "Replace all regex matches"
@@ -8397,7 +8397,7 @@ msgstr ""
 
 #: ../../src/dialogs/FindReplacePane.cpp:62
 msgid "Replacement:"
-msgstr ""
+msgstr "置換文字列："
 
 #: ../../src/MaximaCommandMenus.cpp:768
 msgid "Replaces the subexpression that part(expr, n_1, n_2, ...) would select by a new value. The part numbers form a path: n_1 selects a part of the expression, n_2 a part of that, and so on."
@@ -8549,7 +8549,7 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:127
 msgid "Right arrow"
-msgstr ""
+msgstr "右矢印"
 
 #: ../../src/MaximaCommandMenus.cpp:1380
 msgid "Right end"
@@ -8589,7 +8589,7 @@ msgstr ""
 
 #: ../../src/wizards/MatWiz.cpp:152
 msgid "Rows:"
-msgstr ""
+msgstr "行数："
 
 #: ../../src/MaximaCommandMenus.cpp:1391
 msgid "Rule"
@@ -8659,7 +8659,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:223
 msgid "Russian"
-msgstr ""
+msgstr "ロシア語"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1578
 msgid "SBCL: use <int>Mbytes of heap"
@@ -8761,7 +8761,7 @@ msgstr "名前を付けて保存"
 
 #: ../../src/wizards/Plot2dWiz.cpp:473 ../../src/wizards/Plot3dWiz.cpp:421
 msgid "Save plot to file"
-msgstr ""
+msgstr "名前を付けて保存"
 
 #: ../../src/wxMaximaFrame.cpp:713
 msgid "Save selection from document to an image file"
@@ -8773,7 +8773,7 @@ msgstr "画像として保存"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2640
 msgid "Save style to file"
-msgstr ""
+msgstr "スタイルの保存"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1384
 msgid "Save the worksheet automatically"
@@ -8805,7 +8805,7 @@ msgstr "散布図"
 
 #: ../../src/sidebars/StatSidebar.cpp:88
 msgid "Scatterplot..."
-msgstr ""
+msgstr "散布図..."
 
 #: ../../src/Autocomplete.cpp:157
 msgid "Scheduling a background task that compiles a new list of autocompletable maxima commands."
@@ -8896,7 +8896,7 @@ msgstr "標本抽出"
 #: ../../src/wizards/IntegrateWiz.cpp:208 ../../src/wizards/LimitWiz.cpp:133
 #: ../../src/wizards/SeriesWiz.cpp:105
 msgid "Select a constant"
-msgstr ""
+msgstr "定数を選択してください"
 
 #: ../../src/ToolBar.cpp:390 ../../src/ToolBar.cpp:392
 #: ../../src/wxMaximaFrame.cpp:710
@@ -8917,7 +8917,7 @@ msgstr "数式の出力形式を選択してください"
 
 #: ../../src/dialogs/TipOfTheDay.cpp:109
 msgid "Selecting a part of an output and right-clicking on the selection will bring up a menu with convenient functions that will operate on the selection."
-msgstr ""
+msgstr "出力結果を選択して右クリックすると、メニューが表示されます。その中には必要最小限のコマンドが入っており、その選択した部分に対して実行できます。"
 
 #: ../../src/Styles.cpp:127
 msgid "Selection color"
@@ -9005,7 +9005,7 @@ msgstr "bigfloat の精度を設定..."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:479
 msgid "Set fixed font in text controls."
-msgstr ""
+msgstr "テキスト入力ボックスで固定幅フォントを使用"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:68
 #: ../../src/worksheet/WorksheetContextMenu.cpp:250
@@ -9232,11 +9232,11 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:465
 msgid "Show long expressions in wxMaxima document."
-msgstr ""
+msgstr "wxMaximaのドキュメントで出力に時間がかかる式も表示"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:722
 msgid "Show long expressions:"
-msgstr ""
+msgstr "出力に時間がかかる式も表示："
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:377
 msgid "Show max. 100 digits"
@@ -9337,7 +9337,7 @@ msgstr ""
 
 #: ../../src/sidebars/MathSidebar.cpp:44
 msgid "Simplify"
-msgstr ""
+msgstr "式の整理"
 
 #: ../../src/wxMaximaFrame.cpp:1550
 msgid "Simplify &Radicals..."
@@ -9345,11 +9345,11 @@ msgstr ""
 
 #: ../../src/sidebars/MathSidebar.cpp:47
 msgid "Simplify (r)"
-msgstr ""
+msgstr "関数の整理"
 
 #: ../../src/sidebars/MathSidebar.cpp:65
 msgid "Simplify (tr)"
-msgstr ""
+msgstr "変形 (tri)"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:352
 msgid "Simplify Expression"
@@ -9389,7 +9389,7 @@ msgstr ""
 
 #: ../../src/wizards/SumWiz.cpp:68
 msgid "Simplify the sum"
-msgstr ""
+msgstr "数式を整理して出力"
 
 #: ../../src/wxMaximaFrame.cpp:1629
 msgid "Simplify trigonometric expression"
@@ -9454,7 +9454,7 @@ msgstr ""
 
 #: ../../src/wizards/BC2Wiz.cpp:30
 msgid "Solution:"
-msgstr ""
+msgstr "一般解："
 
 #: ../../src/MaximaCommandMenus.cpp:3446
 msgid "Solve"
@@ -9494,7 +9494,7 @@ msgstr "連立微分方程式を解く(&C)..."
 
 #: ../../src/sidebars/MathSidebar.cpp:77
 msgid "Solve ODE..."
-msgstr ""
+msgstr "微分方程式..."
 
 #: ../../src/wxMaximaFrame.cpp:1432
 msgid "Solve a linear equation system using dgesv"
@@ -9621,12 +9621,12 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:227
 msgid "Spanish"
-msgstr ""
+msgstr "スペイン語"
 
 #: ../../src/wizards/IntegrateWiz.cpp:44 ../../src/wizards/IntegrateWiz.cpp:50
 #: ../../src/wizards/LimitWiz.cpp:38 ../../src/wizards/SeriesWiz.cpp:39
 msgid "Special"
-msgstr ""
+msgstr "数学定数"
 
 #: ../../src/wizards/DrawWiz.cpp:918
 msgid "Speed versus accuracy"
@@ -9837,15 +9837,15 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:282
 msgid "Style"
-msgstr ""
+msgstr "スタイル"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2082
 msgid "Styles"
-msgstr ""
+msgstr "スタイル"
 
 #: ../../src/sidebars/StatSidebar.cpp:112
 msgid "Subsample..."
-msgstr ""
+msgstr "標本（行ベクトル）抽出..."
 
 #: ../../src/ToolBar.cpp:484 ../../src/sidebars/FormatSidebar.cpp:54
 msgid "Subsection"
@@ -9865,7 +9865,7 @@ msgstr ""
 
 #: ../../src/sidebars/MathSidebar.cpp:59
 msgid "Subst..."
-msgstr ""
+msgstr "部分式の置換..."
 
 #: ../../src/MaximaCommandMenus.cpp:715 ../../src/MaximaCommandMenus.cpp:3490
 #: ../../src/MaximaCommandMenus.cpp:4500 ../../src/wizards/SubstituteWiz.cpp:53
@@ -9941,7 +9941,7 @@ msgstr "総和"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:122
 msgid "Sum sign"
-msgstr ""
+msgstr "総和記号"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:228
 msgid "Swedish"
@@ -10141,7 +10141,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:492
 msgid "The default port used for communication between Maxima and wxMaxima."
-msgstr ""
+msgstr "MaximaとwxMaximaの通信に使用される既定のポート"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:412
 msgid "The default width for embedded plots. Can be read out or overridden by the maxima variable wxplot_size"
@@ -10523,7 +10523,7 @@ msgstr ""
 
 #: ../../src/wizards/Plot2dWiz.cpp:65 ../../src/wizards/Plot2dWiz.cpp:505
 msgid "Ticks:"
-msgstr ""
+msgstr "グラフの滑らかさ："
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1359
 msgid "Time [in Minutes] between autosaves"
@@ -10551,7 +10551,7 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:89
 msgid "Title, section and subsection cells can be folded to hide their contents. To fold or unfold, click in the square next to the cell. If you shift-click, all sublevels of that cell will also fold/unfold."
-msgstr ""
+msgstr "「タイトルセル」，「セクションセル」，「サブセクションセル」は，そのセルよりも下位のセルを折りたたんで隠すことができます。セルの左上側にある正方形をクリックすることで「隠す／展開」の切り替えができます。Shiftを押しながらクリックすると，下位のセル全体に対して「隠す／展開」を行います。"
 
 #: ../../src/wxMaximaFrame.cpp:1831
 msgid "To &Bigfloat"
@@ -10579,15 +10579,15 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:124
 msgid "To plot in polar coordinates, select 'set polar' in the Options entry for Plot2d dialog. You can also plot in spherical and cylindrical coordinates in 3D."
-msgstr ""
+msgstr "２次元プロットでは、Plot2dダイアログのオプションの中から「set polar」を選択することで極座標プロットで出力できます。また３次元プロットでは、Plot3dダイアログのオプションの中から「set mapping spherical」や「set mapping cylindrical」を選択することで球座標や円柱座標プロットで出力できます。"
 
 #: ../../src/dialogs/TipOfTheDay.cpp:131
 msgid "To put parentheses around an expression, select it, and press '(' or ')' depending on where you want the cursor to appear afterwards."
-msgstr ""
+msgstr "セル内の式を選択し、「 ( 」または「 ) 」を押すことでその式をカッコで括ることができます。"
 
 #: ../../src/dialogs/TipOfTheDay.cpp:137
 msgid "To save the size and position of wxMaxima windows between session, use 'Edit->Configure' dialog."
-msgstr ""
+msgstr "wxMaxima起動時のウィンドウサイズと位置を保持したい場合は、メニューバーの「編集」から「設定」ダイアログを開き、「前回のウィンドウサイズと位置を保持」にチェックを入れて下さい"
 
 #: ../../src/dialogs/TipOfTheDay.cpp:51
 msgid "To start using wxMaxima right away, start typing your command. An input cell should appear. Then press Shift-Enter to evaluate your command."
@@ -10771,7 +10771,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:230
 msgid "Turkish"
-msgstr ""
+msgstr "トルコ語"
 
 #: ../../src/wxMaximaFrame.cpp:1965
 msgid "Tutorials"
@@ -10807,7 +10807,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:231
 msgid "Ukrainian"
-msgstr ""
+msgstr "ウクライナ語"
 
 #: ../../src/wxMaxima.cpp:3164
 msgid "Un-closed parenthesis"
@@ -10838,11 +10838,11 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2115
 msgid "Underlined"
-msgstr ""
+msgstr "下線"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:745
 msgid "Underscore converts to subscripts:"
-msgstr ""
+msgstr "アンダースコアを添字に変換："
 
 #: ../../src/ToolBar.cpp:354 ../../src/ToolBar.cpp:357
 msgid "Undo"
@@ -10986,7 +10986,7 @@ msgstr ""
 
 #: ../../src/wizards/SumWiz.cpp:69
 msgid "Use Gosper algorithm"
-msgstr ""
+msgstr "Gosperアルゴリズムを使用"
 
 #: ../../src/sidebars/RegexCtrl.cpp:133
 msgid "Use RegEx filtering"
@@ -11014,7 +11014,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:849
 msgid "Use centered dot character for multiplication"
-msgstr ""
+msgstr "乗法記号を・に置き換える"
 
 #: ../../src/wxMaximaFrame.cpp:1745
 msgid "Use list"
@@ -11199,7 +11199,7 @@ msgstr "変数："
 
 #: ../../src/sidebars/StatSidebar.cpp:58
 msgid "Variance..."
-msgstr ""
+msgstr "標本分散..."
 
 #: ../../src/WXMXformat.cpp:339
 msgid "Verified that we are able to read the whole .zip archive we produced."
@@ -11271,7 +11271,7 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:134
 msgid "When applying functions with one argument from menus, the default argument is '%'. To apply the function to some other value, select it in the document before executing a menu command."
-msgstr ""
+msgstr "メニューバーからコマンドを実行するとき、デフォルトの引数は「％」（直前の出力結果）です。他の引数（それ以前の出力結果）を使用するときは、それを選択してから実行して下さい。"
 
 #: ../../src/wxMaximaFrame.cpp:1092
 msgid "When to invoke the lisp compiler's debugger"
@@ -11299,7 +11299,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:280
 msgid "Worksheet"
-msgstr ""
+msgstr "ワークシート"
 
 #: ../../src/MaximaResponseReader.cpp:117
 #, c-format
@@ -11358,11 +11358,11 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:64
 msgid "You can access the last output using the variable '%'. You can access the output of previous commands using variables '%on' where n is the number of output."
-msgstr ""
+msgstr "以前の出力結果が再び必要になる場合もあるでしょう。一番新しい出力結果を使う場合、「 % 」で代用できます。それより以前の出力結果を使う場合は、「%on」（nは使用する出力結果の番号です）で代用できます。"
 
 #: ../../src/dialogs/TipOfTheDay.cpp:118
 msgid "You can evaluate your whole document by using 'Cell->Evaluate All Cells' menu command or the appropriate key shortcut. The cells will be evaluated in the order they appear in the document."
-msgstr ""
+msgstr "全ての入力セルの内容を一度に評価することができます。メニューバーの「セル」から「全てのセルを評価」を実行するか、そのショートカットキーを押してください。セルは上から順に評価されます。"
 
 #: ../../src/dialogs/TipOfTheDay.cpp:98
 msgid "You can get help on a Maxima function by selecting or clicking on the function name and pressing F1. wxMaxima will search the help index for the selection or the word under the cursor."
@@ -11370,15 +11370,15 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:92
 msgid "You can hide output part of cells by clicking in the triangle on the left side of cells. This works on text cells also."
-msgstr ""
+msgstr "「テキストセル」では，セルの左側の三角形をクリックすることでその内容を隠すことができます。"
 
 #: ../../src/dialogs/TipOfTheDay.cpp:81
 msgid "You can insert different types of 'cells' in wxMaxima documents using the 'Cell' menu. Note that only 'input cells' can be evaluated, while others are used for commenting and structuring your calculations."
-msgstr ""
+msgstr "メニューバーの「セル」より，「入力セル」以外のセルを挿入することができます。ただし、それらのセルはドキュメントの体裁を整えるために使うものです。評価を行えるのは「入力セル」のみであることに注意して下さい。"
 
 #: ../../src/dialogs/TipOfTheDay.cpp:112
 msgid "You can select multiple cells either with a mouse - click'n'drag from between cells or from a cell bracket on the left - or with a keyboard - hold down Shift while moving the horizontal cursor - and then operate on selection. This comes in handy when you want to delete or evaluate multiple cells."
-msgstr ""
+msgstr "複数のセルを選択すれば、それらをまとめて削除または評価できます。複数のセルを選択するには、水平カーソル（またはセルの左側にあるカッコ）をクリックしたままドラッグ、もしくはShiftキーを押しながら矢印キーで水平カーソルを動かしてください。"
 
 #: ../../src/dialogs/TipOfTheDay.cpp:232
 msgid "You found a bug in wxMaxima? Please report it at https://github.com/wxMaxima-developers/wxmaxima/issues\n"
@@ -11450,11 +11450,11 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:95
 msgid "and"
-msgstr ""
+msgstr "かつ"
 
 #: ../../src/wizards/MatWiz.cpp:160
 msgid "antisymmetric"
-msgstr ""
+msgstr "反対称行列"
 
 #: ../../src/wxMaximaFrame.cpp:1727
 msgid "apply function to each element"
@@ -11482,7 +11482,7 @@ msgstr ""
 
 #: ../../src/wizards/LimitWiz.cpp:42
 msgid "both sides"
-msgstr ""
+msgstr "挟み撃ち"
 
 #: ../../src/wxMaximaFrame.cpp:1173
 msgid "char to Ascii code..."
@@ -11500,7 +11500,7 @@ msgstr ""
 #: ../../src/wizards/Plot2dWiz.cpp:70 ../../src/wizards/Plot2dWiz.cpp:372
 #: ../../src/wizards/Plot3dWiz.cpp:61 ../../src/wizards/Plot3dWiz.cpp:358
 msgid "default"
-msgstr ""
+msgstr "ユーザ指定のプロットエンジン"
 
 #: ../../src/sidebars/GreekSidebar.cpp:154
 msgid "delta"
@@ -11508,7 +11508,7 @@ msgstr ""
 
 #: ../../src/wizards/MatWiz.cpp:159
 msgid "diagonal"
-msgstr ""
+msgstr "対角行列"
 
 #: ../../src/cells/FracCell.cpp:73
 msgid "diff(): Cannot find the multiplication sign I should hide"
@@ -11524,7 +11524,7 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:92
 msgid "empty"
-msgstr ""
+msgstr "空集合"
 
 #: ../../src/sidebars/GreekSidebar.cpp:155
 msgid "epsilon"
@@ -11532,7 +11532,7 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:100
 msgid "equivalent"
-msgstr ""
+msgstr "同値"
 
 #: ../../src/sidebars/GreekSidebar.cpp:157
 msgid "eta"
@@ -11544,7 +11544,7 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:88
 msgid "exists"
-msgstr ""
+msgstr "存在"
 
 #: ../../src/MaximaCommandMenus.cpp:3942
 msgid "expression:"
@@ -11590,7 +11590,7 @@ msgstr ""
 
 #: ../../src/wizards/MatWiz.cpp:159
 msgid "general"
-msgstr ""
+msgstr "一般"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1630
 msgid "gnuplot: Without command console"
@@ -11598,11 +11598,11 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:118
 msgid "greater than or equal"
-msgstr ""
+msgstr "以上"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:87
 msgid "in"
-msgstr ""
+msgstr "属する"
 
 #: ../../src/wxMaximaFrame.cpp:784
 msgid "in 2D"
@@ -11613,11 +11613,11 @@ msgstr ""
 #: ../../src/wizards/Plot3dWiz.cpp:61 ../../src/wizards/Plot3dWiz.cpp:194
 #: ../../src/wizards/Plot3dWiz.cpp:358 ../../src/wizards/Plot3dWiz.cpp:386
 msgid "inline"
-msgstr ""
+msgstr "ドキュメント内で表示"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:104
 msgid "intersection"
-msgstr ""
+msgstr "共通部分"
 
 #: ../../src/sidebars/GreekSidebar.cpp:159
 msgid "iota"
@@ -11633,11 +11633,11 @@ msgstr ""
 
 #: ../../src/wizards/LimitWiz.cpp:42
 msgid "left"
-msgstr ""
+msgstr "左極限"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:117
 msgid "less or equal"
-msgstr ""
+msgstr "以下"
 
 #: ../../src/MaximaCommandMenus.cpp:1567
 msgid "list"
@@ -11645,7 +11645,7 @@ msgstr ""
 
 #: ../../src/wizards/Plot2dWiz.cpp:54 ../../src/wizards/Plot2dWiz.cpp:64
 msgid "logscale"
-msgstr ""
+msgstr "対数目盛を使用"
 
 #: ../../src/wizards/DrawWiz.cpp:822
 msgid "matrix([x_1,x_2,...],[y_1,y_2,...])"
@@ -11665,11 +11665,11 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:120
 msgid "much greater than"
-msgstr ""
+msgstr "非常に大きい"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:119
 msgid "much less than"
-msgstr ""
+msgstr "非常に小さい"
 
 #: ../../src/MaximaCommandMenus.cpp:1232
 msgid "m×n Matrix A:"
@@ -11698,7 +11698,7 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:102
 msgid "not"
-msgstr ""
+msgstr "否定"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:116
 msgid "not bytewise identical"
@@ -11706,11 +11706,11 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:108
 msgid "not subset"
-msgstr ""
+msgstr "部分集合でない"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:107
 msgid "not subset or equal"
-msgstr ""
+msgstr "部分集合（等号付き）でない"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:796
 msgid "noun: Not evaluated by default"
@@ -11738,7 +11738,7 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:96
 msgid "or"
-msgstr ""
+msgstr "または"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:793
 msgid "outative: f(2*x) = 2*f(x)"
@@ -11755,7 +11755,7 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:111
 msgid "partial sign"
-msgstr ""
+msgstr "偏微分"
 
 #: ../../src/sidebars/GreekSidebar.cpp:171
 msgid "phi"
@@ -11767,7 +11767,7 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:101
 msgid "plus or minus"
-msgstr ""
+msgstr "プラスマイナス"
 
 #: ../../src/MaximaCommandMenus.cpp:196
 msgid "point:"
@@ -11792,7 +11792,7 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:115
 msgid "proportional to"
-msgstr ""
+msgstr "比例"
 
 #: ../../src/sidebars/GreekSidebar.cpp:173
 msgid "psi"
@@ -11828,7 +11828,7 @@ msgstr ""
 
 #: ../../src/wizards/LimitWiz.cpp:42
 msgid "right"
-msgstr ""
+msgstr "右極限"
 
 #: ../../src/wizards/DrawWiz.cpp:310
 msgid "secondary x axis label"
@@ -11872,15 +11872,15 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:106
 msgid "subset"
-msgstr ""
+msgstr "部分集合"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:105
 msgid "subset or equal"
-msgstr ""
+msgstr "部分集合（等号付き）"
 
 #: ../../src/wizards/MatWiz.cpp:160
 msgid "symmetric"
-msgstr ""
+msgstr "対称行列"
 
 #: ../../src/MaximaCommandMenus.cpp:970
 msgid "t:"
@@ -11905,7 +11905,7 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:89
 msgid "there is no"
-msgstr ""
+msgstr "存在しない"
 
 #: ../../src/sidebars/GreekSidebar.cpp:158
 msgid "theta"
@@ -11913,15 +11913,15 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:78
 msgid "to the power of 2"
-msgstr ""
+msgstr "2乗"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:79
 msgid "to the power of 3"
-msgstr ""
+msgstr "3乗"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:103
 msgid "union"
-msgstr ""
+msgstr "和集合"
 
 #: ../../src/wxMaximaFrame.cpp:1109
 msgid "unnamed function (lambda)..."
@@ -11985,7 +11985,7 @@ msgstr ""
 #: ../../src/dialogs/ConfigDialogue.cpp:142
 #: ../../src/dialogs/ConfigDialogue.cpp:311
 msgid "wxMaxima configuration"
-msgstr ""
+msgstr "設定"
 
 #: ../../src/MaximaProcessManager.cpp:209
 msgid "wxMaxima could not start a server.\n\n"
@@ -11995,7 +11995,7 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:127
 msgid "wxMaxima dialogs set default values for inputs entries, one of which is '%'. If you have made a selection in your document, the selection will be used instead of '%'."
-msgstr ""
+msgstr "メニューからコマンドを実行するとき、ダイアログ画面が現れるものにはその入力欄に「％」（直前の出力結果を表す記号）があらかじめ入力されています。ただし、ドキュメント内に選択状態のものがある場合、「％」の代わりにそれが入力されます。"
 
 #: ../../src/MaximaCommandMenus.cpp:4544
 msgid "wxMaxima document"
@@ -12145,7 +12145,7 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:97
 msgid "xor"
-msgstr ""
+msgstr "排他的論理和"
 
 #: ../../src/wizards/DrawWiz.cpp:279
 msgid "y axis label"

--- a/locales/wxMaxima/kab.po
+++ b/locales/wxMaxima/kab.po
@@ -63,11 +63,11 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1571
 msgid "      -X '--dynamic-space-size <int>'"
-msgstr ""
+msgstr "      -X '--dynamic-space-size <int>'"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1551
 msgid "      -l <name>"
-msgstr ""
+msgstr "      -l <name>"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1557
 msgid "      -u <versionnumber>"
@@ -165,7 +165,7 @@ msgstr ""
 #: ../../src/cells/ImgCell.cpp:212 ../../src/cells/ImgCell.cpp:214
 #: ../../src/cells/ImgCell.cpp:216
 msgid " (Graphics) "
-msgstr ""
+msgstr " (Udlifen) "
 
 #: ../../src/cells/EditorCell.cpp:3551 ../../src/cells/EditorCell.cpp:3820
 #: ../../src/cells/EditorCell.cpp:3945
@@ -314,7 +314,7 @@ msgstr "&Copier\tCtrl+C"
 
 #: ../../src/wizards/IntegrateWiz.cpp:39
 msgid "&Definite integration"
-msgstr ""
+msgstr "Intégrale &définie"
 
 #: ../../src/wxMaximaFrame.cpp:1658
 msgid "&Demoivre"
@@ -430,11 +430,11 @@ msgstr ""
 
 #: ../../src/wizards/IntegrateWiz.cpp:52
 msgid "&Numerical integration"
-msgstr ""
+msgstr "Intégration &numérique"
 
 #: ../../src/wizards/SumWiz.cpp:44
 msgid "&Nusum"
-msgstr ""
+msgstr "&Nusum"
 
 #: ../../src/main.cpp:675
 msgid "&Open\tCtrl+O"
@@ -450,7 +450,7 @@ msgstr "Asuneɣ n tmaknayt"
 
 #: ../../src/wizards/SeriesWiz.cpp:45
 msgid "&Power series"
-msgstr ""
+msgstr "Série entière"
 
 #: ../../src/wxMaximaFrame.cpp:655
 msgid "&Print...\tCtrl+P"
@@ -458,7 +458,7 @@ msgstr "Im&primer\tCtrl+P"
 
 #: ../../src/wizards/SubstituteWiz.cpp:38
 msgid "&Rational"
-msgstr ""
+msgstr "&Rationnel"
 
 #: ../../src/wxMaximaFrame.cpp:1631
 msgid "&Reduce Trigonometric"
@@ -490,11 +490,11 @@ msgstr "&Fru…"
 
 #: ../../src/wizards/Plot2dWiz.cpp:42
 msgid "&Special"
-msgstr ""
+msgstr "&Imeẓli"
 
 #: ../../src/wizards/LimitWiz.cpp:45
 msgid "&Taylor series"
-msgstr ""
+msgstr "Série de Taylor :"
 
 #: ../../src/wxMaximaFrame.cpp:1069
 msgid "&Time Display"
@@ -514,7 +514,7 @@ msgstr ""
 
 #: ../../src/wizards/Plot3dWiz.cpp:79
 msgid "&pm3d"
-msgstr ""
+msgstr "&pm3d"
 
 #: ../../src/cells/AnimationCell.cpp:475
 msgid "(Animation)"
@@ -550,7 +550,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:183
 msgid "(Use default language)"
-msgstr ""
+msgstr "(Seqdec tutlayt tamezwert)"
 
 #: ../../src/MaximaCommandMenus.cpp:440
 msgid "(f(x),x,a,b)), Epsilon algorithm"
@@ -592,7 +592,7 @@ msgstr ""
 #: ../../src/wizards/IntegrateWiz.cpp:217 ../../src/wizards/LimitWiz.cpp:132
 #: ../../src/wizards/LimitWiz.cpp:142
 msgid "- Infinity"
-msgstr ""
+msgstr "- Infini"
 
 #: ../../src/MaximaOutputAppender.cpp:116
 msgid "... [suppressed additional lines as the output is longer than allowed in the wxMaxima configuration] "
@@ -649,7 +649,7 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:102
 msgid "A 'horizontal cursor' was introduced in wxMaxima 0.8.0. It looks like a horizontal line between cells. It indicates where a new cell will appear if you type or paste text or execute a menu command."
-msgstr ""
+msgstr "Un « curseur horizontal » a été introduit avec wxMaxima 0.8.0. Il ressemble à une ligne ligne horizontale entre les cellules et indique où apparaîtra une nouvelle cellule si vous tapez ou collez du texte, ou exécutez une commande du menu."
 
 #: ../../src/MaximaCommandMenus.cpp:3039
 msgid "A Ctrl-F event"
@@ -916,7 +916,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:389
 msgid "Additional parameters for Maxima (e.g. -l clisp)."
-msgstr ""
+msgstr "Paramètres supplémentaires pour Maxima (par exemple -l clisp)"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1543
 msgid "Additional parameters for Maxima (restart Maxima after changes)"
@@ -1012,7 +1012,7 @@ msgstr ""
 
 #: ../../src/dialogs/BinaryNameCtrl.cpp:69
 msgid "All|*"
-msgstr ""
+msgstr "Akk|*"
 
 #: ../../src/wxMaximaFrame.cpp:800
 msgid "Always after underscores"
@@ -1291,7 +1291,7 @@ msgstr ""
 
 #: ../../src/wizards/BC2Wiz.cpp:59
 msgid "BC2"
-msgstr ""
+msgstr "BC2"
 
 #: ../../src/MaximaManual.cpp:559
 msgid "Background task that compiles the Manual anchors scheduled."
@@ -1299,7 +1299,7 @@ msgstr ""
 
 #: ../../src/sidebars/StatSidebar.cpp:91
 msgid "Barsplot..."
-msgstr ""
+msgstr "Udlif s ifeggagen…"
 
 #: ../../src/wxMaximaFrame.cpp:1384
 msgid "Basic matrix operations"
@@ -1342,7 +1342,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:179
 msgid "Beta"
-msgstr ""
+msgstr "Beta"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1898
 msgid "Bitmap"
@@ -1358,7 +1358,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2109
 msgid "Bold"
-msgstr ""
+msgstr "Zur"
 
 #: ../../src/wxMaxima.cpp:2259
 msgid "Both horizontal and vertical cursor active at the same time"
@@ -1382,13 +1382,13 @@ msgstr ""
 
 #: ../../src/sidebars/StatSidebar.cpp:97
 msgid "Boxplot..."
-msgstr ""
+msgstr "Udlif n tnaka…"
 
 #: ../../src/dialogs/BinaryNameCtrl.cpp:42 ../../src/wizards/CsvWiz.cpp:57
 #: ../../src/wizards/CsvWiz.cpp:131 ../../src/wizards/Plot2dWiz.cpp:114
 #: ../../src/wizards/Plot3dWiz.cpp:109
 msgid "Browse"
-msgstr ""
+msgstr "Snirem"
 
 #: ../../src/wxMathml.cpp:101
 msgid "Bug: After removing the whitespace wxMathml.lisp is shorter than expected!"
@@ -1767,11 +1767,11 @@ msgstr ""
 
 #: ../../src/sidebars/MathSidebar.cpp:62
 msgid "Canonical (tr)"
-msgstr ""
+msgstr "Uqnin(asektiɣmer)"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:188
 msgid "Catalan"
-msgstr ""
+msgstr "Takaṭalant"
 
 #: ../../src/MaximaCommandMenus.cpp:466
 msgid "Cauchy principal value of f(x)/(x-c), finite interval"
@@ -1941,7 +1941,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2100
 msgid "Choose font"
-msgstr ""
+msgstr "Choisir la police"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:793
 msgid "Choose how mathematical output is formatted:\n"
@@ -2126,7 +2126,7 @@ msgstr ""
 
 #: ../../src/wizards/MatWiz.cpp:155
 msgid "Columns:"
-msgstr ""
+msgstr "Colonnes :"
 
 #: ../../src/wxMaximaFrame.cpp:1621
 msgid "Combine factorials in an expression"
@@ -2142,11 +2142,11 @@ msgstr ""
 
 #: ../../src/wizards/Plot2dWiz.cpp:626
 msgid "Comma separated x coordinates"
-msgstr ""
+msgstr "Liste x séparée par des virgules"
 
 #: ../../src/wizards/Plot2dWiz.cpp:627
 msgid "Comma separated y coordinates"
-msgstr ""
+msgstr "Liste y séparée par des virgules"
 
 #: ../../src/MaximaCommandMenus.cpp:4071
 msgid "Comma-separated arguments"
@@ -2372,7 +2372,7 @@ msgstr "Condition :"
 #: ../../src/dialogs/ConfigDialogue.cpp:2641
 #: ../../src/dialogs/ConfigDialogue.cpp:2647
 msgid "Config file (*.ini)|*.ini"
-msgstr ""
+msgstr "Fichier de configuration (*.ini)|*.ini"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2539
 #, c-format
@@ -2404,7 +2404,7 @@ msgstr ""
 #: ../../src/wizards/IntegrateWiz.cpp:208 ../../src/wizards/LimitWiz.cpp:133
 #: ../../src/wizards/SeriesWiz.cpp:105
 msgid "Constant"
-msgstr ""
+msgstr "Constante"
 
 #: ../../src/MaximaCommandMenus.cpp:1102
 msgid "Construct a fraction"
@@ -2878,7 +2878,7 @@ msgstr ""
 
 #: ../../src/worksheet/Worksheet.cpp:6115
 msgid "Cursor"
-msgstr ""
+msgstr "Curseur"
 
 #: ../../src/Styles.cpp:126
 msgid "Cursor color"
@@ -2900,11 +2900,11 @@ msgstr "Couper la sélection"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:193
 msgid "Czech"
-msgstr ""
+msgstr "Tchèque"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:194
 msgid "Danish"
-msgstr ""
+msgstr "Danois"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2069
 msgid "Dark"
@@ -3095,7 +3095,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:181
 msgid "Delta"
-msgstr ""
+msgstr "Delta"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:110
 #: ../../src/worksheet/WorksheetContextMenu.cpp:558
@@ -3121,7 +3121,7 @@ msgstr ""
 
 #: ../../src/wizards/SeriesWiz.cpp:42
 msgid "Depth:"
-msgstr ""
+msgstr "talqayt :"
 
 #: ../../src/MaximaCommandMenus.cpp:994
 msgid "Derivate of y at that point:"
@@ -3156,7 +3156,7 @@ msgstr ""
 
 #: ../../src/sidebars/StatSidebar.cpp:61
 msgid "Deviation..."
-msgstr ""
+msgstr "Azza..."
 
 #: ../../src/wxMaximaFrame.cpp:1534
 msgid "Di&vide Polynomials..."
@@ -3188,7 +3188,7 @@ msgstr ""
 
 #: ../../src/sidebars/MathSidebar.cpp:80
 msgid "Diff..."
-msgstr ""
+msgstr "Zlem.."
 
 #: ../../src/dialogs/DiffFrame.cpp:308
 #, c-format
@@ -3217,7 +3217,7 @@ msgstr ""
 
 #: ../../src/wizards/LimitWiz.cpp:41
 msgid "Direction:"
-msgstr ""
+msgstr "Tanila:"
 
 #: ../../src/wxMaximaFrame.cpp:1246
 msgid "Directory operations"
@@ -3229,7 +3229,7 @@ msgstr ""
 
 #: ../../src/wizards/Plot2dWiz.cpp:418 ../../src/wizards/Plot2dWiz.cpp:619
 msgid "Discrete plot"
-msgstr ""
+msgstr "Graphe discret"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:699
 msgid "Display"
@@ -3571,7 +3571,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:196
 msgid "English"
-msgstr ""
+msgstr "Taglizit"
 
 #: ../../src/wizards/DrawWiz.cpp:552
 msgid "Enhanced 3D settings:"
@@ -3583,7 +3583,7 @@ msgstr ""
 
 #: ../../src/sidebars/StatSidebar.cpp:106
 msgid "Enter Matrix..."
-msgstr ""
+msgstr "&Sekcem isirew..."
 
 #: ../../src/MaximaCommandMenus.cpp:2255
 msgid "Enter UUID to jump to:"
@@ -3603,7 +3603,7 @@ msgstr "Entrer une équation pour la simplification rationnelle :"
 
 #: ../../src/wizards/SystemWiz.cpp:50
 msgid "Enter comma separated list of variables."
-msgstr ""
+msgstr "Entrer une liste de variables séparées par des virgules"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:921
 msgid "Enter evaluates cells, Ctrl+Enter adds newlines"
@@ -3623,7 +3623,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:388
 msgid "Enter the path to the Maxima executable."
-msgstr ""
+msgstr "Entrez le chemin vers l'exécutable de Maxima:"
 
 #: ../../src/MaximaCommandMenus.cpp:1103
 msgid "Enumerator:"
@@ -3639,7 +3639,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:182
 msgid "Epsilon"
-msgstr ""
+msgstr "Epsilon :"
 
 #: ../../src/MaximaCommandMenus.cpp:299
 msgid "Epsilon:"
@@ -3732,7 +3732,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:184
 msgid "Eta"
-msgstr ""
+msgstr "Eta"
 
 #: ../../src/sidebars/TableOfContents.cpp:513
 msgid "Evaluate"
@@ -3870,7 +3870,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2659
 msgid "Example text"
-msgstr ""
+msgstr "Texte exemple…"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1547
 msgid "Examples:"
@@ -3886,11 +3886,11 @@ msgstr ""
 
 #: ../../src/sidebars/MathSidebar.cpp:53
 msgid "Expand"
-msgstr ""
+msgstr "Snefli"
 
 #: ../../src/sidebars/MathSidebar.cpp:68
 msgid "Expand (tr)"
-msgstr ""
+msgstr "Snefli (tanf.tasektuɣmirt)"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:356
 msgid "Expand Expression"
@@ -4216,7 +4216,7 @@ msgstr ""
 
 #: ../../src/sidebars/MathSidebar.cpp:50
 msgid "Factor"
-msgstr ""
+msgstr "Factoriser"
 
 #: ../../src/wxMaximaFrame.cpp:1558
 msgid "Factor Complex"
@@ -4291,7 +4291,7 @@ msgstr ""
 #: ../../src/cells/GroupCell.cpp:2115
 #, c-format
 msgid "Figure %d:"
-msgstr ""
+msgstr "Figure %d:"
 
 #: ../../src/main.cpp:678
 msgid "File"
@@ -4472,7 +4472,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:197
 msgid "Finnish"
-msgstr ""
+msgstr "Tafinit"
 
 #: ../../src/wxMaximaFrame.cpp:1749
 msgid "First"
@@ -4489,7 +4489,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:873
 msgid "Fixed font in text controls"
-msgstr ""
+msgstr "Police à chasse fixe dans les contrôles de texte"
 
 #: ../../src/MaximaCommandMenus.cpp:4039
 msgid "Flush stream"
@@ -4533,7 +4533,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2047
 msgid "Fonts"
-msgstr ""
+msgstr "Tisefsiyin"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:442
 msgid "For each Text-, Sectioning or code cell wxMaxima can display a bracket showing the extend of the cell and allowing to fold it. This setting now tells if this bracket is to be printed, as well."
@@ -4561,7 +4561,7 @@ msgstr ""
 
 #: ../../src/wizards/Plot2dWiz.cpp:69 ../../src/wizards/Plot3dWiz.cpp:60
 msgid "Format:"
-msgstr ""
+msgstr "Amasal:"
 
 #: ../../src/worksheet/Worksheet.cpp:301 ../../src/wxMaxima.cpp:3521
 msgid "Forwarding the keyboard focus to a text control"
@@ -4626,7 +4626,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:198
 msgid "French"
-msgstr ""
+msgstr "Tafṛansist"
 
 #: ../../src/wxMaximaFrame.cpp:1447
 msgid "Frobenius Norm sqrt(sum((A(i,j))^2)) (complex)"
@@ -4765,7 +4765,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:201
 msgid "German"
-msgstr ""
+msgstr "Talmanit"
 
 #: ../../src/wxMaximaFrame.cpp:1656
 msgid "Get &Imaginary Part"
@@ -4853,7 +4853,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:202
 msgid "Greek"
-msgstr ""
+msgstr "Tagrigit"
 
 #: ../../src/wxMaximaFrame.cpp:281
 msgid "Greek Letters"
@@ -4869,7 +4869,7 @@ msgstr ""
 
 #: ../../src/wizards/Plot3dWiz.cpp:52
 msgid "Grid:"
-msgstr ""
+msgstr "Iẓiki:"
 
 #: ../../src/wxMaximaFrame.cpp:1852
 msgid "Guess an exact number that could be meant by this float"
@@ -5046,7 +5046,7 @@ msgstr "Amazrudlif"
 
 #: ../../src/sidebars/StatSidebar.cpp:85
 msgid "Histogram..."
-msgstr ""
+msgstr "Amazrudlif…"
 
 #: ../../src/wxMaximaFrame.cpp:246
 msgid "History"
@@ -5058,7 +5058,7 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:105
 msgid "Horizontal cursor works like a normal cursor, but it operates on cells: press up or down arrow to move it, holding down Shift while moving will select cells, pressing backspace or delete twice will delete a cell next to it."
-msgstr ""
+msgstr "Le curseur horizontal fonctionne comme un curseur normal, mais fonctionne sur les cellules : les touches Haut et Bas permettent de le déplacer, maintenir la touche Maj pendant le déplacement sélectionne les cellules, appuyer sur la touche Retour arr. ou Suppr. deux fois permet d'effacer la cellule sélectionnée."
 
 #: ../../src/wxMaximaFrame.cpp:1563
 msgid "Horner's rule"
@@ -5078,7 +5078,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:205
 msgid "Hungarian"
-msgstr ""
+msgstr "Tahungaṛit"
 
 #: ../../src/wxMaximaFrame.cpp:1147
 msgid "I/O"
@@ -5189,7 +5189,7 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:122
 msgid "If your calculation is taking too long to evaluate, you can try 'Maxima->Interrupt' or 'Maxima->Restart Maxima' menu commands."
-msgstr ""
+msgstr "Si votre calcul met trop de temps à être évalué, vous pouvez essayer \"Maxima->Interrompre\" puis \"Maxima->Redémarrer Maxima"
 
 #: ../../src/MaximaManual.cpp:420
 msgid "Ignoring the cache version for the manual anchors."
@@ -5197,7 +5197,7 @@ msgstr ""
 
 #: ../../src/sidebars/FormatSidebar.cpp:66
 msgid "Image"
-msgstr ""
+msgstr "Image"
 
 #: ../../src/Image.cpp:110
 msgid "Image data had zero length!"
@@ -5326,7 +5326,7 @@ msgstr ""
 #: ../../src/wizards/IntegrateWiz.cpp:215 ../../src/wizards/LimitWiz.cpp:132
 #: ../../src/wizards/LimitWiz.cpp:140
 msgid "Infinity"
-msgstr ""
+msgstr "Imifeḍ"
 
 #: ../../src/wxMaximaFrame.cpp:1986
 msgid "Info about Maxima build"
@@ -5804,11 +5804,11 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:207
 msgid "Italian"
-msgstr ""
+msgstr "Taṭelyanit"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2111
 msgid "Italic"
-msgstr ""
+msgstr "Yekna"
 
 #: ../../src/MaximaCommandMenus.cpp:1617 ../../src/MaximaCommandMenus.cpp:1623
 msgid "Item"
@@ -5820,7 +5820,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:208
 msgid "Japanese"
-msgstr ""
+msgstr "Tajapunit"
 
 #: ../../src/MaximaCommandMenus.cpp:2255
 msgid "Jump to UUID"
@@ -5852,12 +5852,12 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:187
 msgid "Kappa"
-msgstr ""
+msgstr "Kappa"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:864
 #, c-format
 msgid "Keep percent sign with special symbols: %e, %i, etc."
-msgstr ""
+msgstr "Conserver le signe pourcentage avec les symboles spéciaux: %e, %i, etc."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:212
 msgid "Korean"
@@ -5916,11 +5916,11 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:470
 msgid "Language used for wxMaxima GUI."
-msgstr ""
+msgstr "Langue utilisée pour l'interface de wxMaxima"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1311
 msgid "Language:"
-msgstr ""
+msgstr "Tutlayt:"
 
 #: ../../src/MaximaCommandMenus.cpp:251
 msgid "Laplace"
@@ -5967,7 +5967,7 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:126
 msgid "Leads to"
-msgstr ""
+msgstr "arama d :"
 
 #: ../../src/wxMaximaFrame.cpp:1530
 msgid "Least Common Multiple..."
@@ -5979,7 +5979,7 @@ msgstr "Aswati s tarrayt s usemẓi uzmir-sin"
 
 #: ../../src/sidebars/StatSidebar.cpp:79
 msgid "Least Squares Fit..."
-msgstr ""
+msgstr "Aswati s tarrayt s usemẓi uzmir-sin..."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2007
 msgid "Left"
@@ -6037,7 +6037,7 @@ msgstr "Talast"
 
 #: ../../src/sidebars/MathSidebar.cpp:86
 msgid "Limit..."
-msgstr ""
+msgstr "Talast..."
 
 #: ../../src/sidebars/DrawSidebar.cpp:88
 msgid "Line color"
@@ -6045,7 +6045,7 @@ msgstr ""
 
 #: ../../src/sidebars/StatSidebar.cpp:76
 msgid "Linear Regression..."
-msgstr ""
+msgstr "Talkeyt timziregt…"
 
 #: ../../src/MaximaCommandMenus.cpp:4068
 msgid "Lisp format string:"
@@ -6178,7 +6178,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2162
 msgid "Load"
-msgstr ""
+msgstr "Sali-d"
 
 #: ../../src/MaximaCommandMenus.cpp:2356
 msgid "Load Package"
@@ -6218,7 +6218,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2645
 msgid "Load style from file"
-msgstr ""
+msgstr "Sali-d aɣanib seg ufaylu"
 
 #: ../../src/wxMaximaFrame.cpp:1232
 msgid "Load the file/dir operations (operatingsystem)"
@@ -6551,7 +6551,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1437
 msgid "Maxima program:"
-msgstr ""
+msgstr "Ahil  Maxima :"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:382
 msgid "Maxima provides no \"forget all\" command that flushes all settings a maxima session could make. wxMaxima therefore normally defaults to starting a fresh maxima process every time the worksheet is to be re-evaluated. As this needs a little bit of time this switch allows to disable this behavior."
@@ -6786,15 +6786,15 @@ msgstr ""
 
 #: ../../src/sidebars/StatSidebar.cpp:70
 msgid "Mean Difference Test..."
-msgstr ""
+msgstr "Akayad n umgired n tlemmassin…"
 
 #: ../../src/sidebars/StatSidebar.cpp:67
 msgid "Mean Test..."
-msgstr ""
+msgstr "Akayad n tlemmast…"
 
 #: ../../src/sidebars/StatSidebar.cpp:52
 msgid "Mean..."
-msgstr ""
+msgstr "Talemmast…"
 
 #: ../../src/MaximaCommandMenus.cpp:1806
 msgid "Mean:"
@@ -6802,7 +6802,7 @@ msgstr "Talemmast :"
 
 #: ../../src/sidebars/StatSidebar.cpp:55
 msgid "Median..."
-msgstr ""
+msgstr "Tanammast…"
 
 #: ../../src/wxMaximaFrame.cpp:1961
 msgid "Memoizing"
@@ -6823,7 +6823,7 @@ msgstr ""
 
 #: ../../src/wizards/IntegrateWiz.cpp:55
 msgid "Method:"
-msgstr ""
+msgstr "Tarrayt :"
 
 #: ../../src/wxMaximaFrame.cpp:1360
 msgid "Methods of generating a matrix"
@@ -6922,7 +6922,7 @@ msgstr ""
 
 #: ../../src/wizards/MatWiz.cpp:163
 msgid "Name:"
-msgstr ""
+msgstr "Isem :"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:216
 msgid "Nepali"
@@ -6985,7 +6985,7 @@ msgstr "Rnu isemli"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:901
 msgid "New lines: Jump to text"
-msgstr ""
+msgstr "Rnu izirigen: Ngez ɣer uḍris"
 
 #: ../../src/MaximaResponseReader.cpp:1015
 #, c-format
@@ -6998,7 +6998,7 @@ msgstr ""
 
 #: ../../src/wizards/SubstituteWiz.cpp:35
 msgid "New value:"
-msgstr ""
+msgstr "Rnu azal"
 
 #: ../../src/MaximaCommandMenus.cpp:151 ../../src/MaximaCommandMenus.cpp:171
 #: ../../src/MaximaCommandMenus.cpp:254 ../../src/MaximaCommandMenus.cpp:259
@@ -7101,7 +7101,7 @@ msgstr ""
 
 #: ../../src/sidebars/StatSidebar.cpp:73
 msgid "Normality Test..."
-msgstr ""
+msgstr "Akayad n tmugna…"
 
 #: ../../src/cells/TextCell.cpp:271
 msgid "Normally computers use floating-point numbers that can be handled incredibly fast while being accurate to dozens of digits. They will, though, introduce a small error into some common numbers. For example 0.1 is represented as 3602879701896397/36028797018963968.\n"
@@ -7303,7 +7303,7 @@ msgstr ""
 
 #: ../../src/wizards/SubstituteWiz.cpp:32
 msgid "Old value:"
-msgstr ""
+msgstr "Ancienne valeur :"
 
 #: ../../src/MaximaCommandMenus.cpp:151 ../../src/MaximaCommandMenus.cpp:172
 #: ../../src/MaximaCommandMenus.cpp:253 ../../src/MaximaCommandMenus.cpp:259
@@ -7349,7 +7349,7 @@ msgstr "Ldi"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:905
 msgid "Open a cell when Maxima expects input"
-msgstr ""
+msgstr "Ldi-d tabniqt ticki Maxima yettṛaǧu anekcam"
 
 #: ../../src/wxMaximaFrame.cpp:629
 msgid "Open a document"
@@ -7432,7 +7432,7 @@ msgstr "Iɣewwaṛ"
 
 #: ../../src/wizards/Plot2dWiz.cpp:75 ../../src/wizards/Plot3dWiz.cpp:66
 msgid "Options:"
-msgstr ""
+msgstr "Iɣewwaṛen:"
 
 #: ../../src/dialogs/FindReplacePane.cpp:109
 msgid "Output"
@@ -7505,7 +7505,7 @@ msgstr "Approximant de Padé d'un développement en série de Taylor"
 
 #: ../../src/sidebars/FormatSidebar.cpp:69
 msgid "Pagebreak"
-msgstr ""
+msgstr "Saut de page"
 
 #: ../../src/wxMaximaFrame.cpp:1674
 msgid "Parallel Substitute..."
@@ -7533,7 +7533,7 @@ msgstr ""
 
 #: ../../src/wizards/Plot2dWiz.cpp:417 ../../src/wizards/Plot2dWiz.cpp:523
 msgid "Parametric plot"
-msgstr ""
+msgstr "Courbe paramétrée"
 
 #: ../../src/MaximaCommandMenus.cpp:4211
 msgid "Parse string"
@@ -7595,15 +7595,15 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:198
 msgid "Phi"
-msgstr ""
+msgstr "Phi"
 
 #: ../../src/sidebars/GreekSidebar.cpp:193
 msgid "Pi"
-msgstr ""
+msgstr "Pi"
 
 #: ../../src/sidebars/StatSidebar.cpp:94
 msgid "Piechart..."
-msgstr ""
+msgstr "Udlif uwnis…"
 
 #: ../../src/wxMaxima.cpp:1585
 msgid "Please configure wxMaxima with 'Edit->Configure'."
@@ -7611,7 +7611,7 @@ msgstr "Configurer wxMaxima avec 'Édition->Configurer'."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2606
 msgid "Please restart wxMaxima for changes to take effect!"
-msgstr ""
+msgstr "Redémarrer wxMaxima pour que les changements prennent effet."
 
 #: ../../src/MaximaCommandMenus.cpp:2250
 msgid "Please select exactly 2 or 3 files."
@@ -7689,7 +7689,7 @@ msgstr ""
 
 #: ../../src/wizards/Plot2dWiz.cpp:84 ../../src/wizards/Plot3dWiz.cpp:80
 msgid "Plot to file:"
-msgstr ""
+msgstr "Tracer dans un fichier :"
 
 #: ../../src/wxMaximaFrame.cpp:341 ../../src/wxMaximaFrame.cpp:749
 msgid "Plot using Draw"
@@ -7723,7 +7723,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:219
 msgid "Polish"
-msgstr ""
+msgstr "Tapolunit"
 
 #: ../../src/MaximaCommandMenus.cpp:215 ../../src/MaximaCommandMenus.cpp:220
 #: ../../src/MaximaCommandMenus.cpp:225
@@ -7759,7 +7759,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:221
 msgid "Portuguese (Brazilian)"
-msgstr ""
+msgstr "Portugais (Brésil)"
 
 #: ../../src/wxMaximaFrame.cpp:1223
 msgid "Position of a match"
@@ -7775,7 +7775,7 @@ msgstr ""
 
 #: ../../src/wizards/Plot2dWiz.cpp:474 ../../src/wizards/Plot3dWiz.cpp:422
 msgid "Postscript file (*.eps)|*.eps|All|*"
-msgstr ""
+msgstr "Fichier postscript (*.eps)|*.eps|Tous|*"
 
 #: ../../src/MaximaCommandMenus.cpp:190
 msgid "Power series"
@@ -7951,7 +7951,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:200
 msgid "Psi"
-msgstr ""
+msgstr "Psi"
 
 #: ../../src/wxMaximaFrame.cpp:1788
 msgid "Push"
@@ -8037,7 +8037,7 @@ msgstr ""
 
 #: ../../src/sidebars/StatSidebar.cpp:103
 msgid "Read Matrix..."
-msgstr ""
+msgstr "&Ɣar isirew…"
 
 #: ../../src/MaximaCommandMenus.cpp:4008
 msgid "Read a structure field"
@@ -8174,7 +8174,7 @@ msgstr ""
 
 #: ../../src/sidebars/MathSidebar.cpp:56
 msgid "Rectform"
-msgstr ""
+msgstr "Talɣa takaṛtizyant"
 
 #: ../../src/wxMaximaFrame.cpp:1677
 msgid "Recursive Substitute..."
@@ -8198,7 +8198,7 @@ msgstr "Sefsex asnifel aneggaru"
 
 #: ../../src/sidebars/MathSidebar.cpp:71
 msgid "Reduce (tr)"
-msgstr ""
+msgstr "Fneẓ (tanfalit asektuɣmir)"
 
 #: ../../src/wxMaximaFrame.cpp:1632
 msgid "Reduce trigonometric expression"
@@ -8533,7 +8533,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:194
 msgid "Rho"
-msgstr ""
+msgstr "Rho"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2015
 msgid "Right"
@@ -8586,7 +8586,7 @@ msgstr ""
 
 #: ../../src/wizards/MatWiz.cpp:152
 msgid "Rows:"
-msgstr ""
+msgstr "Lignes :"
 
 #: ../../src/MaximaCommandMenus.cpp:1391
 msgid "Rule"
@@ -8656,7 +8656,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:223
 msgid "Russian"
-msgstr ""
+msgstr "Russe"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1578
 msgid "SBCL: use <int>Mbytes of heap"
@@ -8758,7 +8758,7 @@ msgstr "Sekles isemli s yisem"
 
 #: ../../src/wizards/Plot2dWiz.cpp:473 ../../src/wizards/Plot3dWiz.cpp:421
 msgid "Save plot to file"
-msgstr ""
+msgstr "Enregistrer le tracé dans un fichier "
 
 #: ../../src/wxMaximaFrame.cpp:713
 msgid "Save selection from document to an image file"
@@ -8770,7 +8770,7 @@ msgstr "Enregistrer la sélection dans un fichier"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2640
 msgid "Save style to file"
-msgstr ""
+msgstr "Enregistrer le style dans un fichier "
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1384
 msgid "Save the worksheet automatically"
@@ -8802,7 +8802,7 @@ msgstr "Asigna n wagazen"
 
 #: ../../src/sidebars/StatSidebar.cpp:88
 msgid "Scatterplot..."
-msgstr ""
+msgstr "Asigna n wagazen..."
 
 #: ../../src/Autocomplete.cpp:157
 msgid "Scheduling a background task that compiles a new list of autocompletable maxima commands."
@@ -8893,7 +8893,7 @@ msgstr "Choisir un sous-échantillon"
 #: ../../src/wizards/IntegrateWiz.cpp:208 ../../src/wizards/LimitWiz.cpp:133
 #: ../../src/wizards/SeriesWiz.cpp:105
 msgid "Select a constant"
-msgstr ""
+msgstr "Choisir une constante"
 
 #: ../../src/ToolBar.cpp:390 ../../src/ToolBar.cpp:392
 #: ../../src/wxMaximaFrame.cpp:710
@@ -9002,7 +9002,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:479
 msgid "Set fixed font in text controls."
-msgstr ""
+msgstr "Sélectionner une police à chasse fixe dans les entrées de texte."
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:68
 #: ../../src/worksheet/WorksheetContextMenu.cpp:250
@@ -9229,7 +9229,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:465
 msgid "Show long expressions in wxMaxima document."
-msgstr ""
+msgstr "Montrer les expressions longues dans la console de wxMaxima"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:722
 msgid "Show long expressions:"
@@ -9322,7 +9322,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:195
 msgid "Sigma"
-msgstr ""
+msgstr "Sigma"
 
 #: ../../src/dialogs/FindReplacePane.cpp:88
 msgid "Simple"
@@ -9334,7 +9334,7 @@ msgstr ""
 
 #: ../../src/sidebars/MathSidebar.cpp:44
 msgid "Simplify"
-msgstr ""
+msgstr "Sefres"
 
 #: ../../src/wxMaximaFrame.cpp:1550
 msgid "Simplify &Radicals..."
@@ -9342,11 +9342,11 @@ msgstr ""
 
 #: ../../src/sidebars/MathSidebar.cpp:47
 msgid "Simplify (r)"
-msgstr ""
+msgstr "Sefres (r)"
 
 #: ../../src/sidebars/MathSidebar.cpp:65
 msgid "Simplify (tr)"
-msgstr ""
+msgstr "Sefres (tanfalit. trig.)"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:352
 msgid "Simplify Expression"
@@ -9386,7 +9386,7 @@ msgstr ""
 
 #: ../../src/wizards/SumWiz.cpp:68
 msgid "Simplify the sum"
-msgstr ""
+msgstr "Simplifier la somme"
 
 #: ../../src/wxMaximaFrame.cpp:1629
 msgid "Simplify trigonometric expression"
@@ -9451,7 +9451,7 @@ msgstr ""
 
 #: ../../src/wizards/BC2Wiz.cpp:30
 msgid "Solution:"
-msgstr ""
+msgstr "Tifrat :"
 
 #: ../../src/MaximaCommandMenus.cpp:3446
 msgid "Solve"
@@ -9491,7 +9491,7 @@ msgstr "Fru tagda tameẓlayt s Lapla&ce…"
 
 #: ../../src/sidebars/MathSidebar.cpp:77
 msgid "Solve ODE..."
-msgstr ""
+msgstr "Fru ta&gda tameẓlayt…"
 
 #: ../../src/wxMaximaFrame.cpp:1432
 msgid "Solve a linear equation system using dgesv"
@@ -9618,12 +9618,12 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:227
 msgid "Spanish"
-msgstr ""
+msgstr "Taspanit"
 
 #: ../../src/wizards/IntegrateWiz.cpp:44 ../../src/wizards/IntegrateWiz.cpp:50
 #: ../../src/wizards/LimitWiz.cpp:38 ../../src/wizards/SeriesWiz.cpp:39
 msgid "Special"
-msgstr ""
+msgstr "Ameẓli"
 
 #: ../../src/wizards/DrawWiz.cpp:918
 msgid "Speed versus accuracy"
@@ -9834,15 +9834,15 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:282
 msgid "Style"
-msgstr ""
+msgstr "Aɣanib"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2082
 msgid "Styles"
-msgstr ""
+msgstr "Iɣunab"
 
 #: ../../src/sidebars/StatSidebar.cpp:112
 msgid "Subsample..."
-msgstr ""
+msgstr "Adtukkist..."
 
 #: ../../src/ToolBar.cpp:484 ../../src/sidebars/FormatSidebar.cpp:54
 msgid "Subsection"
@@ -9862,7 +9862,7 @@ msgstr ""
 
 #: ../../src/sidebars/MathSidebar.cpp:59
 msgid "Subst..."
-msgstr ""
+msgstr "Semselsi…"
 
 #: ../../src/MaximaCommandMenus.cpp:715 ../../src/MaximaCommandMenus.cpp:3490
 #: ../../src/MaximaCommandMenus.cpp:4500 ../../src/wizards/SubstituteWiz.cpp:53
@@ -10003,7 +10003,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:196
 msgid "Tau"
-msgstr ""
+msgstr "Tau"
 
 #: ../../src/MaximaCommandMenus.cpp:181
 msgid "Taylor series"
@@ -10138,7 +10138,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:492
 msgid "The default port used for communication between Maxima and wxMaxima."
-msgstr ""
+msgstr "Le port par défaut utilisé pour la communication entre Maxima et wxMaxima"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:412
 msgid "The default width for embedded plots. Can be read out or overridden by the maxima variable wxplot_size"
@@ -10460,7 +10460,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:185
 msgid "Theta"
-msgstr ""
+msgstr "Theta"
 
 #: ../../src/dialogs/LicenseDialog.cpp:85
 msgid "Third-party notices"
@@ -10520,7 +10520,7 @@ msgstr ""
 
 #: ../../src/wizards/Plot2dWiz.cpp:65 ../../src/wizards/Plot2dWiz.cpp:505
 msgid "Ticks:"
-msgstr ""
+msgstr "Graduations :"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1359
 msgid "Time [in Minutes] between autosaves"
@@ -10548,7 +10548,7 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:89
 msgid "Title, section and subsection cells can be folded to hide their contents. To fold or unfold, click in the square next to the cell. If you shift-click, all sublevels of that cell will also fold/unfold."
-msgstr ""
+msgstr "Les cellules de titre, section et sous-section peuvent être repliées pour masquer leur contenu. Pour replier ou déplier, cliquer dans le petit triangle à côté de la cellule. Si vous cliquez en enfonçant  la touche Maj, tous les sous-niveaux de cette cellule seront aussi repliés ou dépliés."
 
 #: ../../src/wxMaximaFrame.cpp:1831
 msgid "To &Bigfloat"
@@ -10576,7 +10576,7 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:124
 msgid "To plot in polar coordinates, select 'set polar' in the Options entry for Plot2d dialog. You can also plot in spherical and cylindrical coordinates in 3D."
-msgstr ""
+msgstr "Pour un tracé en coordonnées polaires, choisir 'set polar' dans le menu Options de la boîte de dialogue Courbe 2D. Vous pouvez aussi tracer en coordonnées sphériques ou cylindriques en 3D."
 
 #: ../../src/dialogs/TipOfTheDay.cpp:131
 msgid "To put parentheses around an expression, select it, and press '(' or ')' depending on where you want the cursor to appear afterwards."
@@ -10584,7 +10584,7 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:137
 msgid "To save the size and position of wxMaxima windows between session, use 'Edit->Configure' dialog."
-msgstr ""
+msgstr "Pour sauver la taille et la position de la fenêtre de wxMaxima d'une session à l'autre, utilisez 'Maxima->Configurer'."
 
 #: ../../src/dialogs/TipOfTheDay.cpp:51
 msgid "To start using wxMaxima right away, start typing your command. An input cell should appear. Then press Shift-Enter to evaluate your command."
@@ -10768,7 +10768,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:230
 msgid "Turkish"
-msgstr ""
+msgstr "Taṭiṛkit"
 
 #: ../../src/wxMaximaFrame.cpp:1965
 msgid "Tutorials"
@@ -10804,7 +10804,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:231
 msgid "Ukrainian"
-msgstr ""
+msgstr "Takrinit"
 
 #: ../../src/wxMaxima.cpp:3164
 msgid "Un-closed parenthesis"
@@ -10835,7 +10835,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2115
 msgid "Underlined"
-msgstr ""
+msgstr "Souligné"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:745
 msgid "Underscore converts to subscripts:"
@@ -10983,7 +10983,7 @@ msgstr ""
 
 #: ../../src/wizards/SumWiz.cpp:69
 msgid "Use Gosper algorithm"
-msgstr ""
+msgstr "Utiliser l'algorithme de Gosper"
 
 #: ../../src/sidebars/RegexCtrl.cpp:133
 msgid "Use RegEx filtering"
@@ -11011,7 +11011,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:849
 msgid "Use centered dot character for multiplication"
-msgstr ""
+msgstr "Utiliser le point pour désigner la multiplication"
 
 #: ../../src/wxMaximaFrame.cpp:1745
 msgid "Use list"
@@ -11196,7 +11196,7 @@ msgstr "Imuttiyen:"
 
 #: ../../src/sidebars/StatSidebar.cpp:58
 msgid "Variance..."
-msgstr ""
+msgstr "Awliwel…"
 
 #: ../../src/WXMXformat.cpp:339
 msgid "Verified that we are able to read the whole .zip archive we produced."
@@ -11268,7 +11268,7 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:134
 msgid "When applying functions with one argument from menus, the default argument is '%'. To apply the function to some other value, select it in the document before executing a menu command."
-msgstr ""
+msgstr "En appliquant des fonctions avec un argument dans les menus, l'argument par défaut est '%'. Pour appliquer la fonction à une autre valeur, entrez-la dans la ligne d'entrée. Vous pouvez aussi sélectionner dans le document une (sous-)expression avant d'exécuter une commande de menu."
 
 #: ../../src/wxMaximaFrame.cpp:1092
 msgid "When to invoke the lisp compiler's debugger"
@@ -11296,7 +11296,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:280
 msgid "Worksheet"
-msgstr ""
+msgstr "Afer"
 
 #: ../../src/MaximaResponseReader.cpp:117
 #, c-format
@@ -11347,15 +11347,15 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:191
 msgid "Xi"
-msgstr ""
+msgstr "Xi"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:728
 msgid "Yes"
-msgstr ""
+msgstr "ih"
 
 #: ../../src/dialogs/TipOfTheDay.cpp:64
 msgid "You can access the last output using the variable '%'. You can access the output of previous commands using variables '%on' where n is the number of output."
-msgstr ""
+msgstr "La variable '%' représente le dernier résultat obtenu. Les résultats précédents s'obtiennent en utilisant les variables '%on' où n est le numéro du résultat."
 
 #: ../../src/dialogs/TipOfTheDay.cpp:118
 msgid "You can evaluate your whole document by using 'Cell->Evaluate All Cells' menu command or the appropriate key shortcut. The cells will be evaluated in the order they appear in the document."
@@ -11367,7 +11367,7 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:92
 msgid "You can hide output part of cells by clicking in the triangle on the left side of cells. This works on text cells also."
-msgstr ""
+msgstr "Vous pouvez cacher la zone de sortie des cellules d'entrées en cliquant dans le triangle sur le coté gauche des cellules. Cela fonctionne également sur les cellules de texte."
 
 #: ../../src/dialogs/TipOfTheDay.cpp:81
 msgid "You can insert different types of 'cells' in wxMaxima documents using the 'Cell' menu. Note that only 'input cells' can be evaluated, while others are used for commenting and structuring your calculations."
@@ -11375,7 +11375,7 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:112
 msgid "You can select multiple cells either with a mouse - click'n'drag from between cells or from a cell bracket on the left - or with a keyboard - hold down Shift while moving the horizontal cursor - and then operate on selection. This comes in handy when you want to delete or evaluate multiple cells."
-msgstr ""
+msgstr "Vous pouvez sélectionner plusieurs cellules à la souris – cliquez et glissez-déposez entre cellules ou à partir d'un crochet de cellule sur la gauche. Au clavier,maintenez la touche Maj enfoncée tout en déplaçant le curseur horizontal. Ensuite, opérez sur la sélection. Utile pour supprimer ou évaluer plusieurs cellules."
 
 #: ../../src/dialogs/TipOfTheDay.cpp:232
 msgid "You found a bug in wxMaxima? Please report it at https://github.com/wxMaxima-developers/wxmaxima/issues\n"
@@ -11403,7 +11403,7 @@ msgstr "Lqem inek n wxMaximar d aneggaru."
 
 #: ../../src/sidebars/GreekSidebar.cpp:183
 msgid "Zeta"
-msgstr ""
+msgstr "Zeta"
 
 #: ../../src/wxMaximaFrame.cpp:842
 msgid "Zoom &In\tCtrl++"
@@ -11443,15 +11443,15 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:151
 msgid "alpha"
-msgstr ""
+msgstr "alpha"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:95
 msgid "and"
-msgstr ""
+msgstr "akked"
 
 #: ../../src/wizards/MatWiz.cpp:160
 msgid "antisymmetric"
-msgstr ""
+msgstr "antisymétrique"
 
 #: ../../src/wxMaximaFrame.cpp:1727
 msgid "apply function to each element"
@@ -11475,11 +11475,11 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:152
 msgid "beta"
-msgstr ""
+msgstr "beta"
 
 #: ../../src/wizards/LimitWiz.cpp:42
 msgid "both sides"
-msgstr ""
+msgstr "Seg sin idisan :"
 
 #: ../../src/wxMaximaFrame.cpp:1173
 msgid "char to Ascii code..."
@@ -11497,15 +11497,15 @@ msgstr ""
 #: ../../src/wizards/Plot2dWiz.cpp:70 ../../src/wizards/Plot2dWiz.cpp:372
 #: ../../src/wizards/Plot3dWiz.cpp:61 ../../src/wizards/Plot3dWiz.cpp:358
 msgid "default"
-msgstr ""
+msgstr "par défaut"
 
 #: ../../src/sidebars/GreekSidebar.cpp:154
 msgid "delta"
-msgstr ""
+msgstr "delta"
 
 #: ../../src/wizards/MatWiz.cpp:159
 msgid "diagonal"
-msgstr ""
+msgstr "diagonale"
 
 #: ../../src/cells/FracCell.cpp:73
 msgid "diff(): Cannot find the multiplication sign I should hide"
@@ -11521,11 +11521,11 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:92
 msgid "empty"
-msgstr ""
+msgstr "ilem"
 
 #: ../../src/sidebars/GreekSidebar.cpp:155
 msgid "epsilon"
-msgstr ""
+msgstr "epsilon :"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:100
 msgid "equivalent"
@@ -11533,7 +11533,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:157
 msgid "eta"
-msgstr ""
+msgstr "eta"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:799
 msgid "ev() shall evaluate this automatically"
@@ -11541,7 +11541,7 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:88
 msgid "exists"
-msgstr ""
+msgstr "yella"
 
 #: ../../src/MaximaCommandMenus.cpp:3942
 msgid "expression:"
@@ -11587,7 +11587,7 @@ msgstr ""
 
 #: ../../src/wizards/MatWiz.cpp:159
 msgid "general"
-msgstr ""
+msgstr "amatu"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1630
 msgid "gnuplot: Without command console"
@@ -11610,7 +11610,7 @@ msgstr ""
 #: ../../src/wizards/Plot3dWiz.cpp:61 ../../src/wizards/Plot3dWiz.cpp:194
 #: ../../src/wizards/Plot3dWiz.cpp:358 ../../src/wizards/Plot3dWiz.cpp:386
 msgid "inline"
-msgstr ""
+msgstr "en ligne"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:104
 msgid "intersection"
@@ -11630,7 +11630,7 @@ msgstr ""
 
 #: ../../src/wizards/LimitWiz.cpp:42
 msgid "left"
-msgstr ""
+msgstr "S azelmaḍ"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:117
 msgid "less or equal"
@@ -11642,7 +11642,7 @@ msgstr ""
 
 #: ../../src/wizards/Plot2dWiz.cpp:54 ../../src/wizards/Plot2dWiz.cpp:64
 msgid "logscale"
-msgstr ""
+msgstr "sellum alugaritman"
 
 #: ../../src/wizards/DrawWiz.cpp:822
 msgid "matrix([x_1,x_2,...],[y_1,y_2,...])"
@@ -11691,7 +11691,7 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:99
 msgid "nor"
-msgstr ""
+msgstr "ala"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:102
 msgid "not"
@@ -11735,7 +11735,7 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:96
 msgid "or"
-msgstr ""
+msgstr "neɣ"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:793
 msgid "outative: f(2*x) = 2*f(x)"
@@ -11756,7 +11756,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:171
 msgid "phi"
-msgstr ""
+msgstr "phi"
 
 #: ../../src/sidebars/GreekSidebar.cpp:166
 msgid "pi"
@@ -11793,7 +11793,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:173
 msgid "psi"
-msgstr ""
+msgstr "psi"
 
 #: ../../src/MaximaCommandMenus.cpp:642
 msgid "radcan() is a powerful tools for simplification trigonometric functions but needs to be taken with care: If a function has more than one branch radcan uses the one that looks like it would fit best, not necessarily the one that makes sense for the problem that resulted in the Expression that is to be simplified."
@@ -11821,11 +11821,11 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:167
 msgid "rho"
-msgstr ""
+msgstr "rho"
 
 #: ../../src/wizards/LimitWiz.cpp:42
 msgid "right"
-msgstr ""
+msgstr "s ayeffus"
 
 #: ../../src/wizards/DrawWiz.cpp:310
 msgid "secondary x axis label"
@@ -11877,7 +11877,7 @@ msgstr ""
 
 #: ../../src/wizards/MatWiz.cpp:160
 msgid "symmetric"
-msgstr ""
+msgstr "symétrique"
 
 #: ../../src/MaximaCommandMenus.cpp:970
 msgid "t:"
@@ -11885,7 +11885,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:169
 msgid "tau"
-msgstr ""
+msgstr "tau"
 
 #: ../../src/cells/TextCell.cpp:340
 msgid "the [] operator tried to extract an element of a list, a matrix, an equation or an array. But instead of an integer number something was used whose numerical value is unknown or not an integer.\n"
@@ -11906,7 +11906,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:158
 msgid "theta"
-msgstr ""
+msgstr "theta"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:78
 msgid "to the power of 2"
@@ -11982,7 +11982,7 @@ msgstr ""
 #: ../../src/dialogs/ConfigDialogue.cpp:142
 #: ../../src/dialogs/ConfigDialogue.cpp:311
 msgid "wxMaxima configuration"
-msgstr ""
+msgstr "Aswel n  wxMaxima "
 
 #: ../../src/MaximaProcessManager.cpp:209
 msgid "wxMaxima could not start a server.\n\n"
@@ -11992,7 +11992,7 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:127
 msgid "wxMaxima dialogs set default values for inputs entries, one of which is '%'. If you have made a selection in your document, the selection will be used instead of '%'."
-msgstr ""
+msgstr "wxMaxima donne des valeurs par défaut dans les champs d'entrée des boîtes de dialogue, l'une d'entre elles étant '%'. Si vous avez opéré une sélection dans votre document, cette sélection sera utilisée au lieu de '%'."
 
 #: ../../src/MaximaCommandMenus.cpp:4544
 msgid "wxMaxima document"
@@ -12118,7 +12118,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:709
 msgid "x"
-msgstr ""
+msgstr "x"
 
 #: ../../src/wizards/DrawWiz.cpp:266
 msgid "x axis label"
@@ -12134,7 +12134,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:164
 msgid "xi"
-msgstr ""
+msgstr "xi"
 
 #: ../../src/MaximaFileIO.cpp:408 ../../src/MaximaFileIO.cpp:566
 msgid "xml contained in the file claims not to be a wxMaxima worksheet. "
@@ -12142,7 +12142,7 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:97
 msgid "xor"
-msgstr ""
+msgstr "neɣ.tukksa"
 
 #: ../../src/wizards/DrawWiz.cpp:279
 msgid "y axis label"
@@ -12170,7 +12170,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:156
 msgid "zeta"
-msgstr ""
+msgstr "zeta"
 
 #. type: Title #
 #: ../../info/wxmaxima.md:1

--- a/locales/wxMaxima/nb.po
+++ b/locales/wxMaxima/nb.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: nb\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-30 11:38+0200\n"
+"POT-Creation-Date: 2026-08-10 03:42+0000\n"
 "PO-Revision-Date: 2015-01-11 07:47+0100\n"
 "Last-Translator: Asbjørn Apeland <asap openmailbox org>\n"
 "Language-Team: norwegian\n"
@@ -20,7 +20,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 1.7.1\n"
 
-#: ../../src/StatusBar.cpp:328
+#: ../../src/StatusBar.cpp:447
 #, c-format
 msgid ""
 "\n"
@@ -28,1472 +28,2392 @@ msgid ""
 "Maxima is currently using %3.3f%% of all available CPUs."
 msgstr ""
 
-#: ../../src/Image.cpp:690
+#: ../../src/dialogs/AboutDialog.cpp:59
+#, c-format
+msgid ""
+"\n"
+"\n"
+"Operating System: %s\n"
+msgstr ""
+
+#: ../../src/Image.cpp:773
 msgid ""
 "\n"
 "Image was loaded from a .wxmx file"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:5153
+#: ../../src/dialogs/AboutDialog.cpp:57
+msgid ""
+"\n"
+"Not connected to Maxima."
+msgstr ""
+
+#: ../../src/MaximaEvaluator.cpp:398
+msgid ""
+"\n"
+"Now reads: "
+msgstr ""
+
+#: ../../src/wxMaxima.cpp:1981
 msgid ""
 "\n"
 "Use the menu \"View->Toggle log window\" to show/hide a log window with all debug messages."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:4230
+#: ../../src/dialogs/ConfigDialogue.cpp:1569
+msgid "      -X \"--control-stack-size <int>\""
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1568
+msgid "      -X \"--dynamic-space-size <int>\""
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1572
+msgid "      -X '--control-stack-size <int>'"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1571
+msgid "      -X '--dynamic-space-size <int>'"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1551
+msgid "      -l <name>"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1557
+msgid "      -u <versionnumber>"
+msgstr ""
+
+#: ../../src/Configuration.cpp:1397
+#, c-format
+msgid "  Cells converted to 2D: %ld"
+msgstr ""
+
+#: ../../src/Configuration.cpp:1396
+#, c-format
+msgid "  Cells converted to linear: %ld"
+msgstr ""
+
+#: ../../src/Configuration.cpp:1398
+#, c-format
+msgid "  Cells drawn at the wrong font size: %ld"
+msgstr ""
+
+#: ../../src/Configuration.cpp:1388
+#, c-format
+msgid "  Font cache hits: %ld"
+msgstr ""
+
+#: ../../src/Configuration.cpp:1389
+#, c-format
+msgid "  Font cache misses: %ld"
+msgstr ""
+
+#: ../../src/Configuration.cpp:1400
+#, c-format
+msgid "  Full-window worksheet repaints: %ld"
+msgstr ""
+
+#: ../../src/Configuration.cpp:1384
+#, c-format
+msgid "  Manual anchors from built-in: %ld"
+msgstr ""
+
+#: ../../src/Configuration.cpp:1385
+#, c-format
+msgid "  Manual anchors from cache: %ld"
+msgstr ""
+
+#: ../../src/Configuration.cpp:1386
+#, c-format
+msgid "  Manual anchors self-compiled: %ld"
+msgstr ""
+
+#: ../../src/Configuration.cpp:1387
+#, c-format
+msgid "  Maxima processes spawned: %ld"
+msgstr ""
+
+#: ../../src/Configuration.cpp:1394
+#, c-format
+msgid "  Recalculation needed - Cells appended: %ld"
+msgstr ""
+
+#: ../../src/Configuration.cpp:1393
+#, c-format
+msgid "  Recalculation needed - Config changed: %ld"
+msgstr ""
+
+#: ../../src/Configuration.cpp:1395
+#, c-format
+msgid "  Recalculation needed - Editor dirty: %ld"
+msgstr ""
+
+#: ../../src/Configuration.cpp:1390
+#, c-format
+msgid "  Recalculation needed - Font invalid: %ld"
+msgstr ""
+
+#: ../../src/Configuration.cpp:1392
+#, c-format
+msgid "  Recalculation needed - Font mismatch: %ld"
+msgstr ""
+
+#: ../../src/Configuration.cpp:1391
+#, c-format
+msgid "  Recalculation needed - Size invalid: %ld"
+msgstr ""
+
+#: ../../src/Configuration.cpp:1399
+#, c-format
+msgid "  Worksheet repaints: %ld"
+msgstr ""
+
+#: ../../src/MaximaFileIO.cpp:129
 msgid " (File format (WXM version 1, first line of the file) not recognized)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1559
+#: ../../src/cells/ImgCell.cpp:212 ../../src/cells/ImgCell.cpp:214
+#: ../../src/cells/ImgCell.cpp:216
+msgid " (Graphics) "
+msgstr ""
+
+#: ../../src/cells/EditorCell.cpp:3551 ../../src/cells/EditorCell.cpp:3820
+#: ../../src/cells/EditorCell.cpp:3945
+#, c-format
+msgid " ... + %li hidden lines"
+msgstr ""
+
+#: ../../src/cells/EditorCell.cpp:3553
+msgid " ... + 1 hidden line"
+msgstr ""
+
+#: ../../src/dialogs/TipOfTheDay.cpp:273
+msgid " Did you know? "
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:1607
+msgid " Returns the unique elements of the list"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1596
 msgid " Wrong, if a is complex"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7601
+#: ../../src/wizards/DrawWiz.cpp:964 ../../src/wizards/DrawWiz.cpp:980
+#, fuzzy
+msgid " samples"
+msgstr "Eksempel"
+
+#: ../../src/wizards/DrawWiz.cpp:929 ../../src/wizards/DrawWiz.cpp:945
+msgid " samples, on demand split "
+msgstr ""
+
+# hvilken kontekst?
+#: ../../src/wizards/DrawWiz.cpp:933 ../../src/wizards/DrawWiz.cpp:952
+#, fuzzy
+msgid " times"
+msgstr "Antall:"
+
+#: ../../src/MaximaCommandMenus.cpp:4473
 msgid ""
 "\".\" = \"The current directory\"\n"
 "\"..\" = \"One directory up\""
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7557 ../../src/wxMaxima.cpp:7563
-#: ../../src/wxMaxima.cpp:7568
+#: ../../src/MaximaCommandMenus.cpp:4429 ../../src/MaximaCommandMenus.cpp:4435
+#: ../../src/MaximaCommandMenus.cpp:4440
 msgid "\"..\" means \"one directory up\"."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:5053
+#: ../../src/dialogs/ConfigDialogue.cpp:1208
+msgid "\"Copy LaTeX\" adds equation markers"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:446
+msgid ""
+"\"MathML (rendered by the browser)\" is the recommended choice: every current browser renders MathML natively and instantly, and the exported page needs no JavaScript and makes no requests to any external server.\n"
+"\"MathML + MathJaX fall-back for old browsers\" behaves the same on current browsers, but additionally downloads MathJaX from an external server (a CDN) as a fall-back on browsers too old to support MathML. Only choose this if you need to support such browsers and accept the external dependency.\n"
+"Bitmaps tend to need more band width than the other options. They lack support for advanced features like drag-and-drop or accessibility. Also they have problems aligning and scaling with the rest of the text and might use fonts that don't match the rest of the document."
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:930
+#, fuzzy
+msgid "\"Numpad Enter\" always evaluates cells"
+msgstr "Enter utfører celler"
+
+#: ../../src/sidebars/SymbolsSidebar.cpp:90
+msgid "\"implies\" symbol"
+msgstr ""
+
+#: ../../src/dialogs/DiffFrame.cpp:306
+#, c-format
+msgid "%d differences"
+msgstr ""
+
+#: ../../src/wxMaxima.cpp:1831
 #, c-format
 msgid "%i cells in evaluation queue"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:330
+#: ../../src/sidebars/TableOfContents.cpp:570
+#, c-format
+msgid "%li Levels"
+msgstr ""
+
+#: ../../src/worksheet/Worksheet.cpp:423
 #, c-format
 msgid "%s image, %li×%li, %li ppi"
 msgstr ""
 
-#: ../../src/Autocomplete.cpp:319
+#: ../../src/Autocomplete.cpp:405
 #, c-format
 msgid "%s: Can't interpret line: %s"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1655
+#: ../../src/wxMaxima.cpp:2859
+#, c-format
+msgid ""
+"%sCould not write the setting for:%s\n"
+"(Is the client installed?)"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1692
 #, fuzzy
 msgid "&Algebraic Mode"
 msgstr "&Algebra"
 
-#: ../../src/wxMaximaFrame.cpp:1884
+#: ../../src/wxMaximaFrame.cpp:1921
 msgid "&Apropos..."
 msgstr "&Apropos..."
 
-#: ../../src/wxMaximaFrame.cpp:615
+#: ../../src/wxMaximaFrame.cpp:646
 msgid "&Batch File...\tCtrl+B"
 msgstr "&Batchfil...\tCtrl+B"
 
-#: ../../src/wxMaximaFrame.cpp:1278
+#: ../../src/wxMaximaFrame.cpp:1312
 msgid "&Boundary Value Problem..."
 msgstr "&Grenseverdiproblem..."
 
-#: ../../src/wxMaximaFrame.cpp:1950
+#: ../../src/wxMaximaFrame.cpp:1987
 msgid "&Bug Report"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1505
+#: ../../src/wxMaximaFrame.cpp:1542
 msgid "&Calculus"
 msgstr "&Kalkulus"
 
-#: ../../src/wxMaximaFrame.cpp:1601
+#: ../../src/wxMaximaFrame.cpp:1638
 msgid "&Canonical Form"
 msgstr "&Kanonisk Form"
 
-#: ../../src/wxMaximaFrame.cpp:1358
+#: ../../src/wxMaximaFrame.cpp:1392
 msgid "&Characteristic Polynomial..."
 msgstr "&Karakteristisk Polynom..."
 
-#: ../../src/wxMaximaFrame.cpp:990
+#: ../../src/wxMaximaFrame.cpp:1024
 msgid "&Clear Memory"
 msgstr "Tøm &Minnet"
 
-#: ../../src/wxMaximaFrame.cpp:1583
+#: ../../src/wxMaximaFrame.cpp:1620
 msgid "&Combine Factorials"
 msgstr "Trekk &Sammen Fakulteter"
 
-#: ../../src/wxMaximaFrame.cpp:1628
+#: ../../src/wxMaximaFrame.cpp:1665
 msgid "&Complex Simplification"
 msgstr "&Kompleks Forenkling"
 
-#: ../../src/wxMaximaFrame.cpp:1502
+#: ../../src/wxMaximaFrame.cpp:1539
 msgid "&Continued Fraction"
 msgstr "K&jedebrøk"
 
-#: ../../src/wxMaximaFrame.cpp:638
+#: ../../src/wxMaximaFrame.cpp:675
 msgid "&Copy\tCtrl+C"
 msgstr "Kopier\tCtrl+C"
 
-#: ../../src/wxMaximaFrame.cpp:1621
+#: ../../src/wizards/IntegrateWiz.cpp:39
+msgid "&Definite integration"
+msgstr "&Bestemt Integrasjon"
+
+#: ../../src/wxMaximaFrame.cpp:1658
 msgid "&Demoivre"
 msgstr "&Demoivre"
 
-#: ../../src/wxMaximaFrame.cpp:1362
+#: ../../src/wxMaximaFrame.cpp:1396
 msgid "&Determinant"
 msgstr "&Determinant"
 
-#: ../../src/wxMaximaFrame.cpp:1466
+#: ../../src/wxMaximaFrame.cpp:1503
 msgid "&Differentiate..."
 msgstr "&Deriver..."
 
-#: ../../src/wxMaximaFrame.cpp:689
+#: ../../src/wxMaximaFrame.cpp:726
 msgid "&Edit"
 msgstr "&Endre"
 
-#: ../../src/wxMaximaFrame.cpp:1246
+#: ../../src/wxMaximaFrame.cpp:1280
 msgid "&Eliminate Variable..."
 msgstr "&Eliminer Variabel..."
 
-#: ../../src/wxMaximaFrame.cpp:1318
+#: ../../src/wxMaximaFrame.cpp:1352
 msgid "&Enter Matrix..."
 msgstr "&Oppgi Matrise..."
 
-#: ../../src/wxMaximaFrame.cpp:1883
+#: ../../src/wxMaximaFrame.cpp:1920
 msgid "&Example..."
 msgstr "&Eksempel..."
 
-#: ../../src/wxMaximaFrame.cpp:1524
+#: ../../src/wxMaximaFrame.cpp:1561
 msgid "&Expand Expression"
 msgstr "&Utvid Uttrykk"
 
-#: ../../src/wxMaximaFrame.cpp:1597
+#: ../../src/wxMaximaFrame.cpp:1634
 msgid "&Expand Trigonometric"
 msgstr "&Utvid Trigonometrisk uttrykk"
 
-#: ../../src/wxMaximaFrame.cpp:1626
+#: ../../src/wxMaximaFrame.cpp:1663
 msgid "&Exponentialize"
 msgstr "&Eksponentialiser"
 
-#: ../../src/wxMaximaFrame.cpp:618
+#: ../../src/wxMaximaFrame.cpp:651
 msgid "&Export..."
 msgstr "&Eksporter..."
 
-#: ../../src/wxMaximaFrame.cpp:1516
+#: ../../src/wxMaximaFrame.cpp:1553
 msgid "&Factor Expression"
 msgstr "Faktoriser Uttr&ykk"
 
-#: ../../src/wxMaximaFrame.cpp:626
+#: ../../src/wxMaximaFrame.cpp:663
 msgid "&File"
 msgstr "&Fil"
 
-#: ../../src/wxMaximaFrame.cpp:1019
+#: ../../src/wxMaximaFrame.cpp:1053
 #, fuzzy
 msgid "&Functions"
 msgstr "Funksjon:"
 
-#: ../../src/wxMaximaFrame.cpp:1490
+#: ../../src/wxMaximaFrame.cpp:1527
 msgid "&Greatest Common Divisor..."
 msgstr "&Største Felles Divisor..."
 
-#: ../../src/wxMaximaFrame.cpp:1968
+#: ../../src/wxMaximaFrame.cpp:2021
 msgid "&Help"
 msgstr "&Hjelp"
 
-#: ../../src/wxMaximaFrame.cpp:1453
+#: ../../src/wxMaximaFrame.cpp:1490
 msgid "&Integrate..."
 msgstr "&Integrer..."
 
-#: ../../src/wxMaximaFrame.cpp:964
+#: ../../src/wxMaximaFrame.cpp:998
 msgid "&Interrupt\tCtrl+G"
 msgstr "&Avbryt\tCtrl+G"
 
-#: ../../src/wxMaximaFrame.cpp:1355
+#: ../../src/wxMaximaFrame.cpp:1389
 msgid "&Invert Matrix"
 msgstr "&Inverter Matrise"
 
-#: ../../src/wxMaximaFrame.cpp:1952
+#: ../../src/wxMaximaFrame.cpp:1995
 msgid "&License"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1763
+#: ../../src/wxMaximaFrame.cpp:1800
 #, fuzzy
 msgid "&List"
 msgstr "Liste:"
 
-#: ../../src/wxMaximaFrame.cpp:610
+#: ../../src/wxMaximaFrame.cpp:641
 msgid "&Load Package...\tCtrl+L"
 msgstr "Last &Pakke...\tCtrl+L"
 
-#: ../../src/wxMaximaFrame.cpp:1232
+#: ../../src/wxMaximaFrame.cpp:1266
 msgid "&Maxima"
 msgstr "&Maxima"
 
-#: ../../src/wxMaximaFrame.cpp:1882
+#: ../../src/wxMaximaFrame.cpp:1919
 msgid "&Maxima help"
 msgstr "&Maxima-Hjelp"
 
-#: ../../src/wxMaximaFrame.cpp:1660
+#: ../../src/wxMaximaFrame.cpp:1697
 msgid "&Modulus Computation..."
 msgstr "&Moduloregning..."
 
-#: ../../src/main.cpp:435
+#: ../../src/main.cpp:674
 #, fuzzy
 msgid "&New\tCtrl+N"
 msgstr "&Ny\tCtrl+N"
 
-#: ../../src/wxMaximaFrame.cpp:1870
+#: ../../src/wxMaximaFrame.cpp:1907
 msgid "&Numeric"
 msgstr "&Numerisk"
 
-#: ../../src/wxMaximaFrame.cpp:1785
+#: ../../src/wxMaximaFrame.cpp:1822
 #, fuzzy
 msgid "&Numeric Output"
 msgstr "&Veksle Numerisk Utdata"
 
-#: ../../src/main.cpp:436
+#: ../../src/wizards/IntegrateWiz.cpp:52
+msgid "&Numerical integration"
+msgstr "&Numerisk Integrasjon"
+
+#: ../../src/wizards/SumWiz.cpp:44
+msgid "&Nusum"
+msgstr "&Nusum"
+
+#: ../../src/main.cpp:675
 #, fuzzy
 msgid "&Open\tCtrl+O"
 msgstr "&Åpne\tCtrl+O"
 
-#: ../../src/wxMaximaFrame.cpp:598
+#: ../../src/wxMaximaFrame.cpp:629
 msgid "&Open...\tCtrl+O"
 msgstr "&Åpne...\tCtrl+O"
 
-#: ../../src/wxMaximaFrame.cpp:1780
+#: ../../src/wxMaximaFrame.cpp:1817
 msgid "&Plot"
 msgstr "&Plott"
 
-#: ../../src/wxMaximaFrame.cpp:622
+#: ../../src/wizards/SeriesWiz.cpp:45
+msgid "&Power series"
+msgstr "&Potensrekke"
+
+#: ../../src/wxMaximaFrame.cpp:655
 msgid "&Print...\tCtrl+P"
 msgstr "&Skriv Ut...\tCtrl+P"
 
-#: ../../src/wxMaximaFrame.cpp:1594
+#: ../../src/wizards/SubstituteWiz.cpp:38
+msgid "&Rational"
+msgstr "&Rasjonell"
+
+#: ../../src/wxMaximaFrame.cpp:1631
 msgid "&Reduce Trigonometric"
 msgstr "&Reduser Trigonometrisk Uttrykk"
 
-#: ../../src/wxMaximaFrame.cpp:974
+#: ../../src/wxMaximaFrame.cpp:1008
 #, fuzzy
 msgid "&Restart Maxima\tCtrl+Alt+R"
 msgstr "&Restart Maxima"
 
-#: ../../src/wxMaximaFrame.cpp:608
+#: ../../src/wxMaximaFrame.cpp:639
 msgid "&Save\tCtrl+S"
 msgstr "&Lagre\tCtrl+S"
 
-#: ../../src/wxMaximaFrame.cpp:1662
+#: ../../src/wizards/SumWiz.cpp:43 ../../src/wxMaximaFrame.cpp:1699
 msgid "&Simplify"
 msgstr "F&orenkle"
 
-#: ../../src/wxMaximaFrame.cpp:1581
+#: ../../src/wxMaximaFrame.cpp:1618
 msgid "&Simplify Factorials"
 msgstr "&Forenkle Fakulteter"
 
-#: ../../src/wxMaximaFrame.cpp:1591
+#: ../../src/wxMaximaFrame.cpp:1628
 msgid "&Simplify Trigonometric"
 msgstr "&Forenkle Trigonometrisk Uttrykk"
 
-#: ../../src/wxMaximaFrame.cpp:1238
+#: ../../src/wxMaximaFrame.cpp:1272
 msgid "&Solve..."
 msgstr "&Løs..."
 
-#: ../../src/wxMaximaFrame.cpp:1035
+#: ../../src/wizards/Plot2dWiz.cpp:42
+msgid "&Special"
+msgstr "&Spesiell"
+
+#: ../../src/wizards/LimitWiz.cpp:45
+msgid "&Taylor series"
+msgstr "&Taylorrekke"
+
+#: ../../src/wxMaximaFrame.cpp:1069
 #, fuzzy
 msgid "&Time Display"
 msgstr "Veksle &Tidsvisning"
 
-#: ../../src/wxMaximaFrame.cpp:1375
+#: ../../src/wxMaximaFrame.cpp:1409
 msgid "&Transpose Matrix"
 msgstr "&Transponer Matrise"
 
-#: ../../src/wxMaximaFrame.cpp:1605
+#: ../../src/wxMaximaFrame.cpp:1642
 msgid "&Trigonometric Simplification"
 msgstr "&Trigonometrisk Uttrykk"
 
-#: ../../src/wxMaximaFrame.cpp:1021
+#: ../../src/wxMaximaFrame.cpp:1055
 #, fuzzy
 msgid "&Variables"
 msgstr "Variabler"
 
-#: ../../src/wxMaxima.cpp:2443
+#: ../../src/wizards/Plot3dWiz.cpp:79
+msgid "&pm3d"
+msgstr "&pm3d"
+
+#: ../../src/cells/AnimationCell.cpp:475
+msgid "(Animation)"
+msgstr ""
+
+#: ../../src/MaximaProcessManager.cpp:771
 msgid "(Config tells to suppress the output of long cells)"
 msgstr ""
 
-#: ../../src/MathParser.cpp:1288
+#: ../../src/cells/ImgCell.cpp:284
+msgid "(Image)"
+msgstr ""
+
+#: ../../src/MathParser.cpp:1418
 msgid "(Invalid XML from maxima)"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:4221
+#: ../../src/cells/GroupCell.cpp:652
+msgid "(Layout took too long and was suppressed)"
+msgstr ""
+
+#: ../../src/MaximaFileIO.cpp:120
 msgid "(Maybe a permission problem?)"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:9248
+#: ../../src/sidebars/CharButton.cpp:211
+msgid "(Might not be displayed correctly in at least one of the worksheet fonts)"
+msgstr ""
+
+#: ../../src/sidebars/VariablesPane.cpp:254
+msgid "(Not a valid variable name)"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:183
+msgid "(Use default language)"
+msgstr "(Bruk forhåndsvalgt språk)"
+
+#: ../../src/MaximaCommandMenus.cpp:440
 msgid "(f(x),x,a,b)), Epsilon algorithm"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:9235
+#: ../../src/MaximaCommandMenus.cpp:426
 msgid "(f(x),x,a,b)), Strategy of Aind"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:9258
+#: ../../src/MaximaCommandMenus.cpp:453
 msgid "(f(x),x,a,b), (semi-) infinite interval"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1841
+#: ../../src/wxMaximaFrame.cpp:1878
 msgid "(f(x),x,a,b), Epsilon algorithm"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1843
+#: ../../src/wxMaximaFrame.cpp:1880
 msgid "(f(x),x,a,b), infinite interval"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1839
+#: ../../src/wxMaximaFrame.cpp:1876
 msgid "(f(x),x,a,b), strategy of Aind"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:9361 ../../src/wxMaximaFrame.cpp:1867
+#: ../../src/MaximaCommandMenus.cpp:596 ../../src/wxMaximaFrame.cpp:1904
 msgid "(f(x),x,y) with singularities+discontinuities"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2065
+#: ../../src/wizards/DrawWiz.cpp:274 ../../src/wizards/DrawWiz.cpp:287
+#: ../../src/wizards/DrawWiz.cpp:303 ../../src/wizards/DrawWiz.cpp:320
+#: ../../src/wizards/DrawWiz.cpp:335
+msgid "-"
+msgstr ""
+
+#: ../../src/wizards/IntegrateWiz.cpp:192
+#: ../../src/wizards/IntegrateWiz.cpp:202
+#: ../../src/wizards/IntegrateWiz.cpp:207
+#: ../../src/wizards/IntegrateWiz.cpp:217 ../../src/wizards/LimitWiz.cpp:132
+#: ../../src/wizards/LimitWiz.cpp:142
+msgid "- Infinity"
+msgstr "- Uendelig"
+
+#: ../../src/MaximaOutputAppender.cpp:116
 msgid "... [suppressed additional lines as the output is longer than allowed in the wxMaxima configuration] "
 msgstr ""
 
-#: ../../src/Worksheet.cpp:6666
+#: ../../src/worksheet/Worksheet.cpp:4657
 msgid ".wxm clipboard data with unusual header"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8047
-#, fuzzy
-msgid "1×n Matrix b:"
-msgstr "Matrise:"
+#: ../../src/sidebars/TableOfContents.cpp:567
+msgid "1 Level"
+msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1312
+#: ../../src/sidebars/SymbolsSidebar.cpp:77
+msgid "1/2"
+msgstr ""
+
+#: ../../src/sidebars/DrawSidebar.cpp:45
+msgid "2D"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1346
 #, fuzzy
 msgid "2D Array to Matrix..."
 msgstr "Av&bild Matrise..."
 
-#: ../../src/wxMaximaFrame.cpp:743
+#: ../../src/wxMaximaFrame.cpp:780
 msgid "2D equations using ASCII Art"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:746
+#: ../../src/wxMaximaFrame.cpp:783
 msgid "2D equations using ASCII Art with unicode characters, if available"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:5057
+#: ../../src/dialogs/ConfigDialogue.cpp:786
+msgid "2D if it fits on the page width"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:785
+msgid "2D, whenever possible"
+msgstr ""
+
+#: ../../src/sidebars/DrawSidebar.cpp:49
+msgid "3D"
+msgstr ""
+
+#: ../../src/wxMaxima.cpp:1835
 #, c-format
 msgid "; %i commands left in the current cell"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:10617
+#: ../../src/MaximaEvaluator.cpp:500
 msgid "A \":lisp\" as the first command might fail to send a \"finished\" signal."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:6585
+#: ../../src/dialogs/TipOfTheDay.cpp:102
+msgid "A 'horizontal cursor' was introduced in wxMaxima 0.8.0. It looks like a horizontal line between cells. It indicates where a new cell will appear if you type or paste text or execute a menu command."
+msgstr "En \"sidelengs peker\" ble introdusert i wxMaxima 0.8.0. Den ser ut som en horisontal linje mellom celler. Den indikerer hvor en ny celle vil dukke opp om du skriver eller limer inn tekst, eller kjører en kommando fra menyen."
+
+#: ../../src/MaximaCommandMenus.cpp:3099
 msgid "A Ctrl-F event"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1973
+#: ../../src/cells/GroupCell.cpp:2178
+msgid "A Maxima input cell with its output"
+msgstr ""
+
+#: ../../src/worksheet/WorksheetContextMenu.cpp:745
 msgid "A Scalar"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:6653
+#: ../../src/cells/TextCell.cpp:239
+msgid ""
+"A command or number wasn't preceded by a \":\", a \"$\", a \";\" or a \",\".\n"
+"Most probable cause: A missing comma between two list items."
+msgstr ""
+
+#: ../../src/wxMaxima.cpp:2642
 #, c-format
 msgid "A find event, %s"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:2012
+#: ../../src/wizards/ListSortWiz.cpp:63
+#, fuzzy
+msgid "A function f(a,b), named"
+msgstr "Funksjonnavn"
+
+#: ../../src/worksheet/WorksheetContextMenu.cpp:784
 msgid "A function returning integers"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:2014
+#: ../../src/worksheet/WorksheetContextMenu.cpp:786
 msgid "A function returning positive numbers"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1965
+#: ../../src/wizards/DrawWiz.cpp:164
+msgid "A good example equation would be x^2+y^2=1"
+msgstr ""
+
+#: ../../src/cells/GroupCell.cpp:2193 ../../src/cells/GroupCell.cpp:2196
+msgid "A heading"
+msgstr ""
+
+#: ../../src/worksheet/WorksheetContextMenu.cpp:737
 #, fuzzy
 msgid "A irrational variable"
 msgstr "Endre variabel"
 
-#: ../../src/Worksheet.cpp:2016
+#: ../../src/worksheet/WorksheetContextMenu.cpp:788
 msgid "A left-associative function"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:2019
+#: ../../src/worksheet/WorksheetContextMenu.cpp:791
 #, fuzzy
 msgid "A linear function"
 msgstr "Slett en funksjon"
 
-#: ../../src/wxMaxima.cpp:9590
+#: ../../src/MaximaCommandMenus.cpp:1830
 msgid "A matrix in which each row is a set of variables"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1963
+#: ../../src/dialogs/TipOfTheDay.cpp:84
+#, fuzzy
+msgid "A new document format has been introduced in wxMaxima 0.8.2 that saves not only your input and text commentaries, but also the outputs of your calculations. When saving your document, select 'Whole document (*.wxmx)' format."
+msgstr "Et nytt dokumentformat ble introdusert i wxMaxima 0.8.2, som ikke bare lagrer dine uttrykk og kommentarer, men også resultatene av dine utregninger. Når du lagrer dokument, velg 'wxMaxima XML-dokument' som format."
+
+#: ../../src/cells/GroupCell.cpp:2175
+#, fuzzy
+msgid "A page break"
+msgstr "Sideskift"
+
+#: ../../src/dialogs/TipOfTheDay.cpp:168
+msgid "A plot to be embedded into the work sheet by preceding its name with a \"wx\". \"draw\" can be replaced by \"wxdraw\", plot by \"wxplot\" etc."
+msgstr ""
+
+#: ../../src/worksheet/WorksheetContextMenu.cpp:735
 #, fuzzy
 msgid "A rational variable"
 msgstr "Endre variabel"
 
-#: ../../src/Worksheet.cpp:2018
+#: ../../src/worksheet/WorksheetContextMenu.cpp:790
 msgid "A right-associative function"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1634
+#: ../../src/dialogs/ConfigDialogue.cpp:436
+msgid "A scale factor for the printout. Helpful for printing big equations on small pdf pages."
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1671
 msgid "A search-and-replace for equations"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1636
+#: ../../src/cells/EditorCell.cpp:4522 ../../src/cells/GroupCell.cpp:2184
+msgid "A section heading"
+msgstr ""
+
+#: ../../src/wizards/DrawWiz.cpp:479
+#, fuzzy
+msgid "A static plot"
+msgstr "Parametrisk Plott"
+
+#: ../../src/cells/EditorCell.cpp:4534
+msgid "A sub-sub-sub-subsection heading"
+msgstr ""
+
+#: ../../src/cells/EditorCell.cpp:4531
+msgid "A sub-sub-subsection heading"
+msgstr ""
+
+#: ../../src/cells/EditorCell.cpp:4528 ../../src/cells/GroupCell.cpp:2190
+#, fuzzy
+msgid "A sub-subsection heading"
+msgstr "Underseksjoncelle"
+
+#: ../../src/cells/EditorCell.cpp:4525 ../../src/cells/GroupCell.cpp:2187
+#, fuzzy
+msgid "A subsection heading"
+msgstr "Underseksjoncelle"
+
+#: ../../src/wxMaximaFrame.cpp:1673
 msgid "A subst with basic maths knowledge"
 msgstr ""
 
-#: ../../src/BTextCtrl.cpp:64
+#: ../../src/sidebars/SymbolsSidebar.cpp:239
+msgid "A symbol from the configuration dialogue"
+msgstr ""
+
+#: ../../src/cells/GroupCell.cpp:2181
+msgid "A text cell"
+msgstr ""
+
+#: ../../src/BTextCtrl.cpp:66
 msgid "A text control got the mouse focus"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1442
+#: ../../src/cells/GroupCell.cpp:2199
+msgid "A title"
+msgstr ""
+
+#: ../../src/cells/TextCell.cpp:197
+msgid ""
+"A variable that can be assigned a number to.\n"
+"Often used by solve() and algsys(), if there is an infinite number of results."
+msgstr ""
+
+#: ../../src/cells/GroupCell.cpp:2205
+msgid "A worksheet cell"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1479
 #, fuzzy
 msgid "A&pply function to each Matrix element..."
 msgstr "Anvend funksjon på liste"
 
-#: ../../src/wxMaximaFrame.cpp:1291
+#: ../../src/wxMaximaFrame.cpp:1325
 msgid "A&t Value..."
 msgstr "Ved &Verdi..."
 
-#: ../../src/Configuration.cpp:85
+#: ../../src/Styles.cpp:114
 msgid "ASCII maths"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1963
+#: ../../src/dialogs/ConfigDialogue.cpp:1618
+msgid "Abort evaluation on error"
+msgstr ""
+
+#: ../../src/MaximaEvaluator.cpp:214
+#, c-format
+msgid "Aborting due to --exit-on-error (exit code 1). Cell: %s"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:2016
 msgid "About"
 msgstr "&Om"
 
-#: ../../src/wxMaximaFrame.cpp:1963 ../../src/wxMaximaFrame.cpp:1965
+#: ../../src/wxMaximaFrame.cpp:2016 ../../src/wxMaximaFrame.cpp:2018
 msgid "About wxMaxima"
 msgstr "Om wxMaxima"
 
-#: ../../src/wxMaxima.cpp:7837
+#: ../../src/MaximaCommandMenus.cpp:1018
 msgid "Accepts one expression or a list in the format [ode1,ode2,...]"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7841
+#: ../../src/MaximaCommandMenus.cpp:1022
 msgid "Accepts one variable or a list in the format [1,4,...]"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7839
+#: ../../src/MaximaCommandMenus.cpp:1020
 msgid "Accepts one variable or a list in the format [var1,var2,...]"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1371
+#: ../../src/dialogs/ConfigDialogue.cpp:292
+msgid "Accessibility"
+msgstr ""
+
+#: ../../src/sidebars/DrawSidebar.cpp:103
+msgid "Accuracy"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1405
 msgid "Ad&joint Matrix"
 msgstr "Kon&jugert-Transponer Matrise"
 
-#: ../../src/wxMaximaFrame.cpp:1657
+#: ../../src/wxMaximaFrame.cpp:1694
 msgid "Add Algebraic E&quality..."
 msgstr "Legg til Algebraisk Ek&vivalens..."
 
-#: ../../src/wxMaximaFrame.cpp:1015
+#: ../../src/wxMaximaFrame.cpp:1049
 msgid "Add a directory to search path"
 msgstr "Legg en mappe til søkebane"
 
-#: ../../src/wxMaximaFrame.cpp:1752
+#: ../../src/wxMaximaFrame.cpp:1789
 msgid "Add a new item to the beginning of the list. Useful for creating stacks."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8602
+#: ../../src/sidebars/VariablesPane.cpp:228
+msgid "Add all"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:1621
 #, fuzzy
 msgid "Add an element to the end of a list"
 msgstr "Åpne et dokument"
 
-#: ../../src/wxMaxima.cpp:8597
+#: ../../src/MaximaCommandMenus.cpp:1616
 #, fuzzy
 msgid "Add an element to the start of a list"
 msgstr "Åpne et dokument"
 
-#: ../../src/wxMaxima.cpp:7625
+#: ../../src/MaximaCommandMenus.cpp:4497
 msgid "Add dir to path:"
 msgstr "Legg mappe til bane:"
 
-#: ../../src/wxMaximaFrame.cpp:1658
+#: ../../src/wxMaximaFrame.cpp:1695
 msgid "Add equality to the rational simplifier"
 msgstr "Legg ekvivalens til den rasjonelle forenkleren"
 
-#: ../../src/wxMaximaFrame.cpp:1015
+#: ../../src/sidebars/SymbolsSidebar.cpp:204
+msgid "Add more symbols"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1262
+msgid "Add the .wxmx file to the HTML export"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1049
 msgid "Add to &Path..."
 msgstr "Legg til &Bane..."
 
-#: ../../src/Worksheet.cpp:1531 ../../src/Worksheet.cpp:1564
-#: ../../src/Worksheet.cpp:1704
+#: ../../src/sidebars/UnicodeSidebar.cpp:105
+msgid "Add to symbols Sidebar"
+msgstr ""
+
+#: ../../src/worksheet/WorksheetContextMenu.cpp:304
+#: ../../src/worksheet/WorksheetContextMenu.cpp:337
+#: ../../src/worksheet/WorksheetContextMenu.cpp:477
 msgid "Add to watchlist"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1562
+#: ../../src/sidebars/XmlInspector.cpp:147
+#, c-format
+msgid "Added much text (%li chars) to the XML inspector."
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1896
+msgid "Additional clipboard formats to put on the clipboard on ordinary copy"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:393
+msgid "Additional commands to be added to the preamble of LaTeX output for pdftex."
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1187
+msgid "Additional lines for the TeX preamble:"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:389
+msgid "Additional parameters for Maxima (e.g. -l clisp)."
+msgstr "Øvrige parametre for Maxima (f.eks. -l clisp)."
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1543
+msgid "Additional parameters for Maxima (restart Maxima after changes)"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1318
+msgid "Additional symbols for the \"symbols\" sidebar:"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1599
 msgid "Additionally: log(a*b)=log(a)+log(b)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1566
+#: ../../src/wxMaximaFrame.cpp:1603
 msgid "Additionally: log(a/b)=log(a)-log(b), a and b positive integers"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1996
+#: ../../src/worksheet/WorksheetContextMenu.cpp:768
 msgid "Additive function: f(a+b)=f(a)+f(b)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1911
+#: ../../src/wxMaximaFrame.cpp:1948
 msgid "Advanced 2d plotting"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1809
+#: ../../src/wxMaximaFrame.cpp:1846
 msgid "Advanced guess (PSLQ algorithm)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1920
+#: ../../src/wxMaximaFrame.cpp:1957
 msgid "Advanced variable names"
 msgstr ""
 
-#: ../../src/ToolBar.cpp:321 ../../src/ToolBar.cpp:589
-msgid "After clicking on animations created with with_slider_draw() or similar this slider allows to change the current frame."
+#: ../../src/dialogs/ConfigDialogue.cpp:184
+msgid "Afrikaans"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1028
+#: ../../src/ToolBar.cpp:536 ../../src/ToolBar.cpp:789
+msgid "After clicking on animations created with with_slider_draw() or similar, this slider allows changing the current frame."
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:185
+msgid "Albanian"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1062
 msgid "Aliases"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1714
+#: ../../src/sidebars/TableOfContents.cpp:572
+msgid "All Levels"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1751
 #, fuzzy
 msgid "All but the 1st n elements"
 msgstr "Anvend funksjon på liste"
 
-#: ../../src/wxMaximaFrame.cpp:1716
+#: ../../src/wxMaximaFrame.cpp:1753
 #, fuzzy
 msgid "All but the last n elements"
 msgstr "Anvend funksjon på liste"
 
-#: ../../src/main.cpp:594 ../../src/wxMaxima.cpp:6075
+#: ../../src/MaximaCommandMenus.cpp:2198 ../../src/main.cpp:883
 msgid "All openable types (*.wxm, *.wxmx, *.mac, *.out, *.xml)|*.wxm;*.wxmx;*.mac;*.out;*.xml|wxMaxima document (*.wxm, *.wxmx)|*.wxm;*.wxmx|Maxima session (*.mac)|*.mac|Xmaxima session (*.out)|*.out|xml from broken .wxmx (*.xml)|*.xml"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:733
+#: ../../src/dialogs/ConfigDialogue.cpp:750
+#, fuzzy
+msgid "All variable names"
+msgstr "Forrige variabel:"
+
+#: ../../src/wxMaximaFrame.cpp:770
 #, fuzzy
 msgid "All visible sidebars"
 msgstr "Forrige variabel:"
 
-#: ../../src/wxMaximaFrame.cpp:1650
-msgid "Allow to substitute operators"
+#: ../../src/sidebars/HelpBrowser.cpp:48
+msgid "Allow access to an online manual?"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:9040
-msgid "Allows to vary the parameters of a function until it fits experimental data."
+#: ../../src/wxMaximaFrame.cpp:1687
+msgid "Allow substituting operators"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:763
+#: ../../src/wizards/DrawWiz.cpp:722
+msgid "Allows providing separate expressions for calculating"
+msgstr ""
+
+#: ../../src/sidebars/SymbolsSidebar.cpp:182
+msgid "Allows specifying which non-builtin unicode symbols should be displayed in the symbols sidebar along with the built-in symbols."
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:294
+msgid "Allows varying the parameters of a function until it fits experimental data."
+msgstr ""
+
+#: ../../src/dialogs/BinaryNameCtrl.cpp:69
+msgid "All|*"
+msgstr "Alle|*"
+
+#: ../../src/wxMaximaFrame.cpp:800
 msgid "Always after underscores"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:764
+#: ../../src/wxMaximaFrame.cpp:801
 msgid "Always autosubscript after an underscore"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:774
+#: ../../src/wxMaximaFrame.cpp:811
 msgid "Always display this variable with subscript"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1605
+#: ../../src/worksheet/WorksheetContextMenu.cpp:378
 msgid "Always show all digits"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:9241
+#: ../../src/wizards/DrawWiz.cpp:484
+msgid "An animation with multiple frames"
+msgstr ""
+
+#: ../../src/cells/GroupCell.cpp:2202
+msgid "An image cell"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:433
 msgid "An integer between 1..6; Higher numbers work better for oscillating integrands"
 msgstr ""
 
-#: ../../src/MaximaManual.cpp:385
+#: ../../src/cells/TextCell.cpp:202
+msgid "An integration constant."
+msgstr ""
+
+#: ../../src/MaximaManual.cpp:402
 msgid "Anchors file has no top node."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:791
+#: ../../src/wxMaximaFrame.cpp:828
 msgid "Angles"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1775
+#: ../../src/worksheet/WorksheetExport.cpp:1122
+#: ../../src/worksheet/WorksheetExport.cpp:1387
+msgid "Animated Diagram"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1812
 #, fuzzy
 msgid "Animation autoplay"
 msgstr "Lagre animasjon til fil"
 
-#: ../../src/wxMaximaFrame.cpp:1778
+#: ../../src/wxMaximaFrame.cpp:1815
 msgid "Animation framerate..."
 msgstr ""
 
-#: ../../src/Worksheet.cpp:2002
+#: ../../src/dialogs/ConfigDialogue.cpp:1871
+msgid "Announce Maxima's output as MathML"
+msgstr ""
+
+#: ../../src/worksheet/Worksheet.cpp:5467 ../../src/wxMaximaFrame.cpp:1989
+msgid "Anonymize Code for Bug Report"
+msgstr ""
+
+#: ../../src/worksheet/WorksheetContextMenu.cpp:774
 msgid "Antisymmetric function: f(x)=-f(-x)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1739
+#: ../../src/dialogs/ConfigDialogue.cpp:2064
+msgid "Appearance:"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1776
 msgid "Append"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1735
+#: ../../src/wxMaximaFrame.cpp:1772
 msgid "Append a list"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1736
+#: ../../src/wxMaximaFrame.cpp:1773
 #, fuzzy
 msgid "Append a list to an existing list"
 msgstr "Finn grenseverdi til et uttrykk"
 
-#: ../../src/wxMaxima.cpp:8607
+#: ../../src/MaximaCommandMenus.cpp:1626
 #, fuzzy
 msgid "Append a list to another list"
 msgstr "Finn grenseverdi til et uttrykk"
 
-#: ../../src/wxMaximaFrame.cpp:1729
+#: ../../src/wxMaximaFrame.cpp:1766
 #, fuzzy
 msgid "Append an element"
 msgstr "Åpne et dokument"
 
-#: ../../src/wxMaximaFrame.cpp:1734
+#: ../../src/wxMaximaFrame.cpp:1771
 #, fuzzy
 msgid "Append an element to the beginning an existing list"
 msgstr "Finn grenseverdi til et uttrykk"
 
-#: ../../src/wxMaximaFrame.cpp:1730
+#: ../../src/wxMaximaFrame.cpp:1767
 #, fuzzy
 msgid "Append an element to the end of an existing list"
 msgstr "Finn grenseverdi til et uttrykk"
 
-#: ../../src/wxMaxima.cpp:8552
+#: ../../src/MaximaCommandMenus.cpp:1565
 #, fuzzy
 msgid "Apply a function to each list element"
 msgstr "Anvend funksjon på liste"
 
-#: ../../src/wxMaximaFrame.cpp:1810
+#: ../../src/wxMaximaFrame.cpp:1847
 #, c-format
 msgid "Approximate by a fraction using log(), sqrt() and %pi, when needed. Only available in maxima > 5.46.0"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1806
+#: ../../src/wxMaximaFrame.cpp:1843
 msgid "Approximate by nice fraction"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8931
+#: ../../src/MaximaCommandMenus.cpp:182
 msgid ""
 "Approximates a expression around a point as a polynom\n"
 "The trailing \"...\" can be removed by using ratdisrep()"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8939
+#: ../../src/MaximaCommandMenus.cpp:190
 msgid "Approximates a expression as a polynom"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:9474
+#: ../../src/MaximaCommandMenus.cpp:2117
 msgid "Apropos"
 msgstr "Apropos"
 
-#: ../../src/wxMaxima.cpp:7317
+#: ../../src/dialogs/ConfigDialogue.cpp:186
+msgid "Arabic"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:4189
 msgid "Are the chars equal, if case is ignored?"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7312
+#: ../../src/MaximaCommandMenus.cpp:4184
 #, fuzzy
 msgid "Are the chars equal?"
 msgstr "Underseksjoncelle"
 
-#: ../../src/wxMaxima.cpp:7349
+#: ../../src/MaximaCommandMenus.cpp:4221
 msgid "Are these strings equal if case is ignored?"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7344
+#: ../../src/MaximaCommandMenus.cpp:4216
 msgid "Are these strings equal?"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7259
+#: ../../src/MaximaCommandMenus.cpp:4131
 msgid "Arguments:"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8189
+#: ../../src/MaximaCommandMenus.cpp:1379
 #, fuzzy
 msgid "Array"
 msgstr "Array:"
 
-#: ../../src/wxMaximaFrame.cpp:1023
+#: ../../src/wxMaximaFrame.cpp:1057
 #, fuzzy
 msgid "Arrays"
 msgstr "Array:"
 
-#: ../../src/wxMaxima.cpp:7308 ../../src/wxMaxima.cpp:7354
+#: ../../src/cells/TextCell.cpp:212
+msgid ""
+"As calculating 0.1^12 demonstrates maxima by default doesn't tend to hide what looks like being the small error using floating-point numbers introduces.\n"
+"If this seems to be the case here the error can be avoided by using exact numbers like 1/10, 1*10^-1 or rat(.1).\n"
+"It also can be hidden by setting fpprintprec to an appropriate value. But be aware in this case that even small errors can add up."
+msgstr ""
+
+#: ../../src/wizards/ListSortWiz.cpp:51
+msgid "Ascending by magnitude (numeric only)"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:4180 ../../src/MaximaCommandMenus.cpp:4226
 msgid "Ascii code to char"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1138
+#: ../../src/wxMaximaFrame.cpp:1172
 msgid "Ascii code to char..."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:10063
+#: ../../src/dialogs/ConfigDialogue.cpp:1397
+msgid "Ask to save untitled documents"
+msgstr "Spør om å lagre ulagrede dokument"
+
+#: ../../src/dialogs/MaximaNotStartingDialog.cpp:36
+msgid "Asking the user for the location of a working maxima binary"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:3552
 msgid "Assignment(s):"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:10064
+#: ../../src/MaximaCommandMenus.cpp:3553
 msgid "Assignments of the format a=10,b=20"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:6851
+#: ../../src/MaximaCommandMenus.cpp:1754
 msgid "Assume a value range for a variable"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8545
+#: ../../src/MaximaCommandMenus.cpp:1558
 msgid "Attention: Extracting a random list element isn't efficient for long lists.Iterating over lists using makelist() or for loops is way faster."
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1618
+#: ../../src/dialogs/ConfigDialogue.cpp:897
+msgid "Auto-indent new lines"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:893
+#, fuzzy
+msgid "Auto-insert closing parenthesis"
+msgstr "Samsvar parenteser i tekstkontroller"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1441
+#: ../../src/dialogs/ConfigDialogue.cpp:1472
+#: ../../src/dialogs/MaximaNotStartingDialog.cpp:43
+msgid "Autodetect"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1236
+msgid "Automatic"
+msgstr ""
+
+#: ../../src/worksheet/WorksheetContextMenu.cpp:391
 msgid "Automatic labels"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:952
+#: ../../src/dialogs/ConfigDialogue.cpp:769
+#, c-format
+msgid "Automatic labels (%i1, %o1,...)"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:986
 msgid "Automatically answer questions"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:953
+#: ../../src/wxMaximaFrame.cpp:987
 msgid "Automatically fill in answers known from the last run"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1464 ../../src/Worksheet.cpp:1838
+#: ../../src/dialogs/ConfigDialogue.cpp:460
+msgid "Automatically insert a closing parenthesis the moment the user enters an opening one."
+msgstr ""
+
+#: ../../src/worksheet/WorksheetContextMenu.cpp:235
+#: ../../src/worksheet/WorksheetContextMenu.cpp:610
 msgid "Automatically send known answers"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:6021
+#: ../../src/MaximaFileIO.cpp:902
 #, c-format
 msgid "Autosaving as temp file %s"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:6033
+#: ../../src/MaximaFileIO.cpp:914
 #, c-format
 msgid "Autosaving the .wxmx file as %s"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:781
+#: ../../src/wxMaximaFrame.cpp:818
 msgid "Autosubscript"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:782
+#: ../../src/wxMaximaFrame.cpp:819
 msgid "Autosubscript chars after an underscore"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:767
+#: ../../src/wxMaximaFrame.cpp:804
 msgid "Autosubscript numbers and text following single letters"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:6529
+#: ../../src/MaximaCommandMenus.cpp:3049
 msgid "Autosubscript this variable"
 msgstr ""
 
-#: ../../src/MaximaManual.cpp:536
+#: ../../src/dialogs/ConfigDialogue.cpp:734
+msgid "Autowrap long lines:"
+msgstr ""
+
+#: ../../src/sidebars/DrawSidebar.cpp:75
+msgid "Axis"
+msgstr ""
+
+#: ../../src/wizards/BC2Wiz.cpp:59
+msgid "BC2"
+msgstr "BC2"
+
+#: ../../src/MaximaManual.cpp:559
 msgid "Background task that compiles the Manual anchors scheduled."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1350
+#: ../../src/sidebars/StatSidebar.cpp:91
+msgid "Barsplot..."
+msgstr "Søylediagram..."
+
+#: ../../src/wxMaximaFrame.cpp:1384
 msgid "Basic matrix operations"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:6210
+#: ../../src/dialogs/ConfigDialogue.cpp:187
+msgid "Basque"
+msgstr ""
+
+#: ../../src/dialogs/BinaryNameCtrl.cpp:67
+msgid "Bat files (*.bat)|*.bat|Exe files (*.exe)|*.exe|All|*"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:2366
 msgid "Batch File"
 msgstr "Batchfil"
 
-#: ../../src/wxMaxima.cpp:5318
+#: ../../src/wxMaxima.cpp:2079
+#, c-format
+msgid "Batch mode: %d image(s) could not be loaded at all."
+msgstr ""
+
+#: ../../src/wxMaxima.cpp:2084
+#, c-format
+msgid "Batch mode: %d image(s) failed to decode/render (--debug)."
+msgstr ""
+
+#: ../../src/MaximaResponseReader.cpp:523
+#, c-format
+msgid "Batch mode: Maxima asked a question with no scripted answer available (\"%s\"). Halting, as documented for --batch."
+msgstr ""
+
+#: ../../src/cells/TextCell.cpp:305
+msgid "Besides a division by 0 the reason for this error message can be a calculation that returns +/-infinity."
+msgstr ""
+
+#: ../../src/dialogs/TipOfTheDay.cpp:141
+msgid "Besides the global undo functionality that is active when the cursor is between cells, wxMaxima has a per-cell undo function that is active if the cursor is inside a cell. Pressing Ctrl+Z inside a cell can therefore been used for a fine-pitch undo that doesn't affect latter changes made in other cells."
+msgstr ""
+
+#: ../../src/sidebars/GreekSidebar.cpp:179
+msgid "Beta"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1898
+msgid "Bitmap"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1273
+msgid "Bitmap scale for export:"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1223
+msgid "Bitmaps"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:2109
+msgid "Bold"
+msgstr "Fet"
+
+#: ../../src/wxMaxima.cpp:2261
 msgid "Both horizontal and vertical cursor active at the same time"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8191
+#: ../../src/dialogs/ConfigDialogue.cpp:1999
+msgid "Bottom"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:1381
 msgid "Bottom end"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7817
+#: ../../src/MaximaCommandMenus.cpp:998
 #, fuzzy
 msgid "Boundary value problem"
 msgstr "&Grenseverdiproblem..."
+
+#: ../../src/MaximaCommandMenus.cpp:1780
+msgid "Boxplot"
+msgstr ""
+
+#: ../../src/sidebars/StatSidebar.cpp:97
+msgid "Boxplot..."
+msgstr "Boksdiagram..."
+
+#: ../../src/dialogs/BinaryNameCtrl.cpp:42 ../../src/wizards/CsvWiz.cpp:57
+#: ../../src/wizards/CsvWiz.cpp:131 ../../src/wizards/Plot2dWiz.cpp:114
+#: ../../src/wizards/Plot3dWiz.cpp:109
+msgid "Browse"
+msgstr "Utforsk"
 
 #: ../../src/wxMathml.cpp:101
 msgid "Bug: After removing the whitespace wxMathml.lisp is shorter than expected!"
 msgstr ""
 
-#: ../../src/Autocomplete.cpp:509
+#: ../../src/cells/Cell.cpp:498
+#, c-format
+msgid "Bug: AltCopyTexts not implemented for %s cell"
+msgstr ""
+
+#: ../../src/Autocomplete.cpp:642
 msgid "Bug: Autocompletion requested for unknown type of item."
 msgstr ""
 
-#: ../../src/Worksheet.cpp:2992
+#: ../../src/TreeUndoManager.h:138
 msgid "Bug: Cell left but not entered."
 msgstr ""
 
-#: ../../src/Worksheet.cpp:6203
+#: ../../src/worksheet/Worksheet.cpp:4193
 msgid "Bug: Cell with negative y position!"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:7723
+#: ../../src/worksheet/Worksheet.cpp:5905
 msgid "Bug: Encountered a heading I don't know how to move in one sectioning unit"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:7766
+#: ../../src/worksheet/Worksheet.cpp:5952
 msgid "Bug: Encountered a heading I don't know how to move out one sectioning unit"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:3112
+#: ../../src/worksheet/Worksheet.cpp:2244
 msgid "Bug: Got a question but no cell to answer it in"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:6378
-msgid "Bug: Got a request to change the contents of the cell above the beginning of the worksheet."
-msgstr ""
-
-#: ../../src/Worksheet.cpp:6346
+#: ../../src/worksheet/Worksheet.cpp:4293
 msgid "Bug: Got a request to delete the cell above the beginning of the worksheet."
 msgstr ""
 
-#: ../../src/Worksheet.cpp:6415
+#: ../../src/worksheet/WorksheetDocument.cpp:239
 msgid "Bug: Got a request to first change the contents of a cell and to then undelete it."
 msgstr ""
 
-#: ../../src/Worksheet.cpp:5578
+#: ../../src/worksheet/WorksheetExport.cpp:1576
 msgid "Bug: HTML output is no valid XML"
 msgstr ""
 
-#: ../../src/Configuration.h:615
+#: ../../src/cells/Cell.cpp:289
+msgid "Bug: Math Cell that claims to have no group Cell it belongs to"
+msgstr ""
+
+#: ../../src/Configuration.h:741
 msgid "Bug: Maximum number of digits that is to be displayed is too low!"
 msgstr ""
 
-#: ../../src/MathParser.cpp:523
+#: ../../src/MathParser.cpp:575
 msgid "Bug: Missing contents"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:2597 ../../src/Worksheet.cpp:2711
-#: ../../src/Worksheet.cpp:2753 ../../src/Worksheet.cpp:2787
-#: ../../src/Worksheet.cpp:2816 ../../src/Worksheet.cpp:2828
-#: ../../src/Worksheet.cpp:4442 ../../src/Worksheet.cpp:6650
-#: ../../src/Worksheet.cpp:6863
+#: ../../src/cells/GroupCell.cpp:1498
+msgid "Bug: No image counter to write to!"
+msgstr ""
+
+#: ../../src/cells/AnimationCell.cpp:543 ../../src/cells/EditorCell.cpp:2968
+#: ../../src/cells/ImgCell.cpp:353 ../../src/graphical_io/BitmapOut.cpp:161
+#: ../../src/graphical_io/OutCommon.cpp:264
+#: ../../src/worksheet/Worksheet.cpp:1764
+#: ../../src/worksheet/Worksheet.cpp:1901
+#: ../../src/worksheet/Worksheet.cpp:1943
+#: ../../src/worksheet/Worksheet.cpp:1977
+#: ../../src/worksheet/Worksheet.cpp:2006
+#: ../../src/worksheet/Worksheet.cpp:2018
+#: ../../src/worksheet/Worksheet.cpp:3512
+#: ../../src/worksheet/Worksheet.cpp:4641
+#: ../../src/worksheet/Worksheet.cpp:4866
 msgid "Bug: The clipboard is already opened"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:7763
+#: ../../src/cells/EditorCell.cpp:3051
+msgid "Bug: The clipboard isn't open on pasting into an editor cell"
+msgstr ""
+
+#: ../../src/cells/GroupCell.cpp:2288
+msgid "Bug: The predecessor to a GroupCell is not a GroupCell."
+msgstr ""
+
+#: ../../src/cells/GroupCell.cpp:2286
+msgid "Bug: The successor to a GroupCell is not a GroupCell."
+msgstr ""
+
+#: ../../src/cells/GroupCell.cpp:340
+msgid "Bug: Trying to append NULL to a group cell."
+msgstr ""
+
+#: ../../src/worksheet/Worksheet.cpp:5949
 msgid "Bug: Trying to move a title out by one sectioning unit"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:6934
+#: ../../src/worksheet/Worksheet.cpp:4925
 msgid "Bug: Trying to move the horizontally-drawn cursor to a place inside a GroupCell."
 msgstr ""
 
-#: ../../src/Worksheet.h:247 ../../src/Worksheet.h:252
+#: ../../src/TreeUndoAction.h:52 ../../src/TreeUndoAction.h:57
 msgid "Bug: Trying to record a cell contents change for undo without a cell."
 msgstr ""
 
-#: ../../src/Worksheet.cpp:6417
+#: ../../src/TreeUndoAction.h:73
+msgid "Bug: Trying to record a fold/unfold for undo without a cell."
+msgstr ""
+
+#: ../../src/worksheet/WorksheetDocument.cpp:241
 msgid "Bug: Undo action with both cell contents change and cell addition."
 msgstr ""
 
-#: ../../src/Worksheet.cpp:6383
-msgid "Bug: Undo request for cell outside worksheet."
+#: ../../src/cells/EditorCell.cpp:4541
+msgid "Bug: Unknown type of text"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1948
+#: ../../src/cells/EditorCell.cpp:3981 ../../src/cells/TextCell.cpp:479
+msgid "Bug: dc == NULL"
+msgstr ""
+
+#: ../../src/cells/EditorCell.cpp:2637
+msgid "Bug: x position of cell is unknown!"
+msgstr ""
+
+#: ../../src/cells/EditorCell.cpp:2638
+msgid "Bug: y position of cell is unknown!"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1985
 msgid "Build &Info"
 msgstr "Build &Info"
 
-#: ../../src/wxMaxima.cpp:7275
+#: ../../src/dialogs/AboutDialog.cpp:45
+#, c-format
+msgid "Build from Git version: %s\n"
+msgstr ""
+
+#: ../../src/dialogs/TipOfTheDay.cpp:54
+#, fuzzy
+msgid "By default, Shift-Enter is used to evaluate commands, while Enter is used for multiline input. This behaviour can be changed in 'Edit->Configure' dialog by checking 'Enter evaluates cells'. This switches the roles of these two key commands."
+msgstr "Forhåndsvalgt brukes Shift+Enter for å utføre kommandoer, mens Enter brukes for ny linje. Dette kan endres i dialogen 'Endre->Konfigurer' ved å huke av 'Enter utfører celler'. Dette bytter om disse to kommandoenes roller."
+
+#: ../../src/MaximaCommandMenus.cpp:4147
 msgid "Byte:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1458
+#: ../../src/wxMaximaFrame.cpp:1495
 #, fuzzy
 msgid "C&hange Variable in Integrate..."
 msgstr "Endre &Variabel..."
 
-#: ../../src/wxMaximaFrame.cpp:687
+#: ../../src/wxMaximaFrame.cpp:724
 msgid "C&onfigure"
 msgstr "&Konfigurer"
 
-#: ../../src/wxMaximaFrame.cpp:1482
+#: ../../src/wizards/CsvWiz.cpp:105
+msgid "CSV export"
+msgstr ""
+
+#: ../../src/wizards/CsvWiz.cpp:34
+msgid "CSV import"
+msgstr ""
+
+#: ../../src/cells/FontVariantCache.cpp:96
+#, c-format
+msgid "Caching font variant: %s"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1519
 msgid "Calculate &Product..."
 msgstr "Kalkuler &Produkt..."
 
-#: ../../src/wxMaxima.cpp:8057
+#: ../../src/MaximaCommandMenus.cpp:1243
 msgid "Calculate Singular Value Decomposition of a matrix numerically"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8050
+#: ../../src/MaximaCommandMenus.cpp:1236
 msgid "Calculate Singular Value Decomposition, left and right singular vectors numerically"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1480
+#: ../../src/wxMaximaFrame.cpp:1517
 msgid "Calculate Su&m..."
 msgstr "Kalkuler &Sum..."
 
-#: ../../src/wxMaximaFrame.cpp:1795
+#: ../../src/wxMaximaFrame.cpp:1832
 msgid "Calculate bigfloat value of the last result"
 msgstr "Kalkuler desimalverdien av siste resultat med uendelig presisjon"
 
-#: ../../src/wxMaximaFrame.cpp:1792
+#: ../../src/wxMaximaFrame.cpp:1829
 msgid "Calculate float value of the last result"
 msgstr "Kalkuler desimalverdien av siste resultat"
 
-#: ../../src/wxMaxima.cpp:9550
+#: ../../src/MaximaCommandMenus.cpp:1788
 #, fuzzy
 msgid "Calculate mean value"
 msgstr "Kalkuler modulo:"
 
-#: ../../src/wxMaxima.cpp:9554
+#: ../../src/MaximaCommandMenus.cpp:1792
 #, fuzzy
 msgid "Calculate median value"
 msgstr "Kalkuler modulo:"
 
-#: ../../src/wxMaxima.cpp:8871
+#: ../../src/MaximaCommandMenus.cpp:878
 msgid "Calculate modulus:"
 msgstr "Kalkuler modulo:"
 
-#: ../../src/wxMaximaFrame.cpp:1798
+#: ../../src/wxMaximaFrame.cpp:1835
 msgid "Calculate numeric value of the last result"
 msgstr "Kalkuler numerisk verdi av siste resultat"
 
-#: ../../src/wxMaximaFrame.cpp:1483
+#: ../../src/wxMaximaFrame.cpp:1520
 msgid "Calculate products"
 msgstr "Kalkuler produkter"
 
-#: ../../src/wxMaxima.cpp:9562
+#: ../../src/MaximaCommandMenus.cpp:1800
 msgid "Calculate standard deviation"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1480
+#: ../../src/wxMaximaFrame.cpp:1517
 msgid "Calculate sums"
 msgstr "Kalkuler summer"
 
-#: ../../src/wxMaxima.cpp:8025 ../../src/wxMaxima.cpp:8035
+#: ../../src/MaximaCommandMenus.cpp:1209 ../../src/MaximaCommandMenus.cpp:1219
 msgid "Calculate the eigenvalues and eigenvectors numerically"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8020 ../../src/wxMaxima.cpp:8030
+#: ../../src/MaximaCommandMenus.cpp:1204 ../../src/MaximaCommandMenus.cpp:1214
 #, fuzzy
 msgid "Calculate the eigenvalues of a matrix numerically"
 msgstr "Utarbeid inversen til en matrise"
 
-#: ../../src/wxMaxima.cpp:8078 ../../src/wxMaxima.cpp:8099
+#: ../../src/MaximaCommandMenus.cpp:1264 ../../src/MaximaCommandMenus.cpp:1287
 msgid "Calculate the root of the sum of squares of matrix entries"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:9558
-#, fuzzy
-msgid "Calculate variation"
-msgstr "Kalkuler produkter"
+#: ../../src/MaximaCommandMenus.cpp:1796
+msgid "Calculate variance"
+msgstr ""
 
-#: ../../src/wxMaxima.cpp:8949
+#: ../../src/MaximaCommandMenus.cpp:203
 msgid "Calculates the fourier coefficients for the expression from -p to p"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1968
+#: ../../src/worksheet/WorksheetContextMenu.cpp:740
 msgid "Calls assume() in order to tell maxima about the variable's range"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:2031
+#: ../../src/worksheet/WorksheetContextMenu.cpp:803
 msgid "Can be specified as flag in ev(exp, flag)"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:11125
+#: ../../src/wxMaxima.cpp:3438
 msgid "Can not connect to the web server."
 msgstr "Kan ikke koble til web server."
 
-#: ../../src/wxMaxima.cpp:11166
+#: ../../src/wxMaxima.cpp:3384 ../../src/wxMaxima.cpp:3420
+#: ../../src/wxMaxima.cpp:3472
 msgid "Can not download version info."
 msgstr "Kan ikke laste ned versjonsinformasjon."
 
-#: ../../src/wxMaxima.cpp:3016 ../../src/wxMaxima.cpp:4836
+#: ../../src/MaximaProcessManager.cpp:577 ../../src/wxMaxima.cpp:1581
 msgid "Can not start Maxima. The most probable cause is that Maxima isn't installed (it can be downloaded from https://maxima.sourceforge.io) or in wxMaxima's config dialogue the setting for Maxima's location is wrong."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:11203
+#: ../../src/dialogs/MaxSizeChooser.cpp:46
+#: ../../src/dialogs/MaxSizeChooser.cpp:48
+#: ../../src/dialogs/MaximaNotStartingDialog.cpp:71
+#: ../../src/dialogs/MaximaNotStartingDialog.cpp:73
+#: ../../src/dialogs/ResolutionChooser.cpp:41
+#: ../../src/dialogs/ResolutionChooser.cpp:43
+#: ../../src/wizards/ActualValuesStorageWiz.cpp:61
+#: ../../src/wizards/ActualValuesStorageWiz.cpp:63
+#: ../../src/wizards/BC2Wiz.cpp:48 ../../src/wizards/BC2Wiz.cpp:50
+#: ../../src/wizards/CsvWiz.cpp:65 ../../src/wizards/CsvWiz.cpp:139
+#: ../../src/wizards/DrawWiz.cpp:111 ../../src/wizards/DrawWiz.cpp:222
+#: ../../src/wizards/DrawWiz.cpp:354 ../../src/wizards/DrawWiz.cpp:509
+#: ../../src/wizards/DrawWiz.cpp:568 ../../src/wizards/DrawWiz.cpp:665
+#: ../../src/wizards/DrawWiz.cpp:773 ../../src/wizards/DrawWiz.cpp:849
+#: ../../src/wizards/DrawWiz.cpp:987 ../../src/wizards/Gen1Wiz.cpp:44
+#: ../../src/wizards/Gen1Wiz.cpp:46 ../../src/wizards/Gen2Wiz.cpp:47
+#: ../../src/wizards/Gen2Wiz.cpp:49 ../../src/wizards/Gen3Wiz.cpp:55
+#: ../../src/wizards/Gen3Wiz.cpp:57 ../../src/wizards/Gen4Wiz.cpp:62
+#: ../../src/wizards/Gen4Wiz.cpp:64 ../../src/wizards/Gen5Wiz.cpp:70
+#: ../../src/wizards/Gen5Wiz.cpp:72 ../../src/wizards/GenWizPanel.cpp:111
+#: ../../src/wizards/GenWizPanel.cpp:113 ../../src/wizards/IntegrateWiz.cpp:62
+#: ../../src/wizards/IntegrateWiz.cpp:64 ../../src/wizards/LimitWiz.cpp:50
+#: ../../src/wizards/LimitWiz.cpp:52 ../../src/wizards/ListSortWiz.cpp:77
+#: ../../src/wizards/ListSortWiz.cpp:79 ../../src/wizards/MatWiz.cpp:40
+#: ../../src/wizards/MatWiz.cpp:42 ../../src/wizards/MatWiz.cpp:169
+#: ../../src/wizards/MatWiz.cpp:171 ../../src/wizards/Plot2dWiz.cpp:95
+#: ../../src/wizards/Plot2dWiz.cpp:97 ../../src/wizards/Plot2dWiz.cpp:512
+#: ../../src/wizards/Plot2dWiz.cpp:514 ../../src/wizards/Plot2dWiz.cpp:608
+#: ../../src/wizards/Plot2dWiz.cpp:610 ../../src/wizards/Plot3dWiz.cpp:90
+#: ../../src/wizards/Plot3dWiz.cpp:92 ../../src/wizards/PlotFormatWiz.cpp:48
+#: ../../src/wizards/PlotFormatWiz.cpp:50 ../../src/wizards/SeriesWiz.cpp:50
+#: ../../src/wizards/SeriesWiz.cpp:52 ../../src/wizards/SubstituteWiz.cpp:42
+#: ../../src/wizards/SubstituteWiz.cpp:44 ../../src/wizards/SumWiz.cpp:48
+#: ../../src/wizards/SumWiz.cpp:50 ../../src/wizards/SystemWiz.cpp:39
+#: ../../src/wizards/SystemWiz.cpp:41 ../../src/wxMaxima.cpp:3509
 msgid "Cancel"
 msgstr "Avbryt"
 
-#: ../../src/wxMaxima.cpp:3292
+#: ../../src/MaximaResponseReader.cpp:344
 msgid "Cannot authenticate Maxima!"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2677
+#: ../../src/wxMaxima.cpp:1283
+#, c-format
+msgid "Cannot cache the list of known symbols to %s"
+msgstr ""
+
+#: ../../src/cells/FontVariantCache.cpp:85
+#, c-format
+msgid "Cannot create a font based on %s. Falling back to a default font."
+msgstr ""
+
+#: ../../src/MaximaProcessManager.cpp:370
 msgid "Cannot find a maxima binary and no binary chosen in the config dialogue."
 msgstr ""
 
-#: ../../src/Autocomplete.cpp:583
+#: ../../src/Autocomplete.cpp:719
 #, c-format
 msgid "Cannot interpret template %s"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3082
+#: ../../src/MaximaResponseReader.cpp:221
 #, c-format
 msgid "Cannot interpret the numeric value of pid %s"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:11066 ../../src/wxMaxima.cpp:11073
-#: ../../src/wxMaxima.cpp:11080
+#: ../../src/wxMaxima.cpp:3347 ../../src/wxMaxima.cpp:3354
+#: ../../src/wxMaxima.cpp:3361
 #, c-format
 msgid "Cannot interpret version number component %s"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2530
+#: ../../src/cells/EditorCell.cpp:2991
+msgid "Cannot put the copied text on the clipboard"
+msgstr ""
+
+#: ../../src/cells/EditorCell.cpp:2984
+msgid "Cannot put the copied text on the clipboard (1st try)"
+msgstr ""
+
+#: ../../src/cells/EditorCell.cpp:2988
+msgid "Cannot put the copied text on the clipboard (2nd try)"
+msgstr ""
+
+#: ../../src/graphical_io/OutCommon.cpp:98
+#, c-format
+msgid "Cannot remove the file %s"
+msgstr ""
+
+#: ../../src/sidebars/History.cpp:258
+#, c-format
+msgid "Cannot save the command history to %s"
+msgstr ""
+
+#: ../../src/MaximaManual.cpp:386
+#, c-format
+msgid "Cannot save the list of subjects manual contains to the file %s."
+msgstr ""
+
+#: ../../src/MaximaProcessManager.cpp:191
 msgid "Cannot set the communication address to localhost."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2532
+#: ../../src/MaximaProcessManager.cpp:193
 #, c-format
 msgid "Cannot set the communication port to %i."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3656 ../../src/wxMaxima.cpp:6359
+#: ../../src/MaximaCommandMenus.cpp:2795 ../../src/MaximaResponseReader.cpp:880
 #, fuzzy
 msgid "Cannot start gnuplot"
 msgstr "Parametrisk Plott"
 
-#: ../../src/StatusBar.cpp:216 ../../src/wxMaxima.cpp:2662
+#: ../../src/MaximaCommandMenus.cpp:2844
+msgid "Cannot start the headless gnuplot warnings check"
+msgstr ""
+
+#: ../../src/MaximaProcessManager.cpp:341 ../../src/StatusBar.cpp:254
 msgid "Cannot start the maxima binary"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:9268
+#: ../../src/sidebars/MathSidebar.cpp:62
+msgid "Canonical (tr)"
+msgstr "Kanonisk (tr)"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:188
+msgid "Catalan"
+msgstr "Katalan"
+
+#: ../../src/MaximaCommandMenus.cpp:466
 msgid "Cauchy principal value of f(x)/(x-c), finite interval"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1845
+#: ../../src/wxMaximaFrame.cpp:1882
 msgid "Cauchy principal value, finite interval"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:955
+#: ../../src/wxMaximaFrame.cpp:989
 msgid "Ce&ll"
 msgstr "&Celle"
 
-#: ../../src/Configuration.cpp:96
+#: ../../src/Styles.cpp:125
 #, fuzzy
 msgid "Cell bracket fill, Active"
 msgstr "Celleklamme"
 
-#: ../../src/Configuration.cpp:95
+#: ../../src/Styles.cpp:124
 #, fuzzy
 msgid "Cell bracket fill, Inactive"
 msgstr "Celleklamme"
 
-#: ../../src/wxMaxima.cpp:10395
+#: ../../src/wxMaxima.cpp:3082
 msgid "Cell ends in a backslash"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1038
+#: ../../src/MaximaCommandMenus.cpp:2262
+#, c-format
+msgid "Cell with UUID %s not found!"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1072
 msgid "Change &2d Display"
 msgstr "Endre &2D-Visning"
 
-#: ../../src/wxMaxima.cpp:10146
+#: ../../src/MaximaCommandMenus.cpp:3641
 #, fuzzy
 msgid "Change Image"
 msgstr "Endre variabel"
 
-#: ../../src/Worksheet.cpp:1324
+#: ../../src/worksheet/WorksheetContextMenu.cpp:86
 #, fuzzy
 msgid "Change Image..."
 msgstr "Lagre Bilde..."
 
-#: ../../src/wxMaximaFrame.cpp:1954
+#: ../../src/wxMaximaFrame.cpp:1997
 #, fuzzy
 msgid "Change Log"
 msgstr "Endre variabel"
 
-#: ../../src/wxMaxima.cpp:7555
+#: ../../src/MaximaCommandMenus.cpp:4427
 msgid "Change directory"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1202
+#: ../../src/wxMaximaFrame.cpp:1236
 #, fuzzy
 msgid "Change directory..."
 msgstr "Lagre Bilde..."
 
-#: ../../src/wxMaximaFrame.cpp:1039
+#: ../../src/dialogs/ConfigDialogue.cpp:859
+msgid "Change names of greek letters to greek letters"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1073
 msgid "Change the 2d display algorithm used to display math output"
 msgstr "Endre 2D-visningsalgoritme brukt til å vise matteutdata"
 
-#: ../../src/wxMaxima.cpp:8885
+#: ../../src/dialogs/ConfigDialogue.cpp:489
+msgid "Change the text \"alpha\" and \"beta\" to the corresponding greek letter?"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:136
 msgid "Change variable"
 msgstr "Endre variabel"
 
-#: ../../src/wxMaxima.cpp:8905
+#: ../../src/MaximaCommandMenus.cpp:156
 #, fuzzy
 msgid "Change variable and evaluate"
 msgstr "Endre variabel i integral eller sum"
 
-#: ../../src/wxMaximaFrame.cpp:1459
+#: ../../src/wxMaximaFrame.cpp:1496
 msgid "Change variable in integral or sum"
 msgstr "Endre variabel i integral eller sum"
 
-#: ../../src/wxMaximaFrame.cpp:1463
+#: ../../src/wxMaximaFrame.cpp:1500
 #, fuzzy
 msgid "Change variable in integral or sum and evaluate the result"
 msgstr "Endre variabel i integral eller sum"
 
-#: ../../src/wxMaximaFrame.cpp:1026
+#: ../../src/dialogs/ChangeLogDialog.cpp:37
+#, fuzzy
+msgid "ChangeLog"
+msgstr "Endre variabel"
+
+#: ../../src/wxMaximaFrame.cpp:1060
 #, fuzzy
 msgid "Changed option variables"
 msgstr "Endre variabel"
 
-#: ../../src/wxMaxima.cpp:10170
+#: ../../src/MaximaCommandMenus.cpp:3699
 #, c-format
 msgid "Changing image originally loaded from file %s to %s."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7313 ../../src/wxMaxima.cpp:7318
-#: ../../src/wxMaxima.cpp:7323 ../../src/wxMaxima.cpp:7329
-#: ../../src/wxMaxima.cpp:7334 ../../src/wxMaxima.cpp:7340
+#: ../../src/MaximaCommandMenus.cpp:4185 ../../src/MaximaCommandMenus.cpp:4190
+#: ../../src/MaximaCommandMenus.cpp:4195 ../../src/MaximaCommandMenus.cpp:4201
+#: ../../src/MaximaCommandMenus.cpp:4206 ../../src/MaximaCommandMenus.cpp:4212
 msgid "Char #1:"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7314 ../../src/wxMaxima.cpp:7319
-#: ../../src/wxMaxima.cpp:7324 ../../src/wxMaxima.cpp:7329
-#: ../../src/wxMaxima.cpp:7335 ../../src/wxMaxima.cpp:7340
+#: ../../src/MaximaCommandMenus.cpp:4186 ../../src/MaximaCommandMenus.cpp:4191
+#: ../../src/MaximaCommandMenus.cpp:4196 ../../src/MaximaCommandMenus.cpp:4201
+#: ../../src/MaximaCommandMenus.cpp:4207 ../../src/MaximaCommandMenus.cpp:4212
 #, fuzzy
 msgid "Char #2:"
 msgstr "Matrise:"
 
-#: ../../src/wxMaximaFrame.cpp:1140
+#: ../../src/wxMaximaFrame.cpp:1174
 msgid "Char to Unicode code point..."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7358 ../../src/wxMaxima.cpp:7362
+#: ../../src/MaximaCommandMenus.cpp:4230 ../../src/MaximaCommandMenus.cpp:4234
 msgid "Char to unicode code point"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7285 ../../src/wxMaxima.cpp:7289
-#: ../../src/wxMaxima.cpp:7293 ../../src/wxMaxima.cpp:7297
-#: ../../src/wxMaxima.cpp:7301 ../../src/wxMaxima.cpp:7305
-#: ../../src/wxMaxima.cpp:7359 ../../src/wxMaxima.cpp:7363
-#: ../../src/wxMaxima.cpp:7435
+#: ../../src/MaximaCommandMenus.cpp:4157 ../../src/MaximaCommandMenus.cpp:4161
+#: ../../src/MaximaCommandMenus.cpp:4165 ../../src/MaximaCommandMenus.cpp:4169
+#: ../../src/MaximaCommandMenus.cpp:4173 ../../src/MaximaCommandMenus.cpp:4177
+#: ../../src/MaximaCommandMenus.cpp:4231 ../../src/MaximaCommandMenus.cpp:4235
+#: ../../src/MaximaCommandMenus.cpp:4307
 msgid "Char:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1131
+#: ../../src/wxMaximaFrame.cpp:1165
 msgid "Character Tests"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8181
+#: ../../src/MaximaCommandMenus.cpp:1369
 #, fuzzy
 msgid "Characteristic polynom"
 msgstr "&Karakteristisk Polynom..."
 
-#: ../../src/wxMaxima.cpp:7280
+#: ../../src/MaximaCommandMenus.cpp:4152
 msgid "Chars are strings that are one character long"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1957
+#: ../../src/wxMaximaFrame.cpp:2000
 msgid "Check for Updates"
 msgstr "Se etter O&ppdatering"
 
-#: ../../src/wxMaximaFrame.cpp:1958
+#: ../../src/wxMaximaFrame.cpp:2001
 #, fuzzy
 msgid "Check if a newer version of wxMaxima is available."
 msgstr "Sjekk om en nyere versjon av wxMaxima/Maxima finnes."
 
-#: ../../src/wxMaximaFrame.cpp:800
+#: ../../src/sidebars/GreekSidebar.cpp:199
+msgid "Chi"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:189
+msgid "Chinese (Simplified)"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:190
+msgid "Chinese (traditional)"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1554
+msgid "Choose a Lisp Maxima was compiled with"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1560
+msgid "Choose between installed Maxima versions"
+msgstr ""
+
+#: ../../src/sidebars/HelpBrowser.cpp:204
+msgid "Choose between the following help topics:"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:2100
+msgid "Choose font"
+msgstr "Velg font"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:793
+msgid ""
+"Choose how mathematical output is formatted:\n"
+"\"2D, whenever possible\" keeps all expressions in two-dimensional form (fractions stacked, matrices drawn as boxes), even if they overflow the page width.\n"
+"\"2D if it fits on the page width\" (default) switches wide objects to linear notation.\n"
+"\"Prefer 1D\" always uses linear notation."
+msgstr ""
+
+#: ../../src/wizards/PlotFormatWiz.cpp:31
+msgid "Choose new plot format:"
+msgstr "Velg nytt plot-format:"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:2432
+#, fuzzy, c-format
+msgid "Choose the %s Font"
+msgstr "Velg font"
+
+#: ../../src/wxMaximaFrame.cpp:837
 msgid "Choose the parenthesis type for Matrices"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:9530 ../../src/wxMaxima.cpp:9535
+#: ../../src/MaximaCommandMenus.cpp:1768 ../../src/MaximaCommandMenus.cpp:1773
 msgid "Classes:"
 msgstr "Klasser:"
 
-#: ../../src/wxMaximaFrame.cpp:1378
+#: ../../src/wxMaximaFrame.cpp:1412
 msgid "Classic matrix operations"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:998
+#: ../../src/wxMaximaFrame.cpp:1032
 #, fuzzy
 msgid "Clear all aliases"
 msgstr "Tøm &Minnet"
 
-#: ../../src/wxMaximaFrame.cpp:995
+#: ../../src/wxMaximaFrame.cpp:1029
 #, fuzzy
 msgid "Clear all arrays"
 msgstr "Tøm &Minnet"
 
-#: ../../src/wxMaximaFrame.cpp:992
+#: ../../src/wxMaximaFrame.cpp:1026
 #, fuzzy
 msgid "Clear all dependencies"
 msgstr "Tøm &Minnet"
 
-#: ../../src/wxMaximaFrame.cpp:994
+#: ../../src/wxMaximaFrame.cpp:1028
 #, fuzzy
 msgid "Clear all functions"
 msgstr "Slett en funksjon"
 
-#: ../../src/wxMaximaFrame.cpp:1001
+#: ../../src/wxMaximaFrame.cpp:1035
 #, fuzzy
 msgid "Clear all gradefs"
 msgstr "Tøm &Minnet"
 
-#: ../../src/wxMaximaFrame.cpp:1000
+#: ../../src/sidebars/History.cpp:116
+msgid "Clear all history"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1034
 #, fuzzy
 msgid "Clear all labels"
 msgstr "Tøm &Minnet"
 
-#: ../../src/wxMaximaFrame.cpp:1004
+#: ../../src/wxMaximaFrame.cpp:1038
 msgid "Clear all let rule packages"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1003
+#: ../../src/wxMaximaFrame.cpp:1037
 #, fuzzy
 msgid "Clear all macros"
 msgstr "Tøm &Minnet"
 
-#: ../../src/wxMaximaFrame.cpp:1002
+#: ../../src/wxMaximaFrame.cpp:1036
 #, fuzzy
 msgid "Clear all props"
 msgstr "Tøm &Minnet"
 
-#: ../../src/wxMaximaFrame.cpp:997
+#: ../../src/wxMaximaFrame.cpp:1031
 #, fuzzy
 msgid "Clear all rules"
 msgstr "Tøm &Minnet"
 
-#: ../../src/wxMaximaFrame.cpp:999
+#: ../../src/wxMaximaFrame.cpp:1033
 #, fuzzy
 msgid "Clear all structures"
 msgstr "Tøm &Minnet"
 
-#: ../../src/wxMaximaFrame.cpp:993
+#: ../../src/wxMaximaFrame.cpp:1027
 #, fuzzy
 msgid "Clear all variables"
 msgstr "Slett en variabel"
 
-#: ../../src/wxMaximaFrame.cpp:606
+#: ../../src/sidebars/History.cpp:115
+#, fuzzy
+msgid "Clear the selection"
+msgstr "Klipp Ut Utvalg"
+
+#: ../../src/cells/FontVariantCache.cpp:44
+#, c-format
+msgid "Cleared font cache for font %s"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1926
+msgid "Clipboard format parameters"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:637
 msgid "Close\tCtrl+W"
 msgstr "Lukk\tCtrl+W"
 
-#: ../../src/wxMaxima.cpp:7235
+#: ../../src/MaximaCommandMenus.cpp:4107
 msgid "Close Stream"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:606
+#: ../../src/wxMaximaFrame.cpp:637
 msgid "Close window"
 msgstr "Lukk vindu"
 
-#: ../../src/wxMaximaFrame.cpp:1105
+#: ../../src/wxMaximaFrame.cpp:1139
 #, fuzzy
 msgid "Close..."
 msgstr "Løs..."
 
-#: ../../src/WXMXformat.cpp:301
+#: ../../src/WXMXformat.cpp:303
 msgid "Closed the zip archive"
 msgstr ""
 
-#: ../../src/Configuration.cpp:77
+#: ../../src/Styles.cpp:106
 #, fuzzy
 msgid "Code Default (Maxima input)"
 msgstr "Maxima-inndata"
 
-#: ../../src/Configuration.cpp:103
+#: ../../src/Styles.cpp:133
 msgid "Code highlighting: Comments"
 msgstr ""
 
-#: ../../src/Configuration.cpp:108
+#: ../../src/Styles.cpp:138
 msgid "Code highlighting: End of line markers"
 msgstr ""
 
-#: ../../src/Configuration.cpp:102
+#: ../../src/Styles.cpp:132
 msgid "Code highlighting: Functions"
 msgstr ""
 
-#: ../../src/Configuration.cpp:107
+#: ../../src/Styles.cpp:137
 msgid "Code highlighting: Lisp"
 msgstr ""
 
-#: ../../src/Configuration.cpp:104
+#: ../../src/Styles.cpp:134
 msgid "Code highlighting: Numbers"
 msgstr ""
 
-#: ../../src/Configuration.cpp:106
+#: ../../src/Styles.cpp:136
 msgid "Code highlighting: Operators"
 msgstr ""
 
-#: ../../src/Configuration.cpp:105
+#: ../../src/Styles.cpp:135
 msgid "Code highlighting: Strings"
 msgstr ""
 
-#: ../../src/Configuration.cpp:101
+#: ../../src/Styles.cpp:131
 msgid "Code highlighting: Variables"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7309 ../../src/wxMaxima.cpp:7355
+#: ../../src/MaximaCommandMenus.cpp:4181 ../../src/MaximaCommandMenus.cpp:4227
 #, fuzzy
 msgid "Code number:"
 msgstr "Kolonner:"
 
-#: ../../src/wxMaxima.cpp:7367 ../../src/wxMaxima.cpp:7373
+#: ../../src/MaximaCommandMenus.cpp:4239 ../../src/MaximaCommandMenus.cpp:4245
 #, fuzzy
 msgid "Codepoint number:"
 msgstr "Kolonner:"
 
-#: ../../src/wxMaxima.cpp:9590
+#: ../../src/MaximaCommandMenus.cpp:1830
 msgid "Col. names:"
 msgstr "Kol. navn:"
 
-#: ../../src/Configuration.cpp:100
+#: ../../src/Styles.cpp:130
 #, fuzzy
 msgid "Color of Outdated cells"
 msgstr "Utdaterte celler"
 
-#: ../../src/Configuration.cpp:99
+#: ../../src/Styles.cpp:128
 #, fuzzy
 msgid "Color of text equal to selection"
 msgstr "Klipp Ut Utvalg"
 
-#: ../../src/wxMaxima.cpp:7962
+#: ../../src/MaximaCommandMenus.cpp:1142 ../../src/MaximaCommandMenus.cpp:1152
 #, fuzzy
 msgid "Column number:"
 msgstr "Kolonner:"
 
-#: ../../src/wxMaxima.cpp:7978
+#: ../../src/MaximaCommandMenus.cpp:1157
 #, fuzzy
 msgid "Column numbers:"
 msgstr "Kolonner:"
 
-#: ../../src/wxMaxima.cpp:8202
+#: ../../src/MaximaCommandMenus.cpp:1392
 #, fuzzy
 msgid "Columns"
 msgstr "Kolonner:"
 
-#: ../../src/wxMaximaFrame.cpp:1584
+#: ../../src/wizards/MatWiz.cpp:155
+msgid "Columns:"
+msgstr "Kolonner:"
+
+#: ../../src/wxMaximaFrame.cpp:1621
 msgid "Combine factorials in an expression"
 msgstr "Trekk sammen fakulteter i et uttrykk"
 
-#: ../../src/wxMaxima.cpp:10454
+#: ../../src/wizards/CsvWiz.cpp:41 ../../src/wizards/CsvWiz.cpp:112
+msgid "Comma"
+msgstr ""
+
+#: ../../src/wxMaxima.cpp:3141
 msgid "Comma directly followed by a closing parenthesis"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7259
+#: ../../src/wizards/Plot2dWiz.cpp:626
+msgid "Comma separated x coordinates"
+msgstr "Kommaseparerte x-koordinater"
+
+#: ../../src/wizards/Plot2dWiz.cpp:627
+msgid "Comma separated y coordinates"
+msgstr "Kommaseparerte y-koordinater"
+
+#: ../../src/MaximaCommandMenus.cpp:4131
 #, fuzzy
 msgid "Comma-separated arguments"
 msgstr "Kommaseparerte x-koordinater"
 
-#: ../../src/wxMaxima.cpp:7057 ../../src/wxMaxima.cpp:7066
+#: ../../src/MaximaCommandMenus.cpp:3929 ../../src/MaximaCommandMenus.cpp:3938
 #, fuzzy
 msgid "Comma-separated commands"
 msgstr "Kommaseparerte x-koordinater"
 
-#: ../../src/wxMaxima.cpp:8458
+#: ../../src/MaximaCommandMenus.cpp:1461
 #, fuzzy
 msgid "Comma-separated elements"
 msgstr "Kommaseparerte x-koordinater"
 
-#: ../../src/wxMaxima.cpp:7752 ../../src/wxMaxima.cpp:7766
-#: ../../src/wxMaxima.cpp:10031
+#: ../../src/MaximaCommandMenus.cpp:933 ../../src/MaximaCommandMenus.cpp:947
+#: ../../src/MaximaCommandMenus.cpp:3520
 #, fuzzy
 msgid "Comma-separated equations"
 msgstr "Kommaseparerte x-koordinater"
 
-#: ../../src/wxMaxima.cpp:8727 ../../src/wxMaxima.cpp:8735
-#: ../../src/wxMaxima.cpp:8743 ../../src/wxMaxima.cpp:8751
-#: ../../src/wxMaxima.cpp:8760 ../../src/wxMaxima.cpp:8768
+#: ../../src/MaximaCommandMenus.cpp:722 ../../src/MaximaCommandMenus.cpp:732
+#: ../../src/MaximaCommandMenus.cpp:741 ../../src/MaximaCommandMenus.cpp:752
+#: ../../src/MaximaCommandMenus.cpp:764
 #, fuzzy
 msgid "Comma-separated expressions"
 msgstr "Kommaseparerte x-koordinater"
 
-#: ../../src/wxMaxima.cpp:7215
+#: ../../src/MaximaCommandMenus.cpp:4087
 #, fuzzy
 msgid "Comma-separated expressions that shall be converted to a string"
 msgstr "Kommaseparerte x-koordinater"
 
-#: ../../src/wxMaxima.cpp:7100 ../../src/wxMaxima.cpp:7114
+#: ../../src/MaximaCommandMenus.cpp:3972 ../../src/MaximaCommandMenus.cpp:3986
 #, fuzzy
 msgid "Comma-separated expressions."
 msgstr "Kommaseparerte x-koordinater"
 
-#: ../../src/wxMaxima.cpp:7073 ../../src/wxMaxima.cpp:7168
+#: ../../src/MaximaCommandMenus.cpp:3945 ../../src/MaximaCommandMenus.cpp:4040
 #, fuzzy
 msgid "Comma-separated function names"
 msgstr "Kommaseparerte x-koordinater"
 
-#: ../../src/wxMaxima.cpp:7086
+#: ../../src/MaximaCommandMenus.cpp:3958
 #, fuzzy
 msgid "Comma-separated function names."
 msgstr "Kommaseparerte x-koordinater"
 
-#: ../../src/wxMaxima.cpp:8560 ../../src/wxMaxima.cpp:8567
-#: ../../src/wxMaxima.cpp:8573 ../../src/wxMaxima.cpp:8580
+#: ../../src/MaximaCommandMenus.cpp:1576 ../../src/MaximaCommandMenus.cpp:1585
+#: ../../src/MaximaCommandMenus.cpp:1591 ../../src/MaximaCommandMenus.cpp:1598
 msgid "Comma-separated list entry in the format val1=1,val2=2"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7205
+#: ../../src/MaximaCommandMenus.cpp:4077
 msgid "Comma-separated names of the elements that shall be written"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7099
+#: ../../src/MaximaCommandMenus.cpp:3971
 msgid "Comma-separated names the parameters will be referenced by later."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7488 ../../src/wxMaxima.cpp:7493
+#: ../../src/MaximaCommandMenus.cpp:4360 ../../src/MaximaCommandMenus.cpp:4365
 #, fuzzy
 msgid "Comma-separated numbers from 0 to 255"
 msgstr "Kommaseparerte x-koordinater"
 
-#: ../../src/wxMaxima.cpp:8770
-msgid "Comma-separated numbers of the terms to substitute in"
-msgstr ""
-
-#: ../../src/wxMaxima.cpp:7137 ../../src/wxMaxima.cpp:7150
+#: ../../src/MaximaCommandMenus.cpp:4009 ../../src/MaximaCommandMenus.cpp:4022
 msgid "Comma-separated parameter names. A parameter in square brackets [] will be filled with the list of any additional arguments the function gets."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7054
+#: ../../src/MaximaCommandMenus.cpp:776
+msgid "Comma-separated part numbers selecting the subexpression to replace (as in part())"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:3926
 msgid "Comma-separated variable names, can be initialized by the \":\" operator."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7753 ../../src/wxMaxima.cpp:7767
-#: ../../src/wxMaxima.cpp:8719 ../../src/wxMaxima.cpp:8785
-#: ../../src/wxMaxima.cpp:10032
+#: ../../src/MaximaCommandMenus.cpp:711 ../../src/MaximaCommandMenus.cpp:792
+#: ../../src/MaximaCommandMenus.cpp:934 ../../src/MaximaCommandMenus.cpp:948
+#: ../../src/MaximaCommandMenus.cpp:3521
 msgid "Comma-separated variables"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:9469
+#: ../../src/wizards/GenWizPanel.cpp:226
+msgid "Command"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:2112
 msgid "Command:"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1692
+#: ../../src/dialogs/ConfigDialogue.cpp:1145
+msgid "Commands that are executed at every start of maxima."
+msgstr ""
+
+#: ../../src/cells/EditorCell.cpp:4538
+msgid "Comment (ordinary worksheet text that isn't fed to maxima)"
+msgstr ""
+
+#: ../../src/worksheet/WorksheetContextMenu.cpp:465
 msgid "Comment Selection"
 msgstr "Kommenter Utvalg"
 
-#: ../../src/wxMaximaFrame.cpp:681
+#: ../../src/wxMaximaFrame.cpp:718
 msgid "Comment out the currently selected text"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:680
+#: ../../src/wxMaximaFrame.cpp:717
 #, fuzzy
 msgid "Comment selection\tCtrl+/"
 msgstr "Kommenter Utvalg"
 
-#: ../../src/Worksheet.cpp:2004
+#: ../../src/worksheet/WorksheetContextMenu.cpp:776
 msgid "Commutative function"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1396
+#: ../../src/wxMaximaFrame.cpp:649
+msgid "Compare files..."
+msgstr ""
+
+#: ../../src/main.cpp:723
+msgid "Comparing worksheets (the --diff option or the wxmxdiff command) needs 2 or 3 files to compare."
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1430
 msgid "Compile a QR decomposition using dgeqrf"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7162
+#: ../../src/MaximaCommandMenus.cpp:4034
 #, fuzzy
 msgid "Compile a function"
 msgstr "Slett en funksjon"
 
-#: ../../src/wxMaximaFrame.cpp:1188
+#: ../../src/wxMaximaFrame.cpp:1222
 #, fuzzy
 msgid "Compile a regular expression"
 msgstr "Slett en funksjon"
 
-#: ../../src/wxMaximaFrame.cpp:1385
+#: ../../src/wxMaximaFrame.cpp:1419
 msgid "Compile eigenvalues using dgeev"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1388
+#: ../../src/wxMaximaFrame.cpp:1422
 msgid "Compile eigenvalues using zgeev"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1391
+#: ../../src/wxMaximaFrame.cpp:1425
 msgid "Compile eigenvalues+eigenvectors using dgeev"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1394
+#: ../../src/wxMaximaFrame.cpp:1428
 msgid "Compile eigenvalues+eigenvectors using zgeev"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1076
+#: ../../src/wxMaximaFrame.cpp:1110
 #, fuzzy
 msgid "Compile function..."
 msgstr "&Slett Funksjon..."
 
-#: ../../src/wxMaxima.cpp:7511
+#: ../../src/MaximaCommandMenus.cpp:4383
 #, fuzzy
 msgid "Compile regex"
 msgstr "Fullfør ord"
@@ -1502,1783 +2422,2417 @@ msgstr "Fullfør ord"
 msgid "Compiler-Bug? wxMathml.lisp is shorter than expected!"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2234
+#: ../../src/MaximaOutputAppender.cpp:286
 #, c-format
 msgid "Compiling %s"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7163
+#: ../../src/MaximaCommandMenus.cpp:4035
 msgid "Compiling a function can generate a considerable speed boost if the types of the function parameters are made known to the function before it is compiled. Else the generated code has to be hideously generic."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:892
+#: ../../src/wxMaximaFrame.cpp:926
 #, fuzzy
 msgid "Complete Word\tCtrl+Space"
 msgstr "Fullfør Ord\tCtrl+K"
 
-#: ../../src/wxMaximaFrame.cpp:893
+#: ../../src/wxMaximaFrame.cpp:927
 msgid "Complete word"
 msgstr "Fullfør ord"
 
-#: ../../src/ToolBar.cpp:230
+#: ../../src/ToolBar.cpp:412 ../../src/ToolBar.cpp:418
 msgid "Completely stop maxima and restart it"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1503
+#: ../../src/cells/TextCell.cpp:192
+#, fuzzy
+msgid "Complex infinity."
+msgstr "&Kompleks Forenkling"
+
+#: ../../src/graphical_io/Printout.cpp:184
+msgid "Composing a list of the line starts we can use as page starts"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1540
 msgid "Compute continued fraction of a value"
 msgstr "Utarbeid kjedebrøk av en verdi"
 
 # jeg har ikke jobbet med disse, endre til et bedre uttrykk om du vet bedre :)
-#: ../../src/wxMaximaFrame.cpp:1372
+#: ../../src/wxMaximaFrame.cpp:1406
 msgid "Compute the adjoint matrix"
 msgstr "Utarbeid konjugert-transponert matrise"
 
-#: ../../src/wxMaximaFrame.cpp:1359
+#: ../../src/wxMaximaFrame.cpp:1393
 msgid "Compute the characteristic polynomial of a matrix"
 msgstr "Utarbeid det karakteristiske polynomet til en matrise"
 
-#: ../../src/wxMaximaFrame.cpp:1363
+#: ../../src/wxMaximaFrame.cpp:1397
 msgid "Compute the determinant of a matrix"
 msgstr "Utarbeid determinanten til en matrise"
 
-#: ../../src/wxMaximaFrame.cpp:1491
+#: ../../src/wxMaximaFrame.cpp:1528
 msgid "Compute the greatest common divisor"
 msgstr "Utarbeid største felles divisor"
 
-#: ../../src/wxMaximaFrame.cpp:1356
+#: ../../src/wxMaximaFrame.cpp:1390
 msgid "Compute the inverse of a matrix"
 msgstr "Utarbeid inversen til en matrise"
 
-#: ../../src/wxMaximaFrame.cpp:1494
+#: ../../src/wxMaximaFrame.cpp:1531
 msgid "Compute the least common multiple (do load(functs) before using)"
 msgstr "Utarbeid minste felles multiplum (kjør load(functs) før bruk)"
 
-#: ../../src/wxMaximaFrame.cpp:1374
+#: ../../src/wxMaximaFrame.cpp:1408
 #, fuzzy
 msgid "Compute the rank of a matrix"
 msgstr "Utarbeid determinanten til en matrise"
 
-#: ../../src/wxMaxima.cpp:9629
+#: ../../src/MaximaCommandMenus.cpp:1869
 msgid "Condition:"
 msgstr "Betingelse:"
 
-#: ../../src/ToolBar.cpp:200 ../../src/wxMaximaFrame.cpp:685
-#: ../../src/wxMaximaFrame.cpp:687
+#: ../../src/dialogs/ConfigDialogue.cpp:2479
+#: ../../src/dialogs/ConfigDialogue.cpp:2489
+#: ../../src/dialogs/ConfigDialogue.cpp:2641
+#: ../../src/dialogs/ConfigDialogue.cpp:2647
+msgid "Config file (*.ini)|*.ini"
+msgstr "Konfigurasjonsfil (*.ini)|*.ini"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:2539
+#, c-format
+msgid "Config item \"%s\" was of an unknown type"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:2607
+msgid "Configuration warning"
+msgstr ""
+
+#: ../../src/ToolBar.cpp:367 ../../src/ToolBar.cpp:369
+#: ../../src/wxMaximaFrame.cpp:722 ../../src/wxMaximaFrame.cpp:724
 msgid "Configure wxMaxima"
 msgstr "Konfigurer wxMaxima"
 
-#: ../../src/wxMaxima.cpp:2504
+#: ../../src/wizards/DrawWiz.cpp:829
+msgid "Connect the dots"
+msgstr ""
+
+#: ../../src/MaximaProcessManager.cpp:165
 msgid "Connection attempt, but connection failed."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2459
+#: ../../src/MaximaProcessManager.cpp:792
 msgid "Connection to Maxima lost."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7921
+#: ../../src/wizards/IntegrateWiz.cpp:193
+#: ../../src/wizards/IntegrateWiz.cpp:208 ../../src/wizards/LimitWiz.cpp:133
+#: ../../src/wizards/SeriesWiz.cpp:105
+msgid "Constant"
+msgstr "Konstant"
+
+#: ../../src/MaximaCommandMenus.cpp:1102
 #, fuzzy
 msgid "Construct a fraction"
 msgstr "K&jedebrøk"
 
-#: ../../src/wxMaximaFrame.cpp:1305
+#: ../../src/wxMaximaFrame.cpp:1339
 #, fuzzy
 msgid "Construct fraction..."
 msgstr "K&jedebrøk"
 
-#: ../../src/wxMaxima.cpp:7158
+#: ../../src/sidebars/VariablesPane.cpp:58
+msgid "Contents"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:4030
 #, fuzzy
 msgid "Contents:"
 msgstr "Greske konstanter"
 
-#: ../../src/wxMaximaFrame.cpp:1877
+#: ../../src/wxMaximaFrame.cpp:1914
 msgid "Context-sensitive &Help\tCtrl+?"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1879
+#: ../../src/wxMaximaFrame.cpp:1916
 msgid "Context-sensitive &Help\tF1"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1542
+#: ../../src/sidebars/DrawSidebar.cpp:80
+msgid "Contour"
+msgstr ""
+
+#: ../../src/sidebars/DrawSidebar.cpp:101
+msgid "Contour lines for 3d plots"
+msgstr ""
+
+#: ../../src/wizards/DrawWiz.cpp:648
+msgid "Contour lines on surface and Bottom"
+msgstr ""
+
+#: ../../src/wizards/DrawWiz.cpp:644
+msgid "Contour lines on the Bottom"
+msgstr ""
+
+#: ../../src/wizards/DrawWiz.cpp:641
+msgid "Contour lines on the Surface"
+msgstr ""
+
+#: ../../src/wizards/DrawWiz.cpp:629
+msgid "Contour lines settings for the following 3d plots"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1579
 msgid "Contract Logarithms"
 msgstr "Trekk &Sammen Logaritmer"
 
-#: ../../src/wxMaximaFrame.cpp:1161
+#: ../../src/wxMaximaFrame.cpp:1195
 #, fuzzy
 msgid "Conversions"
 msgstr "Omgjør til &Rektangulær Form"
 
-#: ../../src/wxMaximaFrame.cpp:1229
+#: ../../src/wxMaximaFrame.cpp:1263
 #, fuzzy
 msgid "Convert"
 msgstr "Omgjør til &Rektangulær Form"
 
-#: ../../src/wxMaximaFrame.cpp:1230
+#: ../../src/wxMaximaFrame.cpp:1264
 #, fuzzy
 msgid "Convert + Write to file"
 msgstr "Omgjør til &Fakulteter"
 
-#: ../../src/wxMaximaFrame.cpp:1434
+#: ../../src/wxMaximaFrame.cpp:1471
 #, fuzzy
 msgid "Convert Column to list..."
 msgstr "Omgjør til &Fakulteter"
 
-#: ../../src/wxMaximaFrame.cpp:1430
+#: ../../src/wxMaximaFrame.cpp:1467
 #, fuzzy
 msgid "Convert Row to list..."
 msgstr "Omgjør til &Fakulteter"
 
-#: ../../src/wxMaximaFrame.cpp:1044
+#: ../../src/wxMaximaFrame.cpp:1078
 msgid "Convert a command to maxima code"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1321
+#: ../../src/wxMaximaFrame.cpp:1355
 msgid "Convert a list of lists to a matrix"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1574
+#: ../../src/wxMaximaFrame.cpp:1611
 msgid "Convert binomials, beta and gamma function to factorials"
 msgstr "Omgjør binomial, beta- og gammafunksjoner til fakulteter"
 
-#: ../../src/wxMaximaFrame.cpp:1578
+#: ../../src/wxMaximaFrame.cpp:1615
 msgid "Convert binomials, factorials and beta function to gamma function"
 msgstr "Omgjør binomial, beta- og gammafunksjoner til gammafunksjon"
 
-#: ../../src/wxMaximaFrame.cpp:1613
+#: ../../src/wxMaximaFrame.cpp:1650
 msgid "Convert complex expression to polar form"
 msgstr "Omgjør komplekst uttrykk til polar form"
 
-#: ../../src/wxMaximaFrame.cpp:1610
+#: ../../src/wxMaximaFrame.cpp:1647
 msgid "Convert complex expression to rect form"
 msgstr "Omgjør komplekst uttrykk til rektangulær form"
 
-#: ../../src/wxMaximaFrame.cpp:1622
+#: ../../src/wxMaximaFrame.cpp:1659
 msgid "Convert exponential function of imaginary argument to trigonometric form"
 msgstr "Omgjør eksponentiell funksjon av imaginært argument til trigonometrisk form"
 
-#: ../../src/wxMaxima.cpp:7411
+#: ../../src/MaximaCommandMenus.cpp:4283
 #, fuzzy
 msgid "Convert string to lowercase"
 msgstr "Omgjør til &Fakulteter"
 
-#: ../../src/wxMaxima.cpp:7543
+#: ../../src/MaximaCommandMenus.cpp:4415
 #, fuzzy
 msgid "Convert string to matching regex"
 msgstr "Omgjør til &Gamma"
 
-#: ../../src/wxMaximaFrame.cpp:1543
+#: ../../src/wxMaximaFrame.cpp:1580
 msgid "Convert sum of logarithms to logarithm of product"
 msgstr "Omgjør sum av logaritmer til logaritme av produkt"
 
-#: ../../src/wxMaximaFrame.cpp:1573
+#: ../../src/wxMaximaFrame.cpp:1610
 msgid "Convert to &Factorials"
 msgstr "Omgjør til &Fakulteter"
 
-#: ../../src/wxMaximaFrame.cpp:1577
+#: ../../src/wxMaximaFrame.cpp:1614
 msgid "Convert to &Gamma"
 msgstr "Omgjør til &Gamma"
 
-#: ../../src/wxMaximaFrame.cpp:1612
+#: ../../src/wxMaximaFrame.cpp:1649
 msgid "Convert to &Polarform"
 msgstr "Omgjør til &Polar Form"
 
-#: ../../src/wxMaximaFrame.cpp:1609
+#: ../../src/wxMaximaFrame.cpp:1646
 msgid "Convert to &Rectform"
 msgstr "Omgjør til &Rektangulær Form"
 
-#: ../../src/wxMaximaFrame.cpp:1166
+#: ../../src/sidebars/TableOfContents.cpp:522
+#: ../../src/sidebars/TableOfContents.cpp:543
+#, fuzzy
+msgid "Convert to Heading 5"
+msgstr "Omgjør til &Gamma"
+
+#: ../../src/sidebars/TableOfContents.cpp:519
+#, fuzzy
+msgid "Convert to Heading 6"
+msgstr "Omgjør til &Gamma"
+
+#: ../../src/sidebars/TableOfContents.cpp:531
+#: ../../src/sidebars/TableOfContents.cpp:552
+#, fuzzy
+msgid "Convert to Section"
+msgstr "Omgjør til &Rektangulær Form"
+
+#: ../../src/sidebars/TableOfContents.cpp:525
+#: ../../src/sidebars/TableOfContents.cpp:546
+#, fuzzy
+msgid "Convert to Sub-Subsection"
+msgstr "Sett Inn Underseksjoncelle"
+
+#: ../../src/sidebars/TableOfContents.cpp:528
+#: ../../src/sidebars/TableOfContents.cpp:549
+#, fuzzy
+msgid "Convert to Subsection"
+msgstr "Omgjør til &Rektangulær Form"
+
+#: ../../src/sidebars/TableOfContents.cpp:555
+#, fuzzy
+msgid "Convert to Title"
+msgstr "Omgjør til &Fakulteter"
+
+#: ../../src/wxMaximaFrame.cpp:1200
 #, fuzzy
 msgid "Convert to downcase..."
 msgstr "Omgjør til &Fakulteter"
 
-#: ../../src/wxMaxima.cpp:7016
+#: ../../src/MaximaCommandMenus.cpp:3888
 #, fuzzy
 msgid "Convert to programming language"
 msgstr "Omgjør til &Gamma"
 
-#: ../../src/wxMaxima.cpp:7022
+#: ../../src/MaximaCommandMenus.cpp:3894
 msgid "Convert to programming language file"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1602
+#: ../../src/wxMaximaFrame.cpp:1639
 msgid "Convert trigonometric expression to canonical quasilinear form"
 msgstr "Omgjør trigonometrisk uttrykk til kanonisk kvasilineær form"
 
-#: ../../src/wxMaximaFrame.cpp:1627
+#: ../../src/wxMaximaFrame.cpp:1664
 msgid "Convert trigonometric functions to exponential form"
 msgstr "Omgjør trigonometrisk funksjon til eksponentiell form"
 
-#: ../../src/wxMaximaFrame.cpp:1762
+#: ../../src/sidebars/PerformanceSidebar.cpp:46
+msgid "Converted to 2D:"
+msgstr ""
+
+#: ../../src/sidebars/PerformanceSidebar.cpp:45
+msgid "Converted to linear:"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1799
 msgid "Converts a matrix to a list of lists"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1760
+#: ../../src/wxMaximaFrame.cpp:1797
 msgid "Converts a nested list like [[1,2],[3,4]] to a matrix"
 msgstr ""
 
-#: ../../src/ToolBar.cpp:209 ../../src/Worksheet.cpp:1290
-#: ../../src/Worksheet.cpp:1359 ../../src/Worksheet.cpp:1498
-#: ../../src/Worksheet.cpp:1684
+#: ../../src/ToolBar.cpp:380 ../../src/ToolBar.cpp:384
+#: ../../src/dialogs/ConfigDialogue.cpp:285
+#: ../../src/worksheet/WorksheetContextMenu.cpp:48
+#: ../../src/worksheet/WorksheetContextMenu.cpp:122
+#: ../../src/worksheet/WorksheetContextMenu.cpp:269
+#: ../../src/worksheet/WorksheetContextMenu.cpp:457
 msgid "Copy"
 msgstr "Kopier"
 
-#: ../../src/Worksheet.cpp:1296 ../../src/Worksheet.cpp:1375
-#: ../../src/Worksheet.cpp:1514
+#: ../../src/worksheet/WorksheetContextMenu.cpp:58
+#: ../../src/worksheet/WorksheetContextMenu.cpp:140
+#: ../../src/worksheet/WorksheetContextMenu.cpp:287
 #, fuzzy
 msgid "Copy Animation"
 msgstr "Stopp animasjon"
 
-#: ../../src/wxMaximaFrame.cpp:887
+#: ../../src/wxMaximaFrame.cpp:921
 msgid "Copy Previous Input\tCtrl+I"
 msgstr "Kopier Forrige Inndata\tCtrl+I"
 
-#: ../../src/wxMaximaFrame.cpp:890
+#: ../../src/wxMaximaFrame.cpp:924
 msgid "Copy Previous Output\tCtrl+U"
 msgstr "Kopier Forrige Utdata\tCtrl+U"
 
-#: ../../src/wxMaxima.cpp:7992
+#: ../../src/MaximaCommandMenus.cpp:1176
 #, fuzzy
 msgid "Copy a matrix"
 msgstr "Kopier som Bilde"
 
-#: ../../src/Worksheet.cpp:1380 ../../src/Worksheet.cpp:1519
-#: ../../src/wxMaximaFrame.cpp:663
+#: ../../src/worksheet/WorksheetContextMenu.cpp:145
+#: ../../src/worksheet/WorksheetContextMenu.cpp:292
+#: ../../src/wxMaximaFrame.cpp:700
 msgid "Copy as EMF"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1370 ../../src/Worksheet.cpp:1509
-#: ../../src/wxMaximaFrame.cpp:652
+#: ../../src/worksheet/WorksheetContextMenu.cpp:135
+#: ../../src/worksheet/WorksheetContextMenu.cpp:282
+#: ../../src/wxMaximaFrame.cpp:689
 msgid "Copy as Image"
 msgstr "Kopier som Bilde"
 
-#: ../../src/Worksheet.cpp:1362 ../../src/Worksheet.cpp:1501
-#: ../../src/wxMaximaFrame.cpp:645
+#: ../../src/worksheet/WorksheetContextMenu.cpp:126
+#: ../../src/worksheet/WorksheetContextMenu.cpp:273
+#: ../../src/wxMaximaFrame.cpp:682
 msgid "Copy as LaTeX"
 msgstr "Kopier som LaTe&X"
 
-#: ../../src/wxMaximaFrame.cpp:648
+#: ../../src/wxMaximaFrame.cpp:685
 #, fuzzy
 msgid "Copy as MathML"
 msgstr "Kopier som Bilde"
 
-#: ../../src/Worksheet.cpp:1368 ../../src/Worksheet.cpp:1506
+#: ../../src/worksheet/WorksheetContextMenu.cpp:133
+#: ../../src/worksheet/WorksheetContextMenu.cpp:279
 msgid "Copy as MathML (e.g. to word processor)"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1383 ../../src/Worksheet.cpp:1522
-#: ../../src/wxMaximaFrame.cpp:658
+#: ../../src/worksheet/WorksheetContextMenu.cpp:148
+#: ../../src/worksheet/WorksheetContextMenu.cpp:295
+#: ../../src/wxMaximaFrame.cpp:695
 #, fuzzy
 msgid "Copy as RTF"
 msgstr "Kopier som LaTe&X"
 
-#: ../../src/Worksheet.cpp:1377 ../../src/Worksheet.cpp:1516
-#: ../../src/wxMaximaFrame.cpp:655
+#: ../../src/worksheet/WorksheetContextMenu.cpp:142
+#: ../../src/worksheet/WorksheetContextMenu.cpp:289
+#: ../../src/wxMaximaFrame.cpp:692
 #, fuzzy
 msgid "Copy as SVG"
 msgstr "Kopier som LaTe&X"
 
-#: ../../src/wxMaximaFrame.cpp:640
+#: ../../src/wxMaximaFrame.cpp:677
 msgid "Copy as Text\tCtrl+Shift+C"
 msgstr "Kopier som &Tekst\tCtrl+Shift+C"
 
-#: ../../src/Worksheet.cpp:1364 ../../src/Worksheet.cpp:1503
+#: ../../src/worksheet/WorksheetContextMenu.cpp:128
+#: ../../src/worksheet/WorksheetContextMenu.cpp:275
 #, fuzzy
 msgid "Copy as plain text"
 msgstr "Kopier som Bilde"
 
-#: ../../src/wxMaxima.cpp:7576
+#: ../../src/MaximaCommandMenus.cpp:4448
 #, fuzzy
 msgid "Copy file"
 msgstr "Kopier"
 
-#: ../../src/wxMaximaFrame.cpp:1214
+#: ../../src/wxMaximaFrame.cpp:1248
 #, fuzzy
 msgid "Copy file..."
 msgstr "Løs..."
 
-#: ../../src/Worksheet.cpp:1360 ../../src/Worksheet.cpp:1499
-#: ../../src/wxMaximaFrame.cpp:643
+#: ../../src/worksheet/WorksheetContextMenu.cpp:124
+#: ../../src/worksheet/WorksheetContextMenu.cpp:271
+#: ../../src/wxMaximaFrame.cpp:680
 msgid "Copy for Octave/Matlab"
 msgstr ""
 
-#: ../../src/ToolBar.cpp:209 ../../src/wxMaximaFrame.cpp:638
+#: ../../src/worksheet/WorksheetContextMenu.cpp:49
+#: ../../src/worksheet/WorksheetContextMenu.cpp:105
+#: ../../src/worksheet/WorksheetContextMenu.cpp:123
+#: ../../src/worksheet/WorksheetContextMenu.cpp:270
+msgid "Copy position (UUID)"
+msgstr ""
+
+#: ../../src/ToolBar.cpp:380 ../../src/ToolBar.cpp:384
+#: ../../src/wxMaximaFrame.cpp:675
 msgid "Copy selection"
 msgstr "Kopier utvalg"
 
-#: ../../src/wxMaximaFrame.cpp:664
+#: ../../src/wxMaximaFrame.cpp:701
 msgid "Copy selection from document as an Enhanced Metafile"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:656
+#: ../../src/wxMaximaFrame.cpp:693
 #, fuzzy
 msgid "Copy selection from document as an SVG image"
 msgstr "Kopier utvalg fra dokument som et bilde"
 
-#: ../../src/wxMaximaFrame.cpp:653
+#: ../../src/wxMaximaFrame.cpp:690
 msgid "Copy selection from document as an image"
 msgstr "Kopier utvalg fra dokument som et bilde"
 
-#: ../../src/wxMaximaFrame.cpp:659
+#: ../../src/wxMaximaFrame.cpp:696
 #, fuzzy
 msgid "Copy selection from document as rtf that a word processor might understand"
 msgstr "Kopier utvalg fra dokument som et bilde"
 
-#: ../../src/wxMaximaFrame.cpp:641
+#: ../../src/wxMaximaFrame.cpp:678
 msgid "Copy selection from document as text"
 msgstr "Kopier utvalg fra dokument som tekst"
 
-#: ../../src/wxMaximaFrame.cpp:646
+#: ../../src/wxMaximaFrame.cpp:683
 msgid "Copy selection from document in LaTeX format"
 msgstr "Kopier utvalg fra dokument i LaTeX-format"
 
-#: ../../src/wxMaximaFrame.cpp:644
+#: ../../src/wxMaximaFrame.cpp:681
 msgid "Copy selection from document in Matlab format"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:649
+#: ../../src/wxMaximaFrame.cpp:686
 msgid "Copy selection from document in a MathML format many word processors can display as 2d equation"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7403
+#: ../../src/MaximaCommandMenus.cpp:4275
 #, fuzzy
 msgid "Copy string"
 msgstr "Kopier utvalg"
 
-#: ../../src/wxMaximaFrame.cpp:1165
+#: ../../src/wxMaximaFrame.cpp:1199
 #, fuzzy
 msgid "Copy string..."
 msgstr "Oppgi Matrise..."
 
-#: ../../src/ToolBar.cpp:623
+#: ../../src/ToolBar.cpp:823
 msgid "Copy, Cut and Paste button"
 msgstr ""
 
-#: ../../src/WXMXformat.cpp:295
+#: ../../src/dialogs/ConfigDialogue.cpp:2523
+#, c-format
+msgid "Copying config bool \"%s\""
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:2533
+#, c-format
+msgid "Copying config float \"%s\""
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:2528
+#, c-format
+msgid "Copying config int \"%s\""
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:2518
+#, c-format
+msgid "Copying config string \"%s\""
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:191
+msgid "Corsican"
+msgstr ""
+
+#: ../../src/WXMXformat.cpp:297
 msgid "Could not create the backup file during saving => aborting."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3294 ../../src/wxMaxima.cpp:3306
+#: ../../src/MaximaResponseReader.cpp:359
 msgid "Could not make sure that we talk to the maxima we started => discarding all data it sends."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2783
+#: ../../src/MaximaProcessManager.cpp:893
 msgid "Could not map view of the file needed in order to send an interrupt signal to maxima."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2763 ../../src/wxMaxima.cpp:2805
+#: ../../src/Image.cpp:1000
+msgid "Could not parse the SVG image data."
+msgstr ""
+
+#: ../../src/MaximaProcessManager.cpp:873
+#: ../../src/MaximaProcessManager.cpp:916
 msgid "Could not send an interrupt signal to maxima."
 msgstr ""
 
-#: ../../src/WXMXformat.cpp:287
+#: ../../src/WXMXformat.cpp:289
 msgid "Could not write the file's contents during saving => aborting."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1325
+#: ../../src/wxMaximaFrame.cpp:1359
 #, fuzzy
 msgid "Create Matrix"
 msgstr "Generer Matrise"
 
-#: ../../src/wxMaximaFrame.cpp:1688
+#: ../../src/wxMaximaFrame.cpp:1725
 #, fuzzy
 msgid "Create a list"
 msgstr "Lag liste"
 
-#: ../../src/wxMaxima.cpp:8487
+#: ../../src/MaximaCommandMenus.cpp:1491
 msgid "Create a list as a storage for the values of variables"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8463 ../../src/wxMaxima.cpp:8476
+#: ../../src/MaximaCommandMenus.cpp:1479
+msgid "Create a list from a list"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:1466
 #, fuzzy
 msgid "Create a list from a rule"
 msgstr "Lag liste fra uttrykk"
 
-#: ../../src/wxMaximaFrame.cpp:1670
+#: ../../src/wxMaximaFrame.cpp:1707
 msgid "Create a list from comma-separated elements"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:888
+#: ../../src/wxMaximaFrame.cpp:922
 msgid "Create a new cell with previous input"
 msgstr "Lag en ny celle med forrige inndata"
 
-#: ../../src/wxMaximaFrame.cpp:891
+#: ../../src/wxMaximaFrame.cpp:925
 msgid "Create a new cell with previous output"
 msgstr "Lag en ny celle med forrige utdata"
 
-#: ../../src/wxMaximaFrame.cpp:1348
+#: ../../src/wxMaximaFrame.cpp:1382
 msgid "Create copy, not clone..."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7561
+#: ../../src/MaximaCommandMenus.cpp:4433
 #, fuzzy
 msgid "Create directory"
 msgstr "Lag liste"
 
-#: ../../src/wxMaximaFrame.cpp:1203
+#: ../../src/wxMaximaFrame.cpp:1237
 #, fuzzy
 msgid "Create directory..."
 msgstr "Lag liste"
 
-#: ../../src/wxMaxima.cpp:7419
+#: ../../src/MaximaCommandMenus.cpp:4291
 #, fuzzy
 msgid "Create empty string"
 msgstr "Generer Matrise"
 
-#: ../../src/wxMaximaFrame.cpp:1168
+#: ../../src/wxMaximaFrame.cpp:1202
 #, fuzzy
 msgid "Create empty string..."
 msgstr "Lag liste"
 
-#: ../../src/wxMaximaFrame.cpp:1687
+#: ../../src/wxMaximaFrame.cpp:1724
 #, fuzzy
 msgid "Create list"
 msgstr "Lag liste"
 
-#: ../../src/wxMaxima.cpp:8457
+#: ../../src/MaximaCommandMenus.cpp:1460
 msgid "Create list from comma-separated elements"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1082
+#: ../../src/dialogs/ConfigDialogue.cpp:1389
+msgid "Create scalable plots."
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1116
 #, fuzzy
 msgid "Create struct..."
 msgstr "Lag liste"
 
-#: ../../src/WXMXformat.cpp:80
+#: ../../src/WXMXformat.cpp:81
 msgid "Created a .zip archive (the .wxmx file technically is a .zip file)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1349
+#: ../../src/wxMaximaFrame.cpp:1383
 msgid "Creates an independent matrix with the same contents"
 msgstr ""
 
-#: ../../src/Configuration.cpp:97
+#: ../../src/dialogs/ConfigDialogue.cpp:192
+msgid "Croatian"
+msgstr ""
+
+#: ../../src/wizards/CsvWiz.cpp:93 ../../src/wizards/CsvWiz.cpp:167
+msgid "Csv files (*.csv)|*.csv|Text files (*.txt)|*.txt|All|*"
+msgstr ""
+
+#: ../../src/worksheet/Worksheet.cpp:6125
+msgid "Cursor"
+msgstr "Peker"
+
+#: ../../src/Styles.cpp:126
 #, fuzzy
 msgid "Cursor color"
 msgstr "Peker"
 
-#: ../../src/ToolBar.cpp:208 ../../src/Worksheet.cpp:1683
+#: ../../src/ToolBar.cpp:379 ../../src/ToolBar.cpp:383
+#: ../../src/worksheet/WorksheetContextMenu.cpp:456
 msgid "Cut"
 msgstr "Klipp Ut"
 
-#: ../../src/wxMaximaFrame.cpp:636
+#: ../../src/wxMaximaFrame.cpp:673
 msgid "Cut\tCtrl+X"
 msgstr "Klipp Ut\tCtrl+X"
 
-#: ../../src/ToolBar.cpp:208 ../../src/wxMaximaFrame.cpp:636
+#: ../../src/ToolBar.cpp:379 ../../src/ToolBar.cpp:383
+#: ../../src/wxMaximaFrame.cpp:673
 msgid "Cut selection"
 msgstr "Klipp Ut Utvalg"
 
-#: ../../src/wxMaxima.cpp:9589 ../../src/wxMaxima.cpp:9629
+#: ../../src/dialogs/ConfigDialogue.cpp:193
+msgid "Czech"
+msgstr "Tsjekkisk"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:194
+msgid "Danish"
+msgstr "Dansk"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:2069
+msgid "Dark"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:1829 ../../src/MaximaCommandMenus.cpp:1869
 msgid "Data Matrix:"
 msgstr "Datamatrise:"
 
-#: ../../src/wxMaxima.cpp:9599
+#: ../../src/MaximaCommandMenus.cpp:1839
 msgid "Data file (*.csv, *.tab, *.txt)|*.csv;*.tab;*.txt"
 msgstr "Datafil (*.csv, *.tab, *.txt)|*.csv;*.tab;*.txt"
 
-#: ../../src/wxMaxima.cpp:9529 ../../src/wxMaxima.cpp:9534
-#: ../../src/wxMaxima.cpp:9539 ../../src/wxMaxima.cpp:9543
-#: ../../src/wxMaxima.cpp:9547 ../../src/wxMaxima.cpp:9551
-#: ../../src/wxMaxima.cpp:9555 ../../src/wxMaxima.cpp:9559
-#: ../../src/wxMaxima.cpp:9563 ../../src/wxMaxima.cpp:9577
-#: ../../src/wxMaxima.cpp:9582 ../../src/wxMaxima.cpp:10030
+#: ../../src/wizards/DrawWiz.cpp:810
+#, fuzzy
+msgid "Data format"
+msgstr "Plottformat"
+
+#: ../../src/MaximaCommandMenus.cpp:1767 ../../src/MaximaCommandMenus.cpp:1772
+#: ../../src/MaximaCommandMenus.cpp:1777 ../../src/MaximaCommandMenus.cpp:1781
+#: ../../src/MaximaCommandMenus.cpp:1785 ../../src/MaximaCommandMenus.cpp:1789
+#: ../../src/MaximaCommandMenus.cpp:1793 ../../src/MaximaCommandMenus.cpp:1797
+#: ../../src/MaximaCommandMenus.cpp:1801 ../../src/MaximaCommandMenus.cpp:1815
+#: ../../src/MaximaCommandMenus.cpp:1822 ../../src/MaximaCommandMenus.cpp:3519
 msgid "Data:"
 msgstr "Data:"
 
-#: ../../src/wxMaximaFrame.cpp:1057
+#: ../../src/wxMaximaFrame.cpp:1091
 msgid "Debugger trigger"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:779
+#: ../../src/wxMaximaFrame.cpp:816
 msgid "Declare Text to always be displayed as subscript"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7069
+#: ../../src/MaximaCommandMenus.cpp:3941
 msgid "Declare a function local to a Program"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:6539
+#: ../../src/MaximaCommandMenus.cpp:3059
 msgid "Declare a text snippet to always be displayed as subscript"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:2044
+#: ../../src/worksheet/WorksheetContextMenu.cpp:816
 #, c-format
 msgid "Declare facts about %s"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8800
+#: ../../src/MaximaCommandMenus.cpp:807
 #, fuzzy
 msgid "Declare main variable:"
 msgstr "Slett en variabel"
 
-#: ../../src/wxMaxima.cpp:7171
+#: ../../src/MaximaCommandMenus.cpp:4043
 msgid "Declare the type of a function parameter"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:2038
+#: ../../src/worksheet/WorksheetContextMenu.cpp:810
 msgid "Declare these chars as ordinary letters"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1500 ../../src/wxMaximaFrame.cpp:1536
+#: ../../src/wxMaximaFrame.cpp:1537 ../../src/wxMaximaFrame.cpp:1573
 msgid "Decompose rational function to partial fractions"
 msgstr "Utvid rasjonelle funksjoner til delvise brøker"
 
-#: ../../src/Worksheet.cpp:2010
+#: ../../src/worksheet/WorksheetContextMenu.cpp:782
 #, fuzzy
 msgid "Decreasing function f(x)<x"
 msgstr "Slett funksjoner:"
 
-#: ../../src/wxMaxima.cpp:7134
+#: ../../src/dialogs/ConfigDialogue.cpp:1336
+msgid "Default animation framerate:"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:717
+msgid "Default plot size for new maxima sessions:"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1534
+#, fuzzy
+msgid "Default port for communication with wxMaxima:"
+msgstr "Forhåndsvalgt port til kommunikasjon mellom Maxima og wxMaxima."
+
+#: ../../src/MaximaCommandMenus.cpp:4006
 #, fuzzy
 msgid "Define a function"
 msgstr "Slett en funksjon"
 
-#: ../../src/wxMaxima.cpp:7147
+#: ../../src/MaximaCommandMenus.cpp:4019
 msgid "Define a macro"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7189
+#: ../../src/MaximaCommandMenus.cpp:4061
 msgid "Define a structure"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7183
+#: ../../src/MaximaCommandMenus.cpp:4055
 msgid "Define a structure type"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7156
+#: ../../src/MaximaCommandMenus.cpp:4028
 #, fuzzy
 msgid "Define a variable"
 msgstr "Slett en variabel"
 
-#: ../../src/wxMaximaFrame.cpp:1072
+#: ../../src/wxMaximaFrame.cpp:1106
 #, fuzzy
 msgid "Define function..."
 msgstr "&Slett Funksjon..."
 
-#: ../../src/wxMaximaFrame.cpp:1079
+#: ../../src/wxMaximaFrame.cpp:1113
 msgid "Define macro..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1077
+#: ../../src/wxMaximaFrame.cpp:1111
 msgid "Define parameter type..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1081
+#: ../../src/wxMaximaFrame.cpp:1115
 msgid "Define struct..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1080
+#: ../../src/dialogs/ConfigDialogue.cpp:404
+msgid "Define the default speed (in frames per second) animations are played back with."
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1114
 #, fuzzy
 msgid "Define variable..."
 msgstr "Slett en variabel"
 
-#: ../../src/wxMaximaFrame.cpp:1776
+#: ../../src/wxMaximaFrame.cpp:1813
 msgid "Defines if an animation is automatically started or only by clicking on it."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8935
+#: ../../src/MaximaCommandMenus.cpp:186
 msgid "Degree:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:985
+#: ../../src/wxMaximaFrame.cpp:1019
 msgid "Delete F&unction..."
 msgstr "&Slett Funksjon..."
 
-#: ../../src/Worksheet.cpp:1386 ../../src/Worksheet.cpp:1525
+#: ../../src/worksheet/WorksheetContextMenu.cpp:157
+#: ../../src/worksheet/WorksheetContextMenu.cpp:298
 msgid "Delete Selection"
 msgstr "Slett Utvalg"
 
-#: ../../src/wxMaximaFrame.cpp:987
+#: ../../src/wxMaximaFrame.cpp:1021
 msgid "Delete V&ariable..."
 msgstr "&Slett Variabel..."
 
-#: ../../src/wxMaximaFrame.cpp:986
+#: ../../src/wxMaximaFrame.cpp:1020
 msgid "Delete a function"
 msgstr "Slett en funksjon"
 
-#: ../../src/wxMaximaFrame.cpp:988
+#: ../../src/wxMaximaFrame.cpp:1022
 msgid "Delete a variable"
 msgstr "Slett en variabel"
 
-#: ../../src/wxMaximaFrame.cpp:982
+#: ../../src/wxMaximaFrame.cpp:1016
 msgid "Delete all objects with a given name"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:991
+#: ../../src/wxMaximaFrame.cpp:1025
 msgid "Delete all values from memory"
 msgstr "Slett alle verdier fra minnet"
 
-#: ../../src/wxMaxima.cpp:7588
+#: ../../src/MaximaCommandMenus.cpp:4460
 #, fuzzy
 msgid "Delete file"
 msgstr "Slett en variabel"
 
-#: ../../src/wxMaximaFrame.cpp:1216
+#: ../../src/wxMaximaFrame.cpp:1250
 #, fuzzy
 msgid "Delete file..."
 msgstr "&Slett Variabel..."
 
-#: ../../src/wxMaxima.cpp:7683
+#: ../../src/MaximaCommandMenus.cpp:4555
 #, fuzzy
 msgid "Delete function(s)"
 msgstr "Slett funksjoner:"
 
-#: ../../src/wxMaxima.cpp:7679
+#: ../../src/MaximaCommandMenus.cpp:4551
 #, fuzzy
 msgid "Delete named object(s)"
 msgstr "Slett funksjoner:"
 
-#: ../../src/wxMaximaFrame.cpp:981
+#: ../../src/wxMaximaFrame.cpp:1015
 #, fuzzy
 msgid "Delete named object..."
 msgstr "&Slett Funksjon..."
 
-#: ../../src/wxMaxima.cpp:7674
+#: ../../src/MaximaCommandMenus.cpp:4546
 #, fuzzy
 msgid "Delete variable(s)"
 msgstr "Slett variabler:"
 
-#: ../../src/wxMaxima.cpp:7430
+#: ../../src/MaximaCommandMenus.cpp:4302
 #, fuzzy
 msgid "Delimiter:"
 msgstr "Eliminer"
 
-#: ../../src/Worksheet.cpp:1347 ../../src/Worksheet.cpp:1785
+#: ../../src/sidebars/GreekSidebar.cpp:181
+msgid "Delta"
+msgstr ""
+
+#: ../../src/worksheet/WorksheetContextMenu.cpp:110
+#: ../../src/worksheet/WorksheetContextMenu.cpp:558
 #, c-format
 msgid "Demo for \"%s\""
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1930
+#: ../../src/wxMaximaFrame.cpp:1967
 msgid "Demos"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8927
+#: ../../src/MaximaCommandMenus.cpp:178
 msgid "Denom. deg:"
 msgstr "Nevnergrad:"
 
-#: ../../src/wxMaxima.cpp:7923
+#: ../../src/MaximaCommandMenus.cpp:1104
 msgid "Denominator:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1030
+#: ../../src/wxMaximaFrame.cpp:1064
 msgid "Dependencies"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7813
+#: ../../src/wizards/SeriesWiz.cpp:42
+msgid "Depth:"
+msgstr "Dybde:"
+
+#: ../../src/MaximaCommandMenus.cpp:994
 msgid "Derivate of y at that point:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1497
+#: ../../src/wizards/ListSortWiz.cpp:56
+msgid "Descending by magnitude (numeric only)"
+msgstr ""
+
+#: ../../src/wizards/GenWizPanel.cpp:255
+msgid "Description"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:435 ../../src/MaximaCommandMenus.cpp:448
+#: ../../src/MaximaCommandMenus.cpp:461 ../../src/MaximaCommandMenus.cpp:475
+#: ../../src/MaximaCommandMenus.cpp:486 ../../src/MaximaCommandMenus.cpp:499
+#: ../../src/MaximaCommandMenus.cpp:514 ../../src/MaximaCommandMenus.cpp:528
+#: ../../src/MaximaCommandMenus.cpp:546 ../../src/MaximaCommandMenus.cpp:561
+#: ../../src/MaximaCommandMenus.cpp:576 ../../src/MaximaCommandMenus.cpp:591
+#: ../../src/MaximaCommandMenus.cpp:605
+msgid "Desired absolute error of approximation."
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:434 ../../src/MaximaCommandMenus.cpp:447
+#: ../../src/MaximaCommandMenus.cpp:460 ../../src/MaximaCommandMenus.cpp:474
+#: ../../src/MaximaCommandMenus.cpp:513 ../../src/MaximaCommandMenus.cpp:527
+#: ../../src/MaximaCommandMenus.cpp:545 ../../src/MaximaCommandMenus.cpp:560
+#: ../../src/MaximaCommandMenus.cpp:575 ../../src/MaximaCommandMenus.cpp:590
+#: ../../src/MaximaCommandMenus.cpp:604
+msgid "Desired relative error of approximation."
+msgstr ""
+
+#: ../../src/sidebars/StatSidebar.cpp:61
+msgid "Deviation..."
+msgstr "Avvik..."
+
+#: ../../src/wxMaximaFrame.cpp:1534
 msgid "Di&vide Polynomials..."
 msgstr "Di&vider Polynom..."
 
-#: ../../src/MaximaManual.cpp:517
+#: ../../src/worksheet/WorksheetExport.cpp:1400
+msgid "Diagram"
+msgstr ""
+
+#: ../../src/sidebars/DrawSidebar.cpp:71
+msgid "Diagram title"
+msgstr ""
+
+#: ../../src/sidebars/HelpBrowser.cpp:51
+msgid "Didn't find an installed offline manual."
+msgstr ""
+
+#: ../../src/MaximaManual.cpp:534
 msgid "Didn't find the maxima HTML manual."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:4907
+#: ../../src/wxMaxima.cpp:1685
 msgid "Didn't get a help browser launch program command line, but can request the system's default help browser."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:9010 ../../src/wxMaxima.cpp:10055
+#: ../../src/Styles.cpp:129
+msgid "Diff viewer: changed text"
+msgstr ""
+
+#: ../../src/sidebars/MathSidebar.cpp:80
+msgid "Diff..."
+msgstr "Deriver..."
+
+#: ../../src/dialogs/DiffFrame.cpp:308
+#, c-format
+msgid "Difference %d / %d"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:264 ../../src/MaximaCommandMenus.cpp:3544
 msgid "Differentiate"
 msgstr "Deriver"
 
-#: ../../src/wxMaximaFrame.cpp:1467
+#: ../../src/wxMaximaFrame.cpp:1504
 msgid "Differentiate expression"
 msgstr "Deriver uttrykk"
 
-#: ../../src/Worksheet.cpp:1590
+#: ../../src/worksheet/WorksheetContextMenu.cpp:363
 msgid "Differentiate..."
 msgstr "Deriver..."
 
-#: ../../src/wxMaxima.cpp:9010
+#: ../../src/MaximaCommandMenus.cpp:264
 #, fuzzy
 msgid "Differentiates an expression n times"
 msgstr "Deriver uttrykk"
 
-#: ../../src/wxMaxima.cpp:10055
+#: ../../src/MaximaCommandMenus.cpp:3544
 #, fuzzy
 msgid "Differentiates the expression n times"
 msgstr "Deriver uttrykk"
 
-#: ../../src/wxMaximaFrame.cpp:1212
+#: ../../src/wizards/LimitWiz.cpp:41
+msgid "Direction:"
+msgstr "Retning:"
+
+#: ../../src/wxMaximaFrame.cpp:1246
 #, fuzzy
 msgid "Directory operations"
 msgstr "Retning:"
 
-#: ../../src/wxMaximaFrame.cpp:1041
+#: ../../src/main.cpp:315
+msgid "Disabled the console's QuickEdit mode for this batch run so a click into the console cannot suspend wxMaxima."
+msgstr ""
+
+#: ../../src/wizards/Plot2dWiz.cpp:418 ../../src/wizards/Plot2dWiz.cpp:619
+msgid "Discrete plot"
+msgstr "Diskret Plott"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:699
+#, fuzzy
+msgid "Display"
+msgstr "Veksle &Tidsvisning"
+
+#: ../../src/wxMaximaFrame.cpp:1075
 msgid "Display Te&X Form"
 msgstr "Vis Te&X-Form"
 
-#: ../../src/wxMaxima.cpp:6972
+#: ../../src/MaximaCommandMenus.cpp:3844
 msgid "Display algorithm"
 msgstr "Vis algoritme"
 
-#: ../../src/wxMaximaFrame.cpp:751
+#: ../../src/dialogs/ConfigDialogue.cpp:827
+msgid "Display all and allow linebreaks in long numbers"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:820
+#, fuzzy
+msgid "Display all digits"
+msgstr "Vis algoritme"
+
+#: ../../src/wxMaximaFrame.cpp:788
 msgid "Display an expression as maxima's internal lisp representation"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:754
+#: ../../src/wxMaximaFrame.cpp:791
 msgid "Display an expression as wxMaxima's internal XML representation"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:758
+#: ../../src/wxMaximaFrame.cpp:795
 #, fuzzy
 msgid "Display equations"
 msgstr "Løs likninger"
 
-#: ../../src/wxMaxima.cpp:6508
+#: ../../src/MaximaCommandMenus.cpp:3028
 msgid "Display expression in maxima's internal representation"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:6514
+#: ../../src/MaximaCommandMenus.cpp:3034
 msgid "Display expression in wxMaxima's internal representation"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1042
+#: ../../src/wxMaximaFrame.cpp:1076
 msgid "Display last result in TeX form"
 msgstr "Vis siste resultat i TeX-form"
 
-#: ../../src/ToolBar.cpp:360
+#: ../../src/dialogs/ConfigDialogue.cpp:804
+msgid "Display of long numbers"
+msgstr ""
+
+#: ../../src/ToolBar.cpp:580
 #, c-format
 msgid "Display resolution according to wxWidgets: %li x %li ppi"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:802
+#: ../../src/wxMaximaFrame.cpp:839
 #, fuzzy
 msgid "Display string quotation marks"
 msgstr "Løs likninger"
 
-#: ../../src/wxMaximaFrame.cpp:1036
+#: ../../src/wxMaximaFrame.cpp:1070
 msgid "Display time used for evaluation"
 msgstr "Vis brukt tid ved utførelse"
 
-#: ../../src/wxMaxima.cpp:9206
+#: ../../src/MaximaCommandMenus.cpp:397
 #, fuzzy
 msgid "Displayed Precision"
 msgstr "Løs likninger"
 
-#: ../../src/wxMaximaFrame.cpp:1913
+#: ../../src/wxMaximaFrame.cpp:1950
 msgid "Displaying 3d curves"
 msgstr ""
 
 # Jeg ved ikke hvad man skal oversætte noun til?
 # JT: Navn(eord) - det vil u.a.o. kun være for "kendere"?
-#: ../../src/wxMaximaFrame.cpp:1462
+#: ../../src/wxMaximaFrame.cpp:1499
 #, fuzzy
 msgid "Dito, and evaluate the result..."
 msgstr "Utfør &Navneformer"
 
-#: ../../src/wxMaximaFrame.cpp:1445
+#: ../../src/wxMaximaFrame.cpp:1482
 msgid "Dito, but affect all clones of the Matrix..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1255
+#: ../../src/wxMaximaFrame.cpp:1289
 msgid "Dito, but as fraction (real only)..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1532
+#: ../../src/wxMaximaFrame.cpp:1569
 msgid "Dito, including denominator"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1715 ../../src/wxMaximaFrame.cpp:944
+#: ../../src/worksheet/WorksheetContextMenu.cpp:488
+#: ../../src/wxMaximaFrame.cpp:978
 msgid "Divide Cell"
 msgstr "Divider Celle"
 
-#: ../../src/wxMaximaFrame.cpp:1498
+#: ../../src/wxMaximaFrame.cpp:1535
 msgid "Divide numbers or polynomials"
 msgstr "Divider tall eller polynomer"
 
-#: ../../src/wxMaxima.cpp:8578
+#: ../../src/cells/TextCell.cpp:297
+msgid "Division by 0."
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:1596
 #, fuzzy
 msgid "Do for each list element"
 msgstr "Anvend funksjon på liste"
 
-#: ../../src/wxMaxima.cpp:11197
+#: ../../src/wxMaxima.cpp:3503
 #, fuzzy, c-format
 msgid "Do you want to save the changes you made in the document \"%s\"?"
 msgstr "Vil du lagre endringene i dokumentet \""
 
-#: ../../src/wxMaximaFrame.cpp:724
+#: ../../src/wxMaximaFrame.cpp:761
 msgid "Dock all Sidebars"
 msgstr ""
 
-#: ../../src/Configuration.cpp:94
+#: ../../src/Styles.cpp:123
 msgid "Document background"
 msgstr "Dokumentbakgrunn"
 
-#: ../../src/wxMaxima.cpp:4611
+#: ../../src/MaximaFileIO.cpp:534
 #, fuzzy
 msgid "Document was saved using a newer version of wxMaxima so it may not load correctly. Please update your wxMaxima."
 msgstr " ble lagret med en nyere versjon av wxMaxima, så den lastes kanskje ikke korrekt. Vennligst oppdater wxMaxima'n din."
 
-#: ../../src/wxMaxima.cpp:4603
+#: ../../src/MaximaFileIO.cpp:526
 #, fuzzy
 msgid "Document was saved using a newer version of wxMaxima. Please update your wxMaxima."
 msgstr " ble lagret med en nyere versjon av wxMaxima. Vennligst oppdater wxMaxima'n din."
 
-#: ../../src/wxMaximaFrame.cpp:770
+#: ../../src/dialogs/ConfigDialogue.cpp:1170
+msgid "Documentclass for TeX export:"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1178
+msgid "Documentclass options:"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:807
 msgid "Don't autosubscript after an underscore"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1086
+#: ../../src/wxMaximaFrame.cpp:1120
 #, fuzzy
 msgid "Don't evaluate Expression..."
 msgstr "Integrer uttrykk"
 
-#: ../../src/wxMaxima.cpp:7117
+#: ../../src/MaximaCommandMenus.cpp:3989
 #, fuzzy
 msgid "Don't evaluate one command"
 msgstr "Vis et eksempel for kommandoen:"
 
-#: ../../src/wxMaxima.cpp:7129
+#: ../../src/MaximaCommandMenus.cpp:4001
 #, fuzzy
 msgid "Don't evaluate one whole expression"
 msgstr "Finn reell del av et komplekst uttrykk"
 
-#: ../../src/Worksheet.cpp:1931 ../../src/Worksheet.cpp:2064
+#: ../../src/worksheet/WorksheetContextMenu.cpp:703
+#: ../../src/worksheet/WorksheetContextMenu.cpp:836
 msgid "Don't mark cells that contain tooltips in yellow"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1938 ../../src/Worksheet.cpp:2070
+#: ../../src/worksheet/WorksheetContextMenu.cpp:710
+#: ../../src/worksheet/WorksheetContextMenu.cpp:842
 msgid "Don't mark this message text in yellow"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:11203
+#: ../../src/wxMaxima.cpp:3509
 msgid "Don't save"
 msgstr "Ikke lagre"
 
-#: ../../src/Worksheet.cpp:1620
+#: ../../src/worksheet/WorksheetContextMenu.cpp:393
 msgid "Don't show labels"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1979
+#: ../../src/worksheet/WorksheetContextMenu.cpp:751
 msgid "Don't use if unassigned"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:797
+#: ../../src/wxMaximaFrame.cpp:834
 msgid "Don't use parenthesis for matrices"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8525
+#: ../../src/dialogs/DiffFrame.cpp:428 ../../src/dialogs/FindReplacePane.cpp:83
+msgid "Down"
+msgstr ""
+
+#: ../../src/sidebars/SymbolsSidebar.cpp:185
+msgid "Drag-and-drop unicode symbols here"
+msgstr ""
+
+#: ../../src/wizards/DrawWiz.cpp:155
+msgid "Draw all points where an equation is true."
+msgstr ""
+
+#: ../../src/wizards/DrawWiz.cpp:802
+msgid "Draw points"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:1536
 #, fuzzy
 msgid "Drop the first n list elements"
 msgstr "Anvend funksjon på liste"
 
-#: ../../src/wxMaxima.cpp:8531 ../../src/wxMaxima.cpp:8537
+#: ../../src/MaximaCommandMenus.cpp:1542
 #, fuzzy
 msgid "Drop the last n list elements"
 msgstr "Anvend funksjon på liste"
 
-#: ../../src/wxMaximaFrame.cpp:1306
+#: ../../src/dialogs/ConfigDialogue.cpp:195
+msgid "Dutch"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1340
 msgid "E&quations"
 msgstr "&Likninger"
 
-#: ../../src/wxMaximaFrame.cpp:625
+#: ../../src/wxMaximaFrame.cpp:658
 msgid "E&xit\tCtrl+Q"
 msgstr "&Avslutt\tCtrl+Q"
 
-#: ../../src/wxMaximaFrame.cpp:1368
+#: ../../src/wxMaximaFrame.cpp:1402
 msgid "Eige&nvectors"
 msgstr "&Egenvektorer"
 
-#: ../../src/wxMaximaFrame.cpp:1365
+#: ../../src/wxMaximaFrame.cpp:1399
 msgid "Eigen&values"
 msgstr "Egen&verdier"
 
-#: ../../src/wxMaximaFrame.cpp:1387
+#: ../../src/wxMaximaFrame.cpp:1421
 #, fuzzy
 msgid "Eigenvalues (complex)"
 msgstr "Egen&verdier"
 
-#: ../../src/wxMaximaFrame.cpp:1384
+#: ../../src/wxMaximaFrame.cpp:1418
 #, fuzzy
 msgid "Eigenvalues (real)"
 msgstr "Egen&verdier"
 
-#: ../../src/wxMaximaFrame.cpp:1393
+#: ../../src/wxMaximaFrame.cpp:1427
 msgid "Eigenvalues, left+right eigenvectors (complex)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1390
+#: ../../src/wxMaximaFrame.cpp:1424
 msgid "Eigenvalues, left+right eigenvectors (real)"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8584
+#: ../../src/MaximaCommandMenus.cpp:1602
 msgid "Either a single expression or a comma-separated list of expressions between parenthesis. In the latter case the result of the last expression in the parenthesis is used."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8593
+#: ../../src/cells/TextCell.cpp:176
+msgid ""
+"Either negative or zero.\n"
+"A possible result of sign()."
+msgstr ""
+
+#: ../../src/cells/TextCell.cpp:172
+msgid ""
+"Either positive or zero.\n"
+"A possible result of sign()."
+msgstr ""
+
+#: ../../src/cells/TextCell.cpp:168
+msgid ""
+"Either positive, negative or zero.\n"
+"Normally the result of sign() if the sign cannot be determined."
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:1612
 msgid "Element"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8549
+#: ../../src/MaximaCommandMenus.cpp:1562
 msgid "Element number"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8005
+#: ../../src/MaximaCommandMenus.cpp:1189
 msgid "Element-by-element Product of matrices of the same size (Hadamard product)"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8012
+#: ../../src/MaximaCommandMenus.cpp:1196
 msgid "Element-by-element exponentiation of two matrices"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1342
+#: ../../src/wxMaximaFrame.cpp:1376
 msgid "Element-by-element multiplication"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8510
+#: ../../src/MaximaCommandMenus.cpp:1516
 msgid "Element:"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7204
+#: ../../src/MaximaCommandMenus.cpp:4076
 msgid "Elements:"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7847
+#: ../../src/MaximaCommandMenus.cpp:1028
 #, fuzzy
 msgid "Eliminate a variable"
 msgstr "&Eliminer Variabel..."
 
-#: ../../src/wxMaximaFrame.cpp:1247
+#: ../../src/wxMaximaFrame.cpp:1281
 msgid "Eliminate a variable from a system of equations"
 msgstr "Eliminer en variabel fra et likningssett"
 
-#: ../../src/wxMaxima.cpp:10651
+#: ../../src/MaximaEvaluator.cpp:536
 msgid "Empty command => re-triggering evaluation"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:9225
+#: ../../src/MaximaCommandMenus.cpp:416
 #, fuzzy
 msgid "Enable:"
 msgstr "Variabel:"
 
-#: ../../src/MathParser.cpp:99
+#: ../../src/MathParser.cpp:94
 #, c-format
 msgid "Encountered an unknown XML tag: <%s>"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2476
+#: ../../src/MaximaProcessManager.cpp:137
 msgid "Encountered an unknown socket event."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7843
+#: ../../src/sidebars/SymbolsSidebar.cpp:129
+msgid "End of proof"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:1024
 msgid "End of t:"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:4097
+#: ../../src/wizards/DrawWiz.cpp:71 ../../src/wizards/DrawWiz.cpp:176
+msgid "End of the x value"
+msgstr ""
+
+#: ../../src/wizards/DrawWiz.cpp:88 ../../src/wizards/DrawWiz.cpp:191
+msgid "End of the y value"
+msgstr ""
+
+#: ../../src/wizards/DrawWiz.cpp:208
+msgid "End of the z value"
+msgstr ""
+
+#: ../../src/wizards/DrawWiz.cpp:760
+msgid "End value of the parameter"
+msgstr ""
+
+#: ../../src/MaximaResponseReader.cpp:432
+#: ../../src/MaximaResponseReader.cpp:586
 msgid "Ended lisp mode after receiving a maxima prompt!"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1828
+#: ../../src/wxMaximaFrame.cpp:1865
 msgid "Engineering format (12.1e6 etc.)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1319
+#: ../../src/dialogs/ConfigDialogue.cpp:196
+msgid "English"
+msgstr "Engelsk"
+
+#: ../../src/wizards/DrawWiz.cpp:552
+msgid "Enhanced 3D settings:"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1919
+msgid "Enhanced meta file (emf)"
+msgstr ""
+
+#: ../../src/sidebars/StatSidebar.cpp:106
+msgid "Enter Matrix..."
+msgstr "Oppgi Matrise..."
+
+#: ../../src/MaximaCommandMenus.cpp:2255
+msgid "Enter UUID to jump to:"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1353
 msgid "Enter a matrix"
 msgstr "Oppgi en matrise"
 
-#: ../../src/wxMaxima.cpp:8866
+#: ../../src/dialogs/ConfigDialogue.cpp:925
+#, fuzzy
+msgid "Enter adds newlines, Ctrl+Enter evaluates cells"
+msgstr "Enter utfører celler"
+
+#: ../../src/MaximaCommandMenus.cpp:873
 msgid "Enter an equation for rational simplification:"
 msgstr "Oppgi en likning til rasjonell forenkling:"
 
-#: ../../src/wxMaxima.cpp:8169
+#: ../../src/wizards/SystemWiz.cpp:50
+msgid "Enter comma separated list of variables."
+msgstr "Oppgi kommaseparert liste av variabler."
+
+#: ../../src/dialogs/ConfigDialogue.cpp:921
+#, fuzzy
+msgid "Enter evaluates cells, Ctrl+Enter adds newlines"
+msgstr "Enter utfører celler"
+
+#: ../../src/MaximaCommandMenus.cpp:1357
 msgid "Enter matrix"
 msgstr "Oppgi matrise"
 
-#: ../../src/wxMaxima.cpp:9095
+#: ../../src/MaximaCommandMenus.cpp:100
 msgid "Enter new animation frame rate [Hz, integer]:"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:9201
+#: ../../src/MaximaCommandMenus.cpp:392
 #, fuzzy
 msgid "Enter new precision for bigfloats:"
 msgstr "Oppgi ny presisjon:"
 
-#: ../../src/wxMaxima.cpp:7922
+#: ../../src/dialogs/ConfigDialogue.cpp:388
+msgid "Enter the path to the Maxima executable."
+msgstr "Oppgi banen til Maxima-programfilen."
+
+#: ../../src/MaximaCommandMenus.cpp:1103
 msgid "Enumerator:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1220
+#: ../../src/wxMaximaFrame.cpp:1254
 #, fuzzy
 msgid "Environment variables"
 msgstr "Øvrige parametre:"
 
-#: ../../src/wxMaxima.cpp:9045
+#: ../../src/dialogs/ConfigDialogue.cpp:1605
+#, fuzzy
+msgid "Environment variables for maxima"
+msgstr "Øvrige parametre:"
+
+#: ../../src/sidebars/GreekSidebar.cpp:182
+#, fuzzy
+msgid "Epsilon"
+msgstr "Epsilon:"
+
+#: ../../src/MaximaCommandMenus.cpp:299
 msgid "Epsilon:"
 msgstr "Epsilon:"
 
-#: ../../src/wxMaximaFrame.cpp:1124 ../../src/wxMaximaFrame.cpp:1135
+#: ../../src/wxMaximaFrame.cpp:1158 ../../src/wxMaximaFrame.cpp:1169
 msgid "Equal, ignoring case?..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1133
+#: ../../src/wxMaximaFrame.cpp:1167
 msgid "Equal?..."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8561
+#: ../../src/MaximaCommandMenus.cpp:1577 ../../src/wizards/DrawWiz.cpp:161
 #, fuzzy
 msgid "Equation"
 msgstr "Likning:"
 
-#: ../../src/wxMaxima.cpp:7751 ../../src/wxMaxima.cpp:7765
+#: ../../src/wizards/SystemWiz.cpp:67
+#, c-format
+msgid "Equation %ld:"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:932 ../../src/MaximaCommandMenus.cpp:946
 #, fuzzy
 msgid "Equation(s)"
 msgstr "Likninger:"
 
-#: ../../src/wxMaxima.cpp:7848 ../../src/wxMaxima.cpp:7900
+#: ../../src/MaximaCommandMenus.cpp:1029 ../../src/MaximaCommandMenus.cpp:1081
 msgid "Equation(s):"
 msgstr "Likninger:"
 
-#: ../../src/wxMaxima.cpp:7776 ../../src/wxMaxima.cpp:7788
-#: ../../src/wxMaxima.cpp:8899 ../../src/wxMaxima.cpp:8919
-#: ../../src/wxMaxima.cpp:9592 ../../src/wxMaxima.cpp:10039
+#: ../../src/MaximaCommandMenus.cpp:150 ../../src/MaximaCommandMenus.cpp:170
+#: ../../src/MaximaCommandMenus.cpp:957 ../../src/MaximaCommandMenus.cpp:969
+#: ../../src/MaximaCommandMenus.cpp:1832 ../../src/MaximaCommandMenus.cpp:3528
 msgid "Equation:"
 msgstr "Likning:"
 
-#: ../../src/WXMXformat.cpp:258 ../../src/WXMXformat.cpp:288
-#: ../../src/WXMXformat.cpp:296 ../../src/WXMXformat.cpp:311
-#: ../../src/WXMXformat.cpp:332 ../../src/WXMXformat.cpp:362
-#: ../../src/wxMaxima.cpp:3020 ../../src/wxMaxima.cpp:4163
-#: ../../src/wxMaxima.cpp:4222 ../../src/wxMaxima.cpp:4231
-#: ../../src/wxMaxima.cpp:4491 ../../src/wxMaxima.cpp:4502
-#: ../../src/wxMaxima.cpp:4605 ../../src/wxMaxima.cpp:4634
-#: ../../src/wxMaxima.cpp:4645 ../../src/wxMaxima.cpp:11125
-#: ../../src/wxMaxima.cpp:11166
+#: ../../src/dialogs/TipOfTheDay.cpp:196
+msgid "Equations have several advantages over functions. For example they can be manipulated with factor(), expand() and similar functions. They can easily be introduced one into another. Also they are always printed out as 2D maths."
+msgstr ""
+
+#: ../../src/MaximaFileIO.cpp:64 ../../src/MaximaFileIO.cpp:121
+#: ../../src/MaximaFileIO.cpp:130 ../../src/MaximaFileIO.cpp:399
+#: ../../src/MaximaFileIO.cpp:410 ../../src/MaximaFileIO.cpp:528
+#: ../../src/MaximaFileIO.cpp:557 ../../src/MaximaFileIO.cpp:568
+#: ../../src/MaximaProcessManager.cpp:581 ../../src/WXMXformat.cpp:260
+#: ../../src/WXMXformat.cpp:290 ../../src/WXMXformat.cpp:298
+#: ../../src/WXMXformat.cpp:313 ../../src/WXMXformat.cpp:334
+#: ../../src/WXMXformat.cpp:364 ../../src/dialogs/BinaryNameCtrl.cpp:78
+#: ../../src/main.cpp:725 ../../src/wxMaxima.cpp:3384
+#: ../../src/wxMaxima.cpp:3420 ../../src/wxMaxima.cpp:3438
+#: ../../src/wxMaxima.cpp:3472
 msgid "Error"
 msgstr "Feil"
 
-#: ../../src/wxMaxima.cpp:2456
+#: ../../src/MaximaProcessManager.cpp:789
 msgid "Error writing to Maxima"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:6164 ../../src/wxMaxima.cpp:6176
-#: ../../src/wxMaxima.cpp:6187 ../../src/wxMaxima.cpp:7858
-#: ../../src/wxMaxima.cpp:7880 ../../src/wxMaxima.cpp:8163
+#: ../../src/MaximaCommandMenus.cpp:1039 ../../src/MaximaCommandMenus.cpp:1061
+#: ../../src/MaximaCommandMenus.cpp:1351 ../../src/MaximaCommandMenus.cpp:2320
+#: ../../src/MaximaCommandMenus.cpp:2332 ../../src/MaximaCommandMenus.cpp:2343
+#: ../../src/MaximaFileIO.cpp:873 ../../src/sidebars/History.cpp:228
 msgid "Error!"
 msgstr "Feil!"
 
-#: ../../src/Image.cpp:696
+#: ../../src/Image.cpp:779
 #, c-format
 msgid "Error: Cannot render %s."
 msgstr ""
 
-#: ../../src/Image.cpp:699
+#: ../../src/Image.cpp:782
 #, c-format
 msgid ""
 "Error: Cannot render %s:\n"
 "%s"
 msgstr ""
 
-#: ../../src/Image.cpp:704
+#: ../../src/Image.cpp:787
 msgid "Error: Cannot render the image."
 msgstr ""
 
-#: ../../src/Image.cpp:706
+#: ../../src/Image.cpp:789
 #, c-format
 msgid ""
 "Error: Cannot render the image:\n"
 "%s"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7544
+#: ../../src/MaximaCommandMenus.cpp:4416
 msgid "Escapes all special characters in a string. The result is a regex that matches this string exactly."
 msgstr ""
 
+#: ../../src/sidebars/GreekSidebar.cpp:184
+msgid "Eta"
+msgstr ""
+
+#: ../../src/sidebars/TableOfContents.cpp:513
+#, fuzzy
+msgid "Evaluate"
+msgstr "&Utfør Celler"
+
 # Jeg ved ikke hvad man skal oversætte noun til?
 # JT: Navn(eord) - det vil u.a.o. kun være for "kendere"?
-#: ../../src/wxMaximaFrame.cpp:1652
+#: ../../src/wxMaximaFrame.cpp:1689
 #, fuzzy
 msgid "Evaluate &Noun Forms..."
 msgstr "Utfør &Navneformer"
 
-#: ../../src/wxMaximaFrame.cpp:856
+#: ../../src/wxMaximaFrame.cpp:890
 msgid "Evaluate All Cells\tCtrl+Shift+R"
 msgstr "Utfør Alle Celler\tCtrl+Shift+R"
 
-#: ../../src/wxMaximaFrame.cpp:851
+#: ../../src/wxMaximaFrame.cpp:885
 msgid "Evaluate All Visible Cells\tCtrl+R"
 msgstr "Utfør Alle Synlige Celler\tCtrl+R"
 
-#: ../../src/Worksheet.cpp:1395
+#: ../../src/worksheet/WorksheetContextMenu.cpp:166
 #, fuzzy
 msgid "Evaluate Cell"
 msgstr "&Utfør Celler"
 
-#: ../../src/Worksheet.cpp:1398 ../../src/wxMaximaFrame.cpp:844
+#: ../../src/worksheet/WorksheetContextMenu.cpp:169
+#: ../../src/wxMaximaFrame.cpp:878
 msgid "Evaluate Cell(s)"
 msgstr "&Utfør Celler"
 
-#: ../../src/Worksheet.cpp:1391 ../../src/Worksheet.cpp:1674
+#: ../../src/worksheet/WorksheetContextMenu.cpp:162
+#: ../../src/worksheet/WorksheetContextMenu.cpp:447
 #, fuzzy
 msgid "Evaluate Cells Above"
 msgstr "&Utfør Celler"
 
-#: ../../src/wxMaximaFrame.cpp:866
+#: ../../src/wxMaximaFrame.cpp:900
 #, fuzzy
 msgid "Evaluate Cells Above\tCtrl+Shift+P"
 msgstr "Utfør Alle Celler\tCtrl+Shift+R"
 
-#: ../../src/Worksheet.cpp:1402 ../../src/Worksheet.cpp:1676
-#: ../../src/wxMaximaFrame.cpp:876
+#: ../../src/worksheet/WorksheetContextMenu.cpp:173
+#: ../../src/worksheet/WorksheetContextMenu.cpp:449
+#: ../../src/wxMaximaFrame.cpp:910
 #, fuzzy
 msgid "Evaluate Cells Below"
 msgstr "&Utfør Celler"
 
-#: ../../src/Worksheet.cpp:1451 ../../src/Worksheet.cpp:1756
-#: ../../src/Worksheet.cpp:1890
+#: ../../src/worksheet/WorksheetContextMenu.cpp:222
+#: ../../src/worksheet/WorksheetContextMenu.cpp:529
+#: ../../src/worksheet/WorksheetContextMenu.cpp:662
 msgid "Evaluate Heading 5\tShift+Ctrl+Enter"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1457 ../../src/Worksheet.cpp:1761
-#: ../../src/Worksheet.cpp:1901
+#: ../../src/worksheet/WorksheetContextMenu.cpp:228
+#: ../../src/worksheet/WorksheetContextMenu.cpp:534
+#: ../../src/worksheet/WorksheetContextMenu.cpp:673
 msgid "Evaluate Heading 6\tShift+Ctrl+Enter"
 msgstr ""
 
 # Jeg ved ikke hvad man skal oversætte noun til?
 # JT: Navn(eord) - det vil u.a.o. kun være for "kendere"?
-#: ../../src/wxMaxima.cpp:8626
+#: ../../src/MaximaCommandMenus.cpp:618
 #, fuzzy
 msgid "Evaluate Nouns"
 msgstr "Utfør &Navneformer"
 
-#: ../../src/Worksheet.cpp:1425 ../../src/Worksheet.cpp:1736
+#: ../../src/worksheet/WorksheetContextMenu.cpp:196
+#: ../../src/worksheet/WorksheetContextMenu.cpp:509
 msgid "Evaluate Part\tShift+Ctrl+Enter"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1431 ../../src/Worksheet.cpp:1741
+#: ../../src/worksheet/WorksheetContextMenu.cpp:202
+#: ../../src/worksheet/WorksheetContextMenu.cpp:514
 msgid "Evaluate Section\tShift+Ctrl+Enter"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1445 ../../src/Worksheet.cpp:1751
-#: ../../src/Worksheet.cpp:1879
+#: ../../src/worksheet/WorksheetContextMenu.cpp:216
+#: ../../src/worksheet/WorksheetContextMenu.cpp:524
+#: ../../src/worksheet/WorksheetContextMenu.cpp:651
 msgid "Evaluate Sub-Subsection\tShift+Ctrl+Enter"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1438 ../../src/Worksheet.cpp:1746
-#: ../../src/Worksheet.cpp:1868
+#: ../../src/worksheet/WorksheetContextMenu.cpp:209
+#: ../../src/worksheet/WorksheetContextMenu.cpp:519
+#: ../../src/worksheet/WorksheetContextMenu.cpp:640
 msgid "Evaluate Subsection\tShift+Ctrl+Enter"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:845
+#: ../../src/wxMaximaFrame.cpp:879
 msgid "Evaluate active or selected cell(s)"
 msgstr "Utfør aktive eller valgte celler"
 
-#: ../../src/ToolBar.cpp:251
+#: ../../src/ToolBar.cpp:445 ../../src/ToolBar.cpp:457
 msgid "Evaluate all"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:857
+#: ../../src/wxMaximaFrame.cpp:891
 msgid "Evaluate all cells in the document"
 msgstr "Utfør alle celler i dokument"
 
 # Nouns in Verbs umwandeln und auswerten
-#: ../../src/wxMaximaFrame.cpp:1653
+#: ../../src/wxMaximaFrame.cpp:1690
 msgid "Evaluate all noun forms in expression"
 msgstr "Utfør alle navneformer i uttrykk"
 
-#: ../../src/wxMaximaFrame.cpp:852
+#: ../../src/wxMaximaFrame.cpp:886
 msgid "Evaluate all visible cells in the document"
 msgstr "Utfør alle synlige celler i dokument"
 
-#: ../../src/ToolBar.cpp:248
+#: ../../src/ToolBar.cpp:442 ../../src/ToolBar.cpp:454
 msgid "Evaluate current cell"
 msgstr ""
 
 # Jeg ved ikke hvad man skal oversætte noun til?
 # JT: Navn(eord) - det vil u.a.o. kun være for "kendere"?
-#: ../../src/wxMaxima.cpp:7395
+#: ../../src/MaximaCommandMenus.cpp:4267
 #, fuzzy
 msgid "Evaluate string"
 msgstr "Utfør &Navneformer"
 
 # Jeg ved ikke hvad man skal oversætte noun til?
 # JT: Navn(eord) - det vil u.a.o. kun være for "kendere"?
-#: ../../src/wxMaximaFrame.cpp:1151
+#: ../../src/wxMaximaFrame.cpp:1185
 #, fuzzy
 msgid "Evaluate string..."
 msgstr "Utfør &Navneformer"
 
-#: ../../src/ToolBar.cpp:256
+#: ../../src/ToolBar.cpp:449 ../../src/ToolBar.cpp:461
 msgid "Evaluate the file from its beginning to the cell above the cursor"
 msgstr ""
 
-#: ../../src/ToolBar.cpp:259
+#: ../../src/ToolBar.cpp:452 ../../src/ToolBar.cpp:464
 #, fuzzy
 msgid "Evaluate the file from the cursor to its end"
 msgstr "Utfør alle celler i dokument"
 
 # Jeg ved ikke hvad man skal oversætte noun til?
 # JT: Navn(eord) - det vil u.a.o. kun være for "kendere"?
-#: ../../src/ToolBar.cpp:258
+#: ../../src/ToolBar.cpp:451 ../../src/ToolBar.cpp:463
 #, fuzzy
 msgid "Evaluate the rest"
 msgstr "Utfør &Navneformer"
 
 # Jeg ved ikke hvad man skal oversætte noun til?
 # JT: Navn(eord) - det vil u.a.o. kun være for "kendere"?
-#: ../../src/ToolBar.cpp:255
+#: ../../src/ToolBar.cpp:448 ../../src/ToolBar.cpp:460
 #, fuzzy
 msgid "Evaluate to point"
 msgstr "Utfør &Navneformer"
 
-#: ../../src/wxMaxima.cpp:10518
+#: ../../src/MaximaEvaluator.cpp:351
 msgid "Evaluation ended, since evaluation queue is empty."
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1957
+#: ../../src/worksheet/WorksheetContextMenu.cpp:729
 msgid "Even number"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1703
+#: ../../src/dialogs/ConfigDialogue.cpp:2659
+msgid "Example text"
+msgstr "Eksempeltekst"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1547
+msgid "Examples:"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1740
 msgid "Execute a command for each element of the list"
 msgstr ""
 
-#: ../../src/main.cpp:438
+#: ../../src/main.cpp:677
 msgid "Exit"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:625
-msgid "Exit wxMaxima"
-msgstr ""
+#: ../../src/sidebars/MathSidebar.cpp:53
+msgid "Expand"
+msgstr "Utvid"
 
-#: ../../src/Worksheet.cpp:1583
+#: ../../src/sidebars/MathSidebar.cpp:68
+msgid "Expand (tr)"
+msgstr "Utvid (tr)"
+
+#: ../../src/worksheet/WorksheetContextMenu.cpp:356
 msgid "Expand Expression"
 msgstr "Utvid Uttrykk"
 
-#: ../../src/wxMaximaFrame.cpp:1525
+#: ../../src/wxMaximaFrame.cpp:1562
 msgid "Expand an expression"
 msgstr "Utvid et uttrykk"
 
-#: ../../src/wxMaximaFrame.cpp:1531
+#: ../../src/wxMaximaFrame.cpp:1568
 #, fuzzy
 msgid "Expand for given variables"
 msgstr "Endre variabel"
 
-#: ../../src/wxMaxima.cpp:8781
+#: ../../src/MaximaCommandMenus.cpp:788
 msgid "Expand for variable(s) including denominator:"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8716
+#: ../../src/MaximaCommandMenus.cpp:708
 #, fuzzy
 msgid "Expand for variable(s):"
 msgstr "Ny variabel:"
 
-#: ../../src/wxMaximaFrame.cpp:1545
+#: ../../src/wxMaximaFrame.cpp:1582
 #, fuzzy
 msgid "Expand log in previous expression"
 msgstr "Utvid et uttrykk"
 
-#: ../../src/wxMaximaFrame.cpp:1598
+#: ../../src/wxMaximaFrame.cpp:1635
 msgid "Expand trigonometric expression"
 msgstr "Utvid trigonometrisk uttrykk"
 
-#: ../../src/wxMaximaFrame.cpp:1788
+#: ../../src/wxMaximaFrame.cpp:1825
 msgid "Expect numbers harder to be complex"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1789
+#: ../../src/wxMaximaFrame.cpp:1826
 msgid "Expect variables to contain complex numbers"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:6121
+#: ../../src/MaximaCommandMenus.cpp:2277
+#: ../../src/dialogs/ConfigDialogue.cpp:283
 msgid "Export"
 msgstr "Eksporter"
 
-#: ../../src/wxMaximaFrame.cpp:1705
+#: ../../src/sidebars/History.cpp:152
+#, fuzzy
+msgid "Export As"
+msgstr "Eksporter"
+
+#: ../../src/wxMaximaFrame.cpp:1742
 #, fuzzy
 msgid "Export List to csv file..."
 msgstr "Eksport til TeX feilet!"
 
-#: ../../src/wxMaximaFrame.cpp:1706
+#: ../../src/wxMaximaFrame.cpp:1743
 #, fuzzy
 msgid "Export a list to a csv file"
 msgstr "Last en Maxima-pakkefil"
 
-#: ../../src/wxMaximaFrame.cpp:1332
+#: ../../src/wxMaximaFrame.cpp:1366
 #, fuzzy
 msgid "Export a matrix to a csv file"
 msgstr "Last en Maxima-pakkefil"
 
-#: ../../src/wxMaximaFrame.cpp:619
+#: ../../src/sidebars/History.cpp:102
+msgid "Export all history to a .mac file"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1016
+#, fuzzy
+msgid "Export all settings"
+msgstr "Fold alle seksjoner"
+
+#: ../../src/sidebars/History.cpp:105
+msgid "Export commands from the current maxima session to a .mac file"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:652
 #, fuzzy
 msgid "Export document to a HTML or LaTeX file"
 msgstr "Eksporter dokument til en HTML- eller pdfLaTeX-fil"
 
-#: ../../src/wxMaximaFrame.cpp:579
+#: ../../src/dialogs/ConfigDialogue.cpp:1218
+#, fuzzy
+msgid "Export equations to HTML as:"
+msgstr "Eksport til HTML feilet!"
+
+#: ../../src/wxMaximaFrame.cpp:600
 #, fuzzy
 msgid "Export failed."
 msgstr "Eksport til TeX feilet!"
 
-#: ../../src/wxMaximaFrame.cpp:567
+#: ../../src/worksheet/WorksheetContextMenu.cpp:154
+msgid "Export output as PNG to a folder..."
+msgstr ""
+
+#: ../../src/worksheet/WorksheetContextMenu.cpp:151
+msgid "Export output as SVG to a folder..."
+msgstr ""
+
+#: ../../src/sidebars/History.cpp:108
+msgid "Export selected commands to a .mac file"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:588
 msgid "Export successful."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:6187
+#: ../../src/MaximaCommandMenus.cpp:3468
+msgid "Export the selected output(s) to this folder"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1022
+#, fuzzy
+msgid "Export the style settings"
+msgstr "Fold alle seksjoner"
+
+#: ../../src/sidebars/History.cpp:111
+msgid "Export visible commands to a .mac file"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:3477
+#, c-format
+msgid "Exported %d output image(s) to %s"
+msgstr ""
+
+#: ../../src/wxMaxima.cpp:2200 ../../src/wxMaxima.cpp:2242
+#, c-format
+msgid "Exported the worksheet to %s"
+msgstr ""
+
+#: ../../src/sidebars/History.cpp:228
+#, fuzzy
+msgid "Exporting to .mac file failed!"
+msgstr "Eksport til TeX feilet!"
+
+#: ../../src/MaximaCommandMenus.cpp:2343
 msgid "Exporting to HTML failed!"
 msgstr "Eksport til HTML feilet!"
 
-#: ../../src/wxMaxima.cpp:6164
+#: ../../src/MaximaCommandMenus.cpp:2320
 msgid "Exporting to TeX failed!"
 msgstr "Eksport til TeX feilet!"
 
-#: ../../src/wxMaxima.cpp:6175
+#: ../../src/MaximaCommandMenus.cpp:2331
 #, fuzzy
 msgid "Exporting to maxima batch file failed!"
 msgstr "Eksport til TeX feilet!"
 
-#: ../../src/wxMaximaFrame.cpp:561
+#: ../../src/wxMaximaFrame.cpp:582
 #, fuzzy
 msgid "Exporting..."
 msgstr "&Eksporter..."
 
-#: ../../src/wxMaxima.cpp:6510 ../../src/wxMaxima.cpp:6516
-#: ../../src/wxMaxima.cpp:8218 ../../src/wxMaxima.cpp:8633
-#: ../../src/wxMaxima.cpp:8638 ../../src/wxMaxima.cpp:8658
-#: ../../src/wxMaxima.cpp:10065
+#: ../../src/MaximaCommandMenus.cpp:1480
+msgid "Expr:"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:625 ../../src/MaximaCommandMenus.cpp:630
+#: ../../src/MaximaCommandMenus.cpp:650 ../../src/MaximaCommandMenus.cpp:1408
+#: ../../src/MaximaCommandMenus.cpp:3030 ../../src/MaximaCommandMenus.cpp:3036
+#: ../../src/MaximaCommandMenus.cpp:3554 ../../src/sidebars/DrawSidebar.cpp:54
+#: ../../src/wizards/Plot3dWiz.cpp:32
 msgid "Expression"
 msgstr "Uttrykk"
 
-#: ../../src/wxMaxima.cpp:7019 ../../src/wxMaxima.cpp:7025
+#: ../../src/MaximaCommandMenus.cpp:3891 ../../src/MaximaCommandMenus.cpp:3897
 #, fuzzy
 msgid "Expression or a list of comma-separated expressions"
 msgstr "Kommaseparerte x-koordinater"
 
-#: ../../src/wxMaximaFrame.cpp:1088
+#: ../../src/wizards/DrawWiz.cpp:733
+msgid "Expression that calculates the x value"
+msgstr ""
+
+#: ../../src/wizards/DrawWiz.cpp:738
+msgid "Expression that calculates the y value"
+msgstr ""
+
+#: ../../src/wizards/DrawWiz.cpp:744
+msgid "Expression that calculates the z value"
+msgstr ""
+
+#: ../../src/wizards/DrawWiz.cpp:56
+msgid "Expression to plot"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1122
 #, fuzzy
 msgid "Expression to string..."
 msgstr "Uttrykk"
 
-#: ../../src/wxMaxima.cpp:7113
+#: ../../src/MaximaCommandMenus.cpp:3985
 msgid "Expression whose output is to be used as maxima's input."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7214
+#: ../../src/MaximaCommandMenus.cpp:4086 ../../src/wizards/Plot2dWiz.cpp:39
 msgid "Expression(s):"
 msgstr "Uttrykk:"
 
-#: ../../src/wxMaxima.cpp:8933 ../../src/wxMaxima.cpp:8941
-#: ../../src/wxMaxima.cpp:8952 ../../src/wxMaxima.cpp:8976
-#: ../../src/wxMaxima.cpp:8981 ../../src/wxMaxima.cpp:8998
-#: ../../src/wxMaxima.cpp:9004 ../../src/wxMaxima.cpp:9011
-#: ../../src/wxMaxima.cpp:9043 ../../src/wxMaxima.cpp:9062
-#: ../../src/wxMaxima.cpp:10056
+#: ../../src/MaximaCommandMenus.cpp:184 ../../src/MaximaCommandMenus.cpp:195
+#: ../../src/MaximaCommandMenus.cpp:206 ../../src/MaximaCommandMenus.cpp:230
+#: ../../src/MaximaCommandMenus.cpp:235 ../../src/MaximaCommandMenus.cpp:252
+#: ../../src/MaximaCommandMenus.cpp:258 ../../src/MaximaCommandMenus.cpp:265
+#: ../../src/MaximaCommandMenus.cpp:297 ../../src/MaximaCommandMenus.cpp:316
+#: ../../src/MaximaCommandMenus.cpp:3545 ../../src/wizards/IntegrateWiz.cpp:33
+#: ../../src/wizards/LimitWiz.cpp:29 ../../src/wizards/SeriesWiz.cpp:30
+#: ../../src/wizards/SubstituteWiz.cpp:29 ../../src/wizards/SumWiz.cpp:31
 msgid "Expression:"
 msgstr "Uttrykk:"
 
-#: ../../src/wxMaximaFrame.cpp:1423
+#: ../../src/wxMaximaFrame.cpp:1457
 #, fuzzy
 msgid "Extract Column..."
 msgstr "Lag liste fra uttrykk"
 
-#: ../../src/wxMaximaFrame.cpp:1726
+#: ../../src/wxMaximaFrame.cpp:1763
 msgid "Extract Elements"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1421
+#: ../../src/wxMaximaFrame.cpp:1455
 #, fuzzy
 msgid "Extract Row..."
 msgstr "Lag liste fra uttrykk"
 
-#: ../../src/wxMaximaFrame.cpp:1424
+#: ../../src/wxMaximaFrame.cpp:1458
 msgid "Extract a column from the matrix"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1435
+#: ../../src/wxMaximaFrame.cpp:1472
 msgid "Extract a column from the matrix and convert it to a list"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7960
+#: ../../src/MaximaCommandMenus.cpp:1140
 #, fuzzy
 msgid "Extract a matrix column"
 msgstr "Oppgi en matrise"
 
-#: ../../src/wxMaxima.cpp:7970
+#: ../../src/MaximaCommandMenus.cpp:1150
 #, fuzzy
 msgid "Extract a matrix column as a list"
 msgstr "Oppgi en matrise"
 
-#: ../../src/wxMaximaFrame.cpp:1313
+#: ../../src/wxMaximaFrame.cpp:1347
 #, fuzzy
 msgid "Extract a matrix from a 2-dimensional array"
 msgstr "Generer en matrise fra et 2-dimensjonalt array"
 
-#: ../../src/wxMaxima.cpp:7955
+#: ../../src/MaximaCommandMenus.cpp:1135
 #, fuzzy
 msgid "Extract a matrix row"
 msgstr "Oppgi en matrise"
 
-#: ../../src/wxMaxima.cpp:7965
+#: ../../src/MaximaCommandMenus.cpp:1145
 #, fuzzy
 msgid "Extract a matrix row as a list"
 msgstr "Oppgi en matrise"
 
-#: ../../src/wxMaximaFrame.cpp:1422
+#: ../../src/wxMaximaFrame.cpp:1456
 msgid "Extract a row from the matrix"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1431
+#: ../../src/wxMaximaFrame.cpp:1468
 #, fuzzy
 msgid "Extract a row from the matrix and convert it to a list"
 msgstr "Lag liste fra uttrykk"
 
-#: ../../src/wxMaxima.cpp:8564
+#: ../../src/MaximaCommandMenus.cpp:1580
 msgid "Extract a variable's value from a list of variable values"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1723
+#: ../../src/wxMaximaFrame.cpp:1760
 msgid "Extract an actual value for a variable"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1163
+#: ../../src/wxMaximaFrame.cpp:1197
 #, fuzzy
 msgid "Extract char..."
 msgstr "Lag liste fra uttrykk"
 
-#: ../../src/wxMaximaFrame.cpp:1207
+#: ../../src/wxMaximaFrame.cpp:1241
 #, fuzzy
 msgid "Extract dir from path..."
 msgstr "Lag liste fra uttrykk"
 
-#: ../../src/wxMaxima.cpp:7605
+#: ../../src/MaximaCommandMenus.cpp:4477
 #, fuzzy
 msgid "Extract directory part"
 msgstr "Funksjonnavn"
 
-#: ../../src/wxMaxima.cpp:7617
+#: ../../src/MaximaCommandMenus.cpp:4489
 #, fuzzy
 msgid "Extract file type extension"
 msgstr "Lag liste fra uttrykk"
 
-#: ../../src/wxMaximaFrame.cpp:1209
+#: ../../src/wxMaximaFrame.cpp:1243
 msgid "Extract filename from path..."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7611
+#: ../../src/MaximaCommandMenus.cpp:4483
 #, fuzzy
 msgid "Extract filename part"
 msgstr "Lag liste fra uttrykk"
 
-#: ../../src/wxMaximaFrame.cpp:1211
+#: ../../src/wxMaximaFrame.cpp:1245
 msgid "Extract filetype from path..."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8445
+#: ../../src/MaximaCommandMenus.cpp:1442
 #, fuzzy
 msgid "Extract function arguments"
 msgstr "Funksjonnavn"
 
-#: ../../src/wxMaximaFrame.cpp:1727
+#: ../../src/wxMaximaFrame.cpp:1764
 #, fuzzy
 msgid "Extract list Elements"
 msgstr "Lag liste fra uttrykk"
 
-#: ../../src/wxMaxima.cpp:8187
+#: ../../src/MaximaCommandMenus.cpp:1375
 #, fuzzy
 msgid "Extract matrix from 2D array"
 msgstr "Oppgi en matrise"
 
-#: ../../src/wxMaximaFrame.cpp:1686
+#: ../../src/wxMaximaFrame.cpp:1723
 #, fuzzy
 msgid "Extract the argument list from a function call"
 msgstr "Lag liste fra uttrykk"
 
-#: ../../src/wxMaxima.cpp:8538
+#: ../../src/MaximaCommandMenus.cpp:1551
 #, fuzzy
 msgid "Extract the last n elements from a list"
 msgstr "Lag liste fra uttrykk"
 
-#: ../../src/wxMaxima.cpp:7376
+#: ../../src/MaximaCommandMenus.cpp:1550
+msgid "Extract the last n list elements"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:4248
 #, fuzzy
 msgid "Extract the nth char of a string"
 msgstr "Lag liste fra uttrykk"
 
-#: ../../src/wxMaxima.cpp:8544
+#: ../../src/MaximaCommandMenus.cpp:1557
 #, fuzzy
 msgid "Extract the nth list elements"
 msgstr "Lag liste fra uttrykk"
 
-#: ../../src/wxMaximaFrame.cpp:1724
+#: ../../src/wxMaximaFrame.cpp:1761
 msgid "Extract the value for one variable assigned in a list"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1439
+#: ../../src/wxMaximaFrame.cpp:1476
 msgid "Extract, append or delete rows or columns"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8188
+#: ../../src/MaximaCommandMenus.cpp:1376
 #, fuzzy
 msgid "Extracts a rectangle from a 2D array and converts it to a matrix"
 msgstr "Lag liste fra uttrykk"
 
-#: ../../src/wxMaximaFrame.cpp:1521
+#: ../../src/sidebars/MathSidebar.cpp:50
+msgid "Factor"
+msgstr "Faktoriser"
+
+#: ../../src/wxMaximaFrame.cpp:1558
 msgid "Factor Complex"
 msgstr "Faktoriser K&omplekst"
 
-#: ../../src/Worksheet.cpp:1581
+#: ../../src/worksheet/WorksheetContextMenu.cpp:354
 msgid "Factor Expression"
 msgstr "Faktoriser Uttrykk"
 
-#: ../../src/wxMaximaFrame.cpp:1519
+#: ../../src/wxMaximaFrame.cpp:1556
 #, fuzzy
 msgid "Factor Expression including subexpressions"
 msgstr "Faktoriser et uttrykk i gaussiske heltall"
 
-#: ../../src/wxMaximaFrame.cpp:1517 ../../src/wxMaximaFrame.cpp:1520
+#: ../../src/wxMaximaFrame.cpp:1554 ../../src/wxMaximaFrame.cpp:1557
 msgid "Factor an expression"
 msgstr "Faktoriser et uttrykk"
 
-#: ../../src/wxMaximaFrame.cpp:1522
+#: ../../src/wxMaximaFrame.cpp:1559
 msgid "Factor an expression in Gaussian numbers"
 msgstr "Faktoriser et uttrykk i gaussiske heltall"
 
-#: ../../src/wxMaximaFrame.cpp:1587
+#: ../../src/wxMaximaFrame.cpp:1624
 msgid "Factorials and &Gamma"
 msgstr "Fakultet og &Gamma"
 
-#: ../../src/Image.cpp:137
+#: ../../src/Image.cpp:173
 #, c-format
 msgid "Failed to delete gnuplot data file %s"
 msgstr ""
 
-#: ../../src/Image.cpp:121 ../../src/Image.cpp:128
+#: ../../src/Image.cpp:157 ../../src/Image.cpp:164
 #, c-format
 msgid "Failed to delete gnuplot file %s"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2667
+#: ../../src/MaximaProcessManager.cpp:352
 #, fuzzy
 msgid "Failed to start Maxima"
 msgstr "Restart Maxima"
 
-#: ../../src/wxMaximaFrame.cpp:1418
+#: ../../src/MaximaProcessManager.cpp:628
+msgid "Failed to write to Maxima's stdin (LDB)."
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1452
 msgid "Fast fortran routines that perform numerical tasks"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1922
+#: ../../src/wxMaximaFrame.cpp:1959
 msgid "Fast list access"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2553
+#: ../../src/MaximaProcessManager.cpp:218
 msgid "Fatal error"
 msgstr "Fatal feil"
 
-#: ../../src/wxMaxima.cpp:7191
+#: ../../src/wizards/CsvWiz.cpp:38 ../../src/wizards/CsvWiz.cpp:109
+msgid "Field Separator"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:4063
 #, fuzzy
 msgid "Field contents:"
 msgstr "Greske konstanter"
 
-#: ../../src/wxMaxima.cpp:7198
+#: ../../src/MaximaCommandMenus.cpp:4070
 #, fuzzy
 msgid "Field name:"
 msgstr "Forrige variabel:"
 
-#: ../../src/wxMaxima.cpp:7185
+#: ../../src/MaximaCommandMenus.cpp:4057
 msgid "Fields:"
 msgstr ""
 
-#: ../../src/main.cpp:439
+#: ../../src/cells/GroupCell.cpp:2115
+#, c-format
+msgid "Figure %d:"
+msgstr "Figur %d:"
+
+#: ../../src/main.cpp:678
 msgid "File"
 msgstr "Fil"
 
-#: ../../src/wxMaximaFrame.cpp:1333
+#: ../../src/wxMaximaFrame.cpp:1367
 #, fuzzy
 msgid "File I/O"
 msgstr "Fil"
 
-#: ../../src/wxMaxima.cpp:4165 ../../src/wxMaxima.cpp:4224
-#: ../../src/wxMaxima.cpp:4493 ../../src/wxMaxima.cpp:4504
-#: ../../src/wxMaxima.cpp:4606 ../../src/wxMaxima.cpp:4636
-#: ../../src/wxMaxima.cpp:4647 ../../src/wxMaxima.cpp:5641
+#: ../../src/MaximaFileIO.cpp:66 ../../src/MaximaFileIO.cpp:123
+#: ../../src/MaximaFileIO.cpp:401 ../../src/MaximaFileIO.cpp:412
+#: ../../src/MaximaFileIO.cpp:529 ../../src/MaximaFileIO.cpp:559
+#: ../../src/MaximaFileIO.cpp:570 ../../src/MaximaFileIO.cpp:732
 #, fuzzy
 msgid "File could not be opened"
 msgstr "Fant ikke fil"
 
-#: ../../src/wxMaxima.cpp:7241 ../../src/wxMaxima.cpp:7246
-#: ../../src/wxMaxima.cpp:7251
+#: ../../src/MaximaCommandMenus.cpp:4113 ../../src/MaximaCommandMenus.cpp:4118
+#: ../../src/MaximaCommandMenus.cpp:4123
 #, fuzzy
 msgid "File name:"
 msgstr "Forrige variabel:"
 
-#: ../../src/wxMaxima.cpp:10225 ../../src/wxMaxima.cpp:10268
+#: ../../src/wxMaxima.cpp:2995 ../../src/wxMaxima.cpp:3038
 msgid "File not found"
 msgstr "Fant ikke fil"
 
-#: ../../src/wxMaxima.cpp:5631
+#: ../../src/MaximaFileIO.cpp:730
 #, fuzzy
 msgid "File opened"
 msgstr "Fant ikke fil"
 
-#: ../../src/wxMaximaFrame.cpp:1217
+#: ../../src/wxMaximaFrame.cpp:1251
 #, fuzzy
 msgid "File operations"
 msgstr "Fant ikke fil"
 
-#: ../../src/wxMaxima.cpp:10224 ../../src/wxMaxima.cpp:10267
+#: ../../src/wxMaxima.cpp:2994 ../../src/wxMaxima.cpp:3037
 msgid "File you tried to open does not exist."
 msgstr "Filen du forsøkte å åpne finnes ikke."
 
-#: ../../src/wxMaximaFrame.cpp:1221
+#: ../../src/wxMaximaFrame.cpp:1255
 #, fuzzy
 msgid "File/directory functions"
 msgstr "Retning:"
 
-#: ../../src/wxMaxima.cpp:7027
+#: ../../src/wizards/CsvWiz.cpp:54 ../../src/wizards/CsvWiz.cpp:128
+msgid "Filename"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:3899
 msgid "Filename or a list of comma-separated file names"
 msgstr ""
 
-#: ../../src/ToolBar.cpp:222
+#: ../../src/sidebars/DrawSidebar.cpp:93
+msgid "Fill color"
+msgstr ""
+
+#: ../../src/ToolBar.cpp:401 ../../src/ToolBar.cpp:403
 msgid "Find"
 msgstr "Finn"
 
-#: ../../src/wxMaximaFrame.cpp:670
+#: ../../src/wxMaximaFrame.cpp:707
 msgid "Find\tCtrl+F"
 msgstr "&Finn\tCtrl+F"
 
-#: ../../src/wxMaximaFrame.cpp:1468
+#: ../../src/wxMaximaFrame.cpp:1505
 msgid "Find &Limit..."
 msgstr "Finn &Grenseverdi..."
 
-#: ../../src/wxMaximaFrame.cpp:1470
+#: ../../src/wxMaximaFrame.cpp:1507
 msgid "Find Minimum..."
 msgstr "Finn Minim&um..."
 
-#: ../../src/Worksheet.cpp:1576
+#: ../../src/worksheet/WorksheetContextMenu.cpp:349
 msgid "Find Root..."
 msgstr "Finn Rot..."
 
-#: ../../src/wxMaximaFrame.cpp:1471
+#: ../../src/wxMaximaFrame.cpp:1508
 msgid "Find a (unconstrained) minimum of an expression"
 msgstr "Finn et (ubegrenset) minimum til et uttrykk"
 
-#: ../../src/wxMaximaFrame.cpp:1804
+#: ../../src/wxMaximaFrame.cpp:1841
 msgid "Find a fraction that represents this float exactly"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1469
+#: ../../src/wxMaximaFrame.cpp:1506
 msgid "Find a limit of an expression"
 msgstr "Finn grenseverdi til et uttrykk"
 
-#: ../../src/wxMaximaFrame.cpp:1807
+#: ../../src/wxMaximaFrame.cpp:1844
 msgid "Find a nice fraction that is similar to this float"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1283
+#: ../../src/wxMaximaFrame.cpp:1317
 #, fuzzy
 msgid "Find a numerical solution for a first degree ODE"
 msgstr "Løs initialverdiproblem for førstegrads ODE"
 
-#: ../../src/wxMaximaFrame.cpp:1252
+#: ../../src/wxMaximaFrame.cpp:1286
 msgid "Find a root of an equation on an interval"
 msgstr "Finn en rot til en likning i et intervall"
 
-#: ../../src/wxMaximaFrame.cpp:1259
+#: ../../src/wxMaximaFrame.cpp:1293
 msgid "Find all roots of a polynomial"
 msgstr "Finn alle røttene til et polynom"
 
-#: ../../src/wxMaximaFrame.cpp:1262
+#: ../../src/wxMaximaFrame.cpp:1296
 msgid "Find all roots of a polynomial (bfloat)"
 msgstr "Finn alle røttene til et polynom (bigfloat)"
 
-#: ../../src/wxMaxima.cpp:6589
+#: ../../src/MaximaCommandMenus.cpp:3103
 msgid "Find and Replace"
 msgstr "Finn og Erstatt"
 
-#: ../../src/ToolBar.cpp:222 ../../src/wxMaximaFrame.cpp:670
+#: ../../src/ToolBar.cpp:401 ../../src/ToolBar.cpp:403
+#: ../../src/wxMaximaFrame.cpp:707
 msgid "Find and replace"
 msgstr "Finn og erstatt"
 
-#: ../../src/wxMaxima.cpp:7434
+#: ../../src/MaximaCommandMenus.cpp:4306
 msgid "Find char in string"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1172
+#: ../../src/wxMaximaFrame.cpp:1206
 msgid "Find char in string..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1534
+#: ../../src/wxMaximaFrame.cpp:1571
 msgid "Find common denominator"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1366
+#: ../../src/wxMaximaFrame.cpp:1400
 msgid "Find eigenvalues of a matrix"
 msgstr "Finn egenverdier til en matrise"
 
-#: ../../src/wxMaximaFrame.cpp:1369
+#: ../../src/wxMaximaFrame.cpp:1403
 msgid "Find eigenvectors of a matrix"
 msgstr "Finn egenvektorer til en matrise"
 
-#: ../../src/wxMaxima.cpp:7424
+#: ../../src/MaximaCommandMenus.cpp:4296
 msgid "Find first difference"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1170
+#: ../../src/wxMaximaFrame.cpp:1204
 msgid "Find first difference..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1256
+#: ../../src/wxMaximaFrame.cpp:1290
 #, fuzzy
 msgid "Find fractions that real roots of a polynomial and "
 msgstr "Finn reelle røtter til et polynom"
 
-#: ../../src/wxMaxima.cpp:9039
+#: ../../src/MaximaCommandMenus.cpp:293
 msgid "Find minimum"
 msgstr "Finn minimum"
 
-#: ../../src/wxMaximaFrame.cpp:1251
+#: ../../src/wxMaximaFrame.cpp:1285
 msgid "Find numerical solution..."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:10035
+#: ../../src/MaximaCommandMenus.cpp:3524
 msgid "Find root (solve numerically)"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8062 ../../src/wxMaxima.cpp:8083
+#: ../../src/MaximaCommandMenus.cpp:1248 ../../src/MaximaCommandMenus.cpp:1271
 #, fuzzy
 msgid "Find the maximum absolute value of a matrix entry"
 msgstr "Finn egenverdier til en matrise"
 
-#: ../../src/wxMaxima.cpp:8068 ../../src/wxMaxima.cpp:8089
+#: ../../src/MaximaCommandMenus.cpp:1254 ../../src/MaximaCommandMenus.cpp:1277
 msgid "Find the maximum sum of the absolute values of a matrix column"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8073 ../../src/wxMaxima.cpp:8094
+#: ../../src/MaximaCommandMenus.cpp:1259 ../../src/MaximaCommandMenus.cpp:1282
 msgid "Find the maximum sum of the absolute values of a matrix row"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1832
+#: ../../src/dialogs/FindReplacePane.cpp:46
+#, fuzzy
+msgid "Find:"
+msgstr "Finn"
+
+#: ../../src/wxMaximaFrame.cpp:1869
 msgid "Fine-tune the display of engineering-format numbers"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1712
+#: ../../src/dialogs/ConfigDialogue.cpp:197
+#, fuzzy
+msgid "Finnish"
+msgstr "Dansk"
+
+#: ../../src/wxMaximaFrame.cpp:1749
 msgid "First"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1918
+#: ../../src/wxMaximaFrame.cpp:1955
 msgid "Fitting curves to measurement data"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7227
+#: ../../src/dialogs/ConfigDialogue.cpp:1404
+#, c-format
+msgid "Fix reordered reference indices (of %i, %o) before saving"
+msgstr "Fiks omstokkede referanseindekser (av %i, %o) før lagring"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:873
+msgid "Fixed font in text controls"
+msgstr "Fast font i tekstkontroller"
+
+#: ../../src/MaximaCommandMenus.cpp:4099
 msgid "Flush stream"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1103
+#: ../../src/wxMaximaFrame.cpp:1137
 msgid "Flush..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:922
+#: ../../src/wxMaximaFrame.cpp:956
 msgid "Fold All\tCtrl+Alt+["
 msgstr "F&old Alle\tCtrl+A-["
 
-#: ../../src/wxMaximaFrame.cpp:923
+#: ../../src/wxMaximaFrame.cpp:957
 msgid "Fold all sections"
 msgstr "Fold alle seksjoner"
 
-#: ../../src/ToolBar.cpp:240
+#: ../../src/ToolBar.cpp:424 ../../src/ToolBar.cpp:432
 msgid "Follow"
 msgstr ""
 
-#: ../../src/ToolBar.cpp:285
+#: ../../src/dialogs/ConfigDialogue.cpp:2070
+msgid "Follow system"
+msgstr ""
+
+#: ../../src/wizards/DrawWiz.cpp:341
+msgid "Following plots use secondary x axis"
+msgstr ""
+
+#: ../../src/wizards/DrawWiz.cpp:347
+msgid "Following plots use secondary y axis"
+msgstr ""
+
+#: ../../src/sidebars/PerformanceSidebar.cpp:37
+msgid "Font cache hits:"
+msgstr ""
+
+#: ../../src/sidebars/PerformanceSidebar.cpp:38
+msgid "Font cache misses:"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:2047
+msgid "Fonts"
+msgstr "Fonter"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:442
+msgid "For each Text-, Sectioning or code cell wxMaxima can display a bracket showing the extend of the cell and allowing to fold it. This setting now tells if this bracket is to be printed, as well."
+msgstr ""
+
+#: ../../src/ToolBar.cpp:495
 msgid ""
 "For faster creation of cells the following shortcuts exist:\n"
 "\n"
@@ -3292,430 +4846,635 @@ msgid ""
 "   Ctrl+7: Heading6 cell\n"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7038
+#: ../../src/MaximaCommandMenus.cpp:3910
 msgid "For loop"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1062
+#: ../../src/wxMaximaFrame.cpp:1096
 msgid "For loop..."
 msgstr ""
 
-#: ../../src/Worksheet.cpp:237 ../../src/wxMaxima.cpp:11217
+#: ../../src/wizards/Plot2dWiz.cpp:69 ../../src/wizards/Plot3dWiz.cpp:60
+msgid "Format:"
+msgstr "Format:"
+
+#: ../../src/worksheet/Worksheet.cpp:301 ../../src/wxMaxima.cpp:3523
 msgid "Forwarding the keyboard focus to a text control"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:11220
+#: ../../src/wxMaxima.cpp:3526
 msgid "Forwarding the keyboard focus to the worksheet"
 msgstr ""
 
-#: ../../src/MaximaManual.cpp:452
+#: ../../src/MaximaManual.cpp:469
 #, c-format
 msgid "Found %li anchors, URLs (individual files): %li, URLs (singlepage): %li"
 msgstr ""
 
-#: ../../src/MaximaManual.cpp:313
+#: ../../src/graphical_io/Printout.cpp:182
+#, c-format
+msgid "Found %li line breaks"
+msgstr ""
+
+#: ../../src/MaximaManual.cpp:326
 #, c-format
 msgid "Found only %li keywords in maxima's manual. Not caching them to disc."
 msgstr ""
 
-#: ../../src/MaximaManual.cpp:513
+#: ../../src/MaximaManual.cpp:530
 #, c-format
 msgid "Found the maxima HTML manual in the folder %s."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8948
+#: ../../src/MaximaCommandMenus.cpp:202
 msgid "Fourier coefficients"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1476
+#: ../../src/wxMaximaFrame.cpp:1513
 msgid "Fourier coefficients..."
 msgstr ""
 
-#: ../../src/ToolBar.cpp:137
+#: ../../src/ToolBar.cpp:132
 #, c-format
 msgid "Frame %li of %li"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:9097
+#: ../../src/wizards/DrawWiz.cpp:488
+msgid "Frame counter"
+msgstr ""
+
+#: ../../src/wizards/DrawWiz.cpp:499
+#, fuzzy
+msgid "Frame counter end"
+msgstr "Fant ikke fil"
+
+#: ../../src/wizards/DrawWiz.cpp:494
+msgid "Frame counter start"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:102
 msgid "Frame rate"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1005 ../../src/wxMaximaFrame.cpp:1009
+#: ../../src/wxMaximaFrame.cpp:1039 ../../src/wxMaximaFrame.cpp:1043
 msgid "Free all unused items now"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1413
+#: ../../src/dialogs/ConfigDialogue.cpp:198
+msgid "French"
+msgstr "Fransk"
+
+#: ../../src/wxMaximaFrame.cpp:1447
 msgid "Frobenius Norm sqrt(sum((A(i,j))^2)) (complex)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1411
+#: ../../src/wxMaximaFrame.cpp:1445
 msgid "Frobenius Norm sqrt(sum((A(i,j))^2)) (real)"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:9064
+#: ../../src/MaximaCommandMenus.cpp:318 ../../src/wizards/IntegrateWiz.cpp:41
+#: ../../src/wizards/Plot2dWiz.cpp:48 ../../src/wizards/Plot2dWiz.cpp:58
+#: ../../src/wizards/Plot2dWiz.cpp:499 ../../src/wizards/Plot3dWiz.cpp:37
+#: ../../src/wizards/Plot3dWiz.cpp:46 ../../src/wizards/SumWiz.cpp:37
 msgid "From:"
 msgstr "Fra:"
 
-#: ../../src/wxMaximaFrame.cpp:827
+#: ../../src/wxMaximaFrame.cpp:864
 msgid "Full Screen\tAlt+Enter"
 msgstr "F&ullskjerm\tAlt+Enter"
 
-#: ../../src/wxMaximaFrame.cpp:824
+#: ../../src/wxMaximaFrame.cpp:861
 msgid "Full Screen\tF11"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7140
+#: ../../src/sidebars/PerformanceSidebar.cpp:48
+msgid "Full-window repaints:"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:4012
 #, fuzzy
 msgid "Function contents:"
 msgstr "Funksjonnavn"
 
-#: ../../src/wxMaxima.cpp:7908
+#: ../../src/MaximaCommandMenus.cpp:1089
 #, fuzzy
 msgid "Function f(x):"
 msgstr "Funksjoner:"
 
-#: ../../src/wxMaxima.cpp:8572
+#: ../../src/MaximaCommandMenus.cpp:1590
 #, fuzzy
 msgid "Function name"
 msgstr "Funksjonnavn"
 
-#: ../../src/wxMaxima.cpp:7167
+#: ../../src/MaximaCommandMenus.cpp:4039
 #, fuzzy
 msgid "Function name(s):"
 msgstr "Funksjonnavn"
 
-#: ../../src/wxMaxima.cpp:7135 ../../src/wxMaxima.cpp:7684
+#: ../../src/MaximaCommandMenus.cpp:4007 ../../src/MaximaCommandMenus.cpp:4556
 #, fuzzy
 msgid "Function name:"
 msgstr "Funksjonnavn"
 
-#: ../../src/wxMaxima.cpp:8135
+#: ../../src/MaximaCommandMenus.cpp:1323
 msgid "Function:"
 msgstr "Funksjon:"
 
-#: ../../src/wxMaximaFrame.cpp:1630
+#: ../../src/wxMaximaFrame.cpp:1667
 msgid "Functions for complex simplification"
 msgstr "Funksjoner til kompleks forenkling"
 
-#: ../../src/wxMaximaFrame.cpp:1588
+#: ../../src/wxMaximaFrame.cpp:1625
 msgid "Functions for simplifying factorials and gamma function"
 msgstr "Funksjon til forenkling av fakulteter og gammafunksjoner"
 
-#: ../../src/wxMaximaFrame.cpp:1606
+#: ../../src/wxMaximaFrame.cpp:1643
 msgid "Functions for simplifying trigonometric expressions"
 msgstr "Funksjoner til forenkling av trigonometriske uttrykk"
 
-#: ../../src/wxMaxima.cpp:8965 ../../src/wxMaxima.cpp:8970
+#: ../../src/MaximaCommandMenus.cpp:219 ../../src/MaximaCommandMenus.cpp:224
 msgid "GCD"
 msgstr "SFD"
 
-#: ../../src/wxMaxima.cpp:10186
+#: ../../src/MaximaCommandMenus.cpp:3715
 msgid "GIF image (*.gif)|*.gif"
 msgstr "GIF-bilde (*.gif)|*.gif"
 
-#: ../../src/Worksheet.cpp:103
-msgid "GTK_IM_MODULE is set to \"xim\". Expect the program to hideously flicker and hotkeys to be broken, see for example https://trac.wxwidgets.org/ticket/18462."
+#: ../../src/MaximaCommandMenus.cpp:3615
+msgid "GIF image (*.gif)|*.gif|Portable anymap (*.pnm)|*.pnm|Tagged image file format (*.tif)|*.tif|X pixmap (*.xpm)|*.xpm"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:295
+#: ../../src/worksheet/Worksheet.cpp:117
+msgid "GTK_IM_MODULE is set to \"xim\". Expect the program to hideously flicker and hotkeys to be broken, see for example https://github.com/wxWidgets/wxWidgets/issues/18462."
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:199
+msgid "Galician"
+msgstr "Galisisk"
+
+#: ../../src/sidebars/GreekSidebar.cpp:180
+msgid "Gamma"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:316
 msgid "General Math"
 msgstr "Generell Matte"
 
-#: ../../src/wxMaximaFrame.cpp:699
+#: ../../src/wxMaximaFrame.cpp:734
 msgid "General Math\tAlt+Shift+M"
 msgstr "Generell Matte\tAlt+Shift+M"
 
-#: ../../src/wxMaximaFrame.cpp:1316
+#: ../../src/wxMaximaFrame.cpp:1350
 msgid "Generate Matrix from Expression..."
 msgstr "Generer Matrise fra &Uttrykk..."
 
-#: ../../src/wxMaximaFrame.cpp:1317
+#: ../../src/wxMaximaFrame.cpp:1351
 msgid "Generate a matrix from a lambda expression"
 msgstr "Generer en matrise fra et lambdauttrykk"
 
-#: ../../src/wxMaximaFrame.cpp:1675
+#: ../../src/wxMaximaFrame.cpp:1712
 msgid "Generate a new list using a lists' elements"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1681
+#: ../../src/wxMaximaFrame.cpp:1718
 msgid "Generate a storage for variable values that can be introduced into equations at any time"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1672
+#: ../../src/wxMaximaFrame.cpp:1709
 msgid "Generate list elements using a rule"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8196
+#: ../../src/MaximaCommandMenus.cpp:1386
 #, fuzzy
 msgid "Generate matrix from a rule"
 msgstr "Lag liste fra uttrykk"
 
-#: ../../src/wxMaximaFrame.cpp:1094
+#: ../../src/wxMaximaFrame.cpp:1128
 msgid "Generate unused symbol name"
 msgstr ""
 
-#: ../../src/WXMXformat.cpp:231
+#: ../../src/WXMXformat.cpp:232
 msgid "Generated the XML representation of the document"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8197
+#: ../../src/MaximaCommandMenus.cpp:1387
 msgid "Generates a matrix and fills each element with the result of the expression \"Rule\"."
 msgstr ""
 
+#: ../../src/dialogs/ConfigDialogue.cpp:200
+msgid "Georgian"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:201
+msgid "German"
+msgstr "Tysk"
+
 # s/Finn/Bestem|Skaff|Trekk ut ?
-#: ../../src/wxMaximaFrame.cpp:1619
+#: ../../src/wxMaximaFrame.cpp:1656
 msgid "Get &Imaginary Part"
 msgstr "Finn &Imaginær Del"
 
-#: ../../src/wxMaximaFrame.cpp:1485
+#: ../../src/wxMaximaFrame.cpp:1522
 msgid "Get Laplace transformation of an expression"
 msgstr "Finn laplacetransformasjon av et uttrykk"
 
-#: ../../src/wxMaximaFrame.cpp:1615
+#: ../../src/wxMaximaFrame.cpp:1652
 msgid "Get Real P&art"
 msgstr "Finn &Reell Del"
 
-#: ../../src/wxMaximaFrame.cpp:1201
+#: ../../src/wxMaximaFrame.cpp:1235
 msgid "Get current directory"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1489
+#: ../../src/wxMaximaFrame.cpp:1526
 msgid "Get inverse Laplace transformation of an expression"
 msgstr "Finn invers laplacetransformasjon av et uttrykk"
 
-#: ../../src/wxMaxima.cpp:7223
+#: ../../src/MaximaCommandMenus.cpp:4095
 msgid "Get position in stream"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1102
+#: ../../src/wxMaximaFrame.cpp:1136
 #, fuzzy
 msgid "Get position..."
 msgstr "Avvik..."
 
-#: ../../src/wxMaximaFrame.cpp:1620
+#: ../../src/wxMaximaFrame.cpp:1657
 msgid "Get the imaginary part of complex expression"
 msgstr "Finn imaginær del av et komplekst uttrykk"
 
-#: ../../src/wxMaximaFrame.cpp:1616
+#: ../../src/wxMaximaFrame.cpp:1653
 msgid "Get the real part of complex expression"
 msgstr "Finn reell del av et komplekst uttrykk"
 
-#: ../../src/wxMaxima.cpp:3609
+#: ../../src/MaximaProcessManager.cpp:1220
 #, c-format
 msgid "Gnuplot (command line) found at: %s"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3607
+#: ../../src/dialogs/ConfigDialogue.cpp:1629
+msgid "Gnuplot flavour"
+msgstr ""
+
+#: ../../src/MaximaProcessManager.cpp:1218
 #, c-format
 msgid "Gnuplot found at: %s"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2974
+#: ../../src/MaximaProcessManager.cpp:994
 msgid "Gnuplot has closed."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3598 ../../src/wxMaxima.cpp:3603
+#: ../../src/MaximaProcessManager.cpp:1209
+#: ../../src/MaximaProcessManager.cpp:1214
 #, c-format
 msgid "Gnuplot not found, using the default: %s"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:9428 ../../src/wxMaximaFrame.cpp:1887
+#: ../../src/MaximaProcessManager.cpp:1097
+#, c-format
+msgid ""
+"Gnuplot reported the following while preparing the popped-out plot:\n"
+"%s"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:2071 ../../src/wxMaximaFrame.cpp:1924
 msgid "Go to URL"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3989
+#: ../../src/MaximaResponseReader.cpp:396
 #, fuzzy
 msgid "Got a new input prompt!"
 msgstr "Sett inn ny inndatacelle"
 
-#: ../../src/Worksheet.cpp:6354
+#: ../../src/worksheet/Worksheet.cpp:4306
 msgid "Got a request to undo an action that involves a delete which isn't possible at this moment."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1031
+#: ../../src/wxMaximaFrame.cpp:1065
 msgid "Gradefs"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1967
+#: ../../src/worksheet/WorksheetContextMenu.cpp:739
 #, fuzzy
 msgid "Greater or less than a value"
 msgstr "Underseksjoncelle"
 
-#: ../../src/wxMaximaFrame.cpp:1130
+#: ../../src/wxMaximaFrame.cpp:1164
 msgid "Greater, ignoring case?..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:260
+#: ../../src/dialogs/ConfigDialogue.cpp:202
+msgid "Greek"
+msgstr "Gresk"
+
+#: ../../src/wxMaximaFrame.cpp:281
 #, fuzzy
 msgid "Greek Letters"
 msgstr "Greske konstanter"
 
-#: ../../src/wxMaximaFrame.cpp:703
+#: ../../src/wxMaximaFrame.cpp:738
 #, fuzzy
 msgid "Greek Letters\tAlt+Shift+G"
 msgstr "Generell Matte\tAlt+Shift+M"
 
-#: ../../src/wxMaximaFrame.cpp:1815
+#: ../../src/sidebars/DrawSidebar.cpp:97
+msgid "Grid"
+msgstr ""
+
+#: ../../src/wizards/Plot3dWiz.cpp:52
+msgid "Grid:"
+msgstr "Rutenett:"
+
+#: ../../src/wxMaximaFrame.cpp:1852
 msgid "Guess an exact number that could be meant by this float"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:6123
+#: ../../src/dialogs/ConfigDialogue.cpp:1215
+msgid "HTML"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:2279
 #, fuzzy
 msgid "HTML file (*.html)|*.html|maxima batch file (*.mac)|*.mac|LaTeX file (*.tex)|*.tex"
 msgstr "HTML-fil (*.html)|*.html|pdfLaTeX file (*.tex)|*.tex|Alle|*"
 
-#: ../../src/wxMaximaFrame.cpp:1341
+#: ../../src/wxMaximaFrame.cpp:1375
 msgid "Hadamard (element-by-element) product..."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8004
+#: ../../src/MaximaCommandMenus.cpp:1188
 #, fuzzy
 msgid "Hadamard Product"
 msgstr "Produkt"
 
-#: ../../src/wxMaxima.cpp:8011
+#: ../../src/MaximaCommandMenus.cpp:1195
 msgid "Hadamard exponent"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1345
+#: ../../src/wxMaximaFrame.cpp:1379
 #, fuzzy
 msgid "Hadamard exponent..."
 msgstr "Matrisenavn:"
 
-#: ../../src/MaximaManual.cpp:260
+#: ../../src/MaximaManual.cpp:269
 #, c-format
 msgid "Have only %li keyword anchors at the end of parsing the maxima manual => Not caching the result of using the built-in keyword list"
 msgstr ""
 
-#: ../../src/Configuration.cpp:88 ../../src/ToolBar.cpp:276
+#: ../../src/Styles.cpp:117 ../../src/ToolBar.cpp:486
+#: ../../src/sidebars/FormatSidebar.cpp:60
 msgid "Heading 5"
 msgstr ""
 
-#: ../../src/Configuration.cpp:87 ../../src/ToolBar.cpp:277
+#: ../../src/Styles.cpp:116 ../../src/ToolBar.cpp:487
+#: ../../src/sidebars/FormatSidebar.cpp:63
 msgid "Heading 6"
 msgstr ""
 
-#: ../../src/ToolBar.cpp:328 ../../src/wxMaximaFrame.cpp:330
+#: ../../src/dialogs/ConfigDialogue.cpp:203
+msgid "Hebrew"
+msgstr ""
+
+#: ../../src/ToolBar.cpp:544 ../../src/ToolBar.cpp:546
+#: ../../src/wxMaximaFrame.cpp:351
 msgid "Help"
 msgstr "Hjelp"
 
-#: ../../src/ToolBar.cpp:635
+#: ../../src/dialogs/ConfigDialogue.cpp:1461
+msgid "Help browser:"
+msgstr ""
+
+#: ../../src/ToolBar.cpp:835
 msgid "Help button"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1340 ../../src/Worksheet.cpp:1778
+#: ../../src/worksheet/WorksheetContextMenu.cpp:102
+#: ../../src/worksheet/WorksheetContextMenu.cpp:551
 #, c-format
 msgid "Help on \"%s\""
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:729
-#, fuzzy
-msgid "Hide All Toolbars\tAlt+Shift+-"
-msgstr "Gjem Alt\tAlt+Shift+-"
+#: ../../src/wizards/GenWizPanel.cpp:248
+#, c-format
+msgid "Help on %s"
+msgstr ""
 
-#: ../../src/ToolBar.cpp:264
+#: ../../src/sidebars/TableOfContents.cpp:510
+#, fuzzy
+msgid "Hide"
+msgstr "Divider Celle"
+
+#: ../../src/ToolBar.cpp:471 ../../src/ToolBar.cpp:473
 #, fuzzy
 msgid "Hide Code"
 msgstr "Divider Celle"
 
-#: ../../src/wxMaximaFrame.cpp:727
+#: ../../src/wxMaximaFrame.cpp:764
 #, fuzzy
 msgid "Hide Code Cells\tAlt+Ctrl+H"
 msgstr "Sett Inn Celle\tAlt+Shift+C"
 
-#: ../../src/Worksheet.cpp:1896
+#: ../../src/worksheet/WorksheetContextMenu.cpp:668
 msgid "Hide Heading 5"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1907
+#: ../../src/worksheet/WorksheetContextMenu.cpp:679
 msgid "Hide Heading 6"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1855
+#: ../../src/worksheet/WorksheetContextMenu.cpp:627
 #, fuzzy
 msgid "Hide Part"
 msgstr "Divider Celle"
 
-#: ../../src/Worksheet.cpp:1863
+#: ../../src/worksheet/WorksheetContextMenu.cpp:635
 #, fuzzy
 msgid "Hide Section"
 msgstr "Seksjon"
 
-#: ../../src/Worksheet.cpp:1874
+#: ../../src/worksheet/WorksheetContextMenu.cpp:646
 #, fuzzy
 msgid "Hide Subsection"
 msgstr "Underseksjon"
 
-#: ../../src/Worksheet.cpp:1885
+#: ../../src/worksheet/WorksheetContextMenu.cpp:657
 #, fuzzy
 msgid "Hide Subsubsection"
 msgstr "Underseksjon"
 
-#: ../../src/wxMaximaFrame.cpp:730
+#: ../../src/wxMaximaFrame.cpp:766
+msgid "Hide all Sidebars\tAlt+Shift+-"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:487
+msgid "Hide all multiplication signs that aren't really necessary for understanding the equation"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:767
 msgid "Hide all panes"
 msgstr "Gjem alle inndelingsruter"
 
-#: ../../src/Worksheet.cpp:1491
+#: ../../src/worksheet/WorksheetContextMenu.cpp:262
 #, fuzzy
 msgid "Hide cell brackets"
 msgstr "Klammer rundt aktiv celle"
 
-#: ../../src/Worksheet.cpp:1915
+#: ../../src/worksheet/WorksheetContextMenu.cpp:687
 #, fuzzy
 msgid "Hide contents"
 msgstr "Greske konstanter"
 
-#: ../../src/Worksheet.cpp:1552
+#: ../../src/worksheet/WorksheetContextMenu.cpp:325
 msgid "Hide multiplication dots"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1930 ../../src/Worksheet.cpp:2063
+#: ../../src/dialogs/ConfigDialogue.cpp:854
+msgid "Hide multiplication signs, if possible"
+msgstr ""
+
+#: ../../src/wizards/DrawWiz.cpp:555
+msgid "Hide objects behind the surface"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:502
+msgid "Hide the brackets that mark the extend of the worksheet cells at the worksheet's right side and that contain the \"hide\" button of the cell if the cells aren't active."
+msgstr ""
+
+#: ../../src/worksheet/WorksheetContextMenu.cpp:702
+#: ../../src/worksheet/WorksheetContextMenu.cpp:835
 msgid "Hide yellow tooltip marker for this cell"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1937 ../../src/Worksheet.cpp:2069
+#: ../../src/worksheet/WorksheetContextMenu.cpp:709
+#: ../../src/worksheet/WorksheetContextMenu.cpp:841
 msgid "Hide yellow tooltip marker for this message type"
 msgstr ""
 
-#: ../../src/Configuration.cpp:82
+#: ../../src/Styles.cpp:111
 #, fuzzy
 msgid "Highlight (box)"
 msgstr "Fremhev (dpart)"
 
-#: ../../src/wxMaxima.cpp:9528
+#: ../../src/dialogs/ConfigDialogue.cpp:869
+#, fuzzy
+msgid "Highlight the matching parenthesis"
+msgstr "Samsvar parenteser i tekstkontroller"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:463
+msgid "Highlight the opening or closing parenthesis for the parenthesis the cursor is at."
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:204
+msgid "Hindi"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:1766
 msgid "Histogram"
 msgstr "Histogram"
 
-#: ../../src/wxMaximaFrame.cpp:232
+#: ../../src/sidebars/StatSidebar.cpp:85
+msgid "Histogram..."
+msgstr "Histogram..."
+
+#: ../../src/wxMaximaFrame.cpp:246
 msgid "History"
 msgstr "Historikk"
 
-#: ../../src/wxMaximaFrame.cpp:709
+#: ../../src/wxMaximaFrame.cpp:744
 #, fuzzy
 msgid "History\tAlt+Shift+I"
 msgstr "Historikk\tAlt+Shift+H"
 
-#: ../../src/wxMaximaFrame.cpp:1526
+#: ../../src/dialogs/TipOfTheDay.cpp:105
+msgid "Horizontal cursor works like a normal cursor, but it operates on cells: press up or down arrow to move it, holding down Shift while moving will select cells, pressing backspace or delete twice will delete a cell next to it."
+msgstr "Horisontal peker fungerer som en vanlig peker, men den betjener celler: trykk opp- eller nedpil for å flytte den; hold inne Shift mens du flytter den for å velge celler; trykk tilbaketast eller Delete to ganger for å slette celler."
+
+#: ../../src/wxMaximaFrame.cpp:1563
 msgid "Horner's rule"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:9207
+#: ../../src/dialogs/ConfigDialogue.cpp:918
+msgid "Hotkeys for sending commands to maxima"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:398
 msgid "How many digits to show:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:759
+#: ../../src/wxMaximaFrame.cpp:796
 msgid "How to display new equations"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1113
+#: ../../src/dialogs/ConfigDialogue.cpp:205
+msgid "Hungarian"
+msgstr "Ungarsk"
+
+#: ../../src/wxMaximaFrame.cpp:1147
 msgid "I/O"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7062
-msgid "If a program doesn't need local variables maxima allows to put the commands between parenthesis. The result of the last operation is the return value of the program."
+#: ../../src/sidebars/SymbolsSidebar.cpp:121
+msgid "Identical to"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7172
+#: ../../src/MaximaCommandMenus.cpp:3934
+msgid "If a program doesn't need local variables, Maxima allows putting the commands between parentheses. The result of the last operation is the return value of the program."
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:145
+msgid "If maxima versions compiled with different lisps are installed: The name of the lisp to use by default"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:174
+msgid "If maxima was compiled by GCL: Garbage Collect at minimum allocation past this heapsize"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:171
+msgid "If maxima was compiled by GCL: Minimum allocation fraction between Garbage Collects"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:168
+msgid "If maxima was compiled by GCL: Only garbage collect past this heapsize fraction of working mem"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:180
+msgid "If maxima was compiled by GCL: Share the allocated memory between gcl processes. Allows more than one gcl-compiled maxima to run at the same time, but might provoke crashes."
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:177
+msgid "If maxima was compiled by GCL: The fraction of the total installed RAM to reserve for maxima"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:375
+msgid "If multiple cells are evaluated in one go: Abort evaluation if wxMaxima detects that maxima has encountered any error."
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:727
+msgid "If not extremely long"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:726
+msgid "If not very long"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:418
+msgid "If numbers are getting longer than this number of digits they will be displayed abbreviated by an ellipsis."
+msgstr ""
+
+#: ../../src/dialogs/TipOfTheDay.cpp:181
+msgid "If the \"Autosave\" functionality is enabled in the configuration dialogue wxMaxima acts like mobile apps that backup the file every few minutes and save it on closing."
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:396
+msgid "If the font provides big parenthesis symbols: Use them when big parenthesis are needed for maths display."
+msgstr ""
+
+#: ../../src/cells/TextCell.cpp:327
+msgid "If the thing maxima complains about actually looks like a polynomial you can try running it through ratdisrep() in order to fix that problem."
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:4044
 msgid ""
 "If the type of a function parameter is known when compiling a function the code can vastly be optimized.\n"
 "Known types:\n"
@@ -3723,1281 +5482,2022 @@ msgid ""
 "array, boolean, integer, fixnum (machine-length integer), float (machine-size floating-point numbers), real or any (which is useful for declaring arrays of any)"
 msgstr ""
 
-#: ../../src/MathParser.cpp:890
+#: ../../src/dialogs/ConfigDialogue.cpp:399
+msgid "If this checkbox is checked wxMaxima automatically saves the file closing and every few minutes giving wxMaxima a more cellphone-app-like feel as the file is virtually always saved. If this checkbox is unchecked from time to time a backup is made in the temp folder instead."
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:378
+msgid "If this checkbox is set a new code cell is opened as soon as maxima requests data. If it isn't set a new code cell is opened in this case as soon as the user starts typing in code."
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:372
+msgid "If this checkbox isn't checked the current command is sent to maxima only on pressing Ctrl+Enter"
+msgstr ""
+
+#: ../../src/MathParser.cpp:945
 msgid "If this isn't a function returning a lambda() expression a multiplication sign (*) between closing and opening parenthesis is missing here."
 msgstr ""
 
-#: ../../src/MaximaManual.cpp:403
+#: ../../src/dialogs/ConfigDialogue.cpp:942
+msgid ""
+"If this option is enabled, the filename and path of images inserted with \"Cell\" -> \"Insert Image...\" is stored in the worksheet file on save. This enables reloading of the image file via the context menu after re-opening the worksheet, but storing the filenames and paths may be an undesired data leak. If this option is disabled, reloading still works as long as the worksheet is not closed.\n"
+"\n"
+"Note: Storing the filenames for the reload functionality is independent of the automatically generated image captions."
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:439
+msgid "If this option is set the .wxmx source of the current file is copied to a place a link to is put into the result of an export."
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1873
+msgid "If unset, Maxima's output is announced to the screen reader as maths in a linear text form. Set this option if your screen reader can speak MathML properly."
+msgstr ""
+
+#: ../../src/dialogs/TipOfTheDay.cpp:247
+msgid "If you have ideas, how to improve the design or functionality of wxMaxima, please share your ideas at the issue list or discussion forum at https://github.com/wxMaxima-developers/wxmaxima/."
+msgstr ""
+
+#: ../../src/dialogs/TipOfTheDay.cpp:76
+msgid "If you type an operator (one of +*/^=,) as the first symbol in an input cell, % will be automatically inserted before the operator, as on a graphing calculator. You can disable this feature from the 'Edit->Configure' dialog."
+msgstr "Om du bruker en operator (en av +*/^=,) som det første symbolet i en inndatacelle, vil % automatisk bli plassert før operatoren, som på en grafisk kalkulator. Du kan slå av denne funksjonen i dialogen 'Endre->Konfigurer'."
+
+#: ../../src/dialogs/TipOfTheDay.cpp:122
+msgid "If your calculation is taking too long to evaluate, you can try 'Maxima->Interrupt' or 'Maxima->Restart Maxima' menu commands."
+msgstr "Om kalkulasjonen din tar for lang tid å utføre, kan du prøve 'Maxima->Avbryt' eller 'Maxima->Restart Maxima' fra menyen."
+
+#: ../../src/MaximaManual.cpp:420
 msgid "Ignoring the cache version for the manual anchors."
 msgstr ""
 
-#: ../../src/Image.cpp:79
+#: ../../src/sidebars/FormatSidebar.cpp:66
+msgid "Image"
+msgstr "Bilde"
+
+#: ../../src/Image.cpp:110
 msgid "Image data had zero length!"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:10147 ../../src/wxMaxima.cpp:10855
-msgid "Image files (*.png, *.jpg, *.bmp, *.xpm, *.gif, *.svg, *.svgz)|*.png;*.jpg;*.bmp;*.xpm;*.gif;*.svg;*.svgz"
+#: ../../src/MaximaCommandMenus.cpp:2564 ../../src/MaximaCommandMenus.cpp:2933
+#: ../../src/MaximaCommandMenus.cpp:3642
+msgid "Image files ("
 msgstr ""
 
-#: ../../src/Worksheet.cpp:5509
+#: ../../src/Image.cpp:74
+#, c-format
+msgid "Image of type %s found."
+msgstr ""
+
+#: ../../src/worksheet/WorksheetExport.cpp:1407
 msgid "ImageCell without image."
 msgstr ""
 
-#: ../../src/MathParser.cpp:347
+#: ../../src/sidebars/DrawSidebar.cpp:60
+msgid "Implicit Plot"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1028
+msgid "Import settings"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1013
+#, fuzzy
+msgid "Import+Export"
+msgstr "Eksporter"
+
+#: ../../src/MathParser.cpp:395
 msgid "Importing compressed gnuplot sources for an animation"
 msgstr ""
 
-#: ../../src/MathParser.cpp:334
+#: ../../src/MathParser.cpp:382
 msgid "Importing uncompressed gnuplot sources for an animation"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7993
+#: ../../src/MaximaCommandMenus.cpp:1177
 msgid ""
 "In order to save memory the \":\" operator does clone the matrix, not copy it:\n"
 "If you change an element of one matrix the same element will change in all of its clones. copymatrix() instead generates a copy of a matrix: A new matrix that, if changed in any way, won't change the original."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7404
+#: ../../src/MaximaCommandMenus.cpp:4276
 msgid "In order to save memory the : operator doesn't create an individual copy of the string, but a clone that changes when the original string changes."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:9629
+#: ../../src/dialogs/TipOfTheDay.cpp:175
+msgid ""
+"In order to visualize how a parameter affects an equation wxMaxima provides commands that start with \"with_slider_\" and that create animations. One example would be:\n"
+"\n"
+"    with_slider_draw(\n"
+"        a,[-16,-9,-4,-2,0,1,2,3,4,5,6,7],\n"
+"        title=concat(\"a=\",a),\n"
+"        grid=true,\n"
+"        explicit(\n"
+"            x^2-a*x,\n"
+"            x,-10,10\n"
+"        )\n"
+"    );"
+msgstr ""
+
+#: ../../src/dialogs/TipOfTheDay.cpp:214
+msgid "In text cells bullet lists can be created by beginning a line with \" * \". The number of spaces in front of the \"*\" determines the indentation level; Indentation can be continued in the next line by indenting the line using spaces."
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:421
+msgid "In the LaTeX output: Put exponents after an eventual subscript instead of above it. Might increase readability for some fonts and short subscripts."
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:1869
 msgid "Include columns:"
 msgstr "Inkluder kolonner:"
 
-#: ../../src/Worksheet.cpp:2008
+#: ../../src/worksheet/WorksheetContextMenu.cpp:780
 msgid "Increasing function f(x)>x"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8470
+#: ../../src/dialogs/ConfigDialogue.cpp:884
+msgid "Incremental Search"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:844
+msgid "Indent equations by the label width"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:512
+msgid "Indent maths so all lines are in par with the first line that starts after the label."
+msgstr ""
+
+#: ../../src/sidebars/TableOfContents.cpp:583
+msgid "Indentation"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:1473
 msgid "Index End:"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8470
+#: ../../src/MaximaCommandMenus.cpp:1473
 msgid "Index Start:"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8471
+#: ../../src/MaximaCommandMenus.cpp:1474
 msgid "Index Step:"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8467 ../../src/wxMaxima.cpp:8480
+#: ../../src/MaximaCommandMenus.cpp:1470 ../../src/MaximaCommandMenus.cpp:1484
 #, fuzzy
 msgid "Index variable:"
 msgstr "Ny variabel:"
 
-#: ../../src/wxMaximaFrame.cpp:1949
+#: ../../src/dialogs/ConfigDialogue.cpp:206
+msgid "Indonesian"
+msgstr ""
+
+#: ../../src/cells/TextCell.cpp:186
+msgid "Infinitesimal above zero."
+msgstr ""
+
+#: ../../src/cells/TextCell.cpp:188
+msgid "Infinitesimal below zero."
+msgstr ""
+
+#: ../../src/sidebars/SymbolsSidebar.cpp:91
+#: ../../src/wizards/IntegrateWiz.cpp:192
+#: ../../src/wizards/IntegrateWiz.cpp:200
+#: ../../src/wizards/IntegrateWiz.cpp:207
+#: ../../src/wizards/IntegrateWiz.cpp:215 ../../src/wizards/LimitWiz.cpp:132
+#: ../../src/wizards/LimitWiz.cpp:140
+msgid "Infinity"
+msgstr "Uendelig"
+
+#: ../../src/wxMaximaFrame.cpp:1986
 msgid "Info about Maxima build"
 msgstr "Info om Maxima-build"
 
-#: ../../src/Worksheet.cpp:2046
+#: ../../src/worksheet/WorksheetContextMenu.cpp:818
 msgid "Inform maxima about facts you know for this symbol"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1988
+#: ../../src/worksheet/WorksheetContextMenu.cpp:760
 msgid "Inform maxima about the value of the function at a specific point, e.G. for declaring initial conditions"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7793 ../../src/wxMaxima.cpp:7804
+#: ../../src/MaximaCommandMenus.cpp:974 ../../src/MaximaCommandMenus.cpp:985
 #, fuzzy
 msgid "Initial Condition"
 msgstr "Betingelse:"
 
-#: ../../src/wxMaximaFrame.cpp:1270
+#: ../../src/wxMaximaFrame.cpp:1304
 msgid "Initial Value Problem (&1)..."
 msgstr "Initialverdiproblem (&0)..."
 
-#: ../../src/wxMaximaFrame.cpp:1274
+#: ../../src/wxMaximaFrame.cpp:1308
 msgid "Initial Value Problem (&2)..."
 msgstr "Initialverdiproblem (&1)..."
 
-#: ../../src/wxMaxima.cpp:9044
+#: ../../src/MaximaCommandMenus.cpp:298
 #, fuzzy
 msgid "Initial estimates:"
 msgstr "Umiddelbare Estimat:"
 
-#: ../../src/wxMaxima.cpp:7840
+#: ../../src/MaximaCommandMenus.cpp:1021
 #, fuzzy
 msgid "Initial x:"
 msgstr "Umiddelbare Estimat:"
 
-#: ../../src/Configuration.cpp:78
+#: ../../src/dialogs/FindReplacePane.cpp:107
+msgid "Input"
+msgstr ""
+
+#: ../../src/sidebars/RegexCtrl.cpp:38
+msgid ""
+"Input a RegEx here to filter the results.\n"
+"Right-click for options!"
+msgstr ""
+
+#: ../../src/Styles.cpp:107
 msgid "Input labels"
 msgstr "Inndataetiketter"
 
-#: ../../src/wxMaximaFrame.cpp:314
+#: ../../src/sidebars/RegexCtrl.cpp:42
+msgid ""
+"Input your filter text here.\n"
+"Right-click for options!"
+msgstr ""
+
+#: ../../src/wizards/GenWizPanel.cpp:103 ../../src/wxMaximaFrame.cpp:335
 msgid "Insert"
 msgstr "Sett inn"
 
-#: ../../src/wxMaximaFrame.cpp:905
+#: ../../src/dialogs/ConfigDialogue.cpp:889
+msgid "Insert % before an operator at the beginning of a cell"
+msgstr "Sett inn % før en operator ved begynnelsen av celler"
+
+#: ../../src/wxMaximaFrame.cpp:939
 msgid "Insert &Section Cell\tCtrl+3"
 msgstr "Sett Inn &Seksjoncelle\tCtrl+3"
 
-#: ../../src/wxMaximaFrame.cpp:901
+#: ../../src/wxMaximaFrame.cpp:935
 msgid "Insert &Text Cell\tCtrl+1"
 msgstr "Sett Inn &Tekstcelle\tCtrl+1"
 
-#: ../../src/wxMaximaFrame.cpp:713
+#: ../../src/wxMaximaFrame.cpp:748
 msgid "Insert Cell\tAlt+Shift+C"
 msgstr "Sett Inn Celle\tAlt+Shift+C"
 
-#: ../../src/Worksheet.cpp:1669
+#: ../../src/worksheet/WorksheetContextMenu.cpp:442
 msgid "Insert Heading5 Cell"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1671
+#: ../../src/worksheet/WorksheetContextMenu.cpp:444
 msgid "Insert Heading6 Cell"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:10854
+#: ../../src/MaximaCommandMenus.cpp:2563
 msgid "Insert Image"
 msgstr "Sett Inn Bilde"
 
-#: ../../src/wxMaximaFrame.cpp:917
+#: ../../src/wxMaximaFrame.cpp:951
 msgid "Insert Image..."
 msgstr "Sett Inn &Bilde..."
 
-#: ../../src/wxMaximaFrame.cpp:899
+#: ../../src/wxMaximaFrame.cpp:933
 #, fuzzy
 msgid "Insert Input &Cell\tCtrl+0"
 msgstr "Sett Inn Inndata&celle"
 
-#: ../../src/wxMaximaFrame.cpp:919
+#: ../../src/wxMaximaFrame.cpp:953
 msgid "Insert Page Break"
 msgstr "Sett Inn S&ideskift"
 
-#: ../../src/wxMaximaFrame.cpp:907
+#: ../../src/wxMaximaFrame.cpp:941
 msgid "Insert S&ubsection Cell\tCtrl+4"
 msgstr "Sett Inn U&nderseksjoncelle\tCtrl+4"
 
-#: ../../src/wxMaximaFrame.cpp:910
+#: ../../src/wxMaximaFrame.cpp:944
 #, fuzzy
 msgid "Insert S&ubsubsection Cell\tCtrl+5"
 msgstr "Sett Inn U&nderseksjoncelle\tCtrl+4"
 
-#: ../../src/Worksheet.cpp:1662
+#: ../../src/worksheet/WorksheetContextMenu.cpp:435
 msgid "Insert Section Cell"
 msgstr "Sett Inn Seksjoncelle"
 
-#: ../../src/Worksheet.cpp:1664
+#: ../../src/worksheet/WorksheetContextMenu.cpp:437
 msgid "Insert Subsection Cell"
 msgstr "Sett Inn Underseksjoncelle"
 
-#: ../../src/Worksheet.cpp:1667
+#: ../../src/worksheet/WorksheetContextMenu.cpp:440
 #, fuzzy
 msgid "Insert Subsubsection Cell"
 msgstr "Sett Inn Underseksjoncelle"
 
-#: ../../src/wxMaximaFrame.cpp:903
+#: ../../src/wxMaximaFrame.cpp:937
 msgid "Insert T&itle Cell\tCtrl+2"
 msgstr "Sett Inn &Tittelcelle\tCtrl+2"
 
-#: ../../src/Worksheet.cpp:1658
+#: ../../src/worksheet/WorksheetContextMenu.cpp:431
 msgid "Insert Text Cell"
 msgstr "Sett Inn Tekstcelle"
 
-#: ../../src/Worksheet.cpp:1660
+#: ../../src/worksheet/WorksheetContextMenu.cpp:433
 msgid "Insert Title Cell"
 msgstr "Sett Inn Tittelcelle"
 
-#: ../../src/wxMaximaFrame.cpp:913
+#: ../../src/wxMaximaFrame.cpp:947
 msgid "Insert a new heading5 cell"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:915
+#: ../../src/wxMaximaFrame.cpp:949
 msgid "Insert a new heading6 cell"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:900
+#: ../../src/wxMaximaFrame.cpp:934
 msgid "Insert a new input cell"
 msgstr "Sett inn ny inndatacelle"
 
-#: ../../src/wxMaximaFrame.cpp:906
+#: ../../src/wxMaximaFrame.cpp:940
 msgid "Insert a new section cell"
 msgstr "Sett inn ny seksjoncelle"
 
-#: ../../src/wxMaximaFrame.cpp:908
+#: ../../src/wxMaximaFrame.cpp:942
 msgid "Insert a new subsection cell"
 msgstr "Sett inn ny underseksjoncelle"
 
-#: ../../src/wxMaximaFrame.cpp:911
+#: ../../src/wxMaximaFrame.cpp:945
 #, fuzzy
 msgid "Insert a new subsubsection cell"
 msgstr "Sett inn ny underseksjoncelle"
 
-#: ../../src/wxMaximaFrame.cpp:902
+#: ../../src/wxMaximaFrame.cpp:936
 msgid "Insert a new text cell"
 msgstr "Sett inn ny tekstcelle"
 
-#: ../../src/wxMaximaFrame.cpp:904
+#: ../../src/wxMaximaFrame.cpp:938
 msgid "Insert a new title cell"
 msgstr "Sett inn ny tekstcelle"
 
-#: ../../src/wxMaximaFrame.cpp:920
+#: ../../src/wxMaximaFrame.cpp:954
 msgid "Insert a page break"
 msgstr "Sett inn et sideskift"
 
-#: ../../src/wxMaximaFrame.cpp:1164
+#: ../../src/MaximaCommandMenus.cpp:4261
+msgid "Insert a string into another"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1198
 #, fuzzy
 msgid "Insert char..."
 msgstr "Sett Inn &Bilde..."
 
-#: ../../src/wxMaximaFrame.cpp:912
+#: ../../src/wxMaximaFrame.cpp:946
 msgid "Insert heading5 Cell\tCtrl+6"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:914
+#: ../../src/wxMaximaFrame.cpp:948
 msgid "Insert heading6 Cell\tCtrl+7"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:917
+#: ../../src/wxMaximaFrame.cpp:951
 msgid "Insert image"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:916
+#: ../../src/wxMaximaFrame.cpp:950
 #, fuzzy
 msgid "Insert textbased cell"
 msgstr "Sett Inn Tekstcelle"
 
-#: ../../src/wxMaxima.cpp:3566
+#: ../../src/worksheet/Worksheet.cpp:6131
+msgid "Insertion point between cells"
+msgstr ""
+
+#: ../../src/sidebars/HelpBrowser.cpp:111
+msgid "Instantiating the HTML manual browser"
+msgstr ""
+
+#: ../../src/MaximaProcessManager.cpp:1177
 msgid "Instructed to prefer gnuplot over wgnuplot"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3554
+#: ../../src/MaximaProcessManager.cpp:1165
 msgid "Instructed to prefer wgnuplot over gnuplot"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8898 ../../src/wxMaxima.cpp:8919
+#: ../../src/dialogs/ConfigDialogue.cpp:749
+msgid "Integers and single letters"
+msgstr ""
+
+#: ../../src/sidebars/SymbolsSidebar.cpp:113
+#, fuzzy
+msgid "Integral sign"
+msgstr "Integrer uttrykk"
+
+#: ../../src/MaximaCommandMenus.cpp:149 ../../src/MaximaCommandMenus.cpp:170
 msgid "Integral/Sum:"
 msgstr "Integral/Sum:"
 
-#: ../../src/wxMaxima.cpp:8986 ../../src/wxMaxima.cpp:10044
+#: ../../src/MaximaCommandMenus.cpp:240 ../../src/MaximaCommandMenus.cpp:3533
+#: ../../src/wizards/IntegrateWiz.cpp:73
 msgid "Integrate"
 msgstr "Integrer"
 
-#: ../../src/wxMaxima.cpp:8980
+#: ../../src/MaximaCommandMenus.cpp:234
 msgid "Integrate (risch)"
 msgstr "Integrer (risch)"
 
-#: ../../src/wxMaximaFrame.cpp:1454
+#: ../../src/wxMaximaFrame.cpp:1491
 msgid "Integrate expression"
 msgstr "Integrer uttrykk"
 
-#: ../../src/wxMaximaFrame.cpp:1456
+#: ../../src/wxMaximaFrame.cpp:1493
 msgid "Integrate expression with Risch algorithm"
 msgstr "Integrer uttrykk med Risch algoritme"
 
-#: ../../src/wxMaximaFrame.cpp:1869
-#, fuzzy
-msgid "Integrate numerically"
-msgstr "Integrer (risch)"
+#: ../../src/wxMaximaFrame.cpp:1906
+msgid "Integrate numerically (QUADPACK)"
+msgstr ""
 
-#: ../../src/Worksheet.cpp:1588
+#: ../../src/sidebars/MathSidebar.cpp:83
+#: ../../src/worksheet/WorksheetContextMenu.cpp:361
 msgid "Integrate..."
 msgstr "Integrer..."
 
-#: ../../src/wxMaximaFrame.cpp:1737
+#: ../../src/dialogs/ConfigDialogue.cpp:834
+#, fuzzy
+msgid "Intelligently hide cell brackets"
+msgstr "Klammer rundt aktiv celle"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:881
+#, fuzzy
+msgid "Interaction"
+msgstr "Retning:"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1349
+msgid "Interactive popup memory limit [MB/plot]:"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1774
 #, fuzzy
 msgid "Interleave"
 msgstr "Integrer"
 
-#: ../../src/wxMaximaFrame.cpp:1738
+#: ../../src/wxMaximaFrame.cpp:1775
 #, fuzzy
 msgid "Interleave the values of two lists"
 msgstr "Integrer"
 
-#: ../../src/wxMaxima.cpp:8612
+#: ../../src/MaximaCommandMenus.cpp:1631
 #, fuzzy
 msgid "Interleave two lists"
 msgstr "Integrer"
 
-#: ../../src/wxMaximaFrame.cpp:1087
+#: ../../src/dialogs/ConfigDialogue.cpp:1465
+#, fuzzy
+msgid "Internal"
+msgstr "Integrer"
+
+#: ../../src/wxMaximaFrame.cpp:1121
 msgid "Interpret like input..."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7104
+#: ../../src/MaximaCommandMenus.cpp:3976
 msgid "Interpret maxima's output as input"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7502
+#: ../../src/MaximaCommandMenus.cpp:4374
 msgid "Interpret string as maxima code"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1089
+#: ../../src/wxMaximaFrame.cpp:1123
 #, fuzzy
 msgid "Interpret string..."
 msgstr "Oppgi Matrise..."
 
-#: ../../src/ToolBar.cpp:231
+#: ../../src/ToolBar.cpp:413 ../../src/ToolBar.cpp:419
 msgid "Interrupt"
 msgstr "Avbryt"
 
-#: ../../src/wxMaximaFrame.cpp:965
+#: ../../src/wxMaximaFrame.cpp:999
 msgid "Interrupt current computation"
 msgstr "Avbryt løpende kalkulasjon"
 
-#: ../../src/ToolBar.cpp:232
+#: ../../src/ToolBar.cpp:414 ../../src/ToolBar.cpp:420
 msgid "Interrupt current computation. To completely restart maxima press the button left to this one."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2766
+#: ../../src/MaximaProcessManager.cpp:876
 #, c-format
 msgid "Interrupting maxima: %s"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8557
+#: ../../src/MaximaCommandMenus.cpp:1570
 msgid "Introduce a list of actual values into an equation"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1697
+#: ../../src/wxMaximaFrame.cpp:1734
 msgid "Introduce the actual values for variables stored in the list"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:10062
+#: ../../src/MaximaCommandMenus.cpp:3551
 msgid "Introduces one or more assignments into an expression"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:9003
+#: ../../src/sidebars/RegexCtrl.cpp:40
+msgid "Invalid RegEx!"
+msgstr ""
+
+#: ../../src/MathParser.cpp:1338
+#, c-format
+msgid "Invalid XML: %s"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:257
 msgid "Inverse Laplace"
 msgstr "Invers Laplace"
 
-#: ../../src/wxMaximaFrame.cpp:1488
+#: ../../src/wxMaximaFrame.cpp:1525
 msgid "Inverse Laplace T&ransform..."
 msgstr "I&nvers Laplacetransformasjon..."
 
-#: ../../src/wxMaximaFrame.cpp:832
-msgid "Invert worksheet brightness"
+#: ../../src/sidebars/GreekSidebar.cpp:186
+msgid "Iota"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7338
+#: ../../src/MaximaCommandMenus.cpp:4210
 msgid "Is Char 1 greater than Char2, if case is ignored?"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7333
+#: ../../src/MaximaCommandMenus.cpp:4205
 #, fuzzy
 msgid "Is Char 1 greater than Char2?"
 msgstr "Underseksjoncelle"
 
-#: ../../src/wxMaxima.cpp:7327
+#: ../../src/MaximaCommandMenus.cpp:4199
 msgid "Is Char 1 less than Char2, if case is ignored?"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7322
+#: ../../src/MaximaCommandMenus.cpp:4194
 msgid "Is Char 1 less than Char2?"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7280
+#: ../../src/MaximaCommandMenus.cpp:4152
 msgid "Is a char?"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1115
+#: ../../src/wxMaximaFrame.cpp:1149
 msgid "Is a char?..."
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1952
+#: ../../src/worksheet/WorksheetContextMenu.cpp:724
 #, fuzzy
 msgid "Is a complex variable"
 msgstr "Ny variabel:"
 
-#: ../../src/wxMaxima.cpp:7292
+#: ../../src/MaximaCommandMenus.cpp:4164
 #, fuzzy
 msgid "Is a digit?"
 msgstr "Vis algoritme"
 
-#: ../../src/wxMaximaFrame.cpp:1118
+#: ../../src/wxMaximaFrame.cpp:1152
 msgid "Is a digit?..."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7304
+#: ../../src/MaximaCommandMenus.cpp:4176
 msgid "Is a lowercase char?"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7296
+#: ../../src/MaximaCommandMenus.cpp:4168
 msgid "Is a printable char?"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1949
+#: ../../src/worksheet/WorksheetContextMenu.cpp:721
 #, fuzzy
 msgid "Is a real variable"
 msgstr "Endre variabel"
 
-#: ../../src/wxMaxima.cpp:7300
+#: ../../src/MaximaCommandMenus.cpp:4172
 msgid "Is a uppercase char?"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1116
+#: ../../src/wxMaximaFrame.cpp:1150
 msgid "Is alphabetic?..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1117
+#: ../../src/wxMaximaFrame.cpp:1151
 msgid "Is alphanumeric?..."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7284
+#: ../../src/MaximaCommandMenus.cpp:4156
 msgid "Is an alphabetic char?"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7288
+#: ../../src/MaximaCommandMenus.cpp:4160
 msgid "Is an alphanumeric char?"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1991
+#: ../../src/worksheet/WorksheetContextMenu.cpp:763
 #, fuzzy
 msgid "Is an even function"
 msgstr "Slett en funksjon"
 
-#: ../../src/Worksheet.cpp:1955
+#: ../../src/worksheet/WorksheetContextMenu.cpp:727
 #, fuzzy
 msgid "Is an imaginary variable"
 msgstr "Endre variabel"
 
-#: ../../src/Worksheet.cpp:1960
+#: ../../src/worksheet/WorksheetContextMenu.cpp:732
 #, fuzzy
 msgid "Is an integer variable"
 msgstr "Endre variabel"
 
-#: ../../src/Worksheet.cpp:1993
+#: ../../src/worksheet/WorksheetContextMenu.cpp:765
 #, fuzzy
 msgid "Is an odd function"
 msgstr "Slett en funksjon"
 
-#: ../../src/wxMaximaFrame.cpp:1122
+#: ../../src/wxMaximaFrame.cpp:1156
 msgid "Is equal?..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1128
+#: ../../src/wxMaximaFrame.cpp:1162
 #, fuzzy
 msgid "Is greater?..."
 msgstr "Lag liste"
 
-#: ../../src/wxMaximaFrame.cpp:1125
+#: ../../src/wxMaximaFrame.cpp:1159
 msgid "Is lower?..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1121
+#: ../../src/wxMaximaFrame.cpp:1155
 msgid "Is lowercase?..."
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1962
+#: ../../src/worksheet/WorksheetContextMenu.cpp:734
 #, fuzzy
 msgid "Is no integer variable"
 msgstr "Endre variabel"
 
-#: ../../src/wxMaximaFrame.cpp:1119
+#: ../../src/wxMaximaFrame.cpp:1153
 msgid "Is printable?..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1120
+#: ../../src/wxMaximaFrame.cpp:1154
 msgid "Is uppercase?..."
 msgstr ""
 
-#: ../../src/Worksheet.cpp:6256
+#: ../../src/dialogs/ConfigDialogue.cpp:498
+msgid "Issue a notification if maxima finishes calculating while the wxMaxima window isn't in focus."
+msgstr ""
+
+#: ../../src/worksheet/Worksheet.cpp:4247
 msgid "Issuing the active cell's undo function"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:6261
+#: ../../src/worksheet/Worksheet.cpp:4251
 msgid "Issuing the worksheet's undo function"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8598 ../../src/wxMaxima.cpp:8604
+#: ../../src/dialogs/TipOfTheDay.cpp:185
+msgid "It is possible to add custom symbols to the \"symbols\" sidebar by copying them into the respective field in the configuration dialogue."
+msgstr ""
+
+#: ../../src/dialogs/TipOfTheDay.cpp:152
+msgid "It is possible to define reusable Maxima libraries with wxMaxima that can be later loaded by using the load() function. All that has to be done is to export a file in the .mac or to save it in the .wxm format. Note, though, that a few special characters like the \"not equal\" symbol for \"#\" are handled by wxMaxima, not by Maxima and therefore cannot be recognized on load()."
+msgstr ""
+
+#: ../../src/wizards/DrawWiz.cpp:476
+msgid "It needs to be filled with objects to draw afterwards."
+msgstr ""
+
+#: ../../src/wizards/ActualValuesStorageWiz.cpp:38
+msgid "It therefore makes sense to apply the known values for variables as late as possible."
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:207
+msgid "Italian"
+msgstr "Italiensk"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:2111
+msgid "Italic"
+msgstr "Kursiv"
+
+#: ../../src/MaximaCommandMenus.cpp:1617 ../../src/MaximaCommandMenus.cpp:1623
 msgid "Item"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8581
+#: ../../src/MaximaCommandMenus.cpp:1599
 #, fuzzy
 msgid "Iterator name:"
 msgstr "Matrisenavn:"
 
-#: ../../src/wxMaximaFrame.cpp:1048
-msgid "Jump to first error"
+#: ../../src/dialogs/ConfigDialogue.cpp:208
+msgid "Japanese"
+msgstr "Japansk"
+
+#: ../../src/MaximaCommandMenus.cpp:2255
+msgid "Jump to UUID"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1049
-msgid "Jump to the first cell Maxima has reported an error in."
+#: ../../src/wxMaximaFrame.cpp:661
+msgid "Jump to UUID..."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8960
+#: ../../src/wxMaximaFrame.cpp:1082
+msgid "Jump to last error"
+msgstr ""
+
+#: ../../src/dialogs/DiffFrame.cpp:405
+msgid "Jump to next difference"
+msgstr ""
+
+#: ../../src/dialogs/DiffFrame.cpp:404
+msgid "Jump to previous difference"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1083
+msgid "Jump to the last cell Maxima has reported an error in."
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:210
+msgid "Kabyle"
+msgstr ""
+
+#: ../../src/sidebars/GreekSidebar.cpp:187
+msgid "Kappa"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:864
+#, c-format
+msgid "Keep percent sign with special symbols: %e, %i, etc."
+msgstr "Behold prosenttegn ved spesielle symbol: %e, %i, etc."
+
+#: ../../src/dialogs/ConfigDialogue.cpp:212
+msgid "Korean"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:214
 msgid "LCM"
 msgstr "MFM"
 
-#: ../../src/wxMaximaFrame.cpp:1407
+#: ../../src/wxMaximaFrame.cpp:1441
 msgid "L[1] Norm (complex)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1406
+#: ../../src/wxMaximaFrame.cpp:1440
 msgid "L[1] Norm (real)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1409
+#: ../../src/wxMaximaFrame.cpp:1443
 msgid "L[inf] Norm (complex)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1408
+#: ../../src/wxMaximaFrame.cpp:1442
 msgid "L[inf] Norm (real)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1025
+#: ../../src/dialogs/ConfigDialogue.cpp:1166
+msgid "LaTeX"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1199
+msgid "LaTeX: Place exponents after, instead above subscripts"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1204
+msgid "LaTeX: Use the \"partial derivative\" symbol to represent diff()"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:758
+msgid "Label width:"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1059
 #, fuzzy
 msgid "Labels"
 msgstr "Inndataetiketter"
 
-#: ../../src/wxMaxima.cpp:7090
+#: ../../src/MaximaCommandMenus.cpp:3962
+#: ../../src/sidebars/GreekSidebar.cpp:188
 msgid "Lambda"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7091
+#: ../../src/MaximaCommandMenus.cpp:3963
 msgid ""
 "Lambda generates a function, but doesn't give it a name.\n"
 "This is useful if you want to use a function only once, perhaps as a parameter to another function and don't need it to be named.\n"
 "Also you can fill a variable with a lambda() construct, effectively generating a function pointer: A variable that can be used as a function, and filled with a different function, if needed."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8997
+#: ../../src/dialogs/ConfigDialogue.cpp:470
+msgid "Language used for wxMaxima GUI."
+msgstr "Språk brukt til wxMaxima GUI."
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1311
+msgid "Language:"
+msgstr "Språk:"
+
+#: ../../src/MaximaCommandMenus.cpp:251
 msgid "Laplace"
 msgstr "Laplace"
 
-#: ../../src/wxMaximaFrame.cpp:1484
+#: ../../src/wxMaximaFrame.cpp:1521
 msgid "Laplace &Transform..."
 msgstr "Laplace&transformer..."
 
-#: ../../src/wxMaximaFrame.cpp:1718
+#: ../../src/wxMaximaFrame.cpp:1755
 msgid "Last"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3006
+#: ../../src/MaximaProcessManager.cpp:557
 #, c-format
 msgid "Last message from maxima's stderr: %s"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2993
+#: ../../src/MaximaProcessManager.cpp:544
 #, c-format
 msgid "Last message from maxima's stdout: %s"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1720
+#: ../../src/wxMaximaFrame.cpp:1757
 #, fuzzy
 msgid "Last n"
 msgstr "Liste:"
 
-#: ../../src/wxMaxima.cpp:10400
+#: ../../src/wxMaxima.cpp:3087
 msgid "Last non-whitespace is a question mark"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:4899
+#: ../../src/dialogs/ConfigDialogue.cpp:213
+msgid "Latvian"
+msgstr ""
+
+#: ../../src/wxMaxima.cpp:1675
 #, c-format
 msgid "Launching the system's default help browser as %s."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:4909
+#: ../../src/wxMaxima.cpp:1666 ../../src/wxMaxima.cpp:1687
 msgid "Launching the system's default help browser failed."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1493
+#: ../../src/sidebars/SymbolsSidebar.cpp:126
+msgid "Leads to"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1530
 msgid "Least Common Multiple..."
 msgstr "&Minste Felles Multiplum..."
 
-#: ../../src/wxMaxima.cpp:9587
+#: ../../src/MaximaCommandMenus.cpp:1827
 msgid "Least Squares Fit"
 msgstr "Minste Kvadraters Metode"
 
-#: ../../src/wxMaxima.cpp:7982 ../../src/wxMaxima.cpp:7987
-#: ../../src/wxMaxima.cpp:8007 ../../src/wxMaxima.cpp:8013
+#: ../../src/sidebars/StatSidebar.cpp:79
+msgid "Least Squares Fit..."
+msgstr "Minste Kvadraters Metode..."
+
+#: ../../src/dialogs/ConfigDialogue.cpp:2007
+msgid "Left"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:1166 ../../src/MaximaCommandMenus.cpp:1171
+#: ../../src/MaximaCommandMenus.cpp:1191 ../../src/MaximaCommandMenus.cpp:1197
 #, fuzzy
 msgid "Left Matrix:"
 msgstr "Åpne matrise"
 
-#: ../../src/wxMaxima.cpp:8191
+#: ../../src/MaximaCommandMenus.cpp:1381
 msgid "Left end"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1297
+#: ../../src/wxMaximaFrame.cpp:1331
 msgid "Left side to the \"=\""
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1741
+#: ../../src/wxMaximaFrame.cpp:1778
 msgid "Length"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1104 ../../src/wxMaximaFrame.cpp:1167
+#: ../../src/wxMaximaFrame.cpp:1138 ../../src/wxMaximaFrame.cpp:1201
 msgid "Length..."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7421
+#: ../../src/MaximaCommandMenus.cpp:4293
 msgid "Length:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1032
+#: ../../src/wxMaximaFrame.cpp:1066
 msgid "Letrules"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1976
+#: ../../src/dialogs/TipOfTheDay.cpp:163
+msgid "Libraries can be accessed by any wxMaxima process regardless of which directory it runs in, if they are placed in the user directory. This directory can be found by typing maxima_userdir;"
+msgstr ""
+
+#: ../../src/dialogs/LicenseDialog.cpp:63
+#: ../../src/dialogs/LicenseDialog.cpp:77
+msgid "License"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:2068
+msgid "Light"
+msgstr ""
+
+#: ../../src/worksheet/WorksheetContextMenu.cpp:748
 #, fuzzy
 msgid "Likely to be the main variable"
 msgstr "Slett en variabel"
 
-#: ../../src/wxMaxima.cpp:9028
+#: ../../src/MaximaCommandMenus.cpp:282 ../../src/wizards/LimitWiz.cpp:64
 msgid "Limit"
 msgstr "Grenseverdi"
 
-#: ../../src/wxMaxima.cpp:7256
+#: ../../src/sidebars/MathSidebar.cpp:86
+msgid "Limit..."
+msgstr "Grenseverdi..."
+
+#: ../../src/sidebars/DrawSidebar.cpp:88
+msgid "Line color"
+msgstr ""
+
+#: ../../src/sidebars/StatSidebar.cpp:76
+msgid "Linear Regression..."
+msgstr "Lineær Regresjon..."
+
+#: ../../src/MaximaCommandMenus.cpp:4128
 #, fuzzy
 msgid "Lisp format string:"
 msgstr "Maxima-spørsmål"
 
-#: ../../src/wxMaxima.cpp:7258
+#: ../../src/MaximaCommandMenus.cpp:4130
 msgid "Lisp format strings are more powerful than c++ format strings"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:5066
+#: ../../src/wxMaxima.cpp:1874
 msgid "Lisp mode."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1010 ../../src/wxMaximaFrame.cpp:1012
+#: ../../src/wxMaximaFrame.cpp:1044 ../../src/wxMaximaFrame.cpp:1046
 msgid "Lisp normally frees memory only when it has time or runs out of space"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3691
+#: ../../src/MaximaResponseReader.cpp:908
 #, c-format
 msgid "Lisp version: %s"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8435 ../../src/wxMaxima.cpp:8539
-#: ../../src/wxMaxima.cpp:8548 ../../src/wxMaxima.cpp:8565
-#: ../../src/wxMaxima.cpp:8574 ../../src/wxMaxima.cpp:8594
-#: ../../src/wxMaxima.cpp:8599 ../../src/wxMaxima.cpp:8603
+#: ../../src/MaximaCommandMenus.cpp:1432 ../../src/MaximaCommandMenus.cpp:1552
+#: ../../src/MaximaCommandMenus.cpp:1561 ../../src/MaximaCommandMenus.cpp:1583
+#: ../../src/MaximaCommandMenus.cpp:1592 ../../src/MaximaCommandMenus.cpp:1613
+#: ../../src/MaximaCommandMenus.cpp:1618 ../../src/MaximaCommandMenus.cpp:1622
 #, fuzzy
 msgid "List"
 msgstr "Liste:"
 
-#: ../../src/wxMaxima.cpp:8608 ../../src/wxMaxima.cpp:8613
+#: ../../src/MaximaCommandMenus.cpp:1627 ../../src/MaximaCommandMenus.cpp:1632
 #, fuzzy
 msgid "List #1"
 msgstr "Liste:"
 
-#: ../../src/wxMaxima.cpp:8609 ../../src/wxMaxima.cpp:8614
+#: ../../src/MaximaCommandMenus.cpp:1628 ../../src/MaximaCommandMenus.cpp:1633
 #, fuzzy
 msgid "List #2"
 msgstr "Liste:"
 
-#: ../../src/wxMaximaFrame.cpp:1200
+#: ../../src/wxMaximaFrame.cpp:1234
 msgid "List directory"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1205
+#: ../../src/wxMaximaFrame.cpp:1239
 msgid "List directory..."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7385 ../../src/wxMaxima.cpp:7389
+#: ../../src/wizards/ListSortWiz.cpp:34
+msgid "List name:"
+msgstr ""
+
+#: ../../src/sidebars/VariablesPane.cpp:188
+msgid "List of arrays"
+msgstr ""
+
+#: ../../src/sidebars/VariablesPane.cpp:191
+msgid "List of changed options"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:4257
 msgid "List of char to String"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1150
+#: ../../src/wxMaximaFrame.cpp:1184
 #, fuzzy
 msgid "List of chars to string..."
 msgstr "Uttrykk"
 
-#: ../../src/wxMaxima.cpp:7386
+#: ../../src/MaximaCommandMenus.cpp:4258
 #, fuzzy
 msgid "List of chars:"
 msgstr "Inndataetiketter"
 
-#: ../../src/wxMaxima.cpp:8559
+#: ../../src/sidebars/VariablesPane.cpp:179
+msgid "List of functional dependencies"
+msgstr ""
+
+#: ../../src/sidebars/VariablesPane.cpp:203
+#, fuzzy
+msgid "List of labels"
+msgstr "Inndataetiketter"
+
+#: ../../src/sidebars/VariablesPane.cpp:200
+msgid "List of structs"
+msgstr ""
+
+#: ../../src/sidebars/VariablesPane.cpp:197
+msgid "List of user aliases"
+msgstr ""
+
+#: ../../src/sidebars/VariablesPane.cpp:185
+msgid "List of user functions"
+msgstr ""
+
+#: ../../src/sidebars/VariablesPane.cpp:194
+msgid "List of user rules"
+msgstr ""
+
+#: ../../src/sidebars/VariablesPane.cpp:182
+msgid "List of user variables"
+msgstr ""
+
+#: ../../src/sidebars/VariablesPane.cpp:206
+msgid "List of user-defined derivatives"
+msgstr ""
+
+#: ../../src/sidebars/VariablesPane.cpp:216
+msgid "List of user-defined let rule packages"
+msgstr ""
+
+#: ../../src/sidebars/VariablesPane.cpp:212
+msgid "List of user-defined macros"
+msgstr ""
+
+#: ../../src/sidebars/VariablesPane.cpp:209
+msgid "List of user-defined properties"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:1575
 msgid "List with values"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8509 ../../src/wxMaxima.cpp:8527
-#: ../../src/wxMaxima.cpp:8533 ../../src/wxMaxima.cpp:8579
+#: ../../src/MaximaCommandMenus.cpp:1451 ../../src/MaximaCommandMenus.cpp:1510
+#: ../../src/MaximaCommandMenus.cpp:1515 ../../src/MaximaCommandMenus.cpp:1520
+#: ../../src/MaximaCommandMenus.cpp:1524 ../../src/MaximaCommandMenus.cpp:1528
+#: ../../src/MaximaCommandMenus.cpp:1532 ../../src/MaximaCommandMenus.cpp:1538
+#: ../../src/MaximaCommandMenus.cpp:1544 ../../src/MaximaCommandMenus.cpp:1597
+#: ../../src/MaximaCommandMenus.cpp:1608
 msgid "List:"
 msgstr "Liste:"
 
-#: ../../src/wxMaxima.cpp:6200
+#: ../../src/dialogs/ConfigDialogue.cpp:214
+msgid "Lithuanian"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:2162
+msgid "Load"
+msgstr "Last"
+
+#: ../../src/MaximaCommandMenus.cpp:2356
 msgid "Load Package"
 msgstr "Last Pakke"
 
-#: ../../src/wxMaximaFrame.cpp:613
+#: ../../src/wxMaximaFrame.cpp:644
 #, fuzzy
 msgid "Load Recent Package"
 msgstr "Last Pakke"
 
-#: ../../src/wxMaximaFrame.cpp:616
+#: ../../src/wxMaximaFrame.cpp:647
 msgid "Load a Maxima file using the batch command"
 msgstr "Last en Maxima-fil ved bruk av batch-kommandoen"
 
-#: ../../src/wxMaximaFrame.cpp:611
+#: ../../src/wxMaximaFrame.cpp:642
 msgid "Load a Maxima package file"
 msgstr "Last en Maxima-pakkefil"
 
-#: ../../src/wxMaximaFrame.cpp:1678
-#, fuzzy
-msgid "Load a list from a csv file"
-msgstr "Last en Maxima-pakkefil"
-
-#: ../../src/wxMaximaFrame.cpp:1324 ../../src/wxMaximaFrame.cpp:1330
+#: ../../src/wxMaximaFrame.cpp:1358 ../../src/wxMaximaFrame.cpp:1364
 #, fuzzy
 msgid "Load a matrix from a csv file"
 msgstr "Last en Maxima-pakkefil"
 
-#: ../../src/wxMaximaFrame.cpp:1381 ../../src/wxMaximaFrame.cpp:1382
+#: ../../src/wxMaximaFrame.cpp:1715
+msgid "Load a nested list from a csv file"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1415 ../../src/wxMaximaFrame.cpp:1416
 #, fuzzy
 msgid "Load lapack"
 msgstr "Last Pakke"
 
-#: ../../src/wxMaxima.cpp:7208
+#: ../../src/MaximaCommandMenus.cpp:4080
 #, fuzzy
 msgid "Load lisp code"
 msgstr "Last Pakke"
 
-#: ../../src/wxMaximaFrame.cpp:1092
+#: ../../src/wxMaximaFrame.cpp:1126
 #, fuzzy
 msgid "Load lisp..."
 msgstr "Last Pakke"
 
-#: ../../src/wxMaximaFrame.cpp:1198
+#: ../../src/dialogs/ConfigDialogue.cpp:2645
+msgid "Load style from file"
+msgstr "Last en stil fra fil"
+
+#: ../../src/wxMaximaFrame.cpp:1232
 msgid "Load the file/dir operations (operatingsystem)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1187
+#: ../../src/wxMaximaFrame.cpp:1221
 msgid "Load the regular expression package (sregex)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1224
+#: ../../src/wxMaximaFrame.cpp:1258
 msgid "Load the translation generator (gentran)"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8219
+#: ../../src/sidebars/SymbolsSidebar.cpp:128
+msgid "Long Right arrow"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:1409
 #, fuzzy
 msgid "Loop variable"
 msgstr "Ny variabel:"
 
-#: ../../src/wxMaxima.cpp:7778 ../../src/wxMaxima.cpp:10040
+#: ../../src/MaximaCommandMenus.cpp:959 ../../src/MaximaCommandMenus.cpp:3529
 msgid "Lower bound:"
 msgstr "Nedre grense:"
 
-#: ../../src/wxMaximaFrame.cpp:1127
+#: ../../src/wxMaximaFrame.cpp:1161
 msgid "Lower, ignoring case?..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1448
+#: ../../src/wxMaximaFrame.cpp:1485
 #, fuzzy
 msgid "M&atrix"
 msgstr "Matrise"
 
-#: ../../src/wxMaxima.cpp:7153
+#: ../../src/sidebars/XmlInspector.cpp:104
+msgid "MAXIMA RESPONSE:"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:4025
 #, fuzzy
 msgid "Macro contents:"
 msgstr "Greske konstanter"
 
-#: ../../src/wxMaxima.cpp:7148
+#: ../../src/MaximaCommandMenus.cpp:4020
 #, fuzzy
 msgid "Macro name:"
 msgstr "Matrisenavn:"
 
-#: ../../src/wxMaximaFrame.cpp:1024
+#: ../../src/wxMaximaFrame.cpp:1058
 msgid "Macros"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:697
-#, fuzzy
-msgid "Main Toolbar\tAlt+Shift+B"
-msgstr "Verktøylinje\tAlt+Shift+T"
+#: ../../src/wxMaximaFrame.cpp:869
+msgid "Main Toolbar\tShift+Alt+B"
+msgstr ""
 
-#: ../../src/wxMaxima.cpp:7906
+#: ../../src/MaximaCommandMenus.cpp:1087
 msgid "Make a function value at a specific point known"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:2028
+#: ../../src/worksheet/WorksheetContextMenu.cpp:800
 msgid "Make an eventual ev() evaluate this"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1070
+#: ../../src/wxMaximaFrame.cpp:1104
 #, fuzzy
 msgid "Make function local..."
 msgstr "Anvend funksjon på en liste"
 
-#: ../../src/wxMaxima.cpp:8207
+#: ../../src/dialogs/ConfigDialogue.cpp:215
+msgid "Malay"
+msgstr ""
+
+#: ../../src/sidebars/PerformanceSidebar.cpp:33
+msgid "Manual anchors (built-in):"
+msgstr ""
+
+#: ../../src/sidebars/PerformanceSidebar.cpp:34
+msgid "Manual anchors (cache):"
+msgstr ""
+
+#: ../../src/sidebars/PerformanceSidebar.cpp:35
+msgid "Manual anchors (compiled):"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:1397
 msgid "Map"
 msgstr "Avbild"
 
-#: ../../src/wxMaxima.cpp:8215
+#: ../../src/MaximaCommandMenus.cpp:1405
 #, fuzzy
 msgid "Map an expression"
 msgstr "Utvid et uttrykk"
 
-#: ../../src/wxMaximaFrame.cpp:1443
+#: ../../src/wxMaximaFrame.cpp:1480
 msgid "Map function to a matrix"
 msgstr "Anvend funksjon på en matrise"
 
-#: ../../src/wxMaximaFrame.cpp:1446
+#: ../../src/wxMaximaFrame.cpp:1483
 #, fuzzy
 msgid "Map function to a matrix, affecting all of its clones"
 msgstr "Anvend funksjon på en matrise"
 
-#: ../../src/Configuration.cpp:109
+#: ../../src/dialogs/FindReplacePane.cpp:71
+#, fuzzy
+msgid "Match Case"
+msgstr "Batchfil"
+
+#: ../../src/Styles.cpp:139
 #, fuzzy
 msgid "Math Default"
 msgstr "Forhåndsvalgt"
 
-#: ../../src/wxMaximaFrame.cpp:286
+#: ../../src/dialogs/ConfigDialogue.cpp:789
+msgid "Math layout strategy"
+msgstr ""
+
+#: ../../src/cells/Cell.cpp:1490
+msgid "Math output"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1221
+msgid "MathML (rendered by the browser)"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1222
+msgid "MathML + MathJaX fall-back for old browsers"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1906
+msgid "MathML as HTML"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1902
+msgid "MathML description"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:307
 msgid "Mathematical Symbols"
 msgstr ""
 
-#: ../../src/ToolBar.cpp:270
+#: ../../src/ToolBar.cpp:480
 msgid "Maths"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7945 ../../src/wxMaxima.cpp:8022
-#: ../../src/wxMaxima.cpp:8027 ../../src/wxMaxima.cpp:8032
-#: ../../src/wxMaxima.cpp:8037 ../../src/wxMaxima.cpp:8041
-#: ../../src/wxMaxima.cpp:8053 ../../src/wxMaxima.cpp:8059
-#: ../../src/wxMaxima.cpp:8064 ../../src/wxMaxima.cpp:8069
-#: ../../src/wxMaxima.cpp:8075 ../../src/wxMaxima.cpp:8080
-#: ../../src/wxMaxima.cpp:8085 ../../src/wxMaxima.cpp:8090
-#: ../../src/wxMaxima.cpp:8096 ../../src/wxMaxima.cpp:8101
-#: ../../src/wxMaxima.cpp:8152 ../../src/wxMaxima.cpp:8182
+#: ../../src/MaximaCommandMenus.cpp:1125 ../../src/MaximaCommandMenus.cpp:1206
+#: ../../src/MaximaCommandMenus.cpp:1211 ../../src/MaximaCommandMenus.cpp:1216
+#: ../../src/MaximaCommandMenus.cpp:1221 ../../src/MaximaCommandMenus.cpp:1225
+#: ../../src/MaximaCommandMenus.cpp:1239 ../../src/MaximaCommandMenus.cpp:1245
+#: ../../src/MaximaCommandMenus.cpp:1250 ../../src/MaximaCommandMenus.cpp:1255
+#: ../../src/MaximaCommandMenus.cpp:1261 ../../src/MaximaCommandMenus.cpp:1266
+#: ../../src/MaximaCommandMenus.cpp:1273 ../../src/MaximaCommandMenus.cpp:1278
+#: ../../src/MaximaCommandMenus.cpp:1284 ../../src/MaximaCommandMenus.cpp:1289
+#: ../../src/MaximaCommandMenus.cpp:1340 ../../src/MaximaCommandMenus.cpp:1370
 msgid "Matrix"
 msgstr "Matrise"
 
-#: ../../src/wxMaxima.cpp:7986
+#: ../../src/MaximaCommandMenus.cpp:1170
 #, fuzzy
 msgid "Matrix Exponent"
 msgstr "Matrisenavn:"
 
-#: ../../src/wxMaximaFrame.cpp:1339
+#: ../../src/wxMaximaFrame.cpp:1373
 #, fuzzy
 msgid "Matrix exponent..."
 msgstr "Matrisenavn:"
 
-#: ../../src/wxMaximaFrame.cpp:1329
+#: ../../src/wxMaximaFrame.cpp:1363
 #, fuzzy
 msgid "Matrix from csv file"
 msgstr "Last en stil fra fil"
 
-#: ../../src/wxMaximaFrame.cpp:1323
+#: ../../src/wxMaximaFrame.cpp:1357
 #, fuzzy
 msgid "Matrix from csv file..."
 msgstr "Last en stil fra fil"
 
-#: ../../src/wxMaxima.cpp:8137
+#: ../../src/MaximaCommandMenus.cpp:1325
 msgid "Matrix map"
 msgstr "Matrisemapping"
 
-#: ../../src/wxMaxima.cpp:9630
+#: ../../src/MaximaCommandMenus.cpp:1870
 msgid "Matrix name:"
 msgstr "Matrisenavn:"
 
-#: ../../src/wxMaximaFrame.cpp:798
+#: ../../src/wxMaximaFrame.cpp:835
 #, fuzzy
 msgid "Matrix parenthesis"
 msgstr "Samsvar parenteser i tekstkontroller"
 
-#: ../../src/wxMaximaFrame.cpp:1331
+#: ../../src/wxMaximaFrame.cpp:1365
 #, fuzzy
 msgid "Matrix to csv file"
 msgstr "Last en stil fra fil"
 
-#: ../../src/wxMaximaFrame.cpp:1334
+#: ../../src/wxMaximaFrame.cpp:1368
 msgid "Matrix to file or Matrix from file"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1761
+#: ../../src/wxMaximaFrame.cpp:1798
 msgid "Matrix to nested List"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7956 ../../src/wxMaxima.cpp:7961
-#: ../../src/wxMaxima.cpp:7966 ../../src/wxMaxima.cpp:7971
-#: ../../src/wxMaxima.cpp:7976 ../../src/wxMaxima.cpp:8000
-#: ../../src/wxMaxima.cpp:8136
+#: ../../src/MaximaCommandMenus.cpp:1456
+msgid "Matrix to nested list"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:1136 ../../src/MaximaCommandMenus.cpp:1141
+#: ../../src/MaximaCommandMenus.cpp:1146 ../../src/MaximaCommandMenus.cpp:1151
+#: ../../src/MaximaCommandMenus.cpp:1156 ../../src/MaximaCommandMenus.cpp:1161
+#: ../../src/MaximaCommandMenus.cpp:1184 ../../src/MaximaCommandMenus.cpp:1324
+#: ../../src/MaximaCommandMenus.cpp:1457
 msgid "Matrix:"
 msgstr "Matrise:"
 
-#: ../../src/wxMaxima.cpp:8627
-msgid ""
-"Maxima allows to make functions \"nouns\", which means that they aren't automatically evaluated as soon as maxima encounters them.\n"
-"Ways make a function a noun include declaring it a noun, preceding it with a  ' or putting it between the parenthesis of '().\n"
-"\n"
-"This command tells maxima that the nouns in this expression shall now be evaluated, too."
+#: ../../src/dialogs/ConfigDialogue.cpp:1370
+msgid "Max. layout time [s] (0=no limit)"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3473
+#: ../../src/dialogs/ConfigDialogue.cpp:281
+msgid "Maxima"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1433
+#, fuzzy
+msgid "Maxima Location"
+msgstr "Maxima-spørsmål"
+
+#: ../../src/MaximaCommandMenus.cpp:619
+msgid ""
+"Maxima allows making functions \"nouns\", which means that they aren't automatically evaluated as soon as Maxima encounters them.\n"
+"Ways to make a function a noun include declaring it a noun, preceding it with a single quote or putting it between the parentheses of '().\n"
+"\n"
+"This command tells Maxima that the nouns in this expression shall now be evaluated, too."
+msgstr ""
+
+#: ../../src/MaximaResponseReader.cpp:803
 #, c-format
 msgid "Maxima architecture: %s"
 msgstr ""
 
-#: ../../src/StatusBar.cpp:252
+#: ../../src/StatusBar.cpp:330
 #, fuzzy
 msgid "Maxima asks a question"
 msgstr "Maxima-spørsmål"
 
-#: ../../src/wxMaxima.cpp:4066
+#: ../../src/MaximaResponseReader.cpp:560
 #, fuzzy
 msgid "Maxima asks a question!"
 msgstr "Maxima-spørsmål"
 
-#: ../../src/wxMaxima.cpp:7118
+#: ../../src/dialogs/ConfigDialogue.cpp:362
+#, c-format
+msgid "Maxima assigns each command/equation an automatic label (which looks like %i1 or %o1). If a command begins with a descriptive name followed by a : wxMaxima will call the descriptive name a \"user-defined label\" instead. This selection now allows telling wxMaxima whether to show only automatic labels, automatic labels if there aren't user-defined ones or no label at all until a user-defined label can be found by wxMaxima's heuristics. If automatic labels are suppressed extra vertical space is added between equations in order to ease discerning which line starts a new equation and which one only continues the one from the last line."
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:3990
 msgid ""
 "Maxima automatically simplifies expressions it gets as input and then tries to evaluate their value. The ' operator tells maxima that we want a command to be in noun form, which means: stand here as is, and unevaluated.\n"
 "The ' operator can be undone by using the '' operator."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3304
+#: ../../src/cells/EditorCell.cpp:4516
+msgid "Maxima code"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1110
+msgid "Maxima commands to be executed at every start of Maxima"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1063
+msgid "Maxima commands to be executed every time wxMaxima starts Maxima"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1507
+#, fuzzy
+msgid "Maxima configuration"
+msgstr "wxMaxima-konfigurasjon"
+
+#: ../../src/MaximaResponseReader.cpp:346
 msgid "Maxima didn't attempt to authenticate!"
 msgstr ""
 
-#: ../../src/Configuration.cpp:84
+#: ../../src/Styles.cpp:113
 msgid "Maxima errors"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3289
+#: ../../src/MaximaResponseReader.cpp:338
 #, fuzzy
 msgid "Maxima has authenticated!"
 msgstr "Maxima-prosess avsluttet."
 
-#: ../../src/wxMaxima.cpp:10533
+#: ../../src/MaximaEvaluator.cpp:369
 #, fuzzy
 msgid "Maxima has finished calculating."
 msgstr "Maxima kalkulerer"
 
-#: ../../src/wxMaxima.cpp:5832
+#: ../../src/MaximaEvaluator.cpp:191
 #, fuzzy
 msgid "Maxima has issued an error!"
 msgstr "Maxima-spørsmål"
 
-#: ../../src/wxMaxima.cpp:3696
+#: ../../src/MaximaResponseReader.cpp:913
 #, c-format
 msgid "Maxima has loaded the file %s."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3382
+#: ../../src/MaximaResponseReader.cpp:761
 msgid "Maxima has sent a new variable value."
 msgstr ""
 
-#: ../../src/MaximaManual.cpp:552
+#: ../../src/StatusBar.cpp:349
+msgid ""
+"Maxima has stopped in a debugger and is waiting for a command.\n"
+"Common commands (type ':h' for the full list):\n"
+"  :bt        show a backtrace of the call stack\n"
+"  :continue  continue the computation\n"
+"  :top       return to the top level (abandon the computation)\n"
+"  :next / :step   step to the next line\n"
+"  :frame     show the current stack frame"
+msgstr ""
+
+#: ../../src/MaximaManual.cpp:576
 #, fuzzy
 msgid "Maxima help file not found!"
 msgstr "Fant ikke fil"
 
-#: ../../src/wxMaximaFrame.cpp:1043
+#: ../../src/wxMaximaFrame.cpp:1077
 msgid "Maxima input"
 msgstr "Maxima-inndata"
 
-#: ../../src/StatusBar.cpp:236
+#: ../../src/StatusBar.cpp:299
 msgid "Maxima is calculating"
 msgstr "Maxima kalkulerer"
 
-#: ../../src/wxMaxima.cpp:5068
+#: ../../src/wxMaxima.cpp:1876
 #, fuzzy
 msgid "Maxima is ready for input."
 msgstr "Maxima-inndata"
 
-#: ../../src/Dirstructure.cpp:144
+#: ../../src/Dirstructure.cpp:153
 #, c-format
 msgid "Maxima not found as %s"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:6211
+#: ../../src/MaximaCommandMenus.cpp:2367
 msgid "Maxima package (*.mac)|*.mac"
 msgstr "Maxima-pakke (*.mac)|*.mac"
 
-#: ../../src/wxMaxima.cpp:6202
+#: ../../src/MaximaCommandMenus.cpp:2358
 msgid "Maxima package (*.mac)|*.mac|Lisp package (*.lisp)|*.lisp|All|*"
 msgstr "Maxima-pakke (*.mac)|*.mac|Lisp-pakke (*.lisp)|*.lisp|Alle|*"
 
-#: ../../src/wxMaxima.cpp:3012
+#: ../../src/MaximaProcessManager.cpp:569
 msgid "Maxima process terminated unexpectedly."
 msgstr ""
 
-#: ../../src/Configuration.cpp:79
+#: ../../src/dialogs/ConfigDialogue.cpp:1437
+msgid "Maxima program:"
+msgstr "Maxima-program:"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:382
+msgid "Maxima provides no \"forget all\" command that flushes all settings a maxima session could make. wxMaxima therefore normally defaults to starting a fresh maxima process every time the worksheet is to be re-evaluated. As this needs a little bit of time this switch allows to disable this behavior."
+msgstr ""
+
+#: ../../src/Styles.cpp:108
 #, fuzzy
 msgid "Maxima question labels"
 msgstr "Maxima-spørsmål"
 
-#: ../../src/wxMaxima.cpp:3380
+#: ../../src/StatusBar.cpp:339
+msgid "Maxima returned an error message"
+msgstr ""
+
+#: ../../src/MaximaResponseReader.cpp:759
 msgid "Maxima sends a new set of auto-completable symbols."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3908
+#: ../../src/MaximaResponseReader.cpp:1024
 msgid "Maxima sends us a new set of variables for the watch list."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1944
+#: ../../src/sidebars/History.cpp:153
+#, fuzzy
+msgid "Maxima session (*.mac)|*.mac"
+msgstr "Maxima-pakke (*.mac)|*.mac"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1518 ../../src/wxMaximaFrame.cpp:1981
 msgid "Maxima shows help in a browser"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1940
+#: ../../src/dialogs/ConfigDialogue.cpp:1523 ../../src/wxMaximaFrame.cpp:1977
 msgid "Maxima shows help in a sidebar"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1935
+#: ../../src/dialogs/ConfigDialogue.cpp:1511 ../../src/wxMaximaFrame.cpp:1972
 #, fuzzy
 msgid "Maxima shows help in the console"
 msgstr "Fant ikke fil"
 
-#: ../../src/StatusBar.cpp:232
+#: ../../src/StatusBar.cpp:290
 #, fuzzy
 msgid "Maxima started. Waiting for authentication..."
 msgstr "Maxima startet. Venter på tilkobling..."
 
-#: ../../src/StatusBar.cpp:212
+#: ../../src/StatusBar.cpp:245
 msgid "Maxima started. Waiting for connection..."
 msgstr "Maxima startet. Venter på tilkobling..."
 
-#: ../../src/StatusBar.cpp:228
+#: ../../src/StatusBar.cpp:281
 #, fuzzy
 msgid "Maxima started. Waiting for initial prompt..."
 msgstr "Maxima startet. Venter på tilkobling..."
 
-#: ../../src/wxMaximaFrame.cpp:1231
+#: ../../src/sidebars/PerformanceSidebar.cpp:36
+msgid "Maxima starts:"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1143
+msgid "Maxima startup file location: "
+msgstr ""
+
+#: ../../src/dialogs/TipOfTheDay.cpp:68
+msgid "Maxima supports three types of numbers: exact fractions (which can be generated for example by typing 1/10), IEEE floating-point numbers (0.2) and arbitrary precision big floats (1b-1). Note that, owing to their nature as binary (not decimal) numbers, there is for example no way to generate an IEEE floating-point number that exactly equals 0.1. If floating-point numbers are used instead of fractions, Maxima will therefore sometimes have to introduce a (very small) error and use things like 3602879701896397/36028797018963968 for 0.1."
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1265
 #, fuzzy
 msgid "Maxima to other language"
 msgstr "Maxima-spørsmål"
 
-#: ../../src/wxMaxima.cpp:7213
+#: ../../src/MaximaCommandMenus.cpp:4085
 #, fuzzy
 msgid "Maxima to string"
 msgstr "Maxima-spørsmål"
 
-#: ../../src/wxMaxima.cpp:3397
+#: ../../src/cells/TextCell.cpp:255
+msgid "Maxima tried to find out where between two points a curve crosses the zero line. Since the curve is on the same side of the zero line in both points its algorithms fails here. Set find_root_error to false if you want it to return false instead of an error."
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1615
+#, fuzzy
+msgid "Maxima usage"
+msgstr "wxMaxima-ikon"
+
+#: ../../src/MaximaResponseReader.cpp:776
 #, c-format
 msgid "Maxima user configuration is located in directory %s"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3443
+#: ../../src/dialogs/TipOfTheDay.cpp:59
+msgid ""
+"Maxima uses ':' to assign values to a variable ('a : 3;'), not '=' as most programming languages do.\n"
+"This allows, that a mathematical equation can be assigned to a variable, e.g.\n"
+" eq1:3*x=4;\n"
+"which may then be solved for x with\n"
+"solve(eq1,x);"
+msgstr ""
+
+#: ../../src/dialogs/TipOfTheDay.cpp:63
+#, fuzzy
+msgid ""
+"Maxima uses ':=' to define functions, e.g.:\n"
+"f(x) := x^2;"
+msgstr "Maxima bruker ':' for å sette verdier ( 'a : 3;' ) og ':=' for å definere funksjoner ( 'f(x) := x^2;' )."
+
+#: ../../src/MaximaResponseReader.cpp:788
 #, c-format
 msgid "Maxima uses temp directory %s"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3469
+#: ../../src/dialogs/AboutDialog.cpp:50
+#, fuzzy
+msgid "Maxima version: "
+msgstr ""
+"\n"
+"Maxima-versjon: "
+
+#: ../../src/MaximaResponseReader.cpp:799
 #, c-format
 msgid "Maxima version: %s"
 msgstr ""
 
-#: ../../src/MaximaManual.cpp:390
+#: ../../src/MaximaManual.cpp:407
 #, c-format
 msgid "Maxima version: %s, Anchors cache version"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1925
+#: ../../src/wxMaximaFrame.cpp:1962
 #, fuzzy
 msgid "Maxima vs. Programming languages"
 msgstr "Omgjør til &Gamma"
 
-#: ../../src/Configuration.cpp:83
+#: ../../src/Styles.cpp:112
 #, fuzzy
 msgid "Maxima warnings"
 msgstr "Maxima-instillinger"
 
-#: ../../src/wxMaxima.cpp:3687
+#: ../../src/MaximaResponseReader.cpp:904
 #, c-format
 msgid "Maxima was compiled using %s"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3487
+#: ../../src/dialogs/AboutDialog.cpp:53
+#, fuzzy
+msgid "Maxima was compiled using: "
+msgstr ""
+"\n"
+"Maxima-versjon: "
+
+#: ../../src/dialogs/TipOfTheDay.cpp:201
+msgid ""
+"Maxima's \"at\" function allows accessing arbitrary variables in a list of results:\n"
+"\n"
+"    g1:a*x+y=0;\n"
+"    g2:b*y+x*x=1;\n"
+"    solve([g1,g2],[a,b]);\n"
+"    %[1];\n"
+"    result_b:b=at(b,%);"
+msgstr ""
+
+#: ../../src/MaximaResponseReader.cpp:817
 #, c-format
 msgid "Maxima's HTML manuals are in directory %s"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3099
+#: ../../src/MaximaResponseReader.cpp:599
+msgid "Maxima's Lisp (sbcl) has stopped in its low-level debugger (LDB). The Lisp cannot continue; you can enter LDB commands - for example \"backtrace\" for a stack trace, or \"exit\" to quit it."
+msgstr ""
+
+#: ../../src/MaximaResponseReader.cpp:597
+msgid "Maxima's Lisp entered sbcl's low-level debugger (LDB)."
+msgstr ""
+
+#: ../../src/MaximaResponseReader.cpp:240
+#: ../../src/MaximaResponseReader.cpp:242
 #, c-format
 msgid "Maxima's PID is %li"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3681
+#: ../../src/MaximaResponseReader.cpp:898
 #, c-format
 msgid "Maxima's demo files are located in directory %s"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3478
+#: ../../src/MaximaResponseReader.cpp:808
 #, c-format
 msgid "Maxima's manual is located in directory %s"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3670
+#: ../../src/wizards/ActualValuesStorageWiz.cpp:34
+msgid "Maxima's power lies in symbolic operations."
+msgstr ""
+
+#: ../../src/StatusBar.cpp:365
+msgid ""
+"Maxima's reader is in Lisp mode (after to_lisp()).\n"
+"Type Lisp forms; enter (to-maxima) to return to Maxima mode."
+msgstr ""
+
+#: ../../src/MaximaResponseReader.cpp:887
 #, fuzzy, c-format
 msgid "Maxima's share files are located in directory %s"
 msgstr "Start Animasjon"
 
-#: ../../src/StatusBar.cpp:66
+#: ../../src/dialogs/TipOfTheDay.cpp:188
+msgid ""
+"Maxima's strengths are manipulating equations and in symbolic calculations. It therefore makes sense to use functions (as opposed to equations with labels) sparingly and to keep the actual values of variables in a list, instead of directly assigning them values. An example session that does do so would be:\n"
+"\n"
+"/* We keep the actual values in a list so we can use them later on */\n"
+"    Values:[a=10,c=100];\n"
+"    Pyth:a^2+b^2=c^2;\n"
+"    solve(%,b);\n"
+"    result:%[2];\n"
+"    at(result,Values);\n"
+"    float(%);"
+msgstr ""
+
+#: ../../src/StatusBar.cpp:73
 msgid "Maxima, the program that does the actual mathematics and wxMaxima, which displays the worksheet are kept in separate processes. This means that even if maxima crashes wxMaxima (and therefore the worksheet) stays intact. Both programs communicate over a local network socket. This time this socket could not be created which might be caused by a firewall that it setup to not only intercepts connections from the outside, but also to intercept connections between two programs that run on the same computer."
 msgstr ""
 
-#: ../../src/StatusBar.cpp:75
+#: ../../src/StatusBar.cpp:82
 msgid "Maxima, the program that does the actual mathematics and wxMaxima, which displays the worksheet are kept in separate processes. This means that even if maxima crashes wxMaxima (and therefore the worksheet) stays intact. Currently the two programs aren't connected to each other which might mean that maxima is still starting up or couldn't be started. Alternatively it can be caused by a firewall that it setup to not only intercepts connections from the outside, but also to intercept connections between two programs that run on the same computer. Another reason for maxima not starting up might be that maxima cannot be found (see wxMaxima's Configuration dialogue for a way to specify maxima's location) or isn't in a working order."
 msgstr ""
 
-#: ../../src/StatusBar.cpp:61
+#: ../../src/StatusBar.cpp:68
 msgid ""
 "Maxima, the program that does the actual mathematics is started as a separate process. This has the advantage that an eventual crash of maxima cannot harm wxMaxima, which displays the worksheet.\n"
 "This icon indicates if data is transferred between maxima and wxMaxima."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:9228
+#: ../../src/dialogs/MaximaNotStartingDialog.cpp:39
+msgid "Maxima, the program that does the actual maths, cannot be started. This might mean that it isn't installed (it can be found at ↗https://maxima.sourceforge.net) or that wxMaxima doesn't know where to search for it. In that case please choose the location of a working maxima binary"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:419
 msgid "Maximum absolute value printed without exponent"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:9230
+#: ../../src/dialogs/ConfigDialogue.cpp:1931
+msgid "Maximum bitmap size on clipboard [Mb]:"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:488 ../../src/MaximaCommandMenus.cpp:501
+#: ../../src/MaximaCommandMenus.cpp:516 ../../src/MaximaCommandMenus.cpp:530
+msgid "Maximum number of Chebyshev moments. Must be greater than 0."
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:421
 msgid "Maximum number of digits to be displayed:"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:9568
+#: ../../src/dialogs/ConfigDialogue.cpp:811
+msgid "Maximum number of displayed digits:"
+msgstr ""
+
+# oversetter er ikke kjent med 'mean'-stuff. gi lyd om du vet bedre.
+#: ../../src/sidebars/StatSidebar.cpp:70
+msgid "Mean Difference Test..."
+msgstr "Mean Difference Test..."
+
+#: ../../src/sidebars/StatSidebar.cpp:67
+msgid "Mean Test..."
+msgstr "Mean Test..."
+
+#: ../../src/sidebars/StatSidebar.cpp:52
+#, fuzzy
+msgid "Mean..."
+msgstr "Gjennomsnitt..."
+
+#: ../../src/MaximaCommandMenus.cpp:1806
 #, fuzzy
 msgid "Mean:"
 msgstr "Gjennomsnitt:"
 
-#: ../../src/wxMaximaFrame.cpp:1924
+#: ../../src/sidebars/StatSidebar.cpp:55
+msgid "Median..."
+msgstr "Median..."
+
+#: ../../src/wxMaximaFrame.cpp:1961
 msgid "Memoizing"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1013
+#: ../../src/wxMaximaFrame.cpp:1047
 #, fuzzy
 msgid "Memory"
 msgstr "Tøm &Minnet"
 
-#: ../../src/Worksheet.cpp:1409 ../../src/wxMaximaFrame.cpp:935
+#: ../../src/worksheet/WorksheetContextMenu.cpp:180
+#: ../../src/wxMaximaFrame.cpp:969
 msgid "Merge Cells"
 msgstr "Slå Sammen Celler"
 
-#: ../../src/wxMaxima.cpp:5780
+#: ../../src/MaximaResponseReader.cpp:641
 msgid "Message from the stdout of Maxima: "
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1326
+#: ../../src/wizards/IntegrateWiz.cpp:55
+msgid "Method:"
+msgstr "Metode:"
+
+#: ../../src/wxMaximaFrame.cpp:1360
 msgid "Methods of generating a matrix"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:6866
+#: ../../src/worksheet/Worksheet.cpp:4869
 #, c-format
 msgid "Middle-click clipboard data: %s"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:9226
+#: ../../src/cells/TextCell.cpp:303
+msgid "Might also indicate a missing multiplication sign (\"*\")."
+msgstr ""
+
+#: ../../src/cells/TextCell.cpp:323
+msgid ""
+"Might be caused by reading an csv file with an empty last line:\n"
+"Technically that line can be described as having the length 0 which differs from the other lines of this file."
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:417
 msgid "Minimum absolute value printed without exponent:"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:10449 ../../src/wxMaxima.cpp:10451
+#: ../../src/dialogs/ConfigDialogue.cpp:1270
+msgid "Misc"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1963
+#, fuzzy
+msgid "Misc settings"
+msgstr "Fold alle seksjoner"
+
+#: ../../src/wxMaxima.cpp:3136 ../../src/wxMaxima.cpp:3138
 #, fuzzy
 msgid "Mismatched parenthesis"
 msgstr "Samsvar parenteser i tekstkontroller"
 
-#: ../../src/wxMaximaFrame.cpp:1352
+#: ../../src/cells/VisiblyInvalidCell.cpp:43
+msgid "Missing contents. Bug?"
+msgstr ""
+
+#: ../../src/cells/TextCell.cpp:245
+msgid "Most probable cause: A dot instead a comma between two list items containing assignments."
+msgstr ""
+
+#: ../../src/cells/TextCell.cpp:308
+msgid "Most probable cause: A function was called with a parameter that causes it to return infinity and/or -infinity."
+msgstr ""
+
+#: ../../src/cells/TextCell.cpp:249
+msgid "Most probable cause: Two commas or similar separators in a row."
+msgstr ""
+
+#: ../../src/cells/TextCell.cpp:251
+msgid "Most probable cause: an operator was directly followed by a closing parenthesis."
+msgstr ""
+
+#: ../../src/cells/TextCell.cpp:318
+msgid ""
+"Most probably it was attempted to append something to a list that isn't a list.\n"
+"Enclosing the new element for the list in brackets ([]) converts it to a list and makes it appendable."
+msgstr ""
+
+#: ../../src/cells/TextCell.cpp:155
+msgid "Most questions can be avoided using the assume() and the declare() command. If that isn't possible the \"Automatically answer questions\" button makes wxMaxima automatically fill in all answers it still remembers from a previous run."
+msgstr ""
+
+#: ../../src/sidebars/GreekSidebar.cpp:189
+msgid "Mu"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1386
 msgid "Multiplication, exponent and similar"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1998
+#: ../../src/worksheet/WorksheetContextMenu.cpp:770
 msgid "Multiplicative function: f(a*b)=f(a)*f(b)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1338
+#: ../../src/wxMaximaFrame.cpp:1372
 msgid "Multiply matrices..."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7981
+#: ../../src/MaximaCommandMenus.cpp:1165
 msgid "Multiply two matrices"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:9581
-#, fuzzy
-msgid "Multivariate linear regression"
-msgstr "Lineær Regresjon..."
-
-#: ../../src/wxMaxima.cpp:7842
+#: ../../src/MaximaCommandMenus.cpp:1023
 #, fuzzy
 msgid "Name of t:"
 msgstr "Navn:"
 
-#: ../../src/wxMaxima.cpp:7838
+#: ../../src/wizards/DrawWiz.cpp:750
+msgid "Name of the parameter"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:1019
 #, fuzzy
 msgid "Name of x:"
 msgstr "Navn:"
 
-#: ../../src/wxMaximaFrame.cpp:1320 ../../src/wxMaximaFrame.cpp:1759
+#: ../../src/wizards/MatWiz.cpp:163
+msgid "Name:"
+msgstr "Navn:"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:216
+msgid "Nepali"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1354 ../../src/wxMaximaFrame.cpp:1796
 msgid "Nested list to Matrix"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:769 ../../src/wxMaximaFrame.cpp:1053
+#: ../../src/MaximaCommandMenus.cpp:1450
+msgid "Nested list to matrix"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:748
+#: ../../src/dialogs/ConfigDialogue.cpp:772 ../../src/wxMaximaFrame.cpp:806
+#: ../../src/wxMaximaFrame.cpp:1087
 msgid "Never"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:6534
+#: ../../src/MaximaCommandMenus.cpp:3054
 msgid "Never autosubscript this variable"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:776
+#: ../../src/wxMaximaFrame.cpp:813
 msgid "Never display this variable with subscript"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1469 ../../src/Worksheet.cpp:1843
+#: ../../src/worksheet/WorksheetContextMenu.cpp:240
+#: ../../src/worksheet/WorksheetContextMenu.cpp:615
 msgid "Never offer known answers"
 msgstr ""
 
-#: ../../src/ToolBar.cpp:174
+#: ../../src/ToolBar.cpp:324 ../../src/ToolBar.cpp:326
 msgid "New"
 msgstr "Ny"
 
-#: ../../src/wxMaximaFrame.cpp:597
+#: ../../src/wxMaximaFrame.cpp:628
 msgid "New\tCtrl+N"
 msgstr "&Ny\tCtrl+N"
 
-#: ../../src/ToolBar.cpp:611
+#: ../../src/ToolBar.cpp:811
 msgid "New button"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2483
+#: ../../src/MaximaProcessManager.cpp:144
 msgid "New connection attempt whilst already connected."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2491
+#: ../../src/MaximaProcessManager.cpp:152
 msgid "New connection attempt, but no currently no socket maxima could connect to."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2487
+#: ../../src/MaximaProcessManager.cpp:148
 msgid "New connection attempt, but no currently running maxima process."
 msgstr ""
 
-#: ../../src/ToolBar.cpp:174
+#: ../../src/ToolBar.cpp:324 ../../src/ToolBar.cpp:326
 msgid "New document"
 msgstr "Nytt dokument"
 
-#: ../../src/wxMaxima.cpp:3899
+#: ../../src/dialogs/ConfigDialogue.cpp:901
+msgid "New lines: Jump to text"
+msgstr ""
+
+#: ../../src/MaximaResponseReader.cpp:1015
 #, c-format
 msgid "New maxima Operators detected: %s"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7390
+#: ../../src/MaximaCommandMenus.cpp:4262
 #, fuzzy
 msgid "New part:"
 msgstr "Ny variabel:"
 
-#: ../../src/wxMaxima.cpp:8900 ../../src/wxMaxima.cpp:8920
-#: ../../src/wxMaxima.cpp:9000 ../../src/wxMaxima.cpp:9005
+#: ../../src/wizards/SubstituteWiz.cpp:35
+msgid "New value:"
+msgstr "Ny verdi:"
+
+#: ../../src/MaximaCommandMenus.cpp:151 ../../src/MaximaCommandMenus.cpp:171
+#: ../../src/MaximaCommandMenus.cpp:254 ../../src/MaximaCommandMenus.cpp:259
 msgid "New variable:"
 msgstr "Ny variabel:"
 
-#: ../../src/wxMaximaFrame.cpp:929
+#: ../../src/wxMaximaFrame.cpp:963
 msgid "Next Command\tAlt+Down"
 msgstr "Neste Kommando\tAlt+Down"
 
-#: ../../src/wxMaximaFrame.cpp:748
+#: ../../src/dialogs/DiffFrame.cpp:405
+msgid "Next Difference"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:785
 msgid "Nice Graphical Equations"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1550
+#: ../../src/dialogs/ConfigDialogue.cpp:725
+#: ../../src/dialogs/ConfigDialogue.cpp:737 ../../src/wxMaximaFrame.cpp:1587
 msgid "No"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1972
+#: ../../src/worksheet/WorksheetContextMenu.cpp:744
 #, fuzzy
 msgid "No Array"
 msgstr "Array:"
 
-#: ../../src/Worksheet.cpp:1974
+#: ../../src/worksheet/WorksheetContextMenu.cpp:746
 msgid "No Scalar"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:10482
+#: ../../src/worksheet/Worksheet.cpp:5466
+msgid "No cells are selected. Anonymize the code in the whole document?"
+msgstr ""
+
+#: ../../src/wizards/DrawWiz.cpp:636
+msgid "No contour lines"
+msgstr ""
+
+#: ../../src/dialogs/DiffFrame.cpp:304
+msgid "No differences"
+msgstr ""
+
+#: ../../src/wxMaxima.cpp:3169
 msgid "No dollar ($) or semicolon (;) at the end of command"
 msgstr ""
 
-#: ../../src/MaximaManual.cpp:406
+#: ../../src/MaximaManual.cpp:423
 msgid "No entries in the caches for the subjects the manual contains."
 msgstr ""
 
@@ -5005,726 +7505,1091 @@ msgstr ""
 msgid "No file with the subjects the manual contained in the last wxMaxima run."
 msgstr ""
 
-#: ../../src/Image.cpp:495
+#: ../../src/Image.cpp:547
 msgid "No gnuplot data!"
 msgstr ""
 
-#: ../../src/Image.cpp:530
+#: ../../src/Image.cpp:582
 msgid "No gnuplot source!"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:6662 ../../src/wxMaxima.cpp:6668
-#: ../../src/wxMaxima.cpp:6687 ../../src/wxMaxima.cpp:6697
+#: ../../src/cells/GroupCell.cpp:1500
+msgid "No image to export"
+msgstr ""
+
+#: ../../src/wxMaxima.cpp:2653 ../../src/wxMaxima.cpp:2661
+#: ../../src/wxMaxima.cpp:2682 ../../src/wxMaxima.cpp:2694
 msgid "No matches found!"
 msgstr "Ingen treff funnet!"
 
-#: ../../src/wxMaxima.cpp:3240
+#: ../../src/wizards/DrawWiz.cpp:651
+msgid "No plot, only contour lines"
+msgstr ""
+
+#: ../../src/wizards/DrawWiz.cpp:837
+msgid "No points"
+msgstr ""
+
+#: ../../src/MaximaResponseReader.cpp:145
 msgid "No topics found in topic flag"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3227
+#: ../../src/MaximaResponseReader.cpp:130
 msgid "No topics found in topic tag"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:797
+#: ../../src/Image.cpp:1037
+msgid "No usable image data was found."
+msgstr ""
+
+#: ../../src/sidebars/SymbolsSidebar.cpp:179
+msgid "Non-builtin symbols"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:834
 msgid "None"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8163
+#: ../../src/sidebars/StatSidebar.cpp:73
+msgid "Normality Test..."
+msgstr "Normalitetstest..."
+
+#: ../../src/cells/TextCell.cpp:271
+msgid ""
+"Normally computers use floating-point numbers that can be handled incredibly fast while being accurate to dozens of digits. They will, though, introduce a small error into some common numbers. For example 0.1 is represented as 3602879701896397/36028797018963968.\n"
+"As mathematics is based on the fact that numbers that are exactly equal cancel each other out small errors can quickly add up to big errors (see Wilkinson's Polynomials or Rump's Polynomials). Some maxima commands therefore use rat() in order to automatically convert floats to exact numbers (like 1/10 or sqrt(2)/2) where floating-point errors might add up.\n"
+"\n"
+"This error message doesn't occur if exact numbers (1/10 instead of 0.1) are used.\n"
+"The info that numbers have automatically been converted can be suppressed by setting ratprint to false."
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:431
+msgid "Normally html expects images to be rather low-res but space saving. These images tend to look rather blurry when viewed on modern screens. Therefore this setting was introduces that selects the factor by which the HTML export increases the resolution in respect to the default value."
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:217
+msgid "Norwegian"
+msgstr "Norsk"
+
+#: ../../src/MaximaCommandMenus.cpp:1351
 msgid "Not a valid matrix dimension!"
 msgstr "Ikke en gyldig matrisedimensjon!"
 
-#: ../../src/wxMaxima.cpp:7858 ../../src/wxMaxima.cpp:7880
+#: ../../src/MaximaCommandMenus.cpp:1039 ../../src/MaximaCommandMenus.cpp:1061
 msgid "Not a valid number of equations!"
 msgstr "Ikke et gyldig antall likninger!"
 
-#: ../../src/StatusBar.cpp:256
+#: ../../src/StatusBar.cpp:375
 msgid "Not connected to Maxima"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:10496
+#: ../../src/MaximaResponseReader.cpp:841
+msgid "Not re-querying gnuplot's graphics drivers: same gnuplot as before."
+msgstr ""
+
+#: ../../src/MaximaFileIO.cpp:768
+msgid "Not saving: running non-interactively and no file name is set."
+msgstr ""
+
+#: ../../src/MaximaEvaluator.cpp:329
 msgid "Not triggering evaluation as maxima is still busy!"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:10503
+#: ../../src/MaximaEvaluator.cpp:336
 msgid "Not triggering evaluation as maxima still asks a question!"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:10511
+#: ../../src/MaximaEvaluator.cpp:344
 msgid "Not triggering evaluation as there is no working maxima process"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8926
+#: ../../src/sidebars/GreekSidebar.cpp:190
+msgid "Nu"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:177
 msgid "Num. deg:"
 msgstr "Tellergrad:"
 
-#: ../../src/wxMaxima.cpp:8540
+#: ../../src/MaximaCommandMenus.cpp:1553
 #, fuzzy
 msgid "Number of elements"
 msgstr "Antall likninger:"
 
-#: ../../src/wxMaxima.cpp:7852 ../../src/wxMaxima.cpp:7874
+#: ../../src/MaximaCommandMenus.cpp:1033 ../../src/MaximaCommandMenus.cpp:1055
 msgid "Number of equations:"
 msgstr "Antall likninger:"
 
-#: ../../src/wxMaxima.cpp:7481
+#: ../../src/MaximaCommandMenus.cpp:4353
 #, fuzzy
 msgid "Number to octets"
 msgstr "Antall likninger:"
 
-#: ../../src/wxMaximaFrame.cpp:1154
+#: ../../src/wxMaximaFrame.cpp:1188
 #, fuzzy
 msgid "Number to octets..."
 msgstr "Antall likninger:"
 
-#: ../../src/wxMaximaFrame.cpp:1906
+#: ../../src/wxMaximaFrame.cpp:1943
 msgid "Number types"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7482
+#: ../../src/MaximaCommandMenus.cpp:4354
 #, fuzzy
 msgid "Number:"
 msgstr "Tall"
 
-#: ../../src/wxMaximaFrame.cpp:1786
+#: ../../src/wxMaximaFrame.cpp:1823
 #, fuzzy
 msgid "Numeric output"
 msgstr "Veksle numerisk utdata"
 
-#: ../../src/wxMaxima.cpp:8040
+#: ../../src/MaximaCommandMenus.cpp:1224
 msgid "Numerical QR decomposition of a matrix"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1417
+#: ../../src/wxMaximaFrame.cpp:1451
 #, fuzzy
 msgid "Numerical operations (lapack)"
 msgstr "&Numerisk Integrasjon"
 
-#: ../../src/wxMaxima.cpp:7831
+#: ../../src/MaximaCommandMenus.cpp:1012
 #, fuzzy
 msgid "Numerical solution for 1st degree ODE"
 msgstr "Løs initialverdiproblem for førstegrads ODE"
 
-#: ../../src/wxMaximaFrame.cpp:1282
+#: ../../src/wxMaximaFrame.cpp:1316
 #, fuzzy
 msgid "Numerical solution..."
 msgstr "Veksle numerisk utdata"
 
-#: ../../src/wxMaximaFrame.cpp:1261
+#: ../../src/wxMaximaFrame.cpp:1295
 #, fuzzy
 msgid "Numerical solutions of polynomial (bfloat)..."
 msgstr "Finn alle røttene til et polynom"
 
-#: ../../src/wxMaximaFrame.cpp:1258
+#: ../../src/wxMaximaFrame.cpp:1292
 #, fuzzy
 msgid "Numerical solutions of polynomial..."
 msgstr "Finn alle røttene til et polynom"
 
-#: ../../src/wxMaxima.cpp:9802 ../../src/wxMaxima.cpp:10161
+#: ../../src/MaximaCommandMenus.cpp:3265 ../../src/MaximaCommandMenus.cpp:3690
+#: ../../src/dialogs/ChangeLogDialog.cpp:131
+#: ../../src/dialogs/LicenseDialog.cpp:90
+#: ../../src/dialogs/MaxSizeChooser.cpp:44
+#: ../../src/dialogs/MaxSizeChooser.cpp:49
+#: ../../src/dialogs/MaximaNotStartingDialog.cpp:68
+#: ../../src/dialogs/MaximaNotStartingDialog.cpp:74
+#: ../../src/dialogs/ResolutionChooser.cpp:39
+#: ../../src/dialogs/ResolutionChooser.cpp:44
+#: ../../src/dialogs/TipOfTheDay.cpp:295
+#: ../../src/wizards/ActualValuesStorageWiz.cpp:60
+#: ../../src/wizards/ActualValuesStorageWiz.cpp:64
+#: ../../src/wizards/BC2Wiz.cpp:47 ../../src/wizards/BC2Wiz.cpp:51
+#: ../../src/wizards/CsvWiz.cpp:64 ../../src/wizards/CsvWiz.cpp:138
+#: ../../src/wizards/DrawWiz.cpp:110 ../../src/wizards/DrawWiz.cpp:221
+#: ../../src/wizards/DrawWiz.cpp:353 ../../src/wizards/DrawWiz.cpp:508
+#: ../../src/wizards/DrawWiz.cpp:567 ../../src/wizards/DrawWiz.cpp:664
+#: ../../src/wizards/DrawWiz.cpp:772 ../../src/wizards/DrawWiz.cpp:848
+#: ../../src/wizards/DrawWiz.cpp:986 ../../src/wizards/Gen1Wiz.cpp:43
+#: ../../src/wizards/Gen1Wiz.cpp:47 ../../src/wizards/Gen2Wiz.cpp:46
+#: ../../src/wizards/Gen2Wiz.cpp:50 ../../src/wizards/Gen3Wiz.cpp:54
+#: ../../src/wizards/Gen3Wiz.cpp:58 ../../src/wizards/Gen4Wiz.cpp:61
+#: ../../src/wizards/Gen4Wiz.cpp:65 ../../src/wizards/Gen5Wiz.cpp:69
+#: ../../src/wizards/Gen5Wiz.cpp:73 ../../src/wizards/GenWizPanel.cpp:106
+#: ../../src/wizards/GenWizPanel.cpp:114 ../../src/wizards/IntegrateWiz.cpp:61
+#: ../../src/wizards/IntegrateWiz.cpp:65 ../../src/wizards/LimitWiz.cpp:49
+#: ../../src/wizards/LimitWiz.cpp:53 ../../src/wizards/ListSortWiz.cpp:76
+#: ../../src/wizards/ListSortWiz.cpp:80 ../../src/wizards/MatWiz.cpp:39
+#: ../../src/wizards/MatWiz.cpp:43 ../../src/wizards/MatWiz.cpp:168
+#: ../../src/wizards/MatWiz.cpp:172 ../../src/wizards/Plot2dWiz.cpp:94
+#: ../../src/wizards/Plot2dWiz.cpp:98 ../../src/wizards/Plot2dWiz.cpp:511
+#: ../../src/wizards/Plot2dWiz.cpp:515 ../../src/wizards/Plot2dWiz.cpp:607
+#: ../../src/wizards/Plot2dWiz.cpp:611 ../../src/wizards/Plot3dWiz.cpp:89
+#: ../../src/wizards/Plot3dWiz.cpp:93 ../../src/wizards/PlotFormatWiz.cpp:47
+#: ../../src/wizards/PlotFormatWiz.cpp:51 ../../src/wizards/SeriesWiz.cpp:49
+#: ../../src/wizards/SeriesWiz.cpp:53 ../../src/wizards/SubstituteWiz.cpp:41
+#: ../../src/wizards/SubstituteWiz.cpp:45 ../../src/wizards/SumWiz.cpp:47
+#: ../../src/wizards/SumWiz.cpp:51 ../../src/wizards/SystemWiz.cpp:38
+#: ../../src/wizards/SystemWiz.cpp:42 ../../src/wizards/WizardHelp.cpp:37
 msgid "OK"
 msgstr "OK"
 
-#: ../../src/wxMaximaFrame.cpp:122
+#: ../../src/wxMaximaFrame.cpp:130
 #, c-format
 msgid "OS: %s Version %li.%li"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8211 ../../src/wxMaxima.cpp:8221
+#: ../../src/MaximaCommandMenus.cpp:1401 ../../src/MaximaCommandMenus.cpp:1411
 #, fuzzy
 msgid "Object composed of elements"
 msgstr "Antall likninger:"
 
-#: ../../src/wxMaxima.cpp:7680
+#: ../../src/MaximaCommandMenus.cpp:4552
 #, fuzzy
 msgid "Object name:"
 msgstr "Liste:"
 
-#: ../../src/wxMaxima.cpp:7281
+#: ../../src/MaximaCommandMenus.cpp:4153
 #, fuzzy
 msgid "Object:"
 msgstr "Liste:"
 
-#: ../../src/wxMaxima.cpp:7486
+#: ../../src/MaximaCommandMenus.cpp:4358
 msgid "Octets to Number"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7491
+#: ../../src/MaximaCommandMenus.cpp:4363
 msgid "Octets to String"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1156
+#: ../../src/wxMaximaFrame.cpp:1190
 msgid "Octets to number..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1158
+#: ../../src/wxMaximaFrame.cpp:1192
 #, fuzzy
 msgid "Octets to string..."
 msgstr "Uttrykk"
 
-#: ../../src/wxMaxima.cpp:7487 ../../src/wxMaxima.cpp:7492
+#: ../../src/MaximaCommandMenus.cpp:4359 ../../src/MaximaCommandMenus.cpp:4364
 msgid "Octets:"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1958
+#: ../../src/worksheet/WorksheetContextMenu.cpp:730
 msgid "Odd number"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8900 ../../src/wxMaxima.cpp:8921
-#: ../../src/wxMaxima.cpp:8999 ../../src/wxMaxima.cpp:9005
+#: ../../src/dialogs/ConfigDialogue.cpp:910
+msgid "Offer answers for questions known from previous runs"
+msgstr ""
+
+#: ../../src/cells/TextCell.cpp:332
+msgid "Often caused by recursive function calls. Some lisps allow increasing the control stack size using command-line arguments."
+msgstr ""
+
+#: ../../src/wizards/SubstituteWiz.cpp:32
+msgid "Old value:"
+msgstr "Forrige verdi:"
+
+#: ../../src/MaximaCommandMenus.cpp:151 ../../src/MaximaCommandMenus.cpp:172
+#: ../../src/MaximaCommandMenus.cpp:253 ../../src/MaximaCommandMenus.cpp:259
 msgid "Old variable:"
 msgstr "Forrige variabel:"
 
-#: ../../src/wxMaximaFrame.cpp:1055
+#: ../../src/sidebars/GreekSidebar.cpp:201
+msgid "Omega"
+msgstr ""
+
+#: ../../src/sidebars/GreekSidebar.cpp:192
+msgid "Omicron"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1089
 #, fuzzy
 msgid "On all errors"
 msgstr "Fatal feil"
 
-#: ../../src/wxMaximaFrame.cpp:1054
+#: ../../src/wxMaximaFrame.cpp:1088
 msgid "On lisp errors"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:9566
+#: ../../src/MaximaCommandMenus.cpp:1804
 msgid "One sample t-test"
 msgstr "Enmålings t-test"
 
-#: ../../src/wxMaximaFrame.cpp:1927
+#: ../../src/wxMaximaFrame.cpp:1964
 msgid "Online tutorials"
 msgstr "Internett holder åpen buffet på læreressurser :D"
 
-#: ../../src/wxMaximaFrame.cpp:766
+#: ../../src/wxMaximaFrame.cpp:803
 msgid "Only Integers and single letters"
 msgstr ""
 
-#: ../../src/ToolBar.cpp:176 ../../src/main.cpp:593 ../../src/wxMaxima.cpp:6074
+#: ../../src/dialogs/ConfigDialogue.cpp:771
+msgid "Only user-defined labels"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:2197 ../../src/ToolBar.cpp:330
+#: ../../src/ToolBar.cpp:333 ../../src/main.cpp:882
 msgid "Open"
 msgstr "Åpne"
 
-#: ../../src/wxMaximaFrame.cpp:598
+#: ../../src/dialogs/ConfigDialogue.cpp:905
+msgid "Open a cell when Maxima expects input"
+msgstr "Åpne en celle når Maxima forventer inndata"
+
+#: ../../src/wxMaximaFrame.cpp:629
 msgid "Open a document"
 msgstr "Åpne et dokument"
 
-#: ../../src/wxMaximaFrame.cpp:597
+#: ../../src/wxMaximaFrame.cpp:628
 msgid "Open a new window"
 msgstr "Åpne et nytt vindu"
 
-#: ../../src/ToolBar.cpp:617
+#: ../../src/ToolBar.cpp:817
 msgid "Open and save button"
 msgstr ""
 
-#: ../../src/ToolBar.cpp:176
+#: ../../src/ToolBar.cpp:330 ../../src/ToolBar.cpp:333
 msgid "Open document"
 msgstr "Åpne dokument"
 
-#: ../../src/wxMaxima.cpp:7239
+#: ../../src/MaximaCommandMenus.cpp:4111
 msgid "Open for appending"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1099
+#: ../../src/wxMaximaFrame.cpp:1133
 msgid "Open for appending..."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7244
+#: ../../src/MaximaCommandMenus.cpp:4116
 msgid "Open for reading"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1098
+#: ../../src/wxMaximaFrame.cpp:1132
 #, fuzzy
 msgid "Open for reading..."
 msgstr "Uttrykk"
 
-#: ../../src/wxMaxima.cpp:7249
+#: ../../src/MaximaCommandMenus.cpp:4121
 msgid "Open for writing"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1100
+#: ../../src/wxMaximaFrame.cpp:1134
 #, fuzzy
 msgid "Open for writing..."
 msgstr "&Eksporter..."
 
-#: ../../src/wxMaxima.cpp:9598
+#: ../../src/MaximaCommandMenus.cpp:1838
 msgid "Open matrix"
 msgstr "Åpne matrise"
 
-#: ../../src/wxMaximaFrame.cpp:600
+#: ../../src/wxMaximaFrame.cpp:631
 #, fuzzy
 msgid "Open recent"
 msgstr "Åpne N&ylig"
 
-#: ../../src/wxMaxima.cpp:4309
+#: ../../src/MaximaFileIO.cpp:231
 msgid "Opening a wxmx file"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:4153 ../../src/wxMaxima.cpp:4214
-#: ../../src/wxMaxima.cpp:4313 ../../src/wxMaxima.cpp:4622
+#: ../../src/MaximaFileIO.cpp:54 ../../src/MaximaFileIO.cpp:113
+#: ../../src/MaximaFileIO.cpp:235 ../../src/MaximaFileIO.cpp:545
 msgid "Opening file"
 msgstr "Åpne fil"
 
-#: ../../src/wxMaxima.cpp:5030
+#: ../../src/sidebars/HelpBrowser.cpp:175 ../../src/wxMaxima.cpp:1808
 #, c-format
 msgid "Opening help file %s"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1530
+#: ../../src/wxMaximaFrame.cpp:1567
 msgid "Optimize for CPU time"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1529
+#: ../../src/wxMaximaFrame.cpp:1566
 msgid "Optimize for memory"
 msgstr ""
 
-#: ../../src/ToolBar.cpp:199
+#: ../../src/wizards/DrawWiz.cpp:97
+msgid "Optional: A 2nd expression that defines a region to fill"
+msgstr ""
+
+#: ../../src/ToolBar.cpp:367 ../../src/ToolBar.cpp:369
+#: ../../src/dialogs/ConfigDialogue.cpp:284
 msgid "Options"
 msgstr "Valg"
 
-#: ../../src/wxMaximaFrame.cpp:1225
+#: ../../src/wizards/Plot2dWiz.cpp:75 ../../src/wizards/Plot3dWiz.cpp:66
+msgid "Options:"
+msgstr "Valg:"
+
+#: ../../src/dialogs/FindReplacePane.cpp:109
+msgid "Output"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1259
 #, fuzzy
 msgid "Output C"
 msgstr "Utdataetiketter"
 
-#: ../../src/wxMaximaFrame.cpp:1226
+#: ../../src/wxMaximaFrame.cpp:1260
 msgid "Output Fortran"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1228
+#: ../../src/wxMaximaFrame.cpp:1262
 msgid "Output Rational Fortran"
 msgstr ""
 
-#: ../../src/Configuration.cpp:80
+#: ../../src/Styles.cpp:109
 msgid "Output labels"
 msgstr "Utdataetiketter"
 
-#: ../../src/Configuration.cpp:73
+#: ../../src/Styles.cpp:102
 #, fuzzy
 msgid "Output: Function names"
 msgstr "Funksjonnavn"
 
-#: ../../src/Configuration.cpp:75
+#: ../../src/Styles.cpp:104
 msgid "Output: Latin names as greek symbols"
 msgstr ""
 
-#: ../../src/Configuration.cpp:72
+#: ../../src/Styles.cpp:101
 msgid "Output: Numbers and Digits"
 msgstr ""
 
-#: ../../src/Configuration.cpp:71
+#: ../../src/Styles.cpp:100
 #, fuzzy
 msgid "Output: Operators"
 msgstr "Utdataetiketter"
 
-#: ../../src/Configuration.cpp:74
+#: ../../src/Styles.cpp:103
 #, fuzzy, c-format
 msgid "Output: Special constants (%e,%i)"
 msgstr "Spesielle konstanter"
 
-#: ../../src/Configuration.cpp:76
+#: ../../src/Styles.cpp:105
 #, fuzzy
 msgid "Output: Strings"
 msgstr "Strenger"
 
-#: ../../src/Configuration.cpp:70
+#: ../../src/Styles.cpp:99
 #, fuzzy
 msgid "Output: Variable names"
 msgstr "Forrige variabel:"
 
-#: ../../src/wxMaxima.cpp:6442
-msgid "PNG image (*.png)|*.png|JPEG image (*.jpg)|*.jpg|GIF image (*.gif)|*.gif|Scaleable vector graphics (*.svg)|*.svg|Windows bitmap (*.bmp)|*.bmp|Portable anymap (*.pnm)|*.pnm|Tagged image file format (*.tif)|*.tif|X pixmap (*.xpm)|*.xpm"
+#: ../../src/dialogs/ConfigDialogue.cpp:839
+msgid "Overlay scrollbars (slow: repaints the worksheet while they fade)"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:10117
-msgid "PNG image (*.png)|*.png|JPEG image (*.jpg)|*.jpg|Windows bitmap (*.bmp)|*.bmp|GIF image (*.gif)|*.gif|Portable anymap (*.pnm)|*.pnm|Tagged image file format (*.tif)|*.tif|X pixmap (*.xpm)|*.xpm"
+#: ../../src/MaximaCommandMenus.cpp:3609
+msgid "PNG image (*.png)|*.png|JPEG image (*.jpg)|*.jpg|Windows bitmap (*.bmp)|*.bmp|"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8924
+#: ../../src/dialogs/ConfigDialogue.cpp:458
+msgid "PNG images can be read by old wxMaxima versions - but aren't really scalable."
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:175
 msgid "Pade approximation"
 msgstr "Padétilnærming"
 
-#: ../../src/wxMaximaFrame.cpp:1478
+#: ../../src/wxMaximaFrame.cpp:1515
 msgid "Pade approximation of a Taylor series"
 msgstr "Padétilnærming av en taylorrekke"
 
-#: ../../src/wxMaximaFrame.cpp:1637
+#: ../../src/sidebars/FormatSidebar.cpp:69
+msgid "Pagebreak"
+msgstr "Sideskift"
+
+#: ../../src/wxMaximaFrame.cpp:1674
 #, fuzzy
 msgid "Parallel Substitute..."
 msgstr "&Erstatt..."
 
-#: ../../src/wxMaxima.cpp:8738
+#: ../../src/MaximaCommandMenus.cpp:735
 msgid "Parallel substitution"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7179
+#: ../../src/sidebars/SymbolsSidebar.cpp:124
+msgid "Parallel to"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:4051
 #, fuzzy
 msgid "Parameter name:"
 msgstr "Matrisenavn:"
 
-#: ../../src/wxMaxima.cpp:7136 ../../src/wxMaxima.cpp:7149
+#: ../../src/MaximaCommandMenus.cpp:4008 ../../src/MaximaCommandMenus.cpp:4021
 #, fuzzy
 msgid "Parameter(s):"
 msgstr "Variabler:"
 
-#: ../../src/wxMaxima.cpp:7399
+#: ../../src/sidebars/DrawSidebar.cpp:64
+#, fuzzy
+msgid "Parametric Plot"
+msgstr "Parametrisk Plott"
+
+#: ../../src/wizards/Plot2dWiz.cpp:417 ../../src/wizards/Plot2dWiz.cpp:523
+msgid "Parametric plot"
+msgstr "Parametrisk Plott"
+
+#: ../../src/MaximaCommandMenus.cpp:4271
 msgid "Parse string"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1152
+#: ../../src/wxMaximaFrame.cpp:1186
 #, fuzzy
 msgid "Parse string only..."
 msgstr "Oppgi Matrise..."
 
 # s/Kjemmer/Går igjennom, men ikke like gøy? :)
-#: ../../src/StatusBar.cpp:240
+#: ../../src/StatusBar.cpp:308
 msgid "Parsing output"
 msgstr "Kjemmer utdata"
 
-#: ../../src/wxMaxima.cpp:7464
+#: ../../src/MaximaCommandMenus.cpp:4336
 msgid "Part:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1499 ../../src/wxMaximaFrame.cpp:1535
+#: ../../src/wxMaximaFrame.cpp:1536 ../../src/wxMaximaFrame.cpp:1572
 msgid "Partial &Fractions..."
 msgstr "D&elbrøker..."
 
-#: ../../src/wxMaxima.cpp:8975
+#: ../../src/MaximaCommandMenus.cpp:229
 #, fuzzy
 msgid "Partial Fractions"
 msgstr "Delbrøker"
 
-#: ../../src/wxMaxima.cpp:4702
-msgid "Parts of the document will not be loaded correctly!"
-msgstr "Deler av dokumentet vil ikke bli lastet riktig!"
-
-#: ../../src/ToolBar.cpp:210 ../../src/Worksheet.cpp:1654
-#: ../../src/Worksheet.cpp:1685
+#: ../../src/ToolBar.cpp:381 ../../src/ToolBar.cpp:385
+#: ../../src/worksheet/WorksheetContextMenu.cpp:427
+#: ../../src/worksheet/WorksheetContextMenu.cpp:458
 msgid "Paste"
 msgstr "Lim inn"
 
-#: ../../src/wxMaximaFrame.cpp:667
+#: ../../src/wxMaximaFrame.cpp:704
 msgid "Paste\tCtrl+V"
 msgstr "Lim Inn\tCtrl+V"
 
-#: ../../src/ToolBar.cpp:211
+#: ../../src/ToolBar.cpp:381 ../../src/ToolBar.cpp:385
 msgid "Paste from clipboard"
 msgstr "Lim inn fra utklippstavle"
 
-#: ../../src/wxMaximaFrame.cpp:668
+#: ../../src/wxMaximaFrame.cpp:705
 msgid "Paste text from clipboard"
 msgstr "Lim inn tekst fra utklippstavle"
 
-#: ../../src/wxMaxima.cpp:4841
+#: ../../src/wxMaximaFrame.cpp:272 ../../src/wxMaximaFrame.cpp:759
+msgid "Performance Monitor"
+msgstr ""
+
+#: ../../src/Configuration.cpp:1383
+msgid "Performance Statistics:"
+msgstr ""
+
+#: ../../src/sidebars/SymbolsSidebar.cpp:125
+msgid "Perpendicular to"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:218
+msgid "Persian"
+msgstr ""
+
+#: ../../src/sidebars/GreekSidebar.cpp:198
+msgid "Phi"
+msgstr ""
+
+#: ../../src/sidebars/GreekSidebar.cpp:193
+msgid "Pi"
+msgstr ""
+
+#: ../../src/sidebars/StatSidebar.cpp:94
+msgid "Piechart..."
+msgstr "Kakediagram..."
+
+#: ../../src/wxMaxima.cpp:1587
 msgid "Please configure wxMaxima with 'Edit->Configure'."
 msgstr "Vennligst konfigurer wxMaxima med 'Endre->Konfigurer'."
 
-#: ../../src/wxMaximaFrame.cpp:1768
+#: ../../src/dialogs/ConfigDialogue.cpp:2606
+msgid "Please restart wxMaxima for changes to take effect!"
+msgstr "Vennligst restart wxMaxima for at endringene skal tre i kraft!"
+
+#: ../../src/MaximaCommandMenus.cpp:2250
+msgid "Please select exactly 2 or 3 files."
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1805
 msgid "Plot &2d..."
 msgstr "Plott &2D..."
 
-#: ../../src/wxMaximaFrame.cpp:1770
+#: ../../src/wxMaximaFrame.cpp:1807
 msgid "Plot &3d..."
 msgstr "Plott &3D..."
 
-#: ../../src/wxMaximaFrame.cpp:1772
+#: ../../src/wxMaximaFrame.cpp:1809
 msgid "Plot &Format..."
 msgstr "Plott&format..."
 
-#: ../../src/wxMaxima.cpp:9101 ../../src/wxMaxima.cpp:10068
+#: ../../src/MaximaCommandMenus.cpp:107 ../../src/MaximaCommandMenus.cpp:3557
+#: ../../src/wizards/Plot2dWiz.cpp:108 ../../src/wizards/Plot2dWiz.cpp:428
+#: ../../src/wizards/Plot2dWiz.cpp:441
 msgid "Plot 2D"
 msgstr "Plott 2D"
 
-#: ../../src/Worksheet.cpp:1593
+#: ../../src/sidebars/MathSidebar.cpp:89
+#: ../../src/worksheet/WorksheetContextMenu.cpp:366
 msgid "Plot 2D..."
 msgstr "Plott 2D..."
 
-#: ../../src/wxMaxima.cpp:9078 ../../src/wxMaxima.cpp:10079
+#: ../../src/MaximaCommandMenus.cpp:85 ../../src/MaximaCommandMenus.cpp:3568
+#: ../../src/wizards/Plot3dWiz.cpp:103
 msgid "Plot 3D"
 msgstr "Plott 3D"
 
-#: ../../src/Worksheet.cpp:1595
+#: ../../src/sidebars/MathSidebar.cpp:92
+#: ../../src/worksheet/WorksheetContextMenu.cpp:368
 msgid "Plot 3D..."
 msgstr "Plott 3D..."
 
-#: ../../src/wxMaxima.cpp:9538
+#: ../../src/wizards/DrawWiz.cpp:713
+msgid "Plot a parametric curve"
+msgstr ""
+
+#: ../../src/wizards/DrawWiz.cpp:45 ../../src/wizards/DrawWiz.cpp:148
+#: ../../src/wizards/DrawWiz.cpp:255
+#, fuzzy
+msgid "Plot an explicit expression"
+msgstr "Finn grenseverdi til et uttrykk"
+
+#: ../../src/wizards/DrawWiz.cpp:53
+msgid "Plot an expression, for example sin(x) or (x+1)^2."
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:1776
 msgid "Plot as bars"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:9542
-msgid "Plot as error bars"
-msgstr ""
-
-#: ../../src/wxMaxima.cpp:9546
+#: ../../src/MaximaCommandMenus.cpp:1784
 msgid "Plot as pie chart"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:9112
+#: ../../src/MaximaCommandMenus.cpp:118
 msgid "Plot format"
 msgstr "Plottformat"
 
-#: ../../src/wxMaximaFrame.cpp:1768
+#: ../../src/wxMaximaFrame.cpp:1805
 msgid "Plot in 2 dimensions"
 msgstr "Plott i 2 dimensjoner"
 
-#: ../../src/wxMaximaFrame.cpp:1770
+#: ../../src/wxMaximaFrame.cpp:1807
 msgid "Plot in 3 dimensions"
 msgstr "Plott i 3 dimensjoner"
 
-#: ../../src/wxMaximaFrame.cpp:320 ../../src/wxMaximaFrame.cpp:714
+#: ../../src/sidebars/DrawSidebar.cpp:83
+msgid "Plot name"
+msgstr ""
+
+#: ../../src/wizards/Plot2dWiz.cpp:84 ../../src/wizards/Plot3dWiz.cpp:80
+msgid "Plot to file:"
+msgstr "Plott til fil:"
+
+#: ../../src/wxMaximaFrame.cpp:341 ../../src/wxMaximaFrame.cpp:749
 msgid "Plot using Draw"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7824
+#: ../../src/MaximaCommandMenus.cpp:1005
 msgid "Point #1 with known value:"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7826
+#: ../../src/MaximaCommandMenus.cpp:1007
 msgid "Point #2 with known value:"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7800 ../../src/wxMaxima.cpp:7811
+#: ../../src/MaximaCommandMenus.cpp:981 ../../src/MaximaCommandMenus.cpp:992
 msgid "Point the value is known at:"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7909 ../../src/wxMaxima.cpp:8935
+#: ../../src/wizards/DrawWiz.cpp:842
+#, fuzzy
+msgid "Point type:"
+msgstr "Punkt:"
+
+#: ../../src/MaximaCommandMenus.cpp:186 ../../src/MaximaCommandMenus.cpp:1090
+#: ../../src/wizards/BC2Wiz.cpp:33 ../../src/wizards/BC2Wiz.cpp:39
+#: ../../src/wizards/LimitWiz.cpp:35 ../../src/wizards/SeriesWiz.cpp:36
 msgid "Point:"
 msgstr "Punkt:"
 
-#: ../../src/wxMaxima.cpp:8961 ../../src/wxMaxima.cpp:8966
-#: ../../src/wxMaxima.cpp:8971
+#: ../../src/sidebars/DrawSidebar.cpp:67
+msgid "Points"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:219
+msgid "Polish"
+msgstr "Polsk"
+
+#: ../../src/MaximaCommandMenus.cpp:215 ../../src/MaximaCommandMenus.cpp:220
+#: ../../src/MaximaCommandMenus.cpp:225
 msgid "Polynomial 1:"
 msgstr "Polynom 0:"
 
-#: ../../src/wxMaxima.cpp:8961 ../../src/wxMaxima.cpp:8966
-#: ../../src/wxMaxima.cpp:8971
+#: ../../src/MaximaCommandMenus.cpp:215 ../../src/MaximaCommandMenus.cpp:220
+#: ../../src/MaximaCommandMenus.cpp:225
 msgid "Polynomial 2:"
 msgstr "Polynom 1:"
 
-#: ../../src/wxMaxima.cpp:7713 ../../src/wxMaxima.cpp:7724
-#: ../../src/wxMaxima.cpp:7739
+#: ../../src/MaximaCommandMenus.cpp:896 ../../src/MaximaCommandMenus.cpp:906
+#: ../../src/MaximaCommandMenus.cpp:920
 #, fuzzy
 msgid "Polynomial:"
 msgstr "Polynom 0:"
 
-#: ../../src/wxMaximaFrame.cpp:1754
+#: ../../src/wxMaximaFrame.cpp:1791
 msgid "Pop"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1331 ../../src/Worksheet.cpp:1485
+#: ../../src/worksheet/WorksheetContextMenu.cpp:93
+#: ../../src/worksheet/WorksheetContextMenu.cpp:256
 msgid "Popout interactively"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1189
+#: ../../src/MaximaCommandMenus.cpp:3605
+msgid "Portable anymap (*.pnm)|*.pnm|Tagged image file format (*.tif)|*.tif|X pixmap (*.xpm)|*.xpm"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:220
+msgid "Portuguese"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:221
+msgid "Portuguese (Brazilian)"
+msgstr "Portugisisk (brasiliansk)"
+
+#: ../../src/wxMaximaFrame.cpp:1223
 msgid "Position of a match"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7220 ../../src/wxMaxima.cpp:7391
+#: ../../src/MaximaCommandMenus.cpp:4092 ../../src/MaximaCommandMenus.cpp:4263
 #, fuzzy
 msgid "Position:"
 msgstr "Betingelse:"
 
-#: ../../src/wxMaxima.cpp:8939
+#: ../../src/dialogs/DiffFrame.cpp:51
+msgid "Positions of the differences. Click to jump to one."
+msgstr ""
+
+#: ../../src/wizards/Plot2dWiz.cpp:474 ../../src/wizards/Plot3dWiz.cpp:422
+msgid "Postscript file (*.eps)|*.eps|All|*"
+msgstr "Postscript-fil (*.eps)|*.eps|Alle|*"
+
+#: ../../src/MaximaCommandMenus.cpp:190
 #, fuzzy
 msgid "Power series"
 msgstr "&Potensrekke"
 
-#: ../../src/wxMaximaFrame.cpp:1475
+#: ../../src/wxMaximaFrame.cpp:1512
 #, fuzzy
 msgid "Power series..."
 msgstr "&Potensrekke"
 
-#: ../../src/wxMaxima.cpp:9202
+#: ../../src/MaximaCommandMenus.cpp:393
 msgid "Precision"
 msgstr "Presisjon"
 
-#: ../../src/Worksheet.cpp:1616
+#: ../../src/dialogs/ConfigDialogue.cpp:787
+msgid "Prefer 1D"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1492
+msgid "Prefer the all-in-one-file >1000 page manual"
+msgstr ""
+
+#: ../../src/worksheet/WorksheetContextMenu.cpp:389
 msgid "Prefer user labels"
 msgstr ""
 
-#: ../../src/main.cpp:437
+#: ../../src/main.cpp:676
 #, fuzzy
 msgid "Preferences"
 msgstr "Preferanser...\tCtrl+,"
 
-#: ../../src/ToolBar.cpp:626
+#: ../../src/ToolBar.cpp:826
 msgid "Preferences button"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:685
+#: ../../src/wxMaximaFrame.cpp:722
 msgid "Preferences...\tCtrl+,"
 msgstr "Preferanser...\tCtrl+,"
 
-#: ../../src/wxMaximaFrame.cpp:1733
+#: ../../src/wxMaximaFrame.cpp:1770
 #, fuzzy
 msgid "Prepend an element"
 msgstr "Åpne et dokument"
 
-#: ../../src/wxMaximaFrame.cpp:927
+#: ../../src/ToolBar.cpp:266 ../../src/sidebars/CharButton.cpp:137
+msgid "Press"
+msgstr ""
+
+#: ../../src/dialogs/TipOfTheDay.cpp:146
+msgid "Pressing Ctrl+Space or Ctrl+Tab starts an autocomplete function that can not only complete all functions that are integrated into the Maxima core and their parameters: It also knows about parameters from currently loaded packages and from functions that are defined in the current file."
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:961
 msgid "Previous Command\tAlt+Up"
 msgstr "Forrige Kommando\tAlt+Up"
 
-#: ../../src/ToolBar.cpp:184
+#: ../../src/dialogs/DiffFrame.cpp:404
+msgid "Previous Difference"
+msgstr ""
+
+#: ../../src/ToolBar.cpp:343 ../../src/ToolBar.cpp:345
 msgid "Print"
 msgstr "Skriv ut"
 
-#: ../../src/ToolBar.cpp:620
+#: ../../src/dialogs/ConfigDialogue.cpp:1988
+#, fuzzy
+msgid "Print Margins"
+msgstr "Skriv ut"
+
+#: ../../src/ToolBar.cpp:820
 msgid "Print button"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1493
+#: ../../src/worksheet/WorksheetContextMenu.cpp:264
 #, fuzzy
 msgid "Print cell brackets"
 msgstr "Klammer rundt aktiv celle"
 
-#: ../../src/ToolBar.cpp:184 ../../src/wxMaximaFrame.cpp:622
+#: ../../src/ToolBar.cpp:343 ../../src/ToolBar.cpp:345
+#: ../../src/wxMaximaFrame.cpp:655
 msgid "Print document"
 msgstr "Skriv ut dokument"
 
-#: ../../src/wxMaximaFrame.cpp:1829
+#: ../../src/wxMaximaFrame.cpp:1866
 msgid "Print floating-point numbers with exponents dividable by 3"
 msgstr ""
 
-#: ../../src/WXMXformat.cpp:255
-msgid "Produced invalid XML. The erroneous XML data has therefore not been saved but has been put on the clipboard in order to allow to debug it."
+#: ../../src/dialogs/ConfigDialogue.cpp:1968
+#, fuzzy
+msgid "Print scale:"
+msgstr "Skriv ut dokument"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1981
+msgid "Print the cell brackets [drawn to their left]"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:9061
+#: ../../src/dialogs/ConfigDialogue.cpp:287
+#, fuzzy
+msgid "Printout settings"
+msgstr "Fold alle seksjoner"
+
+#: ../../src/graphical_io/Printout.cpp:208
+msgid "Printout: Cannot find a suitable point for a page break!"
+msgstr ""
+
+#: ../../src/graphical_io/Printout.cpp:162
+msgid "Printout: Composing a list of all line starts as possible locations for page breaks"
+msgstr ""
+
+#: ../../src/graphical_io/Printout.cpp:279
+msgid "Printout: Layouting the whole worksheet as a endless scroll of the width of the paper"
+msgstr ""
+
+#: ../../src/graphical_io/Printout.cpp:201
+#, c-format
+msgid "Printout: PageStart=%li, PageHeight=%li, canvasSize=%li"
+msgstr ""
+
+#: ../../src/graphical_io/Printout.cpp:235
+#, c-format
+msgid "Printout: Print ppi: %lix%li"
+msgstr ""
+
+#: ../../src/graphical_io/Printout.cpp:134
+#, c-format
+msgid "Printout: Printing the region %li-%li"
+msgstr ""
+
+#: ../../src/graphical_io/Printout.cpp:76
+#, c-format
+msgid "Printout: Request to print page %li"
+msgstr ""
+
+#: ../../src/graphical_io/Printout.cpp:240
+#, c-format
+msgid "Printout: Scalefactor: %ex%e"
+msgstr ""
+
+#: ../../src/graphical_io/Printout.cpp:112
+#, c-format
+msgid "Printout: Setting the device origin to %lix%li"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:936
+#, fuzzy
+msgid "Privacy settings"
+msgstr "Fold alle seksjoner"
+
+#: ../../src/WXMXformat.cpp:256
+msgid ""
+"Produced invalid XML. The erroneous XML data has therefore not been saved but has been put on the clipboard in order to allow debugging it.\n"
+"Try saving the document in wxm format. Or maybe it helps to remove all output before saving the file, if the conversion of the output causes the problem."
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:315
 msgid "Product"
 msgstr "Produkt"
 
-#: ../../src/wxMaximaFrame.cpp:1095
+#: ../../src/sidebars/SymbolsSidebar.cpp:123
+#, fuzzy
+msgid "Product sign"
+msgstr "Produkt"
+
+#: ../../src/wxMaximaFrame.cpp:1129
 #, fuzzy
 msgid "Program"
 msgstr "Histogram"
 
-#: ../../src/wxMaxima.cpp:7061
+#: ../../src/MaximaCommandMenus.cpp:3933
 #, fuzzy
 msgid "Program (no local variables)"
 msgstr "Endre variabel"
 
-#: ../../src/wxMaxima.cpp:7052
+#: ../../src/MaximaCommandMenus.cpp:3924
 msgid "Program block"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1066
+#: ../../src/wxMaximaFrame.cpp:1100
 msgid "Program block with local variables..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1068
+#: ../../src/wxMaximaFrame.cpp:1102
 msgid "Program block, no local variables..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1751
+#: ../../src/sidebars/GreekSidebar.cpp:200
+msgid "Psi"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1788
 msgid "Push"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8508
+#: ../../src/MaximaCommandMenus.cpp:1514
 #, fuzzy
 msgid "Push an element to a list"
 msgstr "Lag liste fra uttrykk"
 
-#: ../../src/wxMaximaFrame.cpp:1395
+#: ../../src/wxMaximaFrame.cpp:1429
 msgid "QR decomposition"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3621
+#: ../../src/MaximaResponseReader.cpp:845
 msgid "Querying gnuplot which graphics drivers it supports."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8953
+#: ../../src/wxMaximaFrame.cpp:658
+msgid "Quit wxMaxima"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1910
+msgid "RTF with OMML maths"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:207
 msgid "Range radius:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1374
+#: ../../src/wxMaximaFrame.cpp:1408
 msgid "Rank"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:246 ../../src/wxMaximaFrame.cpp:722
+#: ../../src/wxMaximaFrame.cpp:260 ../../src/wxMaximaFrame.cpp:757
 msgid "Raw XML monitor"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:2117
+#: ../../src/wxMaximaFrame.cpp:2168
 #, c-format
 msgid "Re-Reading the config from %s."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:2114
+#: ../../src/wxMaximaFrame.cpp:2165
 msgid "Re-Reading the config from the default location."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:867
+#: ../../src/wxMaximaFrame.cpp:901
 #, fuzzy
 msgid "Re-evaluate all cells above the one the cursor is in"
 msgstr "Utfør alle celler i dokument"
 
-#: ../../src/wxMaximaFrame.cpp:877
+#: ../../src/wxMaximaFrame.cpp:911
 #, fuzzy
 msgid "Re-evaluate all cells below the one the cursor is in"
 msgstr "Utfør alle celler i dokument"
 
-#: ../../src/main.cpp:366
+#: ../../src/main.cpp:605
 msgid "Re-opening STDERR failed."
 msgstr ""
 
-#: ../../src/main.cpp:367
+#: ../../src/main.cpp:606
 #, fuzzy
 msgid "Re-opening STDIN failed."
 msgstr "Åpne fil"
 
-#: ../../src/main.cpp:365
+#: ../../src/main.cpp:604
 msgid "Re-opening STDOUT failed."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7512
+#: ../../src/wxMaxima.cpp:2889
+#, c-format
+msgid "Re-pointed the .wxmx file association at %s"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:4384
 msgid "Re-using a compiled regex is faster that using the same regex string multiple times."
 msgstr ""
 
-#: ../../src/Worksheet.cpp:6668
+#: ../../src/worksheet/Worksheet.cpp:4659
 #, fuzzy
 msgid "Read .wxm data from clipboard"
 msgstr "Lim inn tekst fra utklippstavle"
 
-#: ../../src/wxMaxima.cpp:7599
+#: ../../src/MaximaCommandMenus.cpp:4471
 msgid "Read Directory"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1677
-#, fuzzy
-msgid "Read List from csv file..."
-msgstr "Last en stil fra fil"
+#: ../../src/sidebars/StatSidebar.cpp:103
+msgid "Read Matrix..."
+msgstr "Les Matrise..."
 
-#: ../../src/wxMaxima.cpp:7196
+#: ../../src/MaximaCommandMenus.cpp:4068
 msgid "Read a structure field"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7270 ../../src/wxMaxima.cpp:7274
+#: ../../src/MaximaCommandMenus.cpp:4142 ../../src/MaximaCommandMenus.cpp:4146
 msgid "Read byte"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7266
+#: ../../src/MaximaCommandMenus.cpp:4138
 #, fuzzy
 msgid "Read char"
 msgstr "Les Matrise..."
 
-#: ../../src/wxMaxima.cpp:7593
+#: ../../src/dialogs/ConfigDialogue.cpp:2488
+#, fuzzy
+msgid "Read config to file"
+msgstr "Lagre utvalg til fil"
+
+#: ../../src/MaximaCommandMenus.cpp:4465
 #, fuzzy
 msgid "Read environment variable"
 msgstr "Øvrige parametre:"
 
-#: ../../src/wxMaximaFrame.cpp:1219
+#: ../../src/wxMaximaFrame.cpp:1253
 #, fuzzy
 msgid "Read environment variable..."
 msgstr "Slett en variabel"
 
-#: ../../src/wxMaxima.cpp:7262
+#: ../../src/MaximaCommandMenus.cpp:4134
 msgid "Read line"
 msgstr ""
 
-#: ../../src/MaximaManual.cpp:113
+#: ../../src/wxMaximaFrame.cpp:1714
+msgid "Read nested list from csv file..."
+msgstr ""
+
+#: ../../src/MaximaManual.cpp:114
 #, c-format
 msgid "Read the entries the maxima manual offers from %s"
 msgstr ""
 
-#: ../../src/StatusBar.cpp:245
+#: ../../src/StatusBar.cpp:318
 msgid "Reading Maxima output"
 msgstr "Leser Maxima-utdata"
 
-#: ../../src/StatusBar.cpp:247
+#: ../../src/StatusBar.cpp:320
 #, c-format
 msgid "Reading Maxima output: %li bytes"
 msgstr ""
@@ -5738,527 +8603,794 @@ msgstr ""
 msgid "Reading the Lisp part of wxMaxima from the included header file."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:148
+#: ../../src/wxMaximaFrame.cpp:156
 #, c-format
 msgid "Reading the config from %s."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:151
+#: ../../src/wxMaximaFrame.cpp:159
 msgid "Reading the config from the default location."
 msgstr ""
 
-#: ../../src/StatusBar.cpp:224
+#: ../../src/StatusBar.cpp:272
 msgid "Ready for user input"
 msgstr "Klar for brukerinndata"
 
-#: ../../src/Worksheet.cpp:960
-msgid "Recalculated the whole worksheet at once => Updating its size"
+#: ../../src/sidebars/PerformanceSidebar.cpp:43
+msgid "Recalc (Cells appended):"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:946
-msgid "Recalculation hit the end of the worksheet => Updating its size"
+#: ../../src/sidebars/PerformanceSidebar.cpp:42
+msgid "Recalc (Config changed):"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:930
+#: ../../src/sidebars/PerformanceSidebar.cpp:44
+msgid "Recalc (Editor dirty):"
+msgstr ""
+
+#: ../../src/sidebars/PerformanceSidebar.cpp:39
+msgid "Recalc (Font invalid):"
+msgstr ""
+
+#: ../../src/sidebars/PerformanceSidebar.cpp:41
+msgid "Recalc (Font mismatch):"
+msgstr ""
+
+#: ../../src/sidebars/PerformanceSidebar.cpp:40
+msgid "Recalc (Size invalid):"
+msgstr ""
+
+#: ../../src/worksheet/WorksheetLayout.cpp:162
+#, c-format
+msgid "Recalculated the whole worksheet at once => Updating its size (Visited %d cells, recalculated %d, in %ld ms)"
+msgstr ""
+
+#: ../../src/worksheet/WorksheetLayout.cpp:125
+#, c-format
+msgid "Recalculation covered the whole dirty range => stopping early (Visited %d cells, recalculated %d, in %ld ms)"
+msgstr ""
+
+#: ../../src/worksheet/WorksheetLayout.cpp:146
+#, c-format
+msgid "Recalculation hit the end of the worksheet => Updating its size (Visited %d cells, recalculated %d, in %ld ms)"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:964
 msgid "Recall next command from history"
 msgstr "Hent frem neste kommando fra historikk"
 
-#: ../../src/wxMaximaFrame.cpp:928
+#: ../../src/wxMaximaFrame.cpp:962
 msgid "Recall previous command from history"
 msgstr "Hent frem forrige kommando fra historikk"
 
-#: ../../src/wxMaxima.cpp:3235
+#: ../../src/MaximaResponseReader.cpp:138
 #, c-format
 msgid "Received manual topic request: %s"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3097
+#: ../../src/MaximaResponseReader.cpp:237
 #, c-format
 msgid "Received maxima's first prompt: %s"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:603
+#: ../../src/dialogs/ConfigDialogue.cpp:1327
+msgid "Recent files list length:"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:634
 #, fuzzy
 msgid "Recover unsaved"
 msgstr "ulagret"
 
-#: ../../src/wxMaximaFrame.cpp:1640
+#: ../../src/sidebars/MathSidebar.cpp:56
+msgid "Rectform"
+msgstr "Rekt. form"
+
+#: ../../src/wxMaximaFrame.cpp:1677
 #, fuzzy
 msgid "Recursive Substitute..."
 msgstr "&Erstatt..."
 
-#: ../../src/wxMaxima.cpp:8746
+#: ../../src/MaximaCommandMenus.cpp:744
 msgid "Recursive substitution"
 msgstr ""
 
-#: ../../src/ToolBar.cpp:192
+#: ../../src/ToolBar.cpp:355 ../../src/ToolBar.cpp:358
 msgid "Redo"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:633
+#: ../../src/wxMaximaFrame.cpp:670
 #, fuzzy
 msgid "Redo\tCtrl+Y"
 msgstr "Angre\tCtrl+Z"
 
-#: ../../src/wxMaximaFrame.cpp:633
+#: ../../src/wxMaximaFrame.cpp:670
 msgid "Redo last change"
 msgstr "Gjør om igjen den siste endringen du angret"
 
-#: ../../src/wxMaximaFrame.cpp:1595
+#: ../../src/sidebars/MathSidebar.cpp:71
+msgid "Reduce (tr)"
+msgstr "Reduser (tr)"
+
+#: ../../src/wxMaximaFrame.cpp:1632
 msgid "Reduce trigonometric expression"
 msgstr "Reduser trigonometrisk uttrykk"
 
-#: ../../src/wxMaxima.cpp:2366 ../../src/wxMaxima.cpp:10630
+#: ../../src/MaximaEvaluator.cpp:395
+msgid ""
+"Refusing to evaluate cell: its text changed between being queued and being evaluated (see GH #2196).\n"
+"Queued as: "
+msgstr ""
+
+#: ../../src/MaximaEvaluator.cpp:123 ../../src/MaximaEvaluator.cpp:515
 msgid "Refusing to send cell to maxima: "
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7523
+#: ../../src/dialogs/FindReplacePane.cpp:85
+msgid "Regex"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:4395
 msgid "Regex match"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7518
+#: ../../src/MaximaCommandMenus.cpp:4390
 msgid "Regex match position"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1195
+#: ../../src/wxMaximaFrame.cpp:2009
+msgid "Register wxMaxima as the tool that compares .wxmx files in TortoiseSVN and TortoiseGit"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1229
 #, fuzzy
 msgid "Regular expression that matches a string"
 msgstr "Kommaseparerte x-koordinater"
 
-#: ../../src/wxMaximaFrame.cpp:1196
+#: ../../src/wxMaximaFrame.cpp:1230
 #, fuzzy
 msgid "Regular expressions"
 msgstr "Integrer uttrykk"
 
-#: ../../src/Worksheet.cpp:1314
+#: ../../src/worksheet/WorksheetContextMenu.cpp:76
 #, fuzzy
 msgid "Reload Image"
 msgstr "Kopier som Bilde"
 
-#: ../../src/Worksheet.cpp:1320
+#: ../../src/worksheet/WorksheetContextMenu.cpp:82
 #, c-format
 msgid "Reload Image \"%s\""
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:9809
+#: ../../src/dialogs/ConfigDialogue.cpp:997
+msgid "Reload all GUI settings from disc"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1004
+msgid "Reload the style settings from disc"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:3272
 #, c-format
 msgid "Reloading image file %s."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:883
+#: ../../src/dialogs/ConfigDialogue.cpp:2573
+msgid "Reloading the configuration from disc"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:2581
+#, fuzzy
+msgid "Reloading the styles from disc"
+msgstr "Last en stil fra fil"
+
+#: ../../src/sidebars/VariablesPane.cpp:220
+msgid "Remove"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:917
 msgid "Remove All Output"
 msgstr "&Fjern All Utdata"
 
-#: ../../src/wxMaximaFrame.cpp:1426
-msgid "Remove Rows or Columns..."
+#: ../../src/wxMaximaFrame.cpp:1463
+msgid "Remove Columns..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1748
+#: ../../src/wxMaximaFrame.cpp:1460
+msgid "Remove Rows..."
+msgstr ""
+
+#: ../../src/sidebars/VariablesPane.cpp:225
+msgid "Remove all"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1785
 msgid "Remove all list elements that appear twice in a row. Normally used in conjunction with sort."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1174
+#: ../../src/wxMaximaFrame.cpp:1208
 msgid "Remove all occurrences of a word..."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7439
+#: ../../src/MaximaCommandMenus.cpp:4311
 msgid "Remove all occurrences of part"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8592
+#: ../../src/MaximaCommandMenus.cpp:1611
 #, fuzzy
 msgid "Remove an element from a list"
 msgstr "Lag liste fra uttrykk"
 
-#: ../../src/wxMaxima.cpp:7566
+#: ../../src/MaximaCommandMenus.cpp:1519
+msgid "Remove and return the first element of a list"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1464
+msgid "Remove columns from a matrix"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:4438
 msgid "Remove directory"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1204
+#: ../../src/wxMaximaFrame.cpp:1238
 msgid "Remove directory..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1747
+#: ../../src/wxMaximaFrame.cpp:1784
 msgid "Remove duplicates"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1176
+#: ../../src/wxMaximaFrame.cpp:1210
 msgid "Remove first occurrence of a word..."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7444
+#: ../../src/MaximaCommandMenus.cpp:4316
 msgid "Remove first occurrence of part"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:884
+#: ../../src/MaximaCommandMenus.cpp:1155
+msgid "Remove matrix columns"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:1160
+msgid "Remove matrix rows"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:918
 msgid "Remove output from input cells"
 msgstr "Fjern utdata fra inndataceller"
 
-#: ../../src/wxMaxima.cpp:7975
-msgid "Remove rows and/or columns"
+#: ../../src/wxMaximaFrame.cpp:1461
+msgid "Remove rows from the a matrix"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1427
-msgid "Remove rows and/or columns from the matrix"
-msgstr ""
-
-#: ../../src/wxMaxima.cpp:7582
+#: ../../src/MaximaCommandMenus.cpp:4454
 #, fuzzy
 msgid "Rename file"
 msgstr "Åpne fil"
 
-#: ../../src/wxMaximaFrame.cpp:1215
+#: ../../src/wxMaximaFrame.cpp:1249
 #, fuzzy
 msgid "Rename file..."
 msgstr "Slett en variabel"
 
-#: ../../src/wxMaximaFrame.cpp:1527
+#: ../../src/wxMaximaFrame.cpp:1564
 #, fuzzy
 msgid "Reorganize an expression using horner's rule"
 msgstr "Faktoriser et uttrykk i gaussiske heltall"
 
-#: ../../src/wxMaximaFrame.cpp:1346
+#: ../../src/wxMaximaFrame.cpp:1380
 msgid "Repetitive element-by-element multiplication"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7538
+#: ../../src/dialogs/FindReplacePane.cpp:117
+#, fuzzy
+msgid "Replace All"
+msgstr "Velg Alle"
+
+#: ../../src/MaximaCommandMenus.cpp:4410
 msgid "Replace all regex matches"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7533
+#: ../../src/MaximaCommandMenus.cpp:4405
 msgid "Replace first regex match"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7463
+#: ../../src/wxMaximaFrame.cpp:1990
+msgid "Replace non-builtin variable and function names in the selected code cells (or the whole document) with random names, so a worksheet can be shared without revealing its original names"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:4335
 #, fuzzy
 msgid "Replace the first occurrence of Part"
 msgstr "Erstattet %d forekomster."
 
-#: ../../src/wxMaximaFrame.cpp:1180
+#: ../../src/wxMaximaFrame.cpp:1214
 #, fuzzy
 msgid "Replace..."
 msgstr "Velg Alle"
 
-#: ../../src/wxMaxima.cpp:6719
+#: ../../src/wxMaxima.cpp:2720
 #, fuzzy, c-format
 msgid "Replaced %li occurrences."
 msgstr "Erstattet %d forekomster."
 
-#: ../../src/wxMaximaFrame.cpp:1950
+#: ../../src/dialogs/FindReplacePane.cpp:62
+msgid "Replacement:"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:768
+msgid "Replaces the subexpression that part(expr, n_1, n_2, ...) would select by a new value. The part numbers form a path: n_1 selects a part of the expression, n_2 a part of that, and so on."
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1987
 msgid "Report bug"
 msgstr "Rapporter feil"
 
-#: ../../src/wxMaximaFrame.cpp:996
+#: ../../src/dialogs/ConfigDialogue.cpp:983
+msgid "Reset all GUI settings"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1030
 #, fuzzy
 msgid "Reset option variables"
 msgstr "Endre variabel"
 
-#: ../../src/ToolBar.cpp:229 ../../src/wxMaximaFrame.cpp:974
+#: ../../src/dialogs/ConfigDialogue.cpp:990
+msgid "Reset the Style settings"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:2557
+#: ../../src/dialogs/ConfigDialogue.cpp:2565
+msgid "Resetting all configuration settings"
+msgstr ""
+
+#: ../../src/ToolBar.cpp:411 ../../src/ToolBar.cpp:417
+#: ../../src/wxMaximaFrame.cpp:1008
 msgid "Restart Maxima"
 msgstr "Restart Maxima"
 
-#: ../../src/Worksheet.cpp:1304 ../../src/Worksheet.cpp:1477
+#: ../../src/worksheet/WorksheetContextMenu.cpp:66
+#: ../../src/worksheet/WorksheetContextMenu.cpp:248
 #, fuzzy
 msgid "Restrict Maximum size"
 msgstr "Restart Maxima"
 
-#: ../../src/wxMaxima.cpp:10031
+#: ../../src/MaximaCommandMenus.cpp:3520
 #, fuzzy
 msgid "Result variables:"
 msgstr "Slett variabler:"
 
-#: ../../src/wxMaxima.cpp:8135
+#: ../../src/MaximaCommandMenus.cpp:1323
 msgid "Resulting Matrix name (may be empty):"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1190
+#: ../../src/wxMaximaFrame.cpp:1224
 msgid "Return a match"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7077
+#: ../../src/MaximaCommandMenus.cpp:3949
 msgid "Return from a block or loop"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1069
+#: ../../src/wxMaximaFrame.cpp:1103
 msgid "Return from current block/loop..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1755
+#: ../../src/wxMaximaFrame.cpp:1792
 msgid "Return the first item of the list and remove it from the list. Useful for creating stacks."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8526
+#: ../../src/MaximaCommandMenus.cpp:1537
 msgid "Return the list without its first n elements"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8532
+#: ../../src/MaximaCommandMenus.cpp:1543
 msgid "Return the list without its last n elements"
 msgstr ""
 
-#: ../../src/ToolBar.cpp:241
+#: ../../src/ToolBar.cpp:424 ../../src/ToolBar.cpp:433
 msgid "Return to the cell that is currently being evaluated"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1711
+#: ../../src/wxMaximaFrame.cpp:1748
 msgid "Returns an arbitrary list item"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1713
+#: ../../src/MaximaCommandMenus.cpp:1527
+msgid "Returns the first element of a list"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1750
 msgid "Returns the first item of the list"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1719
+#: ../../src/MaximaCommandMenus.cpp:1531
+msgid "Returns the last element of a list"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1756
 msgid "Returns the last item of the list"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1721
+#: ../../src/wxMaximaFrame.cpp:1758
 msgid "Returns the last n items of the list"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1742
+#: ../../src/wxMaximaFrame.cpp:1779
 msgid "Returns the length of the list"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1715
+#: ../../src/wxMaximaFrame.cpp:1752
 msgid "Returns the list without its first n elements"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1717
+#: ../../src/wxMaximaFrame.cpp:1754
 msgid "Returns the list without its last n elements"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1743
+#: ../../src/MaximaCommandMenus.cpp:1509
+msgid "Returns the number of elements of a list"
+msgstr ""
+
+#: ../../src/wizards/DrawWiz.cpp:836
+#, fuzzy
+msgid "Reuse last"
+msgstr "Lag liste"
+
+#: ../../src/wxMaximaFrame.cpp:1780
 msgid "Reverse"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1744
+#: ../../src/wxMaximaFrame.cpp:1781
 msgid "Reverse the order of the list items"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7983 ../../src/wxMaxima.cpp:7988
-#: ../../src/wxMaxima.cpp:8008 ../../src/wxMaxima.cpp:8014
+#: ../../src/MaximaCommandMenus.cpp:1523
+msgid "Reverses the order of the members of a list"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:295
+msgid "Revert all to defaults"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:980
+#, fuzzy
+msgid "Revert changes"
+msgstr "Gjør om igjen den siste endringen du angret"
+
+#: ../../src/sidebars/GreekSidebar.cpp:194
+msgid "Rho"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:2015
+#, fuzzy
+msgid "Right"
+msgstr "høyre"
+
+#: ../../src/MaximaCommandMenus.cpp:1167 ../../src/MaximaCommandMenus.cpp:1172
+#: ../../src/MaximaCommandMenus.cpp:1192 ../../src/MaximaCommandMenus.cpp:1198
 #, fuzzy
 msgid "Right Matrix:"
 msgstr "Oppgi matrise"
 
-#: ../../src/wxMaxima.cpp:8190
+#: ../../src/sidebars/SymbolsSidebar.cpp:127
+msgid "Right arrow"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:1380
 msgid "Right end"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1301
+#: ../../src/wxMaximaFrame.cpp:1335
 msgid "Right side to the \"=\""
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1455
+#: ../../src/wxMaximaFrame.cpp:1492
 msgid "Risch Integration..."
 msgstr "&Rischintegrasjon..."
 
-#: ../../src/wxMaximaFrame.cpp:785
+#: ../../src/dialogs/ConfigDialogue.cpp:222
+msgid "Romanian"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:822
 msgid "Rounded"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1437
+#: ../../src/wxMaximaFrame.cpp:1474
 msgid "Row and column operations"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7957 ../../src/wxMaxima.cpp:7967
-#: ../../src/wxMaxima.cpp:7972
+#: ../../src/MaximaCommandMenus.cpp:1137 ../../src/MaximaCommandMenus.cpp:1147
 msgid "Row number:"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7977
+#: ../../src/MaximaCommandMenus.cpp:1162
 #, fuzzy
 msgid "Row numbers:"
 msgstr "Tall"
 
-#: ../../src/wxMaxima.cpp:8203
+#: ../../src/MaximaCommandMenus.cpp:1393
 #, fuzzy
 msgid "Rows"
 msgstr "Rader:"
 
-#: ../../src/wxMaxima.cpp:8201
+#: ../../src/wizards/MatWiz.cpp:152
+msgid "Rows:"
+msgstr "Rader:"
+
+#: ../../src/MaximaCommandMenus.cpp:1391
 msgid "Rule"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8464 ../../src/wxMaxima.cpp:8477
+#: ../../src/MaximaCommandMenus.cpp:1467
 msgid "Rule:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1027
+#: ../../src/wxMaximaFrame.cpp:1061
 msgid "Rules"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1693
+#: ../../src/wxMaximaFrame.cpp:1730
 #, fuzzy
 msgid "Run each element through an expression"
 msgstr "Finn grenseverdi til et uttrykk"
 
-#: ../../src/wxMaxima.cpp:6355
+#: ../../src/MaximaCommandMenus.cpp:2790
 #, c-format
 msgid "Running %s on the file %s: "
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2633
+#: ../../src/MaximaProcessManager.cpp:297
 #, c-format
 msgid "Running maxima as: %s"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:130
+#: ../../src/wxMaximaFrame.cpp:138
 msgid "Running on DirectFB"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:114
+#: ../../src/wxMaximaFrame.cpp:122
 msgid "Running on MS Windows"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:116
+#: ../../src/wxMaximaFrame.cpp:124
 msgid "Running on MS Windows using DirectDraw"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:136
+#: ../../src/wxMaximaFrame.cpp:144
 msgid "Running on Mac OS"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:127
+#: ../../src/wxMaximaFrame.cpp:135
 msgid "Running on Motif"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:133
+#: ../../src/wxMaximaFrame.cpp:141
 msgid "Running on the universal wxWidgets port"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8208
+#: ../../src/MaximaCommandMenus.cpp:1398
 msgid "Runs each element of an object (list, matrix, equation,...) through a function individually"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8216
+#: ../../src/MaximaCommandMenus.cpp:1406
 msgid "Runs each element of an object (list, matrix, equation,...) through an expression individually"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1691
+#: ../../src/wxMaximaFrame.cpp:1728
 msgid "Runs each element through a function"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1694
+#: ../../src/wxMaximaFrame.cpp:1731
 #, fuzzy
 msgid "Runs each element through an expression"
 msgstr "Finn grenseverdi til et uttrykk"
 
-#: ../../src/wxMaxima.cpp:9572
+#: ../../src/dialogs/ConfigDialogue.cpp:223
+msgid "Russian"
+msgstr "Russisk"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1578
+msgid "SBCL: use <int>Mbytes of heap"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1585
+msgid "SBCL: use <int>Mbytes of stack for function calls"
+msgstr ""
+
+#: ../../src/sidebars/XmlInspector.cpp:78
+msgid "SENT TO MAXIMA:"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1224
+msgid "SVG graphics"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:1810
 msgid "Sample 1:"
 msgstr "Måling 0:"
 
-#: ../../src/wxMaxima.cpp:9573
+#: ../../src/MaximaCommandMenus.cpp:1811
 msgid "Sample 2:"
 msgstr "Måling 1:"
 
-#: ../../src/wxMaxima.cpp:9567
+#: ../../src/MaximaCommandMenus.cpp:1805
 msgid "Sample:"
 msgstr "Måling:"
 
-#: ../../src/ToolBar.cpp:177 ../../src/wxMaxima.cpp:11203
+#: ../../src/wizards/DrawWiz.cpp:956
+msgid "Samples for explicit and parametric plots:"
+msgstr ""
+
+#: ../../src/wizards/DrawWiz.cpp:969
+msgid "Samples for implicit plots and regions:"
+msgstr ""
+
+#: ../../src/wizards/DrawWiz.cpp:937
+msgid "Samples for implicit plots:"
+msgstr ""
+
+#: ../../src/wizards/DrawWiz.cpp:924
+msgid "Samples on a line:"
+msgstr ""
+
+#: ../../src/ToolBar.cpp:331 ../../src/ToolBar.cpp:334
+#: ../../src/dialogs/ConfigDialogue.cpp:2163 ../../src/wxMaxima.cpp:3509
 msgid "Save"
 msgstr "Lagre"
 
-#: ../../src/Worksheet.cpp:1294
+#: ../../src/worksheet/WorksheetContextMenu.cpp:55
 msgid "Save Animation..."
 msgstr "Lagre Animasjon..."
 
-#: ../../src/wxMaxima.cpp:5672
+#: ../../src/MaximaFileIO.cpp:779
 msgid "Save As"
 msgstr "Lagre Som"
 
-#: ../../src/wxMaximaFrame.cpp:609
+#: ../../src/wxMaximaFrame.cpp:640
 msgid "Save As...\tShift+Ctrl+S"
 msgstr "Lagre &Som...\tShift+Ctrl+S"
 
-#: ../../src/Worksheet.cpp:1291
+#: ../../src/worksheet/WorksheetContextMenu.cpp:50
 msgid "Save Image..."
 msgstr "Lagre Bilde..."
 
-#: ../../src/wxMaxima.cpp:6440
+#: ../../src/MaximaCommandMenus.cpp:2926
 msgid "Save Selection to Image"
 msgstr "Lagre Utvalg til Bilde"
 
-#: ../../src/wxMaximaFrame.cpp:675
+#: ../../src/wxMaximaFrame.cpp:712
 msgid "Save Selection to Image..."
 msgstr "Lagre Utvalg til &Bilde..."
 
-#: ../../src/wxMaxima.cpp:10184
+#: ../../src/MaximaCommandMenus.cpp:3713
 msgid "Save animation to file"
 msgstr "Lagre animasjon til fil"
 
-#: ../../src/wxMaxima.cpp:7203
+#: ../../src/MaximaCommandMenus.cpp:4075
 msgid "Save as lisp code"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1091
+#: ../../src/wxMaximaFrame.cpp:1125
 #, fuzzy
 msgid "Save as lisp..."
 msgstr "Last Pakke"
 
-#: ../../src/ToolBar.cpp:177 ../../src/wxMaximaFrame.cpp:608
+#: ../../src/dialogs/ConfigDialogue.cpp:2478
+#, fuzzy
+msgid "Save config to file"
+msgstr "Lagre utvalg til fil"
+
+#: ../../src/ToolBar.cpp:331 ../../src/ToolBar.cpp:334
+#: ../../src/wxMaximaFrame.cpp:639
 msgid "Save document"
 msgstr "Lagre dokument"
 
-#: ../../src/wxMaximaFrame.cpp:609
+#: ../../src/wxMaximaFrame.cpp:640
 msgid "Save document as"
 msgstr "Lagre dokument som"
 
-#: ../../src/wxMaximaFrame.cpp:676
+#: ../../src/wizards/Plot2dWiz.cpp:473 ../../src/wizards/Plot3dWiz.cpp:421
+msgid "Save plot to file"
+msgstr "Lagre plott til fil"
+
+#: ../../src/wxMaximaFrame.cpp:713
 msgid "Save selection from document to an image file"
 msgstr "Lagre utvalg fra dokument til en bildefil"
 
-#: ../../src/wxMaxima.cpp:10125
+#: ../../src/MaximaCommandMenus.cpp:3620
 msgid "Save selection to file"
 msgstr "Lagre utvalg til fil"
 
-#: ../../src/wxMaximaFrame.cpp:573
+#: ../../src/dialogs/ConfigDialogue.cpp:2640
+msgid "Save style to file"
+msgstr "Lagre stil til fil"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1384
+msgid "Save the worksheet automatically"
+msgstr ""
+
+#: ../../src/MaximaFileIO.cpp:873
+msgid "Saving failed!"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:594
 #, fuzzy
 msgid "Saving failed."
 msgstr "Klarte ikke starte server"
 
-#: ../../src/WXMXformat.cpp:310
+#: ../../src/WXMXformat.cpp:312
 msgid "Saving succeeded, but the resulting files has disappeared ?!?."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:10107
-msgid "Scalable Vector image (*.svg)|*.svg|Compressed Scalable Vector Image (*.svgz)|*.svgz|PNG image (*.png)|*.png|JPEG image (*.jpg)|*.jpg|GIF image (*.gif)|*.gif|Windows bitmap (*.bmp)|*.bmp|Portable anymap (*.pnm)|*.pnm|Tagged image file format (*.tif)|*.tif|X pixmap (*.xpm)|*.xpm"
+#: ../../src/dialogs/ConfigDialogue.cpp:1914
+msgid "Scalable Vector Graphics (svg)"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:9533
+#: ../../src/MaximaCommandMenus.cpp:3596
+msgid "Scalable Vector image (*.svg)|*.svg|Compressed Scalable Vector Image (*.svgz)|*.svgz|PNG image (*.png)|*.png|JPEG image (*.jpg)|*.jpg|GIF image (*.gif)|*.gif|Windows bitmap (*.bmp)|*.bmp|"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:1771
 msgid "Scatterplot"
 msgstr "Spredningsplott"
 
-#: ../../src/Autocomplete.cpp:125
+#: ../../src/sidebars/StatSidebar.cpp:88
+msgid "Scatterplot..."
+msgstr "Spredningsplott..."
+
+#: ../../src/Autocomplete.cpp:157
 msgid "Scheduling a background task that compiles a new list of autocompletable maxima commands."
 msgstr ""
 
-#: ../../src/Autocomplete.cpp:458
+#: ../../src/Autocomplete.cpp:586
 msgid "Scheduling a background task that scans for autocompletable file names."
 msgstr ""
 
-#: ../../src/ToolBar.cpp:632
+#: ../../src/dialogs/ConfigDialogue.cpp:1867
+msgid "Screen reader"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:662
+msgid "Scroll to a cell with a certain UUID"
+msgstr ""
+
+#: ../../src/ToolBar.cpp:832
 msgid "Search button"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7454
+#: ../../src/MaximaCommandMenus.cpp:4326
 msgid "Search first occurrence of part"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1178
+#: ../../src/dialogs/DiffFrame.cpp:420
+msgid "Search input / UUID"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1212
 msgid "Search..."
 msgstr ""
 
-#: ../../src/ToolBar.cpp:273
+#: ../../src/ToolBar.cpp:483 ../../src/sidebars/FormatSidebar.cpp:51
 msgid "Section"
 msgstr "Seksjon"
 
-#: ../../src/Configuration.cpp:91
+#: ../../src/Styles.cpp:120
 msgid "Section cell (Heading 2)"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7218
+#: ../../src/sidebars/TableOfContents.cpp:585
+msgid "Section numbers"
+msgstr ""
+
+#: ../../src/wizards/DrawWiz.cpp:158
+msgid "See also the speed <-> accuracy button."
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:4090
 #, fuzzy
 msgid "Seek to position"
 msgstr "Padétilnærming"
@@ -6267,1150 +9399,1665 @@ msgstr "Padétilnærming"
 msgid "Seems like something is broken with a font."
 msgstr ""
 
-#: ../../src/Autocomplete.cpp:350
+#: ../../src/Autocomplete.cpp:438
 msgid "Seems like the package with the maxima share files isn't installed."
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1655 ../../src/Worksheet.cpp:1687
+#: ../../src/sidebars/TableOfContents.cpp:511
+#, fuzzy
+msgid "Select"
+msgstr "Utvalg"
+
+#: ../../src/MaximaCommandMenus.cpp:2239
+msgid "Select 2 or 3 files to compare"
+msgstr ""
+
+#: ../../src/worksheet/WorksheetContextMenu.cpp:428
+#: ../../src/worksheet/WorksheetContextMenu.cpp:460
 msgid "Select All"
 msgstr "Velg Alle"
 
-#: ../../src/wxMaximaFrame.cpp:673
+#: ../../src/wxMaximaFrame.cpp:710
 msgid "Select All\tCtrl+A"
 msgstr "Velg Alle\tCtrl+A"
 
-#: ../../src/ToolBar.cpp:629
+#: ../../src/ToolBar.cpp:829
 msgid "Select All button"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:9631
+#: ../../src/MaximaCommandMenus.cpp:1871
 msgid "Select Subsample"
 msgstr "Velg Undermåling"
 
-#: ../../src/ToolBar.cpp:214 ../../src/ToolBar.cpp:215
-#: ../../src/wxMaximaFrame.cpp:673
+#: ../../src/wizards/IntegrateWiz.cpp:193
+#: ../../src/wizards/IntegrateWiz.cpp:208 ../../src/wizards/LimitWiz.cpp:133
+#: ../../src/wizards/SeriesWiz.cpp:105
+msgid "Select a constant"
+msgstr "Velg en konstant"
+
+#: ../../src/ToolBar.cpp:390 ../../src/ToolBar.cpp:392
+#: ../../src/wxMaximaFrame.cpp:710
 msgid "Select all"
 msgstr "Velg alle"
 
+#: ../../src/dialogs/BinaryNameCtrl.cpp:64
+msgid "Select binary location program"
+msgstr ""
+
+#: ../../src/wizards/CsvWiz.cpp:92 ../../src/wizards/CsvWiz.cpp:166
+msgid "Select csv file to read"
+msgstr ""
+
 # vi elsker sammensatte ord, gjør vi ikke?
-#: ../../src/wxMaxima.cpp:6971
+#: ../../src/MaximaCommandMenus.cpp:3843
 msgid "Select math display algorithm"
 msgstr "Velg matematikkvisningsalgoritme"
 
-#: ../../src/Configuration.cpp:98
+#: ../../src/dialogs/TipOfTheDay.cpp:109
+#, fuzzy
+msgid "Selecting a part of an output and right-clicking on the selection will bring up a menu with convenient functions that will operate on the selection."
+msgstr "Velg en del av utdataen og høyreklikk på utvalget for å vise en meny med nyttige funksjoner som er relevante for utvalget."
+
+#: ../../src/Styles.cpp:127
 #, fuzzy
 msgid "Selection color"
 msgstr "Utvalg"
 
-#: ../../src/ToolBar.cpp:252
+#: ../../src/wizards/CsvWiz.cpp:40 ../../src/wizards/CsvWiz.cpp:111
+msgid "Semicolon"
+msgstr ""
+
+#: ../../src/ToolBar.cpp:446 ../../src/ToolBar.cpp:458
 msgid "Send all cells to maxima"
 msgstr ""
 
-#: ../../src/ToolBar.cpp:249
+#: ../../src/ToolBar.cpp:443 ../../src/ToolBar.cpp:455
 msgid "Send the current cell to maxima"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2810
+#: ../../src/MaximaProcessManager.cpp:921
 msgid "Sending Maxima a SIGINT signal."
 msgstr ""
 
-#: ../../src/StatusBar.cpp:220
+#: ../../src/StatusBar.cpp:263
 msgid "Sending a command to Maxima"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:10598
+#: ../../src/MaximaEvaluator.cpp:471
 msgid "Sending a new command to Maxima."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2792
+#: ../../src/MaximaProcessManager.cpp:902
 msgid "Sending an interrupt signal to Maxima."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:169
+#: ../../src/wxMaxima.cpp:218
 msgid "Sending configuration data to maxima."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:4718
+#: ../../src/MaximaEvaluator.cpp:558
 msgid "Sending maxima the info how to express 2d maths as XML"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1533
+#: ../../src/wxMaximaFrame.cpp:1570
 #, fuzzy
 msgid "Sequential Comparative Simplification"
 msgstr "&Kompleks Forenkling"
 
-#: ../../src/wxMaxima.cpp:9016
+#: ../../src/dialogs/ConfigDialogue.cpp:224
+msgid "Serbian"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:270 ../../src/wizards/SeriesWiz.cpp:60
 msgid "Series"
 msgstr "Rekke"
 
-#: ../../src/wxMaximaFrame.cpp:1479
+#: ../../src/wxMaximaFrame.cpp:1516
 #, fuzzy
 msgid "Series approximation"
 msgstr "Padétilnærming"
 
-#: ../../src/wxMaxima.cpp:2561
+#: ../../src/MaximaProcessManager.cpp:227
 msgid "Server started"
 msgstr "Server startet"
 
-#: ../../src/wxMaximaFrame.cpp:1824
+#: ../../src/wxMaximaFrame.cpp:1861
 #, fuzzy
 msgid "Set &displayed Precision..."
 msgstr "Sett &Presisjon..."
 
-#: ../../src/wxMaximaFrame.cpp:1563
+#: ../../src/wxMaximaFrame.cpp:1600
 msgid "Set Maxima option variable logexpand:all"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1567
+#: ../../src/wxMaximaFrame.cpp:1604
 msgid "Set Maxima option variable logexpand:super"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1560
+#: ../../src/wxMaximaFrame.cpp:1597
 msgid "Set Maxima option variable logexpand:true"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:822
+#: ../../src/wxMaximaFrame.cpp:859
 msgid "Set Zoom"
 msgstr "Sett &Zoom"
 
-#: ../../src/wxMaximaFrame.cpp:1819
+#: ../../src/wxMaximaFrame.cpp:1856
 #, fuzzy
 msgid "Set bigfloat &Precision..."
 msgstr "Sett bigfloat-presisjon"
 
-#: ../../src/Worksheet.cpp:1306 ../../src/Worksheet.cpp:1479
+#: ../../src/dialogs/ConfigDialogue.cpp:479
+msgid "Set fixed font in text controls."
+msgstr "Set fast font i tekstkontroller."
+
+#: ../../src/worksheet/WorksheetContextMenu.cpp:68
+#: ../../src/worksheet/WorksheetContextMenu.cpp:250
 msgid "Set image resolution"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1510
+#: ../../src/dialogs/ResolutionChooser.cpp:29
+msgid "Set image resolution [in ppi]"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1547
 #, fuzzy
 msgid "Set main variable..."
 msgstr "Slett en variabel"
 
-#: ../../src/wxMaximaFrame.cpp:1773
+#: ../../src/dialogs/MaxSizeChooser.cpp:29
+msgid "Set maximum image size [in mm]"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1810
 msgid "Set plot format"
 msgstr "Sett plottformat"
 
-#: ../../src/wxMaximaFrame.cpp:1101
+#: ../../src/wxMaximaFrame.cpp:1135
 #, fuzzy
 msgid "Set position..."
 msgstr "Lagre Animasjon..."
 
-#: ../../src/wxMaximaFrame.cpp:1656
+#: ../../src/wxMaximaFrame.cpp:1693
 #, fuzzy
 msgid "Set the \"algebraic\" flag"
 msgstr "Veksle algebraisk flagg"
 
-#: ../../src/wxMaxima.cpp:8314
+#: ../../src/MaximaCommandMenus.cpp:1960
 msgid "Set the diagram title"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1779
+#: ../../src/wxMaximaFrame.cpp:1816
 #, fuzzy
 msgid "Set the frame rate for animations."
 msgstr "Start animasjon"
 
-#: ../../src/wxMaxima.cpp:8377
+#: ../../src/MaximaCommandMenus.cpp:2023
 msgid "Set the grid density."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8327
+#: ../../src/MaximaCommandMenus.cpp:1973
 msgid "Set the next plot's title. Empty = no title."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1820
+#: ../../src/wxMaximaFrame.cpp:1857
 msgid "Set the precision for numbers that are defined as bigfloat. Such numbers can be generated by entering 1.5b12 or as bfloat(1.234)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:811
+#: ../../src/wxMaximaFrame.cpp:848
 msgid "Set zoom to 100%"
 msgstr "Sett zoom til 100%"
 
-#: ../../src/wxMaximaFrame.cpp:813
+#: ../../src/wxMaximaFrame.cpp:850
 msgid "Set zoom to 120%"
 msgstr "Sett zoom til 120%"
 
-#: ../../src/wxMaximaFrame.cpp:815
+#: ../../src/wxMaximaFrame.cpp:852
 msgid "Set zoom to 150%"
 msgstr "Sett zoom til 150%"
 
-#: ../../src/wxMaximaFrame.cpp:817
+#: ../../src/wxMaximaFrame.cpp:854
 msgid "Set zoom to 200%"
 msgstr "Sett zoom til 200%"
 
-#: ../../src/wxMaximaFrame.cpp:819
+#: ../../src/wxMaximaFrame.cpp:856
 msgid "Set zoom to 300%"
 msgstr "Sett zoom til 300%"
 
-#: ../../src/wxMaximaFrame.cpp:809
+#: ../../src/wxMaximaFrame.cpp:846
 msgid "Set zoom to 80%"
 msgstr "Sett zoom til 80%"
 
-#: ../../src/wxMaxima.cpp:4731
+#: ../../src/dialogs/ConfigDialogue.cpp:163
+msgid "Sets the language, line ending type and charset encoding programs will use"
+msgstr ""
+
+#: ../../src/MaximaEvaluator.cpp:574
 #, c-format
 msgid "Setting gnuplot_binary to %s"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:4804
+#: ../../src/MaximaEvaluator.cpp:642
 #, fuzzy
 msgid "Setting prompt and help format"
 msgstr "Sett plottformat"
 
+#: ../../src/dialogs/ConfigDialogue.cpp:165
+msgid "Setting this to \"cat\" causes gnuplot not to halt if there is much output"
+msgstr ""
+
+#: ../../src/wizards/DrawWiz.cpp:546
+msgid "Settings for the following 3d plots"
+msgstr ""
+
+#: ../../src/wizards/DrawWiz.cpp:462
+#, c-format
+msgid "Setup a %iD scene"
+msgstr ""
+
+#: ../../src/sidebars/DrawSidebar.cpp:48
+msgid "Setup a 2D plot"
+msgstr ""
+
+#: ../../src/sidebars/DrawSidebar.cpp:52
+msgid "Setup a 3D plot"
+msgstr ""
+
 # send en mail om du vet hva en atvalue er på norsk
-#: ../../src/wxMaximaFrame.cpp:1292
+#: ../../src/wxMaximaFrame.cpp:1326
 #, fuzzy
 msgid "Setup atvalues for solving ODE with Laplace transformation"
 msgstr "Sett opp vedverdier til å løse ODE med laplacetransformasjon"
 
-#: ../../src/wxMaximaFrame.cpp:1661
+#: ../../src/wxMaximaFrame.cpp:1698
 msgid "Setup modulus computation"
 msgstr "Sett opp moduloregning"
 
-#: ../../src/wxMaxima.cpp:9220
+#: ../../src/sidebars/DrawSidebar.cpp:78
+msgid "Setup the axis"
+msgstr ""
+
+#: ../../src/wizards/DrawWiz.cpp:263
+msgid "Setup the axis for the current plot."
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:411
 msgid "Setup the engineering format"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1831
+#: ../../src/wxMaximaFrame.cpp:1868
 msgid "Setup the engineering format..."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:9576
+#: ../../src/MaximaCommandMenus.cpp:1814
 msgid "Shapiro-Wilk test for normality"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1543
+#: ../../src/worksheet/WorksheetContextMenu.cpp:316
 #, fuzzy
 msgid "Show \"%\" in special constants"
 msgstr "Spesielle konstanter"
 
-#: ../../src/wxMaximaFrame.cpp:1889
+#: ../../src/wxMaximaFrame.cpp:1926
 msgid "Show &Tips..."
 msgstr "Vis &Tips..."
 
-#: ../../src/Worksheet.cpp:1556
+#: ../../src/worksheet/WorksheetContextMenu.cpp:329
 msgid "Show * as multiplication dot"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:895
+#: ../../src/wxMaximaFrame.cpp:929
 #, fuzzy
 msgid "Show Template\tCtrl+Shift+Space"
 msgstr "Vis Mal\tCtrl+Shift+K"
 
-#: ../../src/wxMaximaFrame.cpp:753
+#: ../../src/wxMaximaFrame.cpp:790
 #, fuzzy
 msgid "Show XML representation"
 msgstr "Vis lange uttrykk"
 
-#: ../../src/wxMaximaFrame.cpp:1889
+#: ../../src/wxMaximaFrame.cpp:1926
 msgid "Show a tip"
 msgstr "Vis et tips"
 
-#: ../../src/Worksheet.cpp:1607
+#: ../../src/worksheet/WorksheetContextMenu.cpp:380
 msgid "Show all + allow linebreaks in long numbers"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:9475
+#: ../../src/MaximaCommandMenus.cpp:2118
 msgid "Show all commands similar to:"
 msgstr "Vis alle kommandoer som ligner:"
 
-#: ../../src/wxMaxima.cpp:9468
+#: ../../src/sidebars/SymbolsSidebar.cpp:206
+msgid "Show all unicode symbols"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:2111
 msgid "Show an example for the command:"
 msgstr "Vis et eksempel for kommandoen:"
 
-#: ../../src/wxMaximaFrame.cpp:1883
+#: ../../src/wxMaximaFrame.cpp:1920
 msgid "Show an example of usage"
 msgstr "Vis et eksempel av bruk"
 
-#: ../../src/wxMaximaFrame.cpp:1884
+#: ../../src/sidebars/History.cpp:121
+msgid "Show commands from current session only"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1921
 msgid "Show commands similar to"
 msgstr "Vis kommandoer som ligner"
 
-#: ../../src/wxMaximaFrame.cpp:1020
+#: ../../src/wxMaximaFrame.cpp:1054
 msgid "Show defined functions"
 msgstr "Vis definerte funksjoner"
 
-#: ../../src/wxMaximaFrame.cpp:1022
+#: ../../src/wxMaximaFrame.cpp:1056
 msgid "Show defined variables"
 msgstr "Vis definerte variabler"
 
-#: ../../src/wxMaximaFrame.cpp:1074
+#: ../../src/wxMaximaFrame.cpp:1108
 msgid "Show definition of a function"
 msgstr "Vis definisjon av en funksjon"
 
-#: ../../src/wxMaximaFrame.cpp:740
+#: ../../src/wxMaximaFrame.cpp:777
 msgid "Show equations in their linear form"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1073
+#: ../../src/wxMaximaFrame.cpp:1107
 #, fuzzy
 msgid "Show function &Definition..."
 msgstr "Vis &Definisjon..."
 
-#: ../../src/wxMaximaFrame.cpp:896
+#: ../../src/wxMaximaFrame.cpp:930
 msgid "Show function template"
 msgstr "Vis funksjonmal"
 
-#: ../../src/Worksheet.cpp:1614
+#: ../../src/worksheet/WorksheetContextMenu.cpp:387
 #, fuzzy
 msgid "Show input labels"
 msgstr "Inndataetiketter"
 
-#: ../../src/wxMaximaFrame.cpp:750
+#: ../../src/dialogs/ConfigDialogue.cpp:766
+#, fuzzy
+msgid "Show labels:"
+msgstr "Vis &Variabler"
+
+#: ../../src/wxMaximaFrame.cpp:787
 #, fuzzy
 msgid "Show lisp representation"
 msgstr "Vis lange uttrykk"
 
-#: ../../src/Worksheet.cpp:1604
+#: ../../src/dialogs/ConfigDialogue.cpp:465
+msgid "Show long expressions in wxMaxima document."
+msgstr "Vis lange uttrykk i wxMaxima-dokument."
+
+#: ../../src/dialogs/ConfigDialogue.cpp:722
+#, fuzzy
+msgid "Show long expressions:"
+msgstr "Vis lange uttrykk"
+
+#: ../../src/worksheet/WorksheetContextMenu.cpp:377
 msgid "Show max. 100 digits"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1602
+#: ../../src/worksheet/WorksheetContextMenu.cpp:375
 msgid "Show max. 20 digits"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1603
+#: ../../src/worksheet/WorksheetContextMenu.cpp:376
 msgid "Show max. 50 digits"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:835
+#: ../../src/wxMaximaFrame.cpp:868
 msgid "Show or hide the wxMaxima logging window"
 msgstr ""
 
-#: ../../src/ToolBar.cpp:612
+#: ../../src/ToolBar.cpp:812
 msgid "Show the \"New\" button?"
 msgstr ""
 
-#: ../../src/ToolBar.cpp:636
+#: ../../src/ToolBar.cpp:836
 msgid "Show the \"help\" button?"
 msgstr ""
 
-#: ../../src/ToolBar.cpp:633
+#: ../../src/ToolBar.cpp:833
 msgid "Show the \"search\" button?"
 msgstr ""
 
-#: ../../src/ToolBar.cpp:630
+#: ../../src/ToolBar.cpp:830
 msgid "Show the \"select all\" button?"
 msgstr ""
 
-#: ../../src/ToolBar.cpp:624
+#: ../../src/ToolBar.cpp:824
 msgid "Show the Copy, Cut and the Paste button?"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7033
+#: ../../src/wxMaximaFrame.cpp:650
+msgid "Show the differences between 2 or 3 files"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:3905
 #, fuzzy
 msgid "Show the function's definition"
 msgstr "Vis definisjonen av funksjon:"
 
-#: ../../src/ToolBar.cpp:618
+#: ../../src/ToolBar.cpp:818
 msgid "Show the open and the save button?"
 msgstr ""
 
-#: ../../src/ToolBar.cpp:627
+#: ../../src/ToolBar.cpp:827
 msgid "Show the preferences button?"
 msgstr ""
 
-#: ../../src/ToolBar.cpp:621
+#: ../../src/ToolBar.cpp:821
 msgid "Show the print button?"
 msgstr ""
 
-#: ../../src/ToolBar.cpp:615
+#: ../../src/ToolBar.cpp:815
 #, fuzzy
 msgid "Show the undo and redo button?"
 msgstr "Vis definisjonen av funksjon:"
 
-#: ../../src/wxMaximaFrame.cpp:1006 ../../src/wxMaximaFrame.cpp:1011
+#: ../../src/dialogs/TipOfTheDay.cpp:288
+msgid "Show tips at Startup"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1040 ../../src/wxMaximaFrame.cpp:1045
 msgid "Show used + to-be-freed memory"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1033
+#: ../../src/wxMaximaFrame.cpp:1067
 #, fuzzy
 msgid "Show user definitions"
 msgstr "Vis definisjonen av funksjon:"
 
-#: ../../src/ToolBar.cpp:328 ../../src/wxMaximaFrame.cpp:1877
-#: ../../src/wxMaximaFrame.cpp:1879
+#: ../../src/ToolBar.cpp:544 ../../src/ToolBar.cpp:546
+#: ../../src/wxMaximaFrame.cpp:1914 ../../src/wxMaximaFrame.cpp:1916
 msgid "Show wxMaxima help"
 msgstr "Vis wxMaxima-hjelp"
 
-#: ../../src/wxMaximaFrame.cpp:1825
+#: ../../src/wxMaximaFrame.cpp:1862
 msgid "Shows how many digits of a numbers are displayed"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:732
+#: ../../src/wxMaximaFrame.cpp:769
 msgid "Sidebars"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1513
+#: ../../src/sidebars/GreekSidebar.cpp:195
+msgid "Sigma"
+msgstr ""
+
+#: ../../src/dialogs/FindReplacePane.cpp:88
+#, fuzzy
+msgid "Simple"
+msgstr "Måling:"
+
+#: ../../src/MaximaCommandMenus.cpp:1819
+msgid "Simple linear regression"
+msgstr ""
+
+#: ../../src/sidebars/MathSidebar.cpp:44
+msgid "Simplify"
+msgstr "Forenkle"
+
+#: ../../src/wxMaximaFrame.cpp:1550
 #, fuzzy
 msgid "Simplify &Radicals..."
 msgstr "Forenkle &Radikaler"
 
-#: ../../src/Worksheet.cpp:1579
+#: ../../src/sidebars/MathSidebar.cpp:47
+msgid "Simplify (r)"
+msgstr "Forenkle (r)"
+
+#: ../../src/sidebars/MathSidebar.cpp:65
+msgid "Simplify (tr)"
+msgstr "Forenkle (tr)"
+
+#: ../../src/worksheet/WorksheetContextMenu.cpp:352
 msgid "Simplify Expression"
 msgstr "Forenkle Uttrykk"
 
-#: ../../src/wxMaximaFrame.cpp:1568
+#: ../../src/wxMaximaFrame.cpp:1605
 #, fuzzy
 msgid "Simplify Logarithms"
 msgstr "Forenkle summen"
 
-#: ../../src/wxMaximaFrame.cpp:1582
+#: ../../src/wxMaximaFrame.cpp:1619
 msgid "Simplify an expression containing factorials"
 msgstr "Forenkle et uttrykk med fakulteter"
 
-#: ../../src/wxMaximaFrame.cpp:1539
+#: ../../src/wxMaximaFrame.cpp:1576
 #, fuzzy
 msgid "Simplify equations"
 msgstr "Løs likninger"
 
-#: ../../src/wxMaximaFrame.cpp:1514
+#: ../../src/wxMaximaFrame.cpp:1551
 msgid "Simplify expression containing radicals"
 msgstr "Forenkle et uttrykk med radikaler"
 
-#: ../../src/wxMaxima.cpp:8649
+#: ../../src/MaximaCommandMenus.cpp:641
 #, fuzzy
 msgid "Simplify radicals"
 msgstr "Forenkle &Radikaler"
 
-#: ../../src/wxMaximaFrame.cpp:1512
+#: ../../src/wxMaximaFrame.cpp:1549
 msgid "Simplify rational expression"
 msgstr "Forenkle rasjonelt uttrykk"
 
-#: ../../src/wxMaximaFrame.cpp:1538
+#: ../../src/wxMaximaFrame.cpp:1575
 msgid "Simplify sum() commands..."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8636
+#: ../../src/MaximaCommandMenus.cpp:628
 #, fuzzy
 msgid "Simplify sums"
 msgstr "Forenkle"
 
-#: ../../src/wxMaximaFrame.cpp:1592
+#: ../../src/wizards/SumWiz.cpp:68
+msgid "Simplify the sum"
+msgstr "Forenkle summen"
+
+#: ../../src/wxMaximaFrame.cpp:1629
 msgid "Simplify trigonometric expression"
 msgstr "Forenkle trigonometrisk uttrykk"
 
-#: ../../src/wxMaximaFrame.cpp:1399
+#: ../../src/dialogs/TipOfTheDay.cpp:139
+#, fuzzy
+msgid "Since wxMaxima 0.8.2 you can also insert images into your documents. Use 'Cell->Insert Image...' menu command."
+msgstr "Fra wxMaxima 0.8.2 kan du også sette inn bilder i dokumentene dine. Bruk 'Celle->Sett inn bilde' fra menyen. Merk deg at du er nødt til å lagre dokumentet i formatet 'wxMaxima XML-dokument' om du vil at bilder skal lagres i tillegg til dokumentet."
+
+#: ../../src/wxMaximaFrame.cpp:1433
 msgid "Singular Values"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1400 ../../src/wxMaximaFrame.cpp:1403
+#: ../../src/wxMaximaFrame.cpp:1434 ../../src/wxMaximaFrame.cpp:1437
 msgid "Singular values using dgesvd"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1402
+#: ../../src/wxMaximaFrame.cpp:1436
 msgid "Singular values, left + right vectors"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1635
+#: ../../src/MaximaCommandMenus.cpp:487 ../../src/MaximaCommandMenus.cpp:500
+msgid "Size of internal work array. (limit - limlst)/2 is the maximum number of subintervals to use."
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:436 ../../src/MaximaCommandMenus.cpp:449
+#: ../../src/MaximaCommandMenus.cpp:462 ../../src/MaximaCommandMenus.cpp:476
+#: ../../src/MaximaCommandMenus.cpp:547 ../../src/MaximaCommandMenus.cpp:562
+#: ../../src/MaximaCommandMenus.cpp:577 ../../src/MaximaCommandMenus.cpp:592
+#: ../../src/MaximaCommandMenus.cpp:606
+msgid "Size of internal work array. limit is the maximum number of subintervals to use."
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:515 ../../src/MaximaCommandMenus.cpp:529
+msgid "Size of internal work array. limit/2 is the maximum number of subintervals to use."
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:2113
+msgid "Slanted"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:225
+msgid "Slovak"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:226
+msgid "Slovenian"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1672
 #, fuzzy
 msgid "Smart Substitute..."
 msgstr "&Erstatt..."
 
-#: ../../src/wxMaxima.cpp:8730
+#: ../../src/MaximaCommandMenus.cpp:725
 #, fuzzy
 msgid "Smart substitution"
 msgstr "Erstatt"
 
-#: ../../src/wxMaxima.cpp:7799 ../../src/wxMaxima.cpp:7810
-#: ../../src/wxMaxima.cpp:7823
+#: ../../src/MaximaCommandMenus.cpp:980 ../../src/MaximaCommandMenus.cpp:991
+#: ../../src/MaximaCommandMenus.cpp:1004
 #, fuzzy
 msgid "Solution of the ODE:"
 msgstr "Løsning:"
 
-#: ../../src/wxMaxima.cpp:10017
+#: ../../src/wizards/BC2Wiz.cpp:30
+msgid "Solution:"
+msgstr "Løsning:"
+
+#: ../../src/MaximaCommandMenus.cpp:3506
 msgid "Solve"
 msgstr "Løs"
 
-#: ../../src/wxMaximaFrame.cpp:1244
+#: ../../src/wxMaximaFrame.cpp:1278
 msgid "Solve &Algebraic System..."
 msgstr "Løs &Algebraisk System..."
 
-#: ../../src/wxMaximaFrame.cpp:1242
+#: ../../src/wxMaximaFrame.cpp:1276
 msgid "Solve &Linear System..."
 msgstr "Løs L&ineært System..."
 
-#: ../../src/wxMaximaFrame.cpp:1266
+#: ../../src/wxMaximaFrame.cpp:1300
 msgid "Solve &ODE..."
 msgstr "Løs &ODE..."
 
-#: ../../src/wxMaximaFrame.cpp:1240
+#: ../../src/wxMaximaFrame.cpp:1274
 msgid "Solve (to_poly)..."
 msgstr "&Løs (to_poly)..."
 
-#: ../../src/wxMaxima.cpp:8045
+#: ../../src/MaximaCommandMenus.cpp:1231
 msgid "Solve A*x=b numerically"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1397
+#: ../../src/wxMaximaFrame.cpp:1431
 #, fuzzy
 msgid "Solve Ax=b"
 msgstr "Løs"
 
-#: ../../src/wxMaxima.cpp:7783
+#: ../../src/MaximaCommandMenus.cpp:964
 msgid "Solve ODE"
 msgstr "Løs ODE"
 
-#: ../../src/wxMaximaFrame.cpp:1287
+#: ../../src/wxMaximaFrame.cpp:1321
 msgid "Solve ODE with Lapla&ce..."
 msgstr "Løs ODE med Lapla&ce..."
 
-#: ../../src/wxMaximaFrame.cpp:1398
+#: ../../src/sidebars/MathSidebar.cpp:77
+msgid "Solve ODE..."
+msgstr "Løs ODE..."
+
+#: ../../src/wxMaximaFrame.cpp:1432
 #, fuzzy
 msgid "Solve a linear equation system using dgesv"
 msgstr "Løs lineært system av likninger"
 
-#: ../../src/wxMaxima.cpp:7852 ../../src/wxMaxima.cpp:7863
+#: ../../src/MaximaCommandMenus.cpp:1033 ../../src/MaximaCommandMenus.cpp:1044
 msgid "Solve algebraic system"
 msgstr "Løs algebraisk system"
 
-#: ../../src/wxMaximaFrame.cpp:1245
+#: ../../src/wxMaximaFrame.cpp:1279
 msgid "Solve algebraic system of equations"
 msgstr "Løs algebraisk system av likninger"
 
-#: ../../src/wxMaximaFrame.cpp:1279
+#: ../../src/wxMaximaFrame.cpp:1313
 msgid "Solve boundary value problem for second degree ODE"
 msgstr "Løs randverdiproblem for andregrads ODE"
 
-#: ../../src/wxMaxima.cpp:7895
+#: ../../src/MaximaCommandMenus.cpp:1076
 #, fuzzy
 msgid "Solve differential equations using laplace()"
 msgstr "Løs Ordinary Differential Equation-er med laplacetransformasjon"
 
-#: ../../src/wxMaxima.cpp:7744 ../../src/wxMaximaFrame.cpp:1238
+#: ../../src/MaximaCommandMenus.cpp:925 ../../src/wxMaximaFrame.cpp:1272
 msgid "Solve equation(s)"
 msgstr "Løs likninger"
 
-#: ../../src/wxMaximaFrame.cpp:1241
+#: ../../src/wxMaximaFrame.cpp:1275
 msgid "Solve equation(s) with to_poly_solve"
 msgstr "Løs likninger med to_poly_solve"
 
-#: ../../src/wxMaxima.cpp:7773
+#: ../../src/MaximaCommandMenus.cpp:954
 #, fuzzy
 msgid "Solve equations numerically"
 msgstr "Løs likninger"
 
-#: ../../src/wxMaxima.cpp:7757
+#: ../../src/MaximaCommandMenus.cpp:938
 #, fuzzy
 msgid "Solve equations to polynom"
 msgstr "Løs likninger med to_poly_solve"
 
-#: ../../src/wxMaximaFrame.cpp:1271
+#: ../../src/wxMaximaFrame.cpp:1305
 msgid "Solve initial value problem for first degree ODE"
 msgstr "Løs initialverdiproblem for førstegrads ODE"
 
-#: ../../src/wxMaximaFrame.cpp:1275
+#: ../../src/wxMaximaFrame.cpp:1309
 msgid "Solve initial value problem for second degree ODE"
 msgstr "Løs initialverdiproblem for andregrads ODE"
 
-#: ../../src/wxMaxima.cpp:7874 ../../src/wxMaxima.cpp:7884
+#: ../../src/MaximaCommandMenus.cpp:1055 ../../src/MaximaCommandMenus.cpp:1065
 msgid "Solve linear system"
 msgstr "Løs lineært system"
 
-#: ../../src/wxMaximaFrame.cpp:1243
+#: ../../src/wxMaximaFrame.cpp:1277
 msgid "Solve linear system of equations"
 msgstr "Løs lineært system av likninger"
 
-#: ../../src/wxMaximaFrame.cpp:1263
+#: ../../src/wxMaximaFrame.cpp:1297
 msgid "Solve numerical, 1 Variable"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1267
+#: ../../src/wxMaximaFrame.cpp:1301
 msgid "Solve ordinary differential equation of maximum degree 2"
 msgstr "Løs Ordinary Differential Equation-er av maksimum 2. grad"
 
-#: ../../src/wxMaximaFrame.cpp:1288
+#: ../../src/wxMaximaFrame.cpp:1322
 msgid "Solve ordinary differential equations with Laplace transformation"
 msgstr "Løs Ordinary Differential Equation-er med laplacetransformasjon"
 
-#: ../../src/wxMaxima.cpp:7708
+#: ../../src/MaximaCommandMenus.cpp:891
 #, fuzzy
 msgid "Solve polynomials numerically"
 msgstr "Løs likninger"
 
-#: ../../src/wxMaxima.cpp:7718
+#: ../../src/MaximaCommandMenus.cpp:900
 #, fuzzy
 msgid "Solve polynomials numerically (bfloats)"
 msgstr "Løs likninger"
 
-#: ../../src/wxMaxima.cpp:7729
+#: ../../src/MaximaCommandMenus.cpp:910
 #, fuzzy
 msgid "Solve polynomials numerically (real roots)"
 msgstr "Løs likninger"
 
-#: ../../src/wxMaximaFrame.cpp:1249
+#: ../../src/wxMaximaFrame.cpp:1283
 #, fuzzy
 msgid "Solve symbolically"
 msgstr "Løs likninger"
 
-#: ../../src/Worksheet.cpp:1574
+#: ../../src/sidebars/MathSidebar.cpp:74
+#: ../../src/worksheet/WorksheetContextMenu.cpp:347
 msgid "Solve..."
 msgstr "Løs..."
 
-#: ../../src/wxMaximaFrame.cpp:1916
+#: ../../src/wxMaximaFrame.cpp:1953
 msgid "Solving differential equations"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1904
+#: ../../src/wxMaximaFrame.cpp:1941
 msgid "Solving equations with Maxima"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7105
+#: ../../src/MaximaCommandMenus.cpp:3977
 #, c-format
 msgid ""
 "Sometimes one wants maxima to loose the information that a function name was used with the ' operator in order to make maxima not evaluate it. In other places one wants % to mean \"the last expression at the time this function was created\", not \"the last expression now\".\n"
 "In both cases the '' operator will do what is requested."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1746
+#: ../../src/wxMaximaFrame.cpp:1783
 msgid "Sort"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8496
+#: ../../src/wizards/ListSortWiz.cpp:41
+msgid "Sort Criterion:"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:1500
 #, fuzzy
 msgid "Sort a list"
 msgstr "Lag liste"
 
-#: ../../src/wxMaxima.cpp:7459
+#: ../../src/MaximaCommandMenus.cpp:4331
 msgid "Sort all characters in string"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1179
+#: ../../src/wxMaximaFrame.cpp:1213
 #, fuzzy
 msgid "Sort the characters..."
 msgstr "Greske konstanter"
 
-#: ../../src/wxMaxima.cpp:8482
+#: ../../src/MaximaCommandMenus.cpp:1486
 #, fuzzy
 msgid "Source list:"
 msgstr "Lag liste"
 
-#: ../../src/wxMaxima.cpp:7429
+#: ../../src/dialogs/ConfigDialogue.cpp:227
+msgid "Spanish"
+msgstr "Spansk"
+
+#: ../../src/wizards/IntegrateWiz.cpp:44 ../../src/wizards/IntegrateWiz.cpp:50
+#: ../../src/wizards/LimitWiz.cpp:38 ../../src/wizards/SeriesWiz.cpp:39
+msgid "Special"
+msgstr "Spesiell"
+
+#: ../../src/wizards/DrawWiz.cpp:918
+msgid "Speed versus accuracy"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:4301
 msgid "Split"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1191
+#: ../../src/wxMaximaFrame.cpp:1225
 msgid "Split on match"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7528
+#: ../../src/MaximaCommandMenus.cpp:4400
 msgid "Split on regex match"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7449
+#: ../../src/MaximaCommandMenus.cpp:4321
 msgid "Split string into tokens"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1171
+#: ../../src/wxMaximaFrame.cpp:1205
 #, fuzzy
 msgid "Split..."
 msgstr "Boksdiagram..."
 
-#: ../../src/wxMaximaFrame.cpp:788
+#: ../../src/wxMaximaFrame.cpp:825
 msgid "Square"
 msgstr ""
 
-#: ../../src/Configuration.cpp:86
+#: ../../src/dialogs/ConfigDialogue.cpp:1300
+#, fuzzy
+msgid "Standard Options"
+msgstr "Valg"
+
+#: ../../src/Styles.cpp:115
 #, fuzzy
 msgid "Standard Text"
 msgstr "Valg"
 
-#: ../../src/Worksheet.cpp:1298
+#: ../../src/worksheet/WorksheetContextMenu.cpp:60
 msgid "Start Animation"
 msgstr "Start Animasjon"
 
-#: ../../src/wxMaxima.cpp:7842
+#: ../../src/dialogs/ConfigDialogue.cpp:1622
+msgid "Start a new maxima for each re-evaluation"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:1023
 msgid "Start of t:"
 msgstr ""
 
-#: ../../src/ToolBar.cpp:305
+#: ../../src/wizards/DrawWiz.cpp:66 ../../src/wizards/DrawWiz.cpp:171
+msgid "Start of the x value"
+msgstr ""
+
+#: ../../src/wizards/DrawWiz.cpp:83 ../../src/wizards/DrawWiz.cpp:186
+msgid "Start of the y value"
+msgstr ""
+
+#: ../../src/wizards/DrawWiz.cpp:203
+msgid "Start of the z value"
+msgstr ""
+
+#: ../../src/ToolBar.cpp:507 ../../src/ToolBar.cpp:519
 #, fuzzy
 msgid "Start or Stop animation"
 msgstr "Start animasjon"
 
-#: ../../src/ToolBar.cpp:306
+#: ../../src/ToolBar.cpp:508 ../../src/ToolBar.cpp:520
 msgid "Start or stop the currently selected animation that has been created with the with_slider class of commands"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:386
+#: ../../src/dialogs/ConfigDialogue.cpp:496
+msgid "Start searching while the phrase to search for is still being typed."
+msgstr ""
+
+#: ../../src/wizards/DrawWiz.cpp:755
+#, fuzzy
+msgid "Start value of the parameter"
+msgstr "Kalkuler desimalverdien av siste resultat"
+
+#: ../../src/wxMaxima.cpp:403
 msgid "Starting Maxima process failed"
 msgstr "Klarte ikke starte Maxima-prosess"
 
-#: ../../src/main.cpp:667
+#: ../../src/main.cpp:956
 #, fuzzy
 msgid "Starting a new wxMaxima process for a new window"
 msgstr "Klarte ikke starte Maxima-prosess"
 
-#: ../../src/wxMaxima.cpp:3105 ../../src/wxMaxima.cpp:5633
+#: ../../src/wxMaxima.cpp:1858 ../../src/wxMaxima.cpp:1884
 msgid "Starting evaluation of the document"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2544
+#: ../../src/MaximaProcessManager.cpp:205
 msgid "Starting server failed"
 msgstr "Klarte ikke starte server"
 
-#: ../../src/WXMXformat.cpp:64
-msgid "Starting to save the worksheet as .wxmx"
+#: ../../src/WXMXformat.cpp:65
+#, c-format
+msgid "Starting to save the worksheet as .wxmx. Filename: %s"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:252
+#: ../../src/dialogs/ConfigDialogue.cpp:286
+msgid "Startup commands"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:266
 msgid "Statistics"
 msgstr "Statistikk"
 
-#: ../../src/wxMaximaFrame.cpp:701
+#: ../../src/wxMaximaFrame.cpp:736
 msgid "Statistics\tAlt+Shift+S"
 msgstr "Statistikk\tAlt+Shift+S"
 
-#: ../../src/wxMaxima.cpp:7844
+#: ../../src/MaximaCommandMenus.cpp:1025
 #, fuzzy
 msgid "Step width:"
 msgstr "Produkt"
 
-#: ../../src/wxMaximaFrame.cpp:794
+#: ../../src/dialogs/ConfigDialogue.cpp:939
+msgid "Store filenames in image cells to enable image reloading after re-opening the worksheet"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:831
 msgid "Straight lines"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1106
+#: ../../src/wxMaximaFrame.cpp:1140
 msgid "Stream"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7231
+#: ../../src/MaximaCommandMenus.cpp:4103
 msgid "Stream length"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7219 ../../src/wxMaxima.cpp:7224
-#: ../../src/wxMaxima.cpp:7228 ../../src/wxMaxima.cpp:7232
-#: ../../src/wxMaxima.cpp:7236 ../../src/wxMaxima.cpp:7240
-#: ../../src/wxMaxima.cpp:7245 ../../src/wxMaxima.cpp:7250
-#: ../../src/wxMaxima.cpp:7256 ../../src/wxMaxima.cpp:7263
-#: ../../src/wxMaxima.cpp:7267 ../../src/wxMaxima.cpp:7271
-#: ../../src/wxMaxima.cpp:7276
+#: ../../src/MaximaCommandMenus.cpp:4091 ../../src/MaximaCommandMenus.cpp:4096
+#: ../../src/MaximaCommandMenus.cpp:4100 ../../src/MaximaCommandMenus.cpp:4104
+#: ../../src/MaximaCommandMenus.cpp:4108 ../../src/MaximaCommandMenus.cpp:4112
+#: ../../src/MaximaCommandMenus.cpp:4117 ../../src/MaximaCommandMenus.cpp:4122
+#: ../../src/MaximaCommandMenus.cpp:4128 ../../src/MaximaCommandMenus.cpp:4135
+#: ../../src/MaximaCommandMenus.cpp:4139 ../../src/MaximaCommandMenus.cpp:4143
+#: ../../src/MaximaCommandMenus.cpp:4148
 msgid "Stream:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1185
+#: ../../src/dialogs/ConfigDialogue.cpp:2117
+msgid "Strike Through"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1219
 #, fuzzy
 msgid "String"
 msgstr "Strenger"
 
-#: ../../src/wxMaxima.cpp:7345 ../../src/wxMaxima.cpp:7350
-#: ../../src/wxMaxima.cpp:7425
+#: ../../src/MaximaCommandMenus.cpp:4217 ../../src/MaximaCommandMenus.cpp:4222
+#: ../../src/MaximaCommandMenus.cpp:4297
 #, fuzzy
 msgid "String #1:"
 msgstr "Strenger"
 
-#: ../../src/wxMaxima.cpp:7346 ../../src/wxMaxima.cpp:7351
-#: ../../src/wxMaxima.cpp:7426
+#: ../../src/MaximaCommandMenus.cpp:4218 ../../src/MaximaCommandMenus.cpp:4223
+#: ../../src/MaximaCommandMenus.cpp:4298
 #, fuzzy
 msgid "String #2:"
 msgstr "Strenger"
 
-#: ../../src/wxMaximaFrame.cpp:1136
+#: ../../src/wxMaximaFrame.cpp:1170
 #, fuzzy
 msgid "String Tests"
 msgstr "Strenger"
 
-#: ../../src/wxMaxima.cpp:7415
+#: ../../src/MaximaCommandMenus.cpp:4287
 #, fuzzy
 msgid "String length"
 msgstr "Strenger"
 
-#: ../../src/wxMaxima.cpp:7381
+#: ../../src/MaximaCommandMenus.cpp:4253
 msgid "String to list of char"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1148
+#: ../../src/wxMaximaFrame.cpp:1182
 msgid "String to list of chars..."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7496
+#: ../../src/MaximaCommandMenus.cpp:4368
 #, fuzzy
 msgid "String to octets"
 msgstr "Strenger"
 
-#: ../../src/wxMaximaFrame.cpp:1160
+#: ../../src/wxMaximaFrame.cpp:1194
 msgid "String to octets..."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7377 ../../src/wxMaxima.cpp:7382
-#: ../../src/wxMaxima.cpp:7391 ../../src/wxMaxima.cpp:7396
-#: ../../src/wxMaxima.cpp:7400 ../../src/wxMaxima.cpp:7407
-#: ../../src/wxMaxima.cpp:7412 ../../src/wxMaxima.cpp:7416
-#: ../../src/wxMaxima.cpp:7420 ../../src/wxMaxima.cpp:7430
-#: ../../src/wxMaxima.cpp:7436 ../../src/wxMaxima.cpp:7441
-#: ../../src/wxMaxima.cpp:7446 ../../src/wxMaxima.cpp:7450
-#: ../../src/wxMaxima.cpp:7456 ../../src/wxMaxima.cpp:7460
-#: ../../src/wxMaxima.cpp:7465 ../../src/wxMaxima.cpp:7470
-#: ../../src/wxMaxima.cpp:7474 ../../src/wxMaxima.cpp:7478
-#: ../../src/wxMaxima.cpp:7497
+#: ../../src/MaximaCommandMenus.cpp:4249 ../../src/MaximaCommandMenus.cpp:4254
+#: ../../src/MaximaCommandMenus.cpp:4263 ../../src/MaximaCommandMenus.cpp:4268
+#: ../../src/MaximaCommandMenus.cpp:4272 ../../src/MaximaCommandMenus.cpp:4279
+#: ../../src/MaximaCommandMenus.cpp:4284 ../../src/MaximaCommandMenus.cpp:4288
+#: ../../src/MaximaCommandMenus.cpp:4292 ../../src/MaximaCommandMenus.cpp:4302
+#: ../../src/MaximaCommandMenus.cpp:4308 ../../src/MaximaCommandMenus.cpp:4313
+#: ../../src/MaximaCommandMenus.cpp:4318 ../../src/MaximaCommandMenus.cpp:4322
+#: ../../src/MaximaCommandMenus.cpp:4328 ../../src/MaximaCommandMenus.cpp:4332
+#: ../../src/MaximaCommandMenus.cpp:4337 ../../src/MaximaCommandMenus.cpp:4342
+#: ../../src/MaximaCommandMenus.cpp:4346 ../../src/MaximaCommandMenus.cpp:4350
+#: ../../src/MaximaCommandMenus.cpp:4369
 #, fuzzy
 msgid "String:"
 msgstr "Strenger"
 
-#: ../../src/wxMaxima.cpp:7197
+#: ../../src/MaximaCommandMenus.cpp:4069
 msgid "Struct :"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7184 ../../src/wxMaxima.cpp:7190
+#: ../../src/MaximaCommandMenus.cpp:4056 ../../src/MaximaCommandMenus.cpp:4062
 msgid "Struct type name:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1029
+#: ../../src/wxMaximaFrame.cpp:1063
 msgid "Structs"
 msgstr ""
 
-#: ../../src/ToolBar.cpp:274
+#: ../../src/dialogs/ConfigDialogue.cpp:282
+msgid "Style"
+msgstr "Stil"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:2082
+msgid "Styles"
+msgstr "Stiler"
+
+#: ../../src/sidebars/StatSidebar.cpp:112
+msgid "Subsample..."
+msgstr "Undermåling..."
+
+#: ../../src/ToolBar.cpp:484 ../../src/sidebars/FormatSidebar.cpp:54
 msgid "Subsection"
 msgstr "Underseksjon"
 
-#: ../../src/Configuration.cpp:90
+#: ../../src/Styles.cpp:119
 msgid "Subsection cell (Heading 3)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1643
+#: ../../src/wxMaximaFrame.cpp:1680
 msgid "Subst constant t into eq with diff(x,t)..."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8724
+#: ../../src/MaximaCommandMenus.cpp:716
 msgid "Subst is a better string-search-and-replace for expressions."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7688 ../../src/wxMaxima.cpp:8723
-#: ../../src/wxMaxima.cpp:10061 ../../src/wxMaximaFrame.cpp:1651
+#: ../../src/sidebars/MathSidebar.cpp:59
+msgid "Subst..."
+msgstr "Erstatt..."
+
+#: ../../src/MaximaCommandMenus.cpp:715 ../../src/MaximaCommandMenus.cpp:3550
+#: ../../src/MaximaCommandMenus.cpp:4560 ../../src/wizards/SubstituteWiz.cpp:53
+#: ../../src/wxMaximaFrame.cpp:1688
 msgid "Substitute"
 msgstr "Erstatt"
 
-#: ../../src/wxMaximaFrame.cpp:1193
+#: ../../src/wxMaximaFrame.cpp:1227
 #, fuzzy
 msgid "Substitute all matches"
 msgstr "&Erstatt..."
 
-#: ../../src/wxMaximaFrame.cpp:1192
+#: ../../src/wxMaximaFrame.cpp:1226
 msgid "Substitute first match"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1646
+#: ../../src/MaximaCommandMenus.cpp:767
+msgid "Substitute only in a specific part"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1683
 #, fuzzy
 msgid "Substitute only in parts..."
 msgstr "&Erstatt..."
 
-#: ../../src/wxMaxima.cpp:8763
-msgid "Substitute only in specific parts"
-msgstr ""
-
-#: ../../src/wxMaximaFrame.cpp:1647
+#: ../../src/wxMaximaFrame.cpp:1684
 msgid "Substitute only in the elements n_1, n_2,..."
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1585 ../../src/wxMaximaFrame.cpp:1633
+#: ../../src/worksheet/WorksheetContextMenu.cpp:358
+#: ../../src/wxMaximaFrame.cpp:1670
 msgid "Substitute..."
 msgstr "&Erstatt..."
 
-#: ../../src/wxMaximaFrame.cpp:1641 ../../src/wxMaximaFrame.cpp:1644
+#: ../../src/wxMaximaFrame.cpp:1678 ../../src/wxMaximaFrame.cpp:1681
 msgid "Substitutes until the equation no more changes"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8747
+#: ../../src/MaximaCommandMenus.cpp:745
 msgid "Substitutes up to lrats_max_iter times, or until the expression stops changing when substituting."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8756
+#: ../../src/MaximaCommandMenus.cpp:757
 #, c-format
 msgid "Substitutes, but makes sure that if substituting t=0 in diff(x,t) the result isn't 0 (as t no more changes), but %at(diff(x,t),t=0)."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8739
+#: ../../src/MaximaCommandMenus.cpp:736
 msgid "Substitutes, but makes sure that nothing is substituted into the other substituents."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1638
+#: ../../src/wxMaximaFrame.cpp:1675
 msgid "Substitutes, but not in the other substituents"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8764
-msgid "Substitutes, but only in the n_1th, n_2th and so on term of the equation."
-msgstr ""
-
-#: ../../src/ToolBar.cpp:275
+#: ../../src/ToolBar.cpp:485 ../../src/sidebars/FormatSidebar.cpp:57
 #, fuzzy
 msgid "Subsubsection"
 msgstr "Underseksjon"
 
-#: ../../src/Configuration.cpp:89
+#: ../../src/Styles.cpp:118
 msgid "Subsubsection cell (Heading 4)"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1831
+#: ../../src/worksheet/WorksheetContextMenu.cpp:603
 #, fuzzy
 msgid "Suggestion: "
 msgstr "Underseksjon"
 
-#: ../../src/Worksheet.cpp:2030
+#: ../../src/worksheet/WorksheetContextMenu.cpp:802
 msgid "Suitable as flag for ev()"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:9049
+#: ../../src/MaximaCommandMenus.cpp:303 ../../src/wizards/SumWiz.cpp:60
 msgid "Sum"
 msgstr "Sum"
 
-#: ../../src/wxMaximaFrame.cpp:1551
+#: ../../src/sidebars/SymbolsSidebar.cpp:122
+msgid "Sum sign"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:228
+msgid "Swedish"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1588
 msgid "Switch off simplifications of log(). Set Maxima option variable logexpand:false"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:4090
+#: ../../src/MaximaResponseReader.cpp:569
 msgid "Switched to lisp mode after receiving a lisp debug prompt!"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:4092
+#: ../../src/MaximaResponseReader.cpp:428
+#: ../../src/MaximaResponseReader.cpp:571
 msgid "Switched to lisp mode after receiving a lisp prompt!"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1971
+#: ../../src/worksheet/WorksheetContextMenu.cpp:743
 #, fuzzy
 msgid "Symbolic Constant"
 msgstr "Velg en konstant"
 
-#: ../../src/wxMaximaFrame.cpp:705
+#: ../../src/wxMaximaFrame.cpp:740
 #, fuzzy
 msgid "Symbols\tAlt+Shift+Y"
 msgstr "Statistikk\tAlt+Shift+S"
 
-#: ../../src/Worksheet.cpp:2006
+#: ../../src/dialogs/ConfigDialogue.cpp:472
+msgid "Symbols that are entered or copied here will appear in the symbols sidebar so they can be entered into the worksheet easily."
+msgstr ""
+
+#: ../../src/worksheet/WorksheetContextMenu.cpp:778
 msgid "Symmetric function: f(x)=f(-x)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:238
+#: ../../src/dialogs/DiffFrame.cpp:370 ../../src/dialogs/DiffFrame.cpp:387
+msgid "Sync Horizontal"
+msgstr ""
+
+#: ../../src/dialogs/DiffFrame.cpp:382 ../../src/dialogs/DiffFrame.cpp:388
+msgid "Sync Vertical"
+msgstr ""
+
+#: ../../src/wizards/CsvWiz.cpp:42 ../../src/wizards/CsvWiz.cpp:113
+msgid "Tab"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:252
 msgid "Table of Contents"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:711
+#: ../../src/wxMaximaFrame.cpp:746
 #, fuzzy
 msgid "Table of Contents\tAlt+Shift+T"
 msgstr "Verktøylinje\tAlt+Shift+T"
 
-#: ../../src/wxMaxima.cpp:8930
+#: ../../src/wizards/DrawWiz.cpp:561
+msgid "Take surface color from steepness"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:229
+msgid "Tamil"
+msgstr ""
+
+#: ../../src/sidebars/GreekSidebar.cpp:196
+msgid "Tau"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:181
 #, fuzzy
 msgid "Taylor series"
 msgstr "Taylorrekke:"
 
-#: ../../src/wxMaximaFrame.cpp:1474
+#: ../../src/wxMaximaFrame.cpp:1511
 #, fuzzy
 msgid "Taylor series..."
 msgstr "Taylorrekke:"
 
-#: ../../src/wxMaxima.cpp:8925
+#: ../../src/MaximaCommandMenus.cpp:176
 msgid "Taylor series:"
 msgstr "Taylorrekke:"
 
-#: ../../src/wxMaxima.cpp:4132
+#: ../../src/wxMaxima.cpp:1488
 msgid "Telling maxima about the new working directory."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7907
+#: ../../src/MaximaCommandMenus.cpp:1088
 msgid "Tells maxima for an f(x), that f(x=t)=a"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1945
+#: ../../src/wxMaximaFrame.cpp:1982
 msgid "Tells maxima to show the help for ?, ?? and describe() in a separate browser window"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1941
+#: ../../src/wxMaximaFrame.cpp:1978
 msgid "Tells maxima to show the help for ?, ?? and describe() in a wxMaxima sidebar"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1936
+#: ../../src/wxMaximaFrame.cpp:1973
 msgid "Tells maxima to show the help for ?, ?? and describe() on the console"
 msgstr ""
 
-#: ../../src/ToolBar.cpp:271
+#: ../../src/dialogs/ConfigDialogue.cpp:148
+msgid "Tells maxima where to store the result of compiling libraries"
+msgstr ""
+
+#: ../../src/ToolBar.cpp:481 ../../src/sidebars/FormatSidebar.cpp:45
 msgid "Text"
 msgstr "Tekst"
 
-#: ../../src/Configuration.cpp:93
+#: ../../src/dialogs/ConfigDialogue.cpp:739
+msgid "Text & Code"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:738
+#, fuzzy
+msgid "Text Only"
+msgstr "Tekstcelle"
+
+#: ../../src/Styles.cpp:122
 msgid "Text cell background"
 msgstr "Tekstcellebakgrunn"
 
-#: ../../src/wxMaxima.cpp:6541
+#: ../../src/dialogs/TipOfTheDay.cpp:219
+msgid "Text cells can hold citations that as marked as such by beginning a line with \" > \". The number of spaces in front of the \">\" determines the indentation level, as it does with bullet lists."
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:3061
 msgid "Text snippet"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:4632
+#: ../../src/dialogs/TipOfTheDay.cpp:205
+msgid ""
+"The \"at\" function allows introducing one equation into another:\n"
+"\n"
+"    ohm:U=R*I;\n"
+"    r_parallel:R=R_1*R_2/(R_1+R_2);\n"
+"    result:at(ohm,r_parallel);"
+msgstr ""
+
+#: ../../src/MaximaFileIO.cpp:555
 msgid "The .xml file doesn't seem to be valid xml or isn't a content.xml extracted from a .wxmx zip archive"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2734
+#: ../../src/MaximaProcessManager.cpp:844
 msgid "The Maxima process doesn't offer a shared memory segment we can send an interrupt signal to."
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:392
+msgid "The URL MathJaX.js should be downloaded from by our HTML export."
+msgstr ""
+
+#: ../../src/cells/TextCell.cpp:336
+msgid "The [] or the part() command tried to access a list or matrix element that doesn't exist."
+msgstr ""
+
+#: ../../src/sidebars/DrawSidebar.cpp:106
+msgid "The accuracy versus speed tradeoff"
+msgstr ""
+
+#: ../../src/cells/TextCell.cpp:357
+msgid "The argument of a function was of the wrong type. Most probably an equation was expected but was lacking an \"=\"."
 msgstr ""
 
 #: ../../src/MaximaManual.cpp:107
 msgid "The cache for the subjects the manual contains cannot be read."
 msgstr ""
 
-#: ../../src/MaximaManual.cpp:378
+#: ../../src/MaximaManual.cpp:395
 msgid "The cache for the subjects the manual contains has no head node."
 msgstr ""
 
-#: ../../src/MaximaManual.cpp:396
+#: ../../src/MaximaManual.cpp:413
 msgid "The cache for the subjects the manual contains is from a different Maxima version."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1379
+#: ../../src/wxMaximaFrame.cpp:1413
 msgid "The classic operations one typically uses matrices for"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7193
+#: ../../src/sidebars/DrawSidebar.cpp:91
+msgid "The color of the next line to draw"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:4065
 msgid "The comma-separated contents of the struct fields"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7186
+#: ../../src/MaximaCommandMenus.cpp:4058
 #, fuzzy
 msgid "The comma-separated names of the struct fields"
 msgstr "Oppgi kommaseparert liste av variabler."
 
-#: ../../src/wxMaxima.cpp:7070
-msgid "The command local() allows to tell maxima which functions to make local to the current program when defined."
+#: ../../src/MaximaCommandMenus.cpp:3942
+msgid "The command local() allows telling Maxima which functions to make local to the current program when defined."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:303
+#: ../../src/wxMaximaFrame.cpp:324
 msgid "The current Wizard"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:9592
+#: ../../src/dialogs/ConfigDialogue.cpp:415
+msgid "The default height for embedded plots. Can be read out or overridden by the maxima variable wxplot_size."
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:492
+msgid "The default port used for communication between Maxima and wxMaxima."
+msgstr "Forhåndsvalgt port til kommunikasjon mellom Maxima og wxMaxima."
+
+#: ../../src/dialogs/ConfigDialogue.cpp:412
+msgid "The default width for embedded plots. Can be read out or overridden by the maxima variable wxplot_size"
+msgstr ""
+
+#: ../../src/sidebars/DrawSidebar.cpp:74
+msgid "The diagram title"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:2401
+#, c-format
+msgid "The directory %s with maxima's startup file doesn't exist. Trying to create it..."
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:150
+msgid "The directory containing the startup files, any user libraries and, if MAXIMA_OBJDIR isn't set the subdirectory with the results from compiling maxima libraries."
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:154
+msgid "The directory maxima places temporary files in, for example plots that are to be included in the worksheet."
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:157
+msgid "The directory the compiled versions of maxima are placed in"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:159
+msgid "The directory the maxima manual can be found in"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:160
+msgid "The directory the user's home directory is in"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:475
+msgid "The document class LaTeX is instructed to use for our documents."
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:1832
 msgid "The equation to fit the data to"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8447
+#: ../../src/MaximaCommandMenus.cpp:774
+msgid "The expression to substitute in"
+msgstr ""
+
+#: ../../src/MaximaFileIO.cpp:444
+#, c-format
+msgid "The file claims %ld watch variables; capping at %ld."
+msgstr ""
+
+#: ../../src/sidebars/DrawSidebar.cpp:96
+msgid "The fill color for the next objects"
+msgstr ""
+
+#: ../../src/cells/TextCell.cpp:354
+msgid "The first argument of subst() isn't an equation or a list of equations. Most probably it was lacking an \"=\"."
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:1444
 msgid "The function call whose arguments to extract"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1298
+#: ../../src/sidebars/DrawSidebar.cpp:100
+msgid "The grid in the background of the diagram"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1332
 msgid "The half of the equation that is to the left of the \"=\""
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1302
+#: ../../src/wxMaximaFrame.cpp:1336
 msgid "The half of the equation that is to the right of the \"=\""
 msgstr ""
 
-#: ../../src/MaximaManual.cpp:399
+#: ../../src/MaximaManual.cpp:416
 msgid "The help dir from the cache differs from the current one."
 msgstr ""
 
-#: ../../src/Image.cpp:985
+#: ../../src/Image.cpp:1136
 msgid ""
 "The image could not be displayed. It may be broken, in a wrong format or be the result of gnuplot not being able to write the image or not being able to understand what maxima wanted to plot.\n"
 "One example of the latter would be: Gnuplot refuses to plot entirely empty images"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:9799 ../../src/wxMaxima.cpp:10158
+#: ../../src/MaximaCommandMenus.cpp:3262 ../../src/MaximaCommandMenus.cpp:3687
 #, c-format
 msgid "The image file \"%s\" cannot be found."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:718
+#: ../../src/wxMaximaFrame.cpp:753
 msgid "The integrated help browser"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:9591
+#: ../../src/cells/TextCell.cpp:397
+#, fuzzy
+msgid "The inverse laplace transform."
+msgstr "I&nvers Laplacetransformasjon..."
+
+#: ../../src/dialogs/TipOfTheDay.cpp:223
+msgid "The key combination Shift+Space results in a non-breakable space."
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:162
+msgid "The list of directories the operating system looks for programs in"
+msgstr ""
+
+#: ../../src/cells/TextCell.cpp:293
+msgid "The list of time-dependent variables to solve to doesn't match the time-dependent variables the list of dgls contains."
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:1831
 msgid "The list of variables contained in each matrix row"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:214
+#: ../../src/dialogs/TipOfTheDay.cpp:166
+msgid "The load() command of Maxima versions >5.38 is able to load .wxm files as library of Maxima's commands."
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:228
 msgid "The main toolbar"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1882
+#: ../../src/wxMaximaFrame.cpp:1919
 #, fuzzy
 msgid "The manual of Maxima"
 msgstr "Offline-manualen til Maxima"
 
-#: ../../src/wxMaximaFrame.cpp:1881
+#: ../../src/wxMaximaFrame.cpp:1918
 #, fuzzy
 msgid "The manual of wxMaxima"
 msgstr "Offline-manualen til Maxima"
 
-#: ../../src/wxMaxima.cpp:7125
+#: ../../src/dialogs/MaxSizeChooser.cpp:59
+msgid "The maximum size for this image. Values <= 0 mean: Unspecified."
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:3997
 msgid "The name of a function we don't want to be evaluated here"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7131
+#: ../../src/MaximaCommandMenus.cpp:4003
 msgid "The name of an expression that we don't want to be evaluated."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7199
+#: ../../src/MaximaCommandMenus.cpp:4071
 msgid "The name of the field to read"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7185
+#: ../../src/MaximaCommandMenus.cpp:4057
 msgid "The name of the new struct type"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7198
+#: ../../src/MaximaCommandMenus.cpp:4070
 msgid "The name of the struct"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7191
+#: ../../src/MaximaCommandMenus.cpp:4063
 msgid "The name of the struct type"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8220
+#: ../../src/MaximaCommandMenus.cpp:1410
 msgid "The name of the variable that shall contain the current element"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8468
+#: ../../src/sidebars/DrawSidebar.cpp:86
+msgid "The next plot's title"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:494
+msgid "The number of recently opened files that is to be remembered."
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:1471
 msgid "The number of the item which is stepped from \"Index Start\" to \"Index End\"."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8465 ../../src/wxMaxima.cpp:8478
+#: ../../src/dialogs/ConfigDialogue.cpp:477
+msgid "The options the document class LaTeX is instructed to use for our documents gets."
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1065
+#: ../../src/dialogs/ConfigDialogue.cpp:1112
+msgid "The part of the output of these commands that isn't declared as \"math\" might be suppressed by wxMaxima. As always maxima commands are required to end in a \";\" or a \"$\""
+msgstr ""
+
+#: ../../src/dialogs/ResolutionChooser.cpp:51
+msgid "The resolution for this image."
+msgstr ""
+
+#: ../../src/cells/TextCell.cpp:182
+msgid "The result was indefinite, which might be infinity, both plus or minus infinity or something additionally potentially involving a complex infinity."
+msgstr ""
+
+#: ../../src/cells/TextCell.cpp:180
+msgid "The result was undefined."
+msgstr ""
+
+#: ../../src/dialogs/TipOfTheDay.cpp:209
+msgid ""
+"The rhs() (\"right hand side\") command allows retrieving the result of an equation in exactly the format a function would have:\n"
+"\n"
+"    Values:[\n"
+"        /* m=1.2 tons */\n"
+"        m=1.2*10^3,\n"
+"        /* 100 km/h*/\n"
+"        v=100*10^3/(60*60)\n"
+"    ];\n"
+"    Energy:W=1/2*m*v^2;\n"
+"    at(Energy,Values);\n"
+"    W_mech:rhs(%);"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:1468
 msgid ""
 "The rule that explains how to generate the value of a list item.\n"
 "Might be something like \"i\", \"i^2\" or \"sin(i)\""
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7785
+#: ../../src/cells/TextCell.cpp:351
+msgid "The second argument of at() isn't an equation or a list of equations. Most probably it was lacking an \"=\"."
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:3481
+msgid "The selection contains no output that could be exported."
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:966
 msgid "The solution of an ODE describes the general shape of the resulting curve. The actual height of that curve is defined by the initial condition or boundary values, later on."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7818
+#: ../../src/MaximaCommandMenus.cpp:999
 msgid ""
 "The solution of an ODE tells the shape, but not the height of the solution.\n"
 "If the ODE's result is known at two points this function fills in the correct values for the  constants"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7794 ../../src/wxMaxima.cpp:7805
+#: ../../src/MaximaCommandMenus.cpp:975 ../../src/MaximaCommandMenus.cpp:986
 msgid ""
 "The solution of an ODE tells the shape, but not the height of the solution.\n"
 "If the ODE's state is known at a point this function fills in the correct values for the constants"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7896
+#: ../../src/MaximaCommandMenus.cpp:1077
 msgid ""
 "The solution variable needs to be in the form\n"
 "   U(t)=1/2*U(t)+3*diff(U(t),t)\n"
 "for this to work; Initial conditions can be specified using atvalue()."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8481 ../../src/wxMaxima.cpp:8582
+#: ../../src/sidebars/DrawSidebar.cpp:58
+msgid "The standard plot command: Plot an equation as a curve"
+msgstr ""
+
+#: ../../src/cells/TextCell.cpp:267
+msgid "The value of few special variables is assigned by Maxima and cannot be changed by the user. Also a few constructs aren't variable names and therefore cannot be written to."
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:1485 ../../src/MaximaCommandMenus.cpp:1600
 msgid "The variable the value of the current source item is stored in."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:9594
+#: ../../src/MaximaCommandMenus.cpp:1834
 msgid "The variables to search the optimum solution for"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:193
+#: ../../src/wxMaximaFrame.cpp:207
 msgid "The worksheet"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:8122
+#: ../../src/worksheet/Worksheet.cpp:6371
 msgid "The worksheet containing maxima's input and output"
 msgstr ""
 
-#: ../../src/MathParser.cpp:629
+#: ../../src/MathParser.cpp:682
 msgid ""
 "The xml data from maxima or from the .wxmx file was missing data here.\n"
 "If you find a way how to reproduce this problem please file a bug report against wxMaxima."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2143
+#: ../../src/MaximaCommandMenus.cpp:1481
+msgid ""
+"The ‘j’th element is equal to ‘ev (<expr>, <x>=<list>[j])’ \n"
+"j are the elements of the source list.\n"
+"Might be something like \"x=i\""
+msgstr ""
+
+#: ../../src/dialogs/TipOfTheDay.cpp:95
+msgid "There are many resources about Maxima and wxMaxima on the internet. Visit https://wxMaxima-developers.github.io/wxmaxima/help.html for more information and to find tutorials on using wxMaxima and Maxima."
+msgstr ""
+
+#: ../../src/dialogs/TipOfTheDay.cpp:251
+msgid ""
+"There is a discussion forum for wxMaxima at https://github.com/wxMaxima-developers/wxmaxima/discussions.\n"
+"You can ask questions there - and please help other users, by answering their questions, if you know an answer."
+msgstr ""
+
+#: ../../src/MaximaResponseReader.cpp:63
+msgid ""
+"There was an error in the XML describing a worksheet-export request.\n"
+"Please report this as a bug to the wxMaxima project."
+msgstr ""
+
+#: ../../src/MaximaOutputAppender.cpp:66 ../../src/MaximaOutputAppender.cpp:194
 #, fuzzy
 msgid ""
 "There was an error in the XML maxima has generated.\n"
@@ -7420,25 +11067,25 @@ msgstr ""
 "\n"
 "Vær grei og feilrapporter dette."
 
-#: ../../src/wxMaxima.cpp:3911
+#: ../../src/MaximaResponseReader.cpp:1027
 msgid ""
 "There was an error in the XML that should contain a list of watch variables.\n"
 "Please report this as a bug to the wxMaxima project."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3869
+#: ../../src/MaximaResponseReader.cpp:986
 msgid ""
 "There was an error in the XML that should contain the list of operators.\n"
 "Please report this as a bug to the wxMaxima project."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3321
+#: ../../src/MaximaResponseReader.cpp:719
 msgid ""
 "There was an error in the XML that should describe the contents of some variables.\n"
 "Please report this as a bug to the wxMaxima project."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3257
+#: ../../src/MaximaResponseReader.cpp:163
 #, fuzzy
 msgid ""
 "There was an error in the XML that should describe the manual topics.\n"
@@ -7448,142 +11095,237 @@ msgstr ""
 "\n"
 "Vær grei og feilrapporter dette."
 
-#: ../../src/wxMaxima.cpp:3202
+#: ../../src/MaximaResponseReader.cpp:42
 msgid ""
 "There was an error in the XML that should describe the status bar message.\n"
 "Please report this as a bug to the wxMaxima project."
 msgstr ""
 
-#: ../../src/MaximaManual.cpp:363
+#: ../../src/sidebars/GreekSidebar.cpp:185
+msgid "Theta"
+msgstr ""
+
+#: ../../src/dialogs/LicenseDialog.cpp:85
+msgid "Third-party notices"
+msgstr ""
+
+#: ../../src/cells/TextCell.cpp:312
+msgid ""
+"This error message is most probably caused by a try to assign a value to a number instead of a variable name.\n"
+"One probable cause is using a variable that already has a numeric value as a loop counter."
+msgstr ""
+
+#: ../../src/MaximaManual.cpp:376
 msgid ""
 "This file is generated by wxMaxima\n"
 "It caches the list of subjects maxima's manual offers and is automatically\n"
 "overwritten if maxima's version changes or the file cannot be read"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1992
+#: ../../src/dialogs/ConfigDialogue.cpp:1097
+msgid "This file won't be read by maxima if maxima is used without wxMaxima. In order to add startup commands that are executed in this case, too, please add them to maxima-init.mac, instead."
+msgstr ""
+
+#: ../../src/worksheet/WorksheetContextMenu.cpp:764
 msgid "This function will return even integers"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1994
+#: ../../src/worksheet/WorksheetContextMenu.cpp:766
 msgid "This function will return odd integers"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1950
+#: ../../src/cells/TextCell.cpp:229
+msgid "This message can appear when trying to numerically find an optimum. In this case it might indicate that a starting point lies in a local optimum that fits the data best if one parameter is increased to infinity or decreased to -infinity. It also can indicate that an attempt was made to fit data to an equation that actually matches the data best if one parameter is set to +/- infinity."
+msgstr ""
+
+#: ../../src/worksheet/WorksheetContextMenu.cpp:722
 msgid "This symbol has no imaginary part"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1956
+#: ../../src/worksheet/WorksheetContextMenu.cpp:728
 msgid "This symbol has no real part"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1953
+#: ../../src/worksheet/WorksheetContextMenu.cpp:725
 msgid "This symbol might have both real and imaginary part"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1980
+#: ../../src/cells/TextCell.cpp:300
+msgid "This warning can be deactivated by setting factor_max_degree_print_warning to false."
+msgstr ""
+
+#: ../../src/wizards/DrawWiz.cpp:471
+#, c-format
+msgid "This wizard setups a %iD scene."
+msgstr ""
+
+#: ../../src/worksheet/WorksheetContextMenu.cpp:752
 msgid "Throw an error if this symbol is used before assigning it any contents"
 msgstr ""
 
+# Det er bestemt et dårligt ord, men jeg kan ikke komme på noget bedre.
+# vi norske sliter vi også...
+#: ../../src/wizards/Plot2dWiz.cpp:65 ../../src/wizards/Plot2dWiz.cpp:505
+msgid "Ticks:"
+msgstr "Haker:"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1359
+msgid "Time [in Minutes] between autosaves"
+msgstr ""
+
 # hvilken kontekst?
-#: ../../src/wxMaxima.cpp:9013 ../../src/wxMaxima.cpp:10058
+#: ../../src/MaximaCommandMenus.cpp:267 ../../src/MaximaCommandMenus.cpp:3547
 msgid "Times:"
 msgstr "Antall:"
 
-#: ../../src/ToolBar.cpp:272
+#: ../../src/dialogs/TipOfTheDay.cpp:49 ../../src/dialogs/TipOfTheDay.cpp:267
+msgid "Tip of the day"
+msgstr ""
+
+#: ../../src/ToolBar.cpp:482 ../../src/sidebars/FormatSidebar.cpp:48
 msgid "Title"
 msgstr "Tittel"
 
-#: ../../src/wxMaxima.cpp:8315 ../../src/wxMaxima.cpp:8328
+#: ../../src/MaximaCommandMenus.cpp:1961 ../../src/MaximaCommandMenus.cpp:1974
 msgid "Title (Sub- and superscripts as x_{10} or x^{10})"
 msgstr ""
 
-#: ../../src/Configuration.cpp:92
+#: ../../src/Styles.cpp:121
 msgid "Title cell (Heading 1)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1794
+#: ../../src/dialogs/TipOfTheDay.cpp:89
+msgid "Title, section and subsection cells can be folded to hide their contents. To fold or unfold, click in the square next to the cell. If you shift-click, all sublevels of that cell will also fold/unfold."
+msgstr "Tittel-, seksjon- og underseksjonceller kan foldes for å gjemme deres innhold. For å folde eller utfolde, klikk i firkanten ved cellen. Hvis du Shift+klikker, vil alle undernivå av cellen også foldes/utfoldes."
+
+#: ../../src/wxMaximaFrame.cpp:1831
 msgid "To &Bigfloat"
 msgstr "Til &Bigfloat"
 
-#: ../../src/wxMaximaFrame.cpp:1791
+#: ../../src/wxMaximaFrame.cpp:1828
 msgid "To &Float"
 msgstr "Til &Desimaltall"
 
-#: ../../src/Worksheet.cpp:1571
+#: ../../src/worksheet/WorksheetContextMenu.cpp:344
 msgid "To Float"
 msgstr "Til Desimaltall"
 
-#: ../../src/wxMaximaFrame.cpp:1797
+#: ../../src/wxMaximaFrame.cpp:1834
 msgid "To Numeri&c\tCtrl+Shift+N"
 msgstr "Til &Numerisk\tCtrl+Shift+N"
 
-#: ../../src/wxMaximaFrame.cpp:1803
+#: ../../src/wxMaximaFrame.cpp:1840
 #, fuzzy
 msgid "To exact fraction"
 msgstr "Delbrøker"
 
-#: ../../src/wxMaximaFrame.cpp:1814
+#: ../../src/wxMaximaFrame.cpp:1851
 #, fuzzy
 msgid "To exact number"
 msgstr "Vis &Funksjoner"
 
-#: ../../src/wxMaxima.cpp:9064
+#: ../../src/dialogs/TipOfTheDay.cpp:124
+msgid "To plot in polar coordinates, select 'set polar' in the Options entry for Plot2d dialog. You can also plot in spherical and cylindrical coordinates in 3D."
+msgstr "For å plotte i polarkoordinater, velg 'set polar' i Valg-feltet til Plott 2d-dialogen. Du kan også plotte sfæriske og sylindriske koordinater i 3D."
+
+#: ../../src/dialogs/TipOfTheDay.cpp:131
+#, fuzzy
+msgid "To put parentheses around an expression, select it, and press '(' or ')' depending on where you want the cursor to appear afterwards."
+msgstr "For å sette parenteser rundt et uttrykk, velg det, og trykk '(' eller ')' alt etter hvor du vil at pekeren skal være etterpå."
+
+#: ../../src/dialogs/TipOfTheDay.cpp:137
+msgid "To save the size and position of wxMaxima windows between session, use 'Edit->Configure' dialog."
+msgstr "For å lagre størrelse og posisjon til wxMaxima-vinduer mellom økter, bruk dialogen 'Endre->Konfigurer'."
+
+#: ../../src/dialogs/TipOfTheDay.cpp:51
+#, fuzzy
+msgid "To start using wxMaxima right away, start typing your command. An input cell should appear. Then press Shift-Enter to evaluate your command."
+msgstr "For å ta i bruk wxMaxima med en gang, kan du bare starte og skrive kommandoer; en inndatacelle hører til å dukke opp. Deretter trykker du Shift+Enter for å utføre kommandoene dine."
+
+#: ../../src/MaximaCommandMenus.cpp:318 ../../src/wizards/IntegrateWiz.cpp:47
+#: ../../src/wizards/Plot2dWiz.cpp:51 ../../src/wizards/Plot2dWiz.cpp:61
+#: ../../src/wizards/Plot2dWiz.cpp:502 ../../src/wizards/Plot3dWiz.cpp:40
+#: ../../src/wizards/Plot3dWiz.cpp:49 ../../src/wizards/SumWiz.cpp:40
 msgid "To:"
 msgstr "Til:"
 
-#: ../../src/wxMaximaFrame.cpp:825 ../../src/wxMaximaFrame.cpp:828
+#: ../../src/sidebars/TableOfContents.cpp:579
+msgid "Toc levels shown here"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:862 ../../src/wxMaximaFrame.cpp:865
 msgid "Toggle full screen editing"
 msgstr "Veksle fullskjermredigering"
 
-#: ../../src/ToolBar.cpp:265
+#: ../../src/dialogs/DiffFrame.cpp:370 ../../src/dialogs/DiffFrame.cpp:387
+msgid "Toggle horizontal scroll synchronization"
+msgstr ""
+
+#: ../../src/ToolBar.cpp:471 ../../src/ToolBar.cpp:473
 msgid "Toggle the visibility of code cells"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1177
+#: ../../src/dialogs/DiffFrame.cpp:382 ../../src/dialogs/DiffFrame.cpp:388
+msgid "Toggle vertical scroll synchronization"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1211
 msgid "Tokenize..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1909
+#: ../../src/wxMaximaFrame.cpp:1946
 msgid "Tolerance calculations with Maxima"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8192
+#: ../../src/ToolBar.cpp:176
+msgid "Toolbar"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1991
+#, fuzzy
+msgid "Top"
+msgstr "Til:"
+
+#: ../../src/MaximaCommandMenus.cpp:1382
 msgid "Top end"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1078
+#: ../../src/wxMaxima.cpp:2862
+msgid "Tortoise diff tool"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1112
 #, fuzzy
 msgid "Trace a function..."
 msgstr "Slett en funksjon"
 
-#: ../../src/wxMaxima.cpp:7084
+#: ../../src/MaximaCommandMenus.cpp:3956
 #, fuzzy
 msgid "Trace function(s)"
 msgstr "Slett funksjoner:"
 
-#: ../../src/wxMaximaFrame.cpp:1184
+#: ../../src/wxMaximaFrame.cpp:1218
 #, fuzzy
 msgid "Transformations"
 msgstr "Transponer en matrise"
 
-#: ../../src/wxMaximaFrame.cpp:1376
+#: ../../src/wxMaximaFrame.cpp:1410
 msgid "Transpose a matrix"
 msgstr "Transponer en matrise"
 
-#: ../../src/wxMaxima.cpp:7832
+#: ../../src/MaximaCommandMenus.cpp:1013
 msgid "Tries to find a numerical solution for a 1st order ODE (or in other words: a equation of the format depends(x,t);diff(x,t)=(something containing x and t)"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:10036
+#: ../../src/MaximaCommandMenus.cpp:3525
 msgid "Tries to find a solution of the equation that lies between the two bounds."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7774
+#: ../../src/MaximaCommandMenus.cpp:955
 msgid "Tries to find a value of the variable that solves the equation between the two bonds"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7719
+#: ../../src/MaximaCommandMenus.cpp:901
 msgid ""
 "Tries to find all solutions of a polynomial numerically using bfloats.\n"
 "Might be able to detect solutions in non-polynomials, as well, if the expression is approximated by an polynomial, beforehand:\n"
@@ -7591,7 +11333,7 @@ msgid ""
 "    bfallroots(ratdisrep(taylor(expression,0,30)));"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7709
+#: ../../src/MaximaCommandMenus.cpp:892
 msgid ""
 "Tries to find all solutions of a polynomial numerically.\n"
 "Might be able to detect solutions in non-polynomials, as well, if the expression is approximated by an polynomial, beforehand:\n"
@@ -7599,7 +11341,7 @@ msgid ""
 "    allroots(ratdisrep(taylor(expression,0,30)));"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7730
+#: ../../src/MaximaCommandMenus.cpp:911
 #, c-format
 msgid ""
 "Tries to find exact fractions that match the numerical solutions of a polynomial.\n"
@@ -7611,298 +11353,413 @@ msgid ""
 "See also guess_exact_value()"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1181
+#: ../../src/wxMaximaFrame.cpp:1215
 msgid "Trim both ends..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1182
+#: ../../src/wxMaximaFrame.cpp:1216
 #, fuzzy
 msgid "Trim left..."
 msgstr "Grenseverdi..."
 
-#: ../../src/wxMaximaFrame.cpp:1183
+#: ../../src/wxMaximaFrame.cpp:1217
 #, fuzzy
 msgid "Trim right..."
 msgstr "Grenseverdi..."
 
-#: ../../src/wxMaxima.cpp:7473
+#: ../../src/MaximaCommandMenus.cpp:4345
 msgid "Trim string left"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7469
+#: ../../src/MaximaCommandMenus.cpp:4341
 msgid "Trim string on both ends"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7477
+#: ../../src/MaximaCommandMenus.cpp:4349
 msgid "Trim string right"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1511
+#: ../../src/wxMaximaFrame.cpp:1548
 msgid "Try to guess which form is &simple"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8637
+#: ../../src/MaximaCommandMenus.cpp:629
 msgid "Try to simplify sums that result from sum() commands."
 msgstr ""
 
-#: ../../src/MaximaManual.cpp:369
+#: ../../src/MaximaManual.cpp:382
 #, c-format
 msgid "Trying to cache the list of subjects the manual contains in the file %s."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:4423
+#: ../../src/MaximaFileIO.cpp:357
 msgid "Trying to discard all output."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:4380
+#: ../../src/MaximaFileIO.cpp:326
 msgid "Trying to extract content.xml out of a broken .zip file."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:5519
+#: ../../src/MaximaFileIO.cpp:610
 msgid "Trying to open a file with an empty name!"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:5523
+#: ../../src/MaximaFileIO.cpp:622
 #, c-format
 msgid "Trying to open the non-existing file %s"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:4457
+#: ../../src/MaximaFileIO.cpp:378
 msgid "Trying to reconstruct the xml closing markers."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:4376
+#: ../../src/MaximaFileIO.cpp:322
 msgid "Trying to recover a broken .wxmx file."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:6026
+#: ../../src/MaximaFileIO.cpp:907
 #, c-format
 msgid "Trying to remove the old temp file %s"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2507
+#: ../../src/MaximaProcessManager.cpp:168
 msgid "Trying to restart maxima."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2523
+#: ../../src/MaximaProcessManager.cpp:184
 #, c-format
 msgid "Trying to start the socket a Maxima on the local machine can connect to on port %i"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1928
+#: ../../src/dialogs/ConfigDialogue.cpp:230
+msgid "Turkish"
+msgstr "Tyrkisk"
+
+#: ../../src/wxMaximaFrame.cpp:1965
 msgid "Tutorials"
 msgstr "&Læreressurser"
 
-#: ../../src/wxMaxima.cpp:9571
+#: ../../src/MaximaCommandMenus.cpp:1809
 msgid "Two sample t-test"
 msgstr "Tomålings t-test"
 
-#: ../../src/Worksheet.cpp:8013
+#: ../../src/worksheet/Worksheet.cpp:6249
 #, fuzzy
 msgid "Type"
 msgstr "Type:"
 
-#: ../../src/wxMaxima.cpp:7180
+#: ../../src/cells/EditorCell.cpp:4550
+#, fuzzy
+msgid "Type in text"
+msgstr "Kopier som Bilde"
+
+#: ../../src/MaximaCommandMenus.cpp:4052 ../../src/wizards/MatWiz.cpp:158
 msgid "Type:"
 msgstr "Type:"
 
-#: ../../src/wxMaxima.cpp:9429
+#: ../../src/MaximaCommandMenus.cpp:2072
 msgid "URL"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1146
+#: ../../src/dialogs/ConfigDialogue.cpp:1231
+msgid "URL MathJaX.js is located at:"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1180
 msgid "UTF8 to Unicode code point..."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:10479
+#: ../../src/dialogs/ConfigDialogue.cpp:231
+msgid "Ukrainian"
+msgstr "Ukrainsk"
+
+#: ../../src/wxMaxima.cpp:3166
 msgid "Un-closed parenthesis"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:10467
+#: ../../src/wxMaxima.cpp:3154
 msgid "Un-closed parenthesis on encountering ; or $"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:11160
-msgid "Unable to interpret the version info I got from http://wxMaxima-developers.github.io/wxmaxima/version.txt: "
+#: ../../src/wxMaxima.cpp:3468
+#, c-format
+msgid "Unable to interpret the version info I got from %s: %s"
+msgstr ""
+
+#: ../../src/wxMaxima.cpp:3414
+#, c-format
+msgid "Unable to interpret the version info I got: %s"
 msgstr ""
 
 # s/linjet/streket|streking ?
-#: ../../src/wxMaximaFrame.cpp:1007
+#: ../../src/wxMaximaFrame.cpp:1041
 #, fuzzy
 msgid "Undefine"
 msgstr "Underlinjet"
 
-#: ../../src/ToolBar.cpp:191
+#: ../../src/sidebars/VariablesPane.cpp:303
+#: ../../src/sidebars/VariablesPane.cpp:386
+msgid "Undefined"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:2115
+msgid "Underlined"
+msgstr "Underlinjet"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:745
+msgid "Underscore converts to subscripts:"
+msgstr ""
+
+#: ../../src/ToolBar.cpp:354 ../../src/ToolBar.cpp:357
 msgid "Undo"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:631
+#: ../../src/wxMaximaFrame.cpp:668
 msgid "Undo\tCtrl+Z"
 msgstr "Angre\tCtrl+Z"
 
-#: ../../src/ToolBar.cpp:614
+#: ../../src/ToolBar.cpp:814
 msgid "Undo and redo button"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:631
+#: ../../src/wxMaximaFrame.cpp:668
 msgid "Undo last change"
 msgstr "Angre siste endring"
 
-#: ../../src/wxMaximaFrame.cpp:924
+#: ../../src/cells/TextCell.cpp:115
+#, c-format
+msgid "Unexpected text style %li for TextCell"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:958
 msgid "Unfold All\tCtrl+Alt+]"
 msgstr "Fo&ld Ut Alle\tCtrl+A-]"
 
-#: ../../src/wxMaximaFrame.cpp:925
+#: ../../src/wxMaximaFrame.cpp:959
 msgid "Unfold all folded sections"
 msgstr "Fold ut alle foldede seksjoner"
 
-#: ../../src/Worksheet.cpp:1893
+#: ../../src/sidebars/TableOfContents.cpp:507
+msgid "Unhide"
+msgstr ""
+
+#: ../../src/worksheet/WorksheetContextMenu.cpp:665
 msgid "Unhide Heading 5"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1904
+#: ../../src/worksheet/WorksheetContextMenu.cpp:676
 msgid "Unhide Heading 6"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1852
+#: ../../src/worksheet/WorksheetContextMenu.cpp:624
 msgid "Unhide Part"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1860
+#: ../../src/worksheet/WorksheetContextMenu.cpp:632
 #, fuzzy
 msgid "Unhide Section"
 msgstr "Seksjon"
 
-#: ../../src/Worksheet.cpp:1871
+#: ../../src/worksheet/WorksheetContextMenu.cpp:643
 #, fuzzy
 msgid "Unhide Subsection"
 msgstr "Underseksjon"
 
-#: ../../src/Worksheet.cpp:1882
+#: ../../src/worksheet/WorksheetContextMenu.cpp:654
 #, fuzzy
 msgid "Unhide Subsubsection"
 msgstr "Underseksjon"
 
-#: ../../src/Worksheet.cpp:1912
+#: ../../src/worksheet/WorksheetContextMenu.cpp:684
 #, fuzzy
 msgid "Unhide contents"
 msgstr "Greske konstanter"
 
-#: ../../src/wxMaximaFrame.cpp:266
+#: ../../src/wxMaximaFrame.cpp:287
 #, fuzzy
 msgid "Unicode characters"
 msgstr "Greske konstanter"
 
-#: ../../src/wxMaximaFrame.cpp:707
+#: ../../src/wxMaximaFrame.cpp:742
 msgid "Unicode chars\tAlt+Shift+U"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1144
+#: ../../src/wxMaximaFrame.cpp:1178
 msgid "Unicode code point to UTF8..."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7366
+#: ../../src/MaximaCommandMenus.cpp:4238
 msgid "Unicode code point to char"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1142
+#: ../../src/wxMaximaFrame.cpp:1176
 msgid "Unicode code point to char..."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7371
+#: ../../src/MaximaCommandMenus.cpp:4243
 msgid "Unicode code point to utf8 numbers"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7078
+#: ../../src/sidebars/SymbolsSidebar.cpp:180
+msgid "Unicode symbols:"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:3950
 msgid "Unlike in other programming language return() only exits from the current loop or block(), not from the whole function."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:10418
+#: ../../src/wxMaxima.cpp:3105
 msgid "Unterminated comment."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:10461
+#: ../../src/wxMaxima.cpp:3148
 msgid "Unterminated string."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:4786
+#: ../../src/wizards/ActualValuesStorageWiz.cpp:43
+msgid "Until then the actual values for all variables can be kept in a list."
+msgstr ""
+
+#: ../../src/dialogs/DiffFrame.cpp:429 ../../src/dialogs/FindReplacePane.cpp:80
+msgid "Up"
+msgstr ""
+
+#: ../../src/MaximaEvaluator.cpp:629
 msgid "Updating maxima's configuration"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:11150 ../../src/wxMaxima.cpp:11157
-#: ../../src/wxMaxima.cpp:11163
+#: ../../src/wxMaxima.cpp:3407 ../../src/wxMaxima.cpp:3412
+#: ../../src/wxMaxima.cpp:3414 ../../src/wxMaxima.cpp:3461
+#: ../../src/wxMaxima.cpp:3466 ../../src/wxMaxima.cpp:3469
 msgid "Upgrade"
 msgstr "Oppgrader"
 
-#: ../../src/wxMaxima.cpp:7779 ../../src/wxMaxima.cpp:10041
+#: ../../src/MaximaCommandMenus.cpp:489 ../../src/MaximaCommandMenus.cpp:502
+#: ../../src/MaximaCommandMenus.cpp:517 ../../src/MaximaCommandMenus.cpp:531
+msgid "Upper bound on the number of cycles. Must be greater than or equal to 3."
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:960 ../../src/MaximaCommandMenus.cpp:3530
 msgid "Upper bound:"
 msgstr "Øvre grense:"
 
-#: ../../src/wxMaximaFrame.cpp:792
+#: ../../src/sidebars/GreekSidebar.cpp:197
+#, fuzzy
+msgid "Upsilon"
+msgstr "Epsilon:"
+
+#: ../../src/wxMaximaFrame.cpp:829
 msgid "Use \"<\" and \">\" as parenthesis for matrices"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1708 ../../src/wxMaximaFrame.cpp:1739
+#: ../../src/dialogs/ConfigDialogue.cpp:507
+msgid "Use GTK's overlay scrollbars, which appear over the worksheet and fade out when unused. Looks modern, but GTK repaints the whole worksheet on every frame of the fade animation - which runs after every mouse movement - so classic scrollbars are much faster."
+msgstr ""
+
+#: ../../src/wizards/SumWiz.cpp:69
+msgid "Use Gosper algorithm"
+msgstr "Bruk Gospers algoritme"
+
+#: ../../src/sidebars/RegexCtrl.cpp:133
+msgid "Use RegEx filtering"
+msgstr ""
+
+#: ../../src/sidebars/RegexCtrl.cpp:134
+msgid "Use Text search filtering"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1745 ../../src/wxMaximaFrame.cpp:1776
 #, fuzzy
 msgid "Use a list"
 msgstr "Lag liste"
 
-#: ../../src/wxMaxima.cpp:8571
+#: ../../src/MaximaCommandMenus.cpp:1589
 msgid "Use a list as parameter list for a function"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1708
+#: ../../src/wxMaximaFrame.cpp:2008
+msgid "Use as TortoiseSVN/Git diff tool"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:485
+msgid "Use centered dot and Minus, not Star and Hyphen"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:849
+msgid "Use centered dot character for multiplication"
+msgstr "Bruk 'midtstilt prikk'-tegn til multiplikasjon"
+
+#: ../../src/wxMaximaFrame.cpp:1745
 #, fuzzy
 msgid "Use list"
 msgstr "Lag liste"
 
-#: ../../src/wxMaximaFrame.cpp:1701
+#: ../../src/wxMaximaFrame.cpp:1738
 msgid "Use list as the arguments of a function"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:786
+#: ../../src/wxMaximaFrame.cpp:823
 msgid "Use rounded parenthesis for matrices"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:789
+#: ../../src/wxMaximaFrame.cpp:826
 msgid "Use square parenthesis for matrices"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1083
+#: ../../src/wxMaximaFrame.cpp:1117
 #, fuzzy
 msgid "Use struct field..."
 msgstr "K&jedebrøk"
 
-#: ../../src/wxMaximaFrame.cpp:795
+#: ../../src/dialogs/ConfigDialogue.cpp:425
+msgid "Use the \"partial derivative\" symbol to represent the fraction that represents a diff() when exporting LaTeX"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:2052
+msgid "Use unicode Math Symbols, if available"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:832
 msgid "Use vertical lines instead of parenthesis for matrices"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1619
+#: ../../src/worksheet/WorksheetContextMenu.cpp:392
 msgid "User labels only"
 msgstr ""
 
-#: ../../src/Configuration.cpp:81
+#: ../../src/dialogs/ConfigDialogue.cpp:1248
+#: ../../src/dialogs/ConfigDialogue.cpp:1452
+#: ../../src/dialogs/ConfigDialogue.cpp:1480
+#: ../../src/dialogs/MaximaNotStartingDialog.cpp:54
+msgid "User specified"
+msgstr ""
+
+#: ../../src/Styles.cpp:110
 msgid "User-defined labels"
 msgstr ""
 
-#: ../../src/MaximaManual.cpp:483
+#: ../../src/dialogs/ConfigDialogue.cpp:770
+msgid "User-defined labels if available"
+msgstr ""
+
+#: ../../src/MaximaManual.cpp:500
 msgid "Using Maxima help file from wxMaxima configuration file (helpFile=...))"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:4825
+#: ../../src/wxMaxima.cpp:1566
 msgid "Using Maxima path from command line."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:4822
+#: ../../src/wxMaxima.cpp:1563
 #, fuzzy
 msgid "Using configured Maxima path."
 msgstr "Konfigurer wxMaxima"
 
-#: ../../src/wxMaxima.cpp:2961
+#: ../../src/MaximaProcessManager.cpp:976
 msgid "Using gnuplot's antialiassing-less png driver for embedded plots as pngcairo could not be found"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2956
+#: ../../src/MaximaProcessManager.cpp:971
 msgid "Using gnuplot's pngcairo driver for embedded plots"
 msgstr ""
 
@@ -7910,484 +11767,971 @@ msgstr ""
 msgid "Using the built-in list of manual anchors."
 msgstr ""
 
-#: ../../src/WXMXformat.cpp:266
+#: ../../src/dialogs/AboutDialog.cpp:46
+#, c-format
+msgid ""
+"Using: %s\n"
+"\n"
+msgstr ""
+
+#: ../../src/WXMXformat.cpp:268
 msgid "Validated that the XML representation of the document actually is valid XML"
 msgstr ""
 
+#: ../../src/dialogs/ConfigDialogue.cpp:542
+#: ../../src/wizards/ActualValuesStorageWiz.cpp:49
+#, fuzzy
+msgid "Value"
+msgstr "Verdi:"
+
 # Jeg ved ikke hvad man skal oversætte noun til?
 # JT: Navn(eord) - det vil u.a.o. kun være for "kendere"?
-#: ../../src/wxMaxima.cpp:8755
+#: ../../src/MaximaCommandMenus.cpp:756
 #, fuzzy
 msgid "Value at a given point"
 msgstr "Utfør &Navneformer"
 
-#: ../../src/Worksheet.cpp:1987
+#: ../../src/worksheet/WorksheetContextMenu.cpp:759
 msgid "Value at a specific point"
 msgstr ""
 
 # Jeg ved ikke hvad man skal oversætte noun til?
 # JT: Navn(eord) - det vil u.a.o. kun være for "kendere"?
-#: ../../src/wxMaxima.cpp:7801
+#: ../../src/MaximaCommandMenus.cpp:982
 #, fuzzy
 msgid "Value at that point:"
 msgstr "Utfør &Navneformer"
 
 # Jeg ved ikke hvad man skal oversætte noun til?
 # JT: Navn(eord) - det vil u.a.o. kun være for "kendere"?
-#: ../../src/wxMaxima.cpp:7812 ../../src/wxMaxima.cpp:7825
-#: ../../src/wxMaxima.cpp:7827
+#: ../../src/MaximaCommandMenus.cpp:993 ../../src/MaximaCommandMenus.cpp:1006
+#: ../../src/MaximaCommandMenus.cpp:1008
 #, fuzzy
 msgid "Value y at that point:"
 msgstr "Utfør &Navneformer"
 
-#: ../../src/wxMaxima.cpp:7910
+#: ../../src/MaximaCommandMenus.cpp:1091 ../../src/wizards/BC2Wiz.cpp:36
+#: ../../src/wizards/BC2Wiz.cpp:42
 msgid "Value:"
 msgstr "Verdi:"
 
-#: ../../src/wxMaxima.cpp:8201
+#: ../../src/MaximaCommandMenus.cpp:1391
 msgid "Var #1"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8202
+#: ../../src/MaximaCommandMenus.cpp:1392
 msgid "Var #2"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:6852 ../../src/wxMaxima.cpp:8183
+#: ../../src/MaximaCommandMenus.cpp:1371 ../../src/MaximaCommandMenus.cpp:1755
+#: ../../src/dialogs/ConfigDialogue.cpp:541
+#: ../../src/sidebars/VariablesPane.cpp:54
 msgid "Variable"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:6530 ../../src/wxMaxima.cpp:6536
-#: ../../src/wxMaxima.cpp:8568
+#: ../../src/wizards/DrawWiz.cpp:61 ../../src/wizards/DrawWiz.cpp:166
+msgid "Variable for the x value"
+msgstr ""
+
+#: ../../src/wizards/DrawWiz.cpp:78 ../../src/wizards/DrawWiz.cpp:181
+msgid "Variable for the y value"
+msgstr ""
+
+#: ../../src/wizards/DrawWiz.cpp:198
+msgid "Variable for the z value"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:1586 ../../src/MaximaCommandMenus.cpp:3050
+#: ../../src/MaximaCommandMenus.cpp:3056
+#: ../../src/wizards/ActualValuesStorageWiz.cpp:48
 #, fuzzy
 msgid "Variable name"
 msgstr "Forrige variabel:"
 
-#: ../../src/wxMaximaFrame.cpp:1085
+#: ../../src/wxMaximaFrame.cpp:1119
 #, fuzzy
 msgid "Variable name, not contents..."
 msgstr "Forrige variabel:"
 
-#: ../../src/wxMaxima.cpp:7157 ../../src/wxMaxima.cpp:7675
+#: ../../src/MaximaCommandMenus.cpp:4029 ../../src/MaximaCommandMenus.cpp:4547
 #, fuzzy
 msgid "Variable name:"
 msgstr "Forrige variabel:"
 
-#: ../../src/wxMaxima.cpp:7752 ../../src/wxMaxima.cpp:7766
+#: ../../src/MaximaCommandMenus.cpp:933 ../../src/MaximaCommandMenus.cpp:947
 #, fuzzy
 msgid "Variable(s)"
 msgstr "Variabler:"
 
-#: ../../src/wxMaxima.cpp:7849 ../../src/wxMaxima.cpp:7901
-#: ../../src/wxMaxima.cpp:9012 ../../src/wxMaxima.cpp:10057
+#: ../../src/MaximaCommandMenus.cpp:266 ../../src/MaximaCommandMenus.cpp:1030
+#: ../../src/MaximaCommandMenus.cpp:1082 ../../src/MaximaCommandMenus.cpp:3546
 msgid "Variable(s):"
 msgstr "Variabler:"
 
-#: ../../src/wxMaxima.cpp:7714 ../../src/wxMaxima.cpp:7725
-#: ../../src/wxMaxima.cpp:7777 ../../src/wxMaxima.cpp:8934
-#: ../../src/wxMaxima.cpp:8941 ../../src/wxMaxima.cpp:8952
-#: ../../src/wxMaxima.cpp:8977 ../../src/wxMaxima.cpp:8982
-#: ../../src/wxMaxima.cpp:9063 ../../src/wxMaxima.cpp:10039
+#: ../../src/MaximaCommandMenus.cpp:185 ../../src/MaximaCommandMenus.cpp:195
+#: ../../src/MaximaCommandMenus.cpp:206 ../../src/MaximaCommandMenus.cpp:231
+#: ../../src/MaximaCommandMenus.cpp:236 ../../src/MaximaCommandMenus.cpp:317
+#: ../../src/MaximaCommandMenus.cpp:958 ../../src/MaximaCommandMenus.cpp:3528
+#: ../../src/wizards/IntegrateWiz.cpp:36 ../../src/wizards/LimitWiz.cpp:32
+#: ../../src/wizards/Plot2dWiz.cpp:45 ../../src/wizards/Plot2dWiz.cpp:55
+#: ../../src/wizards/Plot2dWiz.cpp:496 ../../src/wizards/Plot3dWiz.cpp:34
+#: ../../src/wizards/Plot3dWiz.cpp:43 ../../src/wizards/SeriesWiz.cpp:33
+#: ../../src/wizards/SumWiz.cpp:34
 msgid "Variable:"
 msgstr "Variabel:"
 
-#: ../../src/wxMaximaFrame.cpp:277 ../../src/wxMaximaFrame.cpp:720
+#: ../../src/wxMaximaFrame.cpp:298 ../../src/wxMaximaFrame.cpp:755
 msgid "Variables"
 msgstr "Variabler"
 
-#: ../../src/wxMaxima.cpp:9043 ../../src/wxMaxima.cpp:9593
+#: ../../src/MaximaCommandMenus.cpp:297 ../../src/MaximaCommandMenus.cpp:1833
+#: ../../src/wizards/SystemWiz.cpp:72
 msgid "Variables:"
 msgstr "Variabler:"
 
-#: ../../src/WXMXformat.cpp:337
+#: ../../src/sidebars/StatSidebar.cpp:58
+msgid "Variance..."
+msgstr "Varians..."
+
+#: ../../src/WXMXformat.cpp:339
 msgid "Verified that we are able to read the whole .zip archive we produced."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:836
+#: ../../src/dialogs/ConfigDialogue.cpp:232
+msgid "Vietnamese"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:870
 msgid "View"
 msgstr ""
 
-#: ../../src/Autocomplete.cpp:235
+#: ../../src/Autocomplete.cpp:305
 msgid "Waiting for m_addFiles_backgroundThread to finish"
 msgstr ""
 
-#: ../../src/Autocomplete.cpp:122 ../../src/Autocomplete.cpp:240
+#: ../../src/Autocomplete.cpp:154 ../../src/Autocomplete.cpp:310
 msgid "Waiting for m_addSymbols_backgroundThread to finish"
 msgstr ""
 
-#: ../../src/MaximaManual.cpp:533
-msgid "Waiting for the Manual anchors background task."
-msgstr ""
-
-#: ../../src/MaximaManual.cpp:562
+#: ../../src/MaximaManual.cpp:586
 msgid "Waiting for the thread that parses the maxima manual to finish"
 msgstr ""
 
-#: ../../src/MathParser.cpp:1229 ../../src/wxMaxima.cpp:3296
-#: ../../src/wxMaxima.cpp:3308 ../../src/wxMaxima.cpp:4613
-#: ../../src/wxMaxima.cpp:4703 ../../src/wxMaxima.cpp:4840
+#: ../../src/dialogs/ConfigDialogue.cpp:1410
+msgid "Warn if an inactive window is idle"
+msgstr ""
+
+#: ../../src/MathParser.cpp:1343 ../../src/MaximaFileIO.cpp:536
+#: ../../src/MaximaProcessManager.cpp:1100
+#: ../../src/MaximaResponseReader.cpp:361 ../../src/wxMaxima.cpp:1585
 msgid "Warning"
 msgstr "Advarsel"
 
-#: ../../src/wxMaximaFrame.cpp:1556
+#: ../../src/wxMaximaFrame.cpp:1593
 #, fuzzy
 msgid "Warning:"
 msgstr "Advarsel"
 
-#: ../../src/Dirstructure.cpp:72
+#: ../../src/Dirstructure.cpp:73
 #, c-format
 msgid ""
 "Warning: Cannot create %s, the directory maxima keeps configuration, user packages and caches in.\n"
 "Make sure that your system's home directory is set up correctly"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1546
+#: ../../src/cells/GroupCell.cpp:400 ../../src/cells/GroupCell.cpp:406
+msgid "Warning: Lookalike chars: "
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1583
 msgid "Warning: No test if the argument of the log is complex, positive or negative"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:5063
+#: ../../src/dialogs/BinaryNameCtrl.cpp:76
+msgid ""
+"We weren't searching for the location of wxMaxima!\n"
+"\n"
+"Please enter the path to the program again."
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:3603 ../../src/MaximaCommandMenus.cpp:3613
+msgid "WebP (*.webp)|*.webp|"
+msgstr ""
+
+#: ../../src/wxMaxima.cpp:1871
 msgid "Welcome to wxMaxima"
 msgstr "Velkommen til wxMaxima"
 
-#: ../../src/wxMaxima.cpp:8583
+#: ../../src/MaximaCommandMenus.cpp:1601
 msgid "What to do:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1058
+# Det kan vist godt formuleres klarere...
+#: ../../src/dialogs/TipOfTheDay.cpp:134
+msgid "When applying functions with one argument from menus, the default argument is '%'. To apply the function to some other value, select it in the document before executing a menu command."
+msgstr "Når du anvender funksjoner med ett argument fra menyer, er det forhåndsvalgte argumentet '%'. For å bruke funksjonen på en annen verdi, velg verdien i dokumentet før du utfører menykommandoen."
+
+#: ../../src/wxMaximaFrame.cpp:1092
 msgid "When to invoke the lisp compiler's debugger"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7046
+#: ../../src/MaximaCommandMenus.cpp:3918
 msgid "While loop"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1063
+#: ../../src/wxMaximaFrame.cpp:1097
 msgid "While loop..."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:5673
+#: ../../src/dialogs/TipOfTheDay.cpp:243
+msgid "While wxMaxima is programmed mostly in C++, it also uses some Lisp code. You can help to improve wxMaxima, if you have knowledge of Common Lisp."
+msgstr ""
+
+#: ../../src/MaximaFileIO.cpp:780
 msgid "Whole document (*.wxmx)|*.wxmx|The input, readable by load() (maxima > 5.38) (*.wxm)|*.wxm|All Files (*.*)|*"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:210
+#: ../../src/wxMaxima.cpp:309
 msgid "Will try to generate a stack backtrace, if the program ever crashes"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:6920
+#: ../../src/dialogs/ConfigDialogue.cpp:280
+msgid "Worksheet"
+msgstr ""
+
+#: ../../src/MaximaResponseReader.cpp:117
+#, c-format
+msgid "Worksheet export of type \"%s\" is not supported yet."
+msgstr ""
+
+#: ../../src/worksheet/Worksheet.cpp:4911
 msgid "Worksheet got activated"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:6840
+#: ../../src/worksheet/Worksheet.cpp:4843
 msgid "Worksheet got the mouse focus"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:7191 ../../src/Worksheet.cpp:7279
+#: ../../src/sidebars/PerformanceSidebar.cpp:47
+msgid "Worksheet repaints:"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:428
+msgid "Wrap equations exported by the \"copy as LaTeX\" feature between \\[ and \\] as equation markers"
+msgstr ""
+
+#: ../../src/worksheet/Worksheet.cpp:5200
 msgid "Wrapped search"
 msgstr ""
 
-#: ../../src/WXMXformat.cpp:282
+#: ../../src/WXMXformat.cpp:284
 msgid "Wrote all image and gnuplot files to the zip archive"
 msgstr ""
 
-#: ../../src/WXMXformat.cpp:272
+#: ../../src/WXMXformat.cpp:274
 msgid "Wrote the XML representation of the document to the zip archive"
 msgstr ""
 
-#: ../../src/WXMXformat.cpp:116
+#: ../../src/WXMXformat.cpp:117
 msgid "Wrote the mimetype info"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:11147
-#, fuzzy, c-format
+#: ../../src/wizards/DrawWiz.cpp:942 ../../src/wizards/DrawWiz.cpp:949
+#: ../../src/wizards/DrawWiz.cpp:961 ../../src/wizards/DrawWiz.cpp:974
+#: ../../src/wizards/DrawWiz.cpp:977
+msgid "X"
+msgstr ""
+
+#: ../../src/MathParser.cpp:1279
+msgid "XML nesting limit exceeded"
+msgstr ""
+
+#: ../../src/sidebars/GreekSidebar.cpp:191
+msgid "Xi"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:728
+#, fuzzy
+msgid "Yes"
+msgstr "ja"
+
+#: ../../src/dialogs/TipOfTheDay.cpp:64
+msgid "You can access the last output using the variable '%'. You can access the output of previous commands using variables '%on' where n is the number of output."
+msgstr "Du kan bruke siste utdata ved å bruke variabelen '%'. Du kan bruke utdata fra forrige kommandoer ved å bruke variablene '%on', hvor n er utdatanummer."
+
+#: ../../src/dialogs/TipOfTheDay.cpp:118
+msgid "You can evaluate your whole document by using 'Cell->Evaluate All Cells' menu command or the appropriate key shortcut. The cells will be evaluated in the order they appear in the document."
+msgstr "Du kan utføre hele dokumentet ved å bruke 'Celle->Utfør alle celler' fra menyen, eller relevant tastsnarvei. Cellene vil utføres i samme rekkefølge som i dokumentet."
+
+#: ../../src/dialogs/TipOfTheDay.cpp:98
+#, fuzzy
+msgid "You can get help on a Maxima function by selecting or clicking on the function name and pressing F1. wxMaxima will search the help index for the selection or the word under the cursor."
+msgstr "Du kan få hjelp til en Maxima-funksjon ved å velge eller klikke på funksjonnavnet, og trykke F1. wxMaxima vil søke gjennom hjelpefilene etter utvalget eller ordet under pekeren."
+
+#: ../../src/dialogs/TipOfTheDay.cpp:92
+msgid "You can hide output part of cells by clicking in the triangle on the left side of cells. This works on text cells also."
+msgstr "Du kan gjemme utdatadelen av celler ved å klikke i triangelet på den venstre siden av celler. Dette fungerer også på tekstceller."
+
+#: ../../src/dialogs/TipOfTheDay.cpp:81
+#, fuzzy
+msgid "You can insert different types of 'cells' in wxMaxima documents using the 'Cell' menu. Note that only 'input cells' can be evaluated, while others are used for commenting and structuring your calculations."
+msgstr "Du kan sette inn forskjellige typer 'celler' i wxMaxima-dokument ved å bruke 'Celle'-menyen. Merk deg at kun 'inndataceller' kan utføres, mens andre brukes til kommentering og strukturering."
+
+#: ../../src/dialogs/TipOfTheDay.cpp:112
+msgid "You can select multiple cells either with a mouse - click'n'drag from between cells or from a cell bracket on the left - or with a keyboard - hold down Shift while moving the horizontal cursor - and then operate on selection. This comes in handy when you want to delete or evaluate multiple cells."
+msgstr "Du kan velge flere celler enten med en mus — klikk-og-dra fra mellom celler eller fra en celleklamme til venstre — eller med et tastatur — hold inne Shift mens du flytter den horisontale pekeren — og betjen deretter utvalget. Dette er hendig når du vil slette eller utføre flere celler."
+
+#: ../../src/dialogs/TipOfTheDay.cpp:232
 msgid ""
-"You have version %s. The newest version source code is available for is %s.\n"
+"You found a bug in wxMaxima? Please report it at https://github.com/wxMaxima-developers/wxmaxima/issues\n"
+"A mathematical bug is maybe a bug in Maxima (the backend), which can be reported at https://sourceforge.net/p/maxima/bugs/\n"
+"Please check, before, if the bug was not already reported."
+msgstr ""
+
+#: ../../src/dialogs/TipOfTheDay.cpp:238
+msgid "You got an idea for an improvement of wxMaxima? Great! Please submit your idea at https://github.com/wxMaxima-developers/wxmaxima/issues. "
+msgstr ""
+
+#: ../../src/wxMaxima.cpp:3404 ../../src/wxMaxima.cpp:3458
+#, c-format
+msgid ""
+"You have version %s. The newest wxMaxima release is %s.\n"
 "\n"
 "Select OK to visit the wxMaxima webpage."
 msgstr ""
-"Du har versjon %s. Aktuell versjon er %s.\n"
-"\n"
-"Velg OK for å besøke wxMaxima-nettsiden."
 
-#: ../../src/wxMaxima.cpp:11202
+#: ../../src/wxMaxima.cpp:3508
 msgid "Your changes will be lost if you don't save them."
 msgstr "Endringene dine vil gå tapt om du ikke lagrer dem."
 
-#: ../../src/wxMaxima.cpp:11156
+#: ../../src/wxMaxima.cpp:3412 ../../src/wxMaxima.cpp:3466
 msgid "Your version of wxMaxima is up to date."
 msgstr "Du har siste versjon av wxMaxima."
 
-#: ../../src/wxMaximaFrame.cpp:805
+#: ../../src/sidebars/GreekSidebar.cpp:183
+msgid "Zeta"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:842
 #, fuzzy
 msgid "Zoom &In\tCtrl++"
 msgstr "Zoom Inn\tAlt+I"
 
-#: ../../src/wxMaximaFrame.cpp:806
+#: ../../src/wxMaximaFrame.cpp:843
 #, fuzzy
 msgid "Zoom Ou&t\tCtrl+-"
 msgstr "Zoom Ut\tAlt+O"
 
-#: ../../src/wxMaximaFrame.cpp:805
+#: ../../src/wxMaximaFrame.cpp:842
 msgid "Zoom in 10%"
 msgstr "Zoom inn 10%"
 
-#: ../../src/wxMaximaFrame.cpp:806
+#: ../../src/wxMaximaFrame.cpp:843
 msgid "Zoom out 10%"
 msgstr "Zoom ut 10%"
 
-#: ../../src/wxMaxima.cpp:10915 ../../src/wxMaximaFrame.cpp:187
+#: ../../src/wxMaxima.cpp:3204 ../../src/wxMaximaFrame.cpp:201
 msgid "[ unsaved ]"
 msgstr "[ ulagret ]"
 
-#: ../../src/wxMaxima.cpp:10920
+#: ../../src/wxMaxima.cpp:3206
 msgid "[ unsaved* ]"
 msgstr "[ ulagret* ]"
 
-#: ../../src/Worksheet.cpp:5278
-#, c-format
-msgid "_%d.gif\"  alt=\"Animated Diagram\" loading=\"lazy\" style=\"max-width:90%%;\">\n"
+#: ../../src/wizards/DrawWiz.cpp:819 ../../src/wizards/DrawWiz.cpp:825
+msgid "[[x_1,x_2,...],[y_1,y_2,...]]"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:5484
-#, c-format
-msgid "_%d.gif\" alt=\"Animated Diagram\" style=\"max-width:90%%;\" loading=\"lazy\">"
+#: ../../src/wizards/DrawWiz.cpp:814
+msgid "[x_1, x_2,...] or [x_1, x_2,...],[y_1, y_2,...] or matrix([x_1,y_1],[x_2,y_2],...)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1690
+#: ../../src/wizards/ListSortWiz.cpp:46
+msgid "a<b (Maxima default)"
+msgstr ""
+
+#: ../../src/sidebars/GreekSidebar.cpp:151
+msgid "alpha"
+msgstr ""
+
+#: ../../src/sidebars/SymbolsSidebar.cpp:95
+#, fuzzy
+msgid "and"
+msgstr "Utvid"
+
+#: ../../src/wizards/MatWiz.cpp:160
+msgid "antisymmetric"
+msgstr "antisymmetrisk"
+
+#: ../../src/wxMaximaFrame.cpp:1727
 #, fuzzy
 msgid "apply function to each element"
 msgstr "Anvend funksjon på liste"
 
-#: ../../src/wxMaximaFrame.cpp:739
+#: ../../src/wxMaximaFrame.cpp:776
 msgid "as 1D ASCII"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:742
+#: ../../src/wxMaximaFrame.cpp:779
 msgid "as ASCII Art"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:745
+#: ../../src/wxMaximaFrame.cpp:782
 msgid "as ASCII+Unicode Art"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1680
+#: ../../src/wxMaximaFrame.cpp:1717
 msgid "as storage for actual values for variables"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1139
+#: ../../src/sidebars/GreekSidebar.cpp:152
+msgid "beta"
+msgstr ""
+
+#: ../../src/wizards/LimitWiz.cpp:42
+msgid "both sides"
+msgstr "begge sider"
+
+#: ../../src/wxMaximaFrame.cpp:1173
 msgid "char to Ascii code..."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7836
+#: ../../src/sidebars/GreekSidebar.cpp:172
+msgid "chi"
+msgstr ""
+
+#: ../../src/MaximaFileIO.cpp:318
+#, c-format
+msgid "content.xml exceeds the sanity limit of %zu bytes; the file may be corrupt or a decompression bomb."
+msgstr ""
+
+#: ../../src/wizards/Plot2dWiz.cpp:70 ../../src/wizards/Plot2dWiz.cpp:372
+#: ../../src/wizards/Plot3dWiz.cpp:61 ../../src/wizards/Plot3dWiz.cpp:358
+msgid "default"
+msgstr "forhåndsvalgt"
+
+#: ../../src/sidebars/GreekSidebar.cpp:154
+msgid "delta"
+msgstr ""
+
+#: ../../src/wizards/MatWiz.cpp:159
+msgid "diagonal"
+msgstr "diagonalt"
+
+#: ../../src/cells/FracCell.cpp:73
+msgid "diff(): Cannot find the multiplication sign I should hide"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:1017
 msgid "diff(x,t)="
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1064 ../../src/wxMaximaFrame.cpp:1702
+#: ../../src/wxMaximaFrame.cpp:1098 ../../src/wxMaximaFrame.cpp:1739
 msgid "do for each element"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:2027
+#: ../../src/sidebars/SymbolsSidebar.cpp:92
+msgid "empty"
+msgstr ""
+
+#: ../../src/sidebars/GreekSidebar.cpp:155
+#, fuzzy
+msgid "epsilon"
+msgstr "Epsilon:"
+
+#: ../../src/sidebars/SymbolsSidebar.cpp:100
+msgid "equivalent"
+msgstr ""
+
+#: ../../src/sidebars/GreekSidebar.cpp:157
+msgid "eta"
+msgstr ""
+
+#: ../../src/worksheet/WorksheetContextMenu.cpp:799
 msgid "ev() shall evaluate this automatically"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7130
+#: ../../src/sidebars/SymbolsSidebar.cpp:88
+msgid "exists"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:4002
 #, fuzzy
 msgid "expression:"
 msgstr "Uttrykk:"
 
-#: ../../src/Worksheet.cpp:2025
+#: ../../src/worksheet/WorksheetContextMenu.cpp:797
 msgid "f(x) stays f(x) even if the value of f(x) is computable"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7204 ../../src/wxMaxima.cpp:7209
+#: ../../src/dialogs/ConfigDialogue.cpp:467
+msgid ""
+"false=Don't generate subscripts\n"
+"true=Automatically convert underscores to subscript markers if the would-be subscript is a number or a single letter\n"
+"all=_ marks subscripts."
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:4076 ../../src/MaximaCommandMenus.cpp:4081
 #, fuzzy
 msgid "filename:"
 msgstr "Forrige variabel:"
 
-#: ../../src/wxMaximaFrame.cpp:1674
+#: ../../src/wxMaximaFrame.cpp:1711
 #, fuzzy
 msgid "from a list"
 msgstr "Lag liste"
 
-#: ../../src/wxMaximaFrame.cpp:1671
+#: ../../src/wxMaximaFrame.cpp:1708
 msgid "from a rule"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1685
+#: ../../src/wxMaximaFrame.cpp:1722
 #, fuzzy
 msgid "from function arguments"
 msgstr "Funksjonnavn"
 
-#: ../../src/wxMaximaFrame.cpp:1669
+#: ../../src/wxMaximaFrame.cpp:1706
 msgid "from individual elements"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8210 ../../src/wxMaxima.cpp:8553
+#: ../../src/MaximaCommandMenus.cpp:1400 ../../src/MaximaCommandMenus.cpp:1566
 #, fuzzy
 msgid "function"
 msgstr "Funksjon"
 
-#: ../../src/wxMaximaFrame.cpp:747
+#: ../../src/sidebars/GreekSidebar.cpp:153
+msgid "gamma"
+msgstr ""
+
+# generelt?
+#: ../../src/wizards/MatWiz.cpp:159
+msgid "general"
+msgstr "generell"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1630
+msgid "gnuplot: Without command console"
+msgstr ""
+
+#: ../../src/sidebars/SymbolsSidebar.cpp:118
+#, fuzzy
+msgid "greater than or equal"
+msgstr "Underseksjoncelle"
+
+#: ../../src/sidebars/SymbolsSidebar.cpp:87
+#, fuzzy
+msgid "in"
+msgstr "Finn"
+
+#: ../../src/wxMaximaFrame.cpp:784
 msgid "in 2D"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8554
+#: ../../src/wizards/Plot2dWiz.cpp:70 ../../src/wizards/Plot2dWiz.cpp:198
+#: ../../src/wizards/Plot2dWiz.cpp:372 ../../src/wizards/Plot2dWiz.cpp:402
+#: ../../src/wizards/Plot3dWiz.cpp:61 ../../src/wizards/Plot3dWiz.cpp:194
+#: ../../src/wizards/Plot3dWiz.cpp:358 ../../src/wizards/Plot3dWiz.cpp:386
+msgid "inline"
+msgstr "inline"
+
+#: ../../src/sidebars/SymbolsSidebar.cpp:104
+#, fuzzy
+msgid "intersection"
+msgstr "Retning:"
+
+#: ../../src/sidebars/GreekSidebar.cpp:159
+msgid "iota"
+msgstr ""
+
+#: ../../src/sidebars/GreekSidebar.cpp:160
+msgid "kappa"
+msgstr ""
+
+#: ../../src/sidebars/GreekSidebar.cpp:161
+msgid "lambda"
+msgstr ""
+
+#: ../../src/wizards/LimitWiz.cpp:42
+msgid "left"
+msgstr "venstre"
+
+#: ../../src/sidebars/SymbolsSidebar.cpp:117
+#, fuzzy
+msgid "less or equal"
+msgstr "Underseksjoncelle"
+
+#: ../../src/MaximaCommandMenus.cpp:1567
 #, fuzzy
 msgid "list"
 msgstr "Lag liste"
 
-#: ../../src/wxMaximaFrame.cpp:1405
+#: ../../src/wizards/Plot2dWiz.cpp:54 ../../src/wizards/Plot2dWiz.cpp:64
+msgid "logscale"
+msgstr "logscale"
+
+#: ../../src/wizards/DrawWiz.cpp:822
+msgid "matrix([x_1,x_2,...],[y_1,y_2,...])"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1439
 msgid "max(abs(A(i,j))) (complex)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1404
+#: ../../src/wxMaximaFrame.cpp:1438
 msgid "max(abs(A(i,j))) (real)"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8046
+#: ../../src/sidebars/GreekSidebar.cpp:162
+msgid "mu"
+msgstr ""
+
+#: ../../src/sidebars/SymbolsSidebar.cpp:120
+#, fuzzy
+msgid "much greater than"
+msgstr "Underseksjoncelle"
+
+#: ../../src/sidebars/SymbolsSidebar.cpp:119
+msgid "much less than"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:1232
 #, fuzzy
 msgid "m×n Matrix A:"
 msgstr "Matrise:"
 
-#: ../../src/wxMaxima.cpp:7378 ../../src/wxMaxima.cpp:8527
-#: ../../src/wxMaxima.cpp:8533
+#: ../../src/MaximaCommandMenus.cpp:1538 ../../src/MaximaCommandMenus.cpp:1544
+#: ../../src/MaximaCommandMenus.cpp:4250
 #, fuzzy
 msgid "n:"
 msgstr "Finn"
 
-#: ../../src/Worksheet.cpp:2000
+#: ../../src/sidebars/SymbolsSidebar.cpp:112
+msgid "nabla sign"
+msgstr ""
+
+#: ../../src/sidebars/SymbolsSidebar.cpp:98
+msgid "nand"
+msgstr ""
+
+#: ../../src/worksheet/WorksheetContextMenu.cpp:772
 msgid "nary: f(x, f(y,z)) = foo(x,y,z)"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:2024
+#: ../../src/sidebars/SymbolsSidebar.cpp:99
+#, fuzzy
+msgid "nor"
+msgstr "nei"
+
+#: ../../src/sidebars/SymbolsSidebar.cpp:102
+#, fuzzy
+msgid "not"
+msgstr "nei"
+
+#: ../../src/sidebars/SymbolsSidebar.cpp:116
+msgid "not bytewise identical"
+msgstr ""
+
+#: ../../src/sidebars/SymbolsSidebar.cpp:108
+msgid "not subset"
+msgstr ""
+
+#: ../../src/sidebars/SymbolsSidebar.cpp:107
+msgid "not subset or equal"
+msgstr ""
+
+#: ../../src/worksheet/WorksheetContextMenu.cpp:796
 msgid "noun: Not evaluated by default"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1710
+#: ../../src/wxMaximaFrame.cpp:1747
 #, fuzzy
 msgid "nth"
 msgstr "nei"
 
-#: ../../src/Worksheet.cpp:2021
+#: ../../src/sidebars/GreekSidebar.cpp:163
+msgid "nu"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:1233
+msgid "n×1 Matrix b:"
+msgstr ""
+
+#: ../../src/sidebars/GreekSidebar.cpp:174
+msgid "omega"
+msgstr ""
+
+#: ../../src/sidebars/GreekSidebar.cpp:165
+msgid "omicron"
+msgstr ""
+
+#: ../../src/sidebars/SymbolsSidebar.cpp:96
+msgid "or"
+msgstr ""
+
+#: ../../src/worksheet/WorksheetContextMenu.cpp:793
 msgid "outative: f(2*x) = 2*f(x)"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7440 ../../src/wxMaxima.cpp:7445
-#: ../../src/wxMaxima.cpp:7455
+#: ../../src/cells/TextCell.cpp:260
+msgid "part() or the [] operator was used in order to extract the nth element of something that was less than n elements long."
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:4312 ../../src/MaximaCommandMenus.cpp:4317
+#: ../../src/MaximaCommandMenus.cpp:4327
 msgid "part:"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8942
+#: ../../src/sidebars/SymbolsSidebar.cpp:111
+#, fuzzy
+msgid "partial sign"
+msgstr "Delbrøker"
+
+#: ../../src/sidebars/GreekSidebar.cpp:171
+msgid "phi"
+msgstr ""
+
+#: ../../src/sidebars/GreekSidebar.cpp:166
+msgid "pi"
+msgstr ""
+
+#: ../../src/sidebars/SymbolsSidebar.cpp:101
+msgid "plus or minus"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:196
 #, fuzzy
 msgid "point:"
 msgstr "Punkt:"
 
-#: ../../src/wxMaxima.cpp:7740
+#: ../../src/MaximaCommandMenus.cpp:921
 #, fuzzy
 msgid "precision:"
 msgstr "Presisjon"
 
-#: ../../src/wxMaxima.cpp:7255
+#: ../../src/graphical_io/Printout.cpp:95
+#, c-format
+msgid "printOut: Setting the page size to (%li,%li)"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:4127
 #, fuzzy
 msgid "printf"
 msgstr "Skriv ut"
 
-#: ../../src/wxMaximaFrame.cpp:1108
+#: ../../src/wxMaximaFrame.cpp:1142
 #, fuzzy
 msgid "printf..."
 msgstr "Deriver..."
 
-#: ../../src/wxMaxima.cpp:8650
+#: ../../src/sidebars/SymbolsSidebar.cpp:115
+msgid "proportional to"
+msgstr ""
+
+#: ../../src/sidebars/GreekSidebar.cpp:173
+msgid "psi"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:642
 msgid "radcan() is a powerful tools for simplification trigonometric functions but needs to be taken with care: If a function has more than one branch radcan uses the one that looks like it would fit best, not necessarily the one that makes sense for the problem that resulted in the Expression that is to be simplified."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8731
+#: ../../src/MaximaCommandMenus.cpp:726
 msgid "ratsubst works like subst, but it knows some basic maths, if needed."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1111
+#: ../../src/wxMaximaFrame.cpp:1145
 #, fuzzy
 msgid "readbyte..."
 msgstr "Integrer..."
 
-#: ../../src/wxMaximaFrame.cpp:1110
+#: ../../src/wxMaximaFrame.cpp:1144
 #, fuzzy
 msgid "readchar..."
 msgstr "Kakediagram..."
 
-#: ../../src/wxMaximaFrame.cpp:1109
+#: ../../src/wxMaximaFrame.cpp:1143
 #, fuzzy
 msgid "readline..."
 msgstr "Varians..."
 
-#: ../../src/wxMaxima.cpp:10018
+#: ../../src/cells/TextCell.cpp:264
+msgid "rest() tried to drop more entries from a list than the list was long."
+msgstr ""
+
+#: ../../src/sidebars/GreekSidebar.cpp:167
+msgid "rho"
+msgstr ""
+
+#: ../../src/wizards/LimitWiz.cpp:42
+msgid "right"
+msgstr "høyre"
+
+#: ../../src/wizards/DrawWiz.cpp:310
+msgid "secondary x axis label"
+msgstr ""
+
+#: ../../src/wizards/DrawWiz.cpp:315
+msgid "secondary x range (automatic if incomplete)"
+msgstr ""
+
+#: ../../src/wizards/DrawWiz.cpp:325
+msgid "secondary y axis label"
+msgstr ""
+
+#: ../../src/wizards/DrawWiz.cpp:330
+msgid "secondary y range (automatic if incomplete)"
+msgstr ""
+
+#: ../../src/sidebars/GreekSidebar.cpp:168
+msgid "sigma"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:3507
 msgid ""
 "solve() will solve a list of equations only if for n independent equations there are n variables to solve to.\n"
 "If only one result variable is of interest the other result variables can be used to to tell solve() which variables to eliminate from the solution\n"
 "solve() searches for a global solution. If a problem has different solutions depending on the range its variables are in one way to successfully use solve() is to use solve() to eliminate variables one by one and to manually choose which of the solutions solve() found matches the current problem."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7745
+#: ../../src/MaximaCommandMenus.cpp:926
 msgid ""
 "solve() will solve a list of equations only if for n independent equations there are n variables to solve to.\n"
 "If only one result variable is of interest the other result variables solve needs to do its work can be used to tell solve() which variables to eliminate in the solution for the interesting variable."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7784
+#: ../../src/MaximaCommandMenus.cpp:965
 msgid ""
 "solves an equation of the form\n"
 "    'diff(y,t) = -y;"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7789
+#: ../../src/sidebars/SymbolsSidebar.cpp:81
+msgid "sqrt (needs parenthesis for its argument to work as a Maxima command)"
+msgstr ""
+
+#: ../../src/sidebars/SymbolsSidebar.cpp:106
+#, fuzzy
+msgid "subset"
+msgstr "Underseksjon"
+
+#: ../../src/sidebars/SymbolsSidebar.cpp:105
+#, fuzzy
+msgid "subset or equal"
+msgstr "Underseksjoncelle"
+
+#: ../../src/wizards/MatWiz.cpp:160
+msgid "symmetric"
+msgstr "symmetrisk"
+
+#: ../../src/MaximaCommandMenus.cpp:970
 msgid "t:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1075
+#: ../../src/sidebars/GreekSidebar.cpp:169
+msgid "tau"
+msgstr ""
+
+#: ../../src/cells/TextCell.cpp:340
+msgid ""
+"the [] operator tried to extract an element of a list, a matrix, an equation or an array. But instead of an integer number something was used whose numerical value is unknown or not an integer.\n"
+"Floating-point numbers are bound to contain small rounding errors and therefore in most cases don't work as an array index thatneeds to be an exact integer number."
+msgstr ""
+
+#: ../../src/wizards/DrawWiz.cpp:725
+#, fuzzy
+msgid "the x and the y coordinate."
+msgstr "Kommaseparerte y-koordinater"
+
+#: ../../src/wizards/DrawWiz.cpp:729
+msgid "the x, the y and the z coordinate."
+msgstr ""
+
+#: ../../src/sidebars/SymbolsSidebar.cpp:89
+msgid "there is no"
+msgstr ""
+
+#: ../../src/sidebars/GreekSidebar.cpp:158
+msgid "theta"
+msgstr ""
+
+#: ../../src/sidebars/SymbolsSidebar.cpp:78
+msgid "to the power of 2"
+msgstr ""
+
+#: ../../src/sidebars/SymbolsSidebar.cpp:79
+msgid "to the power of 3"
+msgstr ""
+
+#: ../../src/sidebars/SymbolsSidebar.cpp:103
+msgid "union"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1109
 msgid "unnamed function (lambda)..."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:11190
+#: ../../src/wxMaxima.cpp:3496
 msgid "unsaved"
 msgstr "ulagret"
 
-#: ../../src/wxMaxima.cpp:5667 ../../src/wxMaxima.cpp:6114
-#: ../../src/wxMaximaFrame.cpp:189
+#: ../../src/MaximaCommandMenus.cpp:2270 ../../src/MaximaFileIO.cpp:774
+#: ../../src/wxMaximaFrame.cpp:203
 msgid "untitled"
 msgstr "navnløs"
 
-#: ../../src/wxMaximaFrame.cpp:1700
+#: ../../src/sidebars/GreekSidebar.cpp:170
+#, fuzzy
+msgid "upsilon"
+msgstr "Epsilon:"
+
+#: ../../src/wxMaximaFrame.cpp:1737
 #, fuzzy
 msgid "use as function arguments"
 msgstr "Funksjonnavn"
 
-#: ../../src/wxMaximaFrame.cpp:1696
+#: ../../src/wxMaximaFrame.cpp:1733
 msgid "use the actual values stored"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1112
+#: ../../src/dialogs/ConfigDialogue.cpp:1633
+msgid "wgnuplot: Steals the mouse focus during plotting"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1146
 msgid "writebyte..."
 msgstr ""
 
-#: ../../src/main.cpp:509
+#: ../../src/dialogs/AboutDialog.cpp:64 ../../src/main.cpp:796
 msgid "wxMaxima"
 msgstr ""
 
-#: ../../src/main.cpp:516
+#: ../../src/main.cpp:805
 #, fuzzy, c-format
 msgid "wxMaxima %ld"
 msgstr "wxMaxima %s "
 
-#: ../../src/wxMaxima.cpp:10913 ../../src/wxMaxima.cpp:10918
-#: ../../src/wxMaxima.cpp:10929 ../../src/wxMaxima.cpp:10934
-#: ../../src/wxMaximaFrame.cpp:185
+#: ../../src/wxMaxima.cpp:3193 ../../src/wxMaximaFrame.cpp:199
 #, fuzzy, c-format
 msgid "wxMaxima %s (%s) "
 msgstr "wxMaxima %s "
 
-#: ../../src/wxMaxima.cpp:4490
+#: ../../src/dialogs/DiffFrame.cpp:352
+msgid "wxMaxima Diff Viewer"
+msgstr ""
+
+#: ../../src/dialogs/TipOfTheDay.cpp:159
+msgid "wxMaxima can be made to execute commands at every start-up by placing them in a text file with the name wxmaxima.rc in the user directory. This directory can be found by typing maxima_userdir;"
+msgstr ""
+
+#: ../../src/MaximaFileIO.cpp:398
 msgid "wxMaxima cannot read the xml contents of "
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2546
+#: ../../src/dialogs/ConfigDialogue.cpp:142
+#: ../../src/dialogs/ConfigDialogue.cpp:311
+msgid "wxMaxima configuration"
+msgstr "wxMaxima-konfigurasjon"
+
+#: ../../src/MaximaProcessManager.cpp:211
 msgid ""
 "wxMaxima could not start a server.\n"
 "\n"
@@ -8395,82 +12739,202 @@ msgid ""
 "enabled, that no internet safety appliance is configured to intercept creation of servers even if said server only accepts connections from local application (maxima insists on the graphical frontend acting as a server it can connect on over a local socket) and try again!"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:5285
+#: ../../src/dialogs/TipOfTheDay.cpp:127
+msgid "wxMaxima dialogs set default values for inputs entries, one of which is '%'. If you have made a selection in your document, the selection will be used instead of '%'."
+msgstr "wxMaxima-dialoger setter forhåndsvalgte verdier for inndatafelt, hvorav en er '%'. Om du har gjordt et utvalg i dokumentet ditt, vil utvalget bli brukt i stedet for '%'."
+
+#: ../../src/MaximaCommandMenus.cpp:4604
 msgid "wxMaxima document"
 msgstr "wxMaxima-dokument"
 
-#: ../../src/wxMaxima.cpp:4162 ../../src/wxMaxima.cpp:4221
-#: ../../src/wxMaxima.cpp:4230
+#: ../../src/MaximaCommandMenus.cpp:2241
+msgid "wxMaxima document (*.wxm, *.wxmx)|*.wxm;*.wxmx"
+msgstr "wxMaxima-dokument (*.wxm, *.wxmx)|*.wxm;*.wxmx"
+
+#: ../../src/MaximaFileIO.cpp:63 ../../src/MaximaFileIO.cpp:120
+#: ../../src/MaximaFileIO.cpp:129
 msgid "wxMaxima encountered an error loading "
 msgstr "wxMaxima støtte på et problem under lasting"
 
-#: ../../src/wxMaximaFrame.cpp:1881
+#: ../../src/wxMaximaFrame.cpp:1918
 msgid "wxMaxima help"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1465 ../../src/Worksheet.cpp:1839
+#: ../../src/dialogs/AboutDialog.cpp:41
+#, fuzzy
+msgid "wxMaxima is a cross-platform graphical user interface for the computer algebra system Maxima based on wxWidgets.\n"
+msgstr "wxMaxima er et grafisk brukergrensesnitt til Computer Algebra System-et Maxima basert på wxWidgets."
+
+#: ../../src/wxMaxima.cpp:2854
+#, c-format
+msgid ""
+"wxMaxima is now the .wxmx diff tool for:%s\n"
+"\n"
+"Open a .wxmx file's \"Diff\" in TortoiseSVN/TortoiseGit to compare it side by side."
+msgstr ""
+
+#: ../../src/dialogs/TipOfTheDay.cpp:240
+msgid "wxMaxima is programmed in C++ using the wxWidgets toolkit and uses CMake as build system. You can contribute to wxMaxima, if you have some knowledge with this environment."
+msgstr ""
+
+#: ../../src/dialogs/TipOfTheDay.cpp:228
+msgid "wxMaxima needs more developers. It is an open source project where you can contribute. Join the wxMaxima development at: https://github.com/wxMaxima-developers/wxmaxima"
+msgstr ""
+
+#: ../../src/dialogs/TipOfTheDay.cpp:224
+msgid "wxMaxima needs more translators. We do not speak every language. Help us to translate wxMaxima and the manual to your language. Join the wxMaxima development at: https://github.com/wxMaxima-developers/wxmaxima"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:407
+msgid "wxMaxima normally stores the gnuplot sources for every plot made using draw() in order to be able to open plots interactively in gnuplot later. This setting defines the limit [in Megabytes per plot] for this feature."
+msgstr ""
+
+#: ../../src/dialogs/TipOfTheDay.cpp:172
+msgid ""
+"wxMaxima provides the \"table_form\" command that shows lists in an alternative form. One example would be:\n"
+"\n"
+"table_form([1,2,3,4,5]);"
+msgstr ""
+
+#: ../../src/worksheet/WorksheetContextMenu.cpp:236
+#: ../../src/worksheet/WorksheetContextMenu.cpp:611
 msgid "wxMaxima remembers answers from the last run and is able to automatically send them to maxima, if requested"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1470 ../../src/Worksheet.cpp:1844
+#: ../../src/worksheet/WorksheetContextMenu.cpp:241
+#: ../../src/worksheet/WorksheetContextMenu.cpp:616
 msgid "wxMaxima remembers answers from the last run and is able to offer them as the default answer"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1896
+#: ../../src/dialogs/ConfigDialogue.cpp:481
+msgid "wxMaxima remembers the answers to maxima's questions. If this checkbox is set it automatically offers to enter the last answer to this question the user has input."
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1933
 #, fuzzy
 msgid "wxMaxima shows help in a browser"
 msgstr "Fant ikke fil"
 
-#: ../../src/wxMaximaFrame.cpp:1894
+#: ../../src/wxMaximaFrame.cpp:1931
 #, fuzzy
 msgid "wxMaxima shows help in the sidebar"
 msgstr "Fant ikke fil"
 
-#: ../../src/wxMaximaFrame.cpp:111
+#: ../../src/dialogs/ConfigDialogue.cpp:1095
+#, fuzzy
+msgid "wxMaxima startup file location: "
+msgstr "Start Animasjon"
+
+#: ../../src/wxMaximaFrame.cpp:119
 #, c-format
 msgid "wxMaxima version %s"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1954
+#: ../../src/worksheet/Worksheet.cpp:6164
+msgid "wxMaxima worksheet"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1997
 #, fuzzy
 msgid "wxMaxima's ChangeLog"
 msgstr "wxMaxima-ikon"
 
-#: ../../src/wxMaximaFrame.cpp:1952
+#: ../../src/wxMaximaFrame.cpp:1995
 msgid "wxMaxima's license"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:144
+#: ../../src/wxMaximaFrame.cpp:152
 msgid "wxWidgets is using GTK 2"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:142
+#: ../../src/wxMaximaFrame.cpp:150
 msgid "wxWidgets is using GTK 3"
 msgstr ""
 
-#: ../../src/WXMXformat.cpp:367
+#: ../../src/WXMXformat.cpp:369
 msgid "wxmx file saved"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8375
+#: ../../src/MaximaResponseReader.cpp:104
+msgid "wxworksheettohtml/totex: no target file name was given."
+msgstr ""
+
+#: ../../src/wxMaxima.cpp:2204
+#, c-format
+msgid "wxworksheettohtml: could not write \"%s\"."
+msgstr ""
+
+#: ../../src/wxMaxima.cpp:2178
+#, c-format
+msgid "wxworksheettohtml: unknown flavor \"%s\"; using native MathML. Known flavors: mathml, mathjax, svg, bitmap."
+msgstr ""
+
+#: ../../src/wxMaxima.cpp:2246
+#, c-format
+msgid "wxworksheettotex: could not write \"%s\"."
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:709
+msgid "x"
+msgstr ""
+
+#: ../../src/wizards/DrawWiz.cpp:266
+msgid "x axis label"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:2021
 msgid "x direction [in multiples of the tick frequency]"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:4500 ../../src/wxMaxima.cpp:4643
+#: ../../src/wizards/DrawWiz.cpp:269
+msgid "x range (automatic if incomplete)"
+msgstr ""
+
+#: ../../src/sidebars/GreekSidebar.cpp:164
+msgid "xi"
+msgstr ""
+
+#: ../../src/MaximaFileIO.cpp:408 ../../src/MaximaFileIO.cpp:566
 msgid "xml contained in the file claims not to be a wxMaxima worksheet. "
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8376
+#: ../../src/sidebars/SymbolsSidebar.cpp:97
+#, fuzzy
+msgid "xor"
+msgstr "Eksporter"
+
+#: ../../src/wizards/DrawWiz.cpp:279
+msgid "y axis label"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:2022
 msgid "y direction [in multiples of the tick frequency]"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7789
+#: ../../src/wizards/DrawWiz.cpp:282
+msgid "y range (automatic if incomplete)"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:970
 msgid "y:"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:2
-msgid "# The wxMaxima user manual"
+#: ../../src/wizards/DrawWiz.cpp:294
+msgid "z axis label"
+msgstr ""
+
+#: ../../src/wizards/DrawWiz.cpp:298
+msgid "z range (automatic if incomplete)"
+msgstr ""
+
+#: ../../src/sidebars/GreekSidebar.cpp:156
+msgid "zeta"
+msgstr ""
+
+#. type: Title #
+#: ../../info/wxmaxima.md:1
+#, no-wrap
+msgid "The wxMaxima user manual"
 msgstr ""
 
 #. type: Plain text
@@ -8483,24 +12947,16 @@ msgstr ""
 msgid "![wxMaxima logo](./wxMaximaLogo.png){ id=img_wxMaximaLogo }"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:7 ../../info/wxmaxima.md:425
-#: ../../info/wxmaxima.md:880 ../../info/wxmaxima.md:1090
-#: ../../info/wxmaxima.md:1137 ../../info/wxmaxima.md:1161
+#. type: Title #
+#: ../../info/wxmaxima.md:9
 #, no-wrap
-msgid "______________________________________________________________________\n"
+msgid "Introduction to wxMaxima"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:10
-#, fuzzy
-#| msgid "Welcome to wxMaxima"
-msgid "# Introduction to wxMaxima"
-msgstr "Velkommen til wxMaxima"
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:12
-msgid "## _Maxima_ and wxMaxima"
+#. type: Title ##
+#: ../../info/wxmaxima.md:11
+#, no-wrap
+msgid "_Maxima_ and wxMaxima"
 msgstr ""
 
 #. type: Plain text
@@ -8513,12 +12969,11 @@ msgstr ""
 msgid "A computer algebra system (CAS) like _Maxima_ fits into this framework. A CAS can provide the logic behind an arbitrary precision calculator application or it can do automatic transforms of formulas in the background of a bigger system (e.g., [Sage](https://www.sagemath.org/)). Alternatively, it can be used directly as a free-standing system. _Maxima_ can be accessed via a command line. Often, however, an interface like _wxMaxima_ proves a more efficient way to access the software, especially for newcomers."
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:18
-#, fuzzy
-#| msgid "&Maxima"
-msgid "### _Maxima_"
-msgstr "&Maxima"
+#. type: Title ###
+#: ../../info/wxmaxima.md:17
+#, no-wrap
+msgid "_Maxima_"
+msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:20
@@ -8532,15 +12987,15 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:24
-msgid "Extensive documentation for _Maxima_ is [available in the internet](https://maxima.sourceforge.io/documentation.html). Part of this documentation is also available in wxMaxima’s help menu. Pressing the Help key (on most systems the <kbd>F1</kbd> key) causes _wxMaxima_’s context-sensitive help feature to automatically jump to _Maxima_’s manual page for the command at the cursor."
+#, no-wrap
+msgid "Extensive documentation for _Maxima_ is  [available in the internet](https://maxima.sourceforge.io/documentation.html). Part of this documentation is also available in wxMaxima’s help menu. Pressing the Help key (on most systems the <kbd>F1</kbd> key) causes _wxMaxima_’s context-sensitive help feature to automatically jump to _Maxima_’s manual page for the command at the cursor.\n"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:26
-#, fuzzy
-#| msgid "&Maxima"
-msgid "### WxMaxima"
-msgstr "&Maxima"
+#. type: Title ###
+#: ../../info/wxmaxima.md:25
+#, no-wrap
+msgid "WxMaxima"
+msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:28
@@ -8557,9 +13012,10 @@ msgstr ""
 msgid "The calculations that are entered in _wxMaxima_ are performed by the _Maxima_ command-line tool in the background."
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:34
-msgid "## Workbook basics"
+#. type: Title ##
+#: ../../info/wxmaxima.md:33
+#, no-wrap
+msgid "Workbook basics"
 msgstr ""
 
 #. type: Plain text
@@ -8567,9 +13023,10 @@ msgstr ""
 msgid "Much of _wxMaxima_ is self-explaining, but some details require attention. [This site](https://wxMaxima-developers.github.io/wxmaxima/help.html) contains a number of workbooks that address various aspects of _wxMaxima_. Working through some of these (particularly the \"10 minute _(wx)Maxima_ tutorial\") will increase one’s familiarity with both the content of _Maxima_ and the use of _wxMaxima_ to interact with _Maxima_. This manual concentrates on describing aspects of _wxMaxima_ that are not likely to be self-evident and that might not be covered in the online material."
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:38
-msgid "### The workbook approach"
+#. type: Title ###
+#: ../../info/wxmaxima.md:37
+#, no-wrap
+msgid "The workbook approach"
 msgstr ""
 
 #. type: Plain text
@@ -8607,12 +13064,11 @@ msgstr ""
 msgid "![Example of different wxMaxima cells](./cell-example.png){ id=img_cell-example }"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:54
-#, fuzzy
-#| msgid "Merge Cells"
-msgid "### Cells"
-msgstr "Slå Sammen Celler"
+#. type: Title ###
+#: ../../info/wxmaxima.md:53
+#, no-wrap
+msgid "Cells"
+msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:56
@@ -8668,9 +13124,10 @@ msgstr ""
 msgid "\"`/*`\" marks the start of the comment, \"`*/`\" the end."
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:71
-msgid "### Horizontal and vertical cursors"
+#. type: Title ###
+#: ../../info/wxmaxima.md:70
+#, no-wrap
+msgid "Horizontal and vertical cursors"
 msgstr ""
 
 #. type: Plain text
@@ -8695,7 +13152,8 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:80
-msgid "When you start wxMaxima, you will only see the blinking horizontal cursor. If you start typing, a math cell will be automatically created and the cursor will change to a regular vertical one (you will see a right arrow as \"prompt\", after the Math cell is evaluated (<kbd>CTRL</kbd>+<kbd>ENTER</kbd>), you will see the labels, e.g. `(%i1)`, `(%o1)`)."
+#, no-wrap
+msgid "When you start wxMaxima, you will only see the blinking horizontal cursor. If you start typing, a math cell will be automatically created and the cursor will change to a regular vertical one (you will see a right arrow as \"prompt\", after the Math cell is evaluated (<kbd>CTRL</kbd>+<kbd>ENTER</kbd>), you will see the labels, e.g. `(%i1)`, `(%o1)`).\n"
 msgstr ""
 
 #. type: Plain text
@@ -8718,24 +13176,28 @@ msgstr ""
 msgid "![(blinking) horizontal cursor between cells](./horizontal-cursor-between-cells.png){ id=img_horizontal_cursor_between_cells }"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:90
-msgid "### Sending cells to Maxima"
+#. type: Title ###
+#: ../../info/wxmaxima.md:89
+#, no-wrap
+msgid "Sending cells to Maxima"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:92
-msgid "The command in a code cell is executed once by pressing <kbd>CTRL</kbd>+<kbd>ENTER</kbd>, <kbd>SHIFT</kbd>+<kbd>ENTER</kbd> or the <kbd>ENTER</kbd> key on the keypad. The _wxMaxima_ default is to enter commands when either <kbd>CTRL</kbd>+<kbd>ENTER</kbd> or <kbd>SHIFT</kbd>+<kbd>ENTER</kbd> is entered, but _wxMaxima_ can be configured to execute commands in response to <kbd>ENTER</kbd>."
+#, no-wrap
+msgid "The command in a code cell is executed once by pressing <kbd>CTRL</kbd>+<kbd>ENTER</kbd>, <kbd>SHIFT</kbd>+<kbd>ENTER</kbd> or the <kbd>ENTER</kbd> key on the keypad. The _wxMaxima_ default is to enter commands when either <kbd>CTRL</kbd>+<kbd>ENTER</kbd> or <kbd>SHIFT</kbd>+<kbd>ENTER</kbd> is entered, but _wxMaxima_ can be configured to execute commands in response to <kbd>ENTER</kbd>.\n"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:94
-msgid "### Command autocompletion"
+#. type: Title ###
+#: ../../info/wxmaxima.md:93
+#, no-wrap
+msgid "Command autocompletion"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:96
-msgid "_WxMaxima_ contains an autocompletion feature that is triggered via the menu (Cell/Complete Word) or alternatively by pressing the key combination <kbd>CTRL</kbd>+<kbd>SPACE</kbd>. The autocompletion is context-sensitive. For example, if activated within a unit specification for ezUnits it will offer a list of applicable units."
+#, no-wrap
+msgid "_WxMaxima_ contains an autocompletion feature that is triggered via the menu (Cell/Complete Word) or alternatively by pressing the key combination <kbd>CTRL</kbd>+<kbd>SPACE</kbd>. The autocompletion is context-sensitive. For example, if activated within a unit specification for ezUnits it will offer a list of applicable units.\n"
 msgstr ""
 
 #. type: Plain text
@@ -8745,14 +13207,15 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:100
-msgid "Besides completing a file name, a unit name, or the current command or variable name, the autocompletion is able to show a template for most of the commands indicating the type (and meaning) of the parameters this program expects. To activate this feature press <kbd>SHIFT</kbd>+<kbd>CTRL</kbd>+<kbd>SPACE</kbd> or select the respective menu item (Cell/Show Template)."
+#, no-wrap
+msgid "Besides completing a file name, a unit name, or the current command or variable name, the autocompletion is able to show a template for most of the commands indicating the type (and meaning) of the parameters this program expects. To activate this feature press <kbd>SHIFT</kbd>+<kbd>CTRL</kbd>+<kbd>SPACE</kbd> or select the respective menu item (Cell/Show Template).\n"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:102
-#, fuzzy
-msgid "#### Greek characters"
-msgstr "Greske konstanter"
+#. type: Title ####
+#: ../../info/wxmaxima.md:101
+#, no-wrap
+msgid "Greek characters"
+msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:104
@@ -8808,9 +13271,10 @@ msgstr ""
 msgid "You can also use the \"Greek letters\"-sidebar to enter the Greek letters."
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:134
-msgid "##### Attention: Lookalike characters"
+#. type: Title #####
+#: ../../info/wxmaxima.md:133
+#, no-wrap
+msgid "Attention: Lookalike characters"
 msgstr ""
 
 #. type: Plain text
@@ -8896,12 +13360,14 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:203
-msgid "If a special symbol isn’t in the list, it is possible to input arbitrary Unicode characters by pressing <kbd>ESC</kbd> \\[number of the character (hexadecimal)\\] <kbd>ESC</kbd>. Additionally the \"symbols\" sidebar has a right-click menu that allow to display a list of all available Unicode symbols one can add to this toolbar or to the worksheet."
+#, no-wrap
+msgid "If a special symbol isn’t in the list, it is possible to input arbitrary Unicode characters by pressing <kbd>ESC</kbd> \\[number of the character (hexadecimal)\\] <kbd>ESC</kbd>. Additionally the \"symbols\" sidebar has a right-click menu that allow to display a list of all available Unicode symbols one can add to this toolbar or to the worksheet.\n"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:205
-msgid "<kbd>ESC</kbd><kbd>6</kbd><kbd>1</kbd><kbd>ESC</kbd> therefore results in an `a`."
+#, no-wrap
+msgid "<kbd>ESC</kbd><kbd>6</kbd><kbd>1</kbd><kbd>ESC</kbd> therefore results in an `a`.\n"
 msgstr ""
 
 #. type: Plain text
@@ -8911,12 +13377,16 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:210
-msgid "It may be the case that e.g. Greek characters or mathematical symbols are not included in the selected font, then they can not be displayed.  To solve that problem, select other fonts (using: Edit -> Configure -> Style)."
+#, no-wrap
+msgid ""
+"It may be the case that e.g. Greek characters or mathematical symbols are not included in the selected font, then they can not be displayed.\n"
+"To solve that problem, select other fonts (using: Edit -> Configure -> Style).\n"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:212
-msgid "### Unicode replacement"
+#. type: Title ###
+#: ../../info/wxmaxima.md:211
+#, no-wrap
+msgid "Unicode replacement"
 msgstr ""
 
 #. type: Plain text
@@ -8939,9 +13409,10 @@ msgstr ""
 msgid "It is recommended to use **Maxima code** (not these Unicode code points) in input cells (Rationale: (a) it might be possible, that the used font for math input does not contain them; (b) if you save the document as `wxm`-file, it is usually readable by (command line) Maxima, but these changes will of course not work in command line Maxima); but they may occur, if you cut&paste a formula from another document."
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:223
-msgid "### Side Panes"
+#. type: Title ###
+#: ../../info/wxmaxima.md:222
+#, no-wrap
+msgid "Side Panes"
 msgstr ""
 
 #. type: Plain text
@@ -8964,9 +13435,10 @@ msgstr ""
 msgid "![Increase or decrease headings in the TOC side pane](./Sidepane-TOC-convert-headings.png){ id=Sidepane-TOC-convert-headings }"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:234
-msgid "### MathML output"
+#. type: Title ###
+#: ../../info/wxmaxima.md:233
+#, no-wrap
+msgid "MathML output"
 msgstr ""
 
 #. type: Plain text
@@ -8974,9 +13446,10 @@ msgstr ""
 msgid "Several word processors and similar programs either recognize [MathML](https://www.w3.org/Math/) input and automatically insert it as an editable 2D equation - or (like LibreOffice) have an equation editor that offers an “import MathML from clipboard” feature. Others support RTF maths. _WxMaxima_, therefore, offers several entries in the right-click menu."
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:238
-msgid "### Markdown support"
+#. type: Title ###
+#: ../../info/wxmaxima.md:237
+#, no-wrap
+msgid "Markdown support"
 msgstr ""
 
 #. type: Plain text
@@ -8984,11 +13457,10 @@ msgstr ""
 msgid "_WxMaxima_ offers a set of standard [Markdown](https://en.wikipedia.org/wiki/Markdown) conventions that don’t collide with mathematical notation. One of these elements is bullet lists."
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:250
+#. type: Fenced code block (text)
+#: ../../info/wxmaxima.md:241
 #, no-wrap
 msgid ""
-"```text\n"
 "Ordinary text\n"
 " * One item, indentation level 1\n"
 " * Another item at indentation level 1\n"
@@ -8996,37 +13468,47 @@ msgid ""
 "   * A second item at the second indentation level\n"
 " * A third item at the first indentation level\n"
 "Ordinary text\n"
-"```\n"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:252
-msgid "_WxMaxima_ will recognize text starting with `>` chars as block quotes:"
+#, no-wrap
+msgid "_WxMaxima_ will recognize text starting with `>` chars as block quotes:\n"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:260
-msgid "```text Ordinary text > quote quote quote quote > quote quote quote quote > quote quote quote quote Ordinary text ```"
+#. type: Fenced code block (text)
+#: ../../info/wxmaxima.md:253
+#, no-wrap
+msgid ""
+"Ordinary text\n"
+"> quote quote quote quote\n"
+"> quote quote quote quote\n"
+"> quote quote quote quote\n"
+"Ordinary text\n"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:262
-msgid "_WxMaxima_’s TeX and HTML output will also recognize `=>` and replace it by the corresponding Unicode sign:"
+#, no-wrap
+msgid "_WxMaxima_’s TeX and HTML output will also recognize `=>` and replace it by the corresponding Unicode sign:\n"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:266
-msgid "```text cogito => sum.  ```"
+#. type: Fenced code block (text)
+#: ../../info/wxmaxima.md:263
+#, no-wrap
+msgid "cogito => sum.\n"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:268
-msgid "Other symbols the HTML and TeX export will recognize are `<=` and `>=` for comparisons, a double-pointed double arrow (`<=>`), single-headed arrows (`<->`, `->` and `<-`) and `+/-` as the respective sign. For TeX output also `<<` and `>>` are recognized."
+#, no-wrap
+msgid "Other symbols the HTML and TeX export will recognize are `<=` and `>=` for comparisons, a double-pointed double arrow (`<=>`), single-headed arrows (`<->`, `->` and `<-`) and `+/-` as the respective sign. For TeX output also `<<` and `>>` are recognized.\n"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:270
-msgid "### Hotkeys"
+#. type: Title ###
+#: ../../info/wxmaxima.md:269
+#, no-wrap
+msgid "Hotkeys"
 msgstr ""
 
 #. type: Plain text
@@ -9049,9 +13531,10 @@ msgstr ""
 msgid "<kbd>SHIFT</kbd>+<kbd>SPACE</kbd> inserts a non-breaking space."
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:278
-msgid "### Raw TeX in the TeX export"
+#. type: Title ###
+#: ../../info/wxmaxima.md:277
+#, no-wrap
+msgid "Raw TeX in the TeX export"
 msgstr ""
 
 #. type: Plain text
@@ -9059,20 +13542,21 @@ msgstr ""
 msgid "If a text cell begins with `TeX:` the TeX export contains the literal text that follows the `TeX:` marker. Using this feature allows the entry of TeX markup within the _wxMaxima_ workbook."
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:282
-#, fuzzy
-msgid "## File Formats"
-msgstr "Fant ikke fil"
+#. type: Title ##
+#: ../../info/wxmaxima.md:281
+#, no-wrap
+msgid "File Formats"
+msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:284
 msgid "The material that is developed in a _wxMaxima_ session can be stored for later use in any of three ways:"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:286
-msgid "### .mac"
+#. type: Title ###
+#: ../../info/wxmaxima.md:285
+#, no-wrap
+msgid ".mac"
 msgstr ""
 
 #. type: Plain text
@@ -9100,14 +13584,18 @@ msgstr ""
 msgid "You can be use `.mac` files for writing your own library of macros. But since they don’t contain enough structural information they cannot be read back as a _wxMaxima_ session."
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:299
-msgid "### .wxm"
+#. type: Title ###
+#: ../../info/wxmaxima.md:298
+#, no-wrap
+msgid ".wxm"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:302
-msgid "`.wxm` files contain the worksheet except for _Maxima_’s output. On Maxima versions >5.38 they can be read using _Maxima_’s `load()` function just as .mac files. Well - mostly. Questions (like `asksign(x)`) are problematic, as the answer is written in the `.wxm` file (so that it can be suggested after loading), but that can Maxima not evaluate.  You can prevent Maxima from asking questions by using `assume()` to declare some properties, Maxima wants to know."
+#, no-wrap
+msgid ""
+"`.wxm` files contain the worksheet except for _Maxima_’s output. On Maxima versions >5.38 they can be read using _Maxima_’s `load()` function just as .mac files. Well - mostly. Questions (like `asksign(x)`) are problematic, as the answer is written in the `.wxm` file (so that it can be suggested after loading), but that can Maxima not evaluate.\n"
+"You can prevent Maxima from asking questions by using `assume()` to declare some properties, Maxima wants to know.\n"
 msgstr ""
 
 #. type: Plain text
@@ -9115,9 +13603,10 @@ msgstr ""
 msgid "With this plain-text format, it sometimes is unavoidable that worksheets that use new features are not downwards-compatible with older versions of _wxMaxima_."
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:306
-msgid "#### File format of wxm files"
+#. type: Title ####
+#: ../../info/wxmaxima.md:305
+#, no-wrap
+msgid "File format of wxm files"
 msgstr ""
 
 #. type: Plain text
@@ -9130,9 +13619,12 @@ msgstr ""
 msgid "It starts with the following comment:"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:315
-msgid "```maxima /* [wxMaxima batch file version 1] [ DO NOT EDIT BY HAND! ]*/ /* [ Created with wxMaxima version 24.02.2_DevelopmentSnapshot ] */ ```"
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:311
+#, no-wrap
+msgid ""
+"/* [wxMaxima batch file version 1] [ DO NOT EDIT BY HAND! ]*/\n"
+"/* [ Created with wxMaxima version 24.02.2_DevelopmentSnapshot ] */\n"
 msgstr ""
 
 #. type: Plain text
@@ -9140,15 +13632,13 @@ msgstr ""
 msgid "And then the cells follow, encoded as Maxima comments, e.g. a section cell:"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:323
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:318
 #, no-wrap
 msgid ""
-"```maxima\n"
 "/* [wxMaxima: section start ]\n"
 "Title of the section\n"
 "   [wxMaxima: section end   ] */\n"
-"```\n"
 msgstr ""
 
 #. type: Plain text
@@ -9156,16 +13646,14 @@ msgstr ""
 msgid "or (in a Math cell the input is of course *not* commented out (the output is not saved in a `wxm` file)):"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:332
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:326
 #, no-wrap
 msgid ""
-"```maxima\n"
 "/* [wxMaxima: input   start ] */\n"
 "f(x):=x^2+1$\n"
 "f(2);\n"
 "/* [wxMaxima: input   end   ] */\n"
-"```\n"
 msgstr ""
 
 #. type: Plain text
@@ -9173,16 +13661,14 @@ msgstr ""
 msgid "Images are [Base64 encoded](https://en.wikipedia.org/wiki/Base64) with the image type as first line):"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:341
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:335
 #, no-wrap
 msgid ""
-"```maxima\n"
 "/* [wxMaxima: image   start ]\n"
 "jpg\n"
 "[very chaotic looking character sequence]\n"
 "   [wxMaxima: image   end   ] */\n"
-"```\n"
 msgstr ""
 
 #. type: Plain text
@@ -9190,13 +13676,10 @@ msgstr ""
 msgid "A page break is just one line containing:"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:347
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:344
 #, no-wrap
-msgid ""
-"```maxima\n"
-"/* [wxMaxima: page break    ] */\n"
-"```\n"
+msgid "/* [wxMaxima: page break    ] */\n"
 msgstr ""
 
 #. type: Plain text
@@ -9204,20 +13687,19 @@ msgstr ""
 msgid "And folded cells marked by:"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:355
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:350
 #, no-wrap
 msgid ""
-"```maxima\n"
 "/* [wxMaxima: fold    start ] */\n"
 "...\n"
 "/* [wxMaxima: fold    end   ] */\n"
-"```\n"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:357
-msgid "### .wxmx"
+#. type: Title ###
+#: ../../info/wxmaxima.md:356
+#, no-wrap
+msgid ".wxmx"
 msgstr ""
 
 #. type: Plain text
@@ -9225,9 +13707,10 @@ msgstr ""
 msgid "This XML-based file format saves the complete worksheet including things like the zoom factor and the watchlist. It is the preferred file format."
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:361
-msgid "#### File format of wxmx files"
+#. type: Title ####
+#: ../../info/wxmaxima.md:360
+#, no-wrap
+msgid "File format of wxmx files"
 msgstr ""
 
 #. type: Plain text
@@ -9265,9 +13748,10 @@ msgstr ""
 msgid "So, if something goes wrong, you can unzip a wxMaxima document (maybe rename it before to a `zip`-file), maybe make changes in the `content.xml` file with a text editor, or replace an broken image, zip the files again, probably rename the `zip` to a `wxmx`-file - and you get another modified `wxmx`-file."
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:375
-msgid "## Configuration options"
+#. type: Title ##
+#: ../../info/wxmaxima.md:374
+#, no-wrap
+msgid "Configuration options"
 msgstr ""
 
 #. type: Plain text
@@ -9290,9 +13774,10 @@ msgstr ""
 msgid "![wxMaxima configuration 1](./wxMaxima_configuration_001.png){ id=img_wxMaxima_configuration_001 }"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:384
-msgid "### Default animation framerate"
+#. type: Title ###
+#: ../../info/wxmaxima.md:383
+#, no-wrap
+msgid "Default animation framerate"
 msgstr ""
 
 #. type: Plain text
@@ -9300,9 +13785,10 @@ msgstr ""
 msgid "The animation framerate that is used for new animations is kept in the variable `wxanimate_framerate`. The initial value this variable will contain in a new worksheet can be changed using the configuration dialogue."
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:388
-msgid "### Default plot size for new _maxima_ sessions"
+#. type: Title ###
+#: ../../info/wxmaxima.md:387
+#, no-wrap
+msgid "Default plot size for new _maxima_ sessions"
 msgstr ""
 
 #. type: Plain text
@@ -9315,26 +13801,23 @@ msgstr ""
 msgid "In order to set the plot size of a single graph only use the following notation can be used that sets a variable’s value for one command only:"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:401
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:393
 #, no-wrap
 msgid ""
-"```maxima\n"
 "wxdraw2d(\n"
 "   explicit(\n"
 "       x^2,\n"
 "       x,-5,5\n"
 "   )\n"
 "), wxplot_size=[480,480]$\n"
-"```\n"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:403
-#, fuzzy
-#| msgid "Set fixed font in text controls."
-msgid "### Match parenthesis in text controls"
-msgstr "Set fast font i tekstkontroller."
+#. type: Title ###
+#: ../../info/wxmaxima.md:402
+#, no-wrap
+msgid "Match parenthesis in text controls"
+msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:405
@@ -9351,9 +13834,10 @@ msgstr ""
 msgid "If text is selected if any of these keys is pressed the selected text will be put between the matched signs."
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:410
-msgid "### Don’t save the worksheet automatically"
+#. type: Title ###
+#: ../../info/wxmaxima.md:409
+#, no-wrap
+msgid "Don’t save the worksheet automatically"
 msgstr ""
 
 #. type: Plain text
@@ -9376,14 +13860,18 @@ msgstr ""
 msgid "And the file will automatically be saved every 3 minutes."
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:419
-msgid "### Where is the configuration saved?"
+#. type: Title ###
+#: ../../info/wxmaxima.md:418
+#, no-wrap
+msgid "Where is the configuration saved?"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:422
-msgid "If you are using Unix/Linux, the configuration information will be saved in a file `.wxMaxima` in your home directory (if you are using wxWidgets \\< 3.1.1), or `.config/wxMaxima.conf` ((XDG-Standard) if wxWidgets >= 3.1.1 is used). You can retrieve the wxWidgets version from the command `wxbuild_info();` or by using the menu option Help->About. [wxWidgets](https://www.wxwidgets.org/) is the cross-platform GUI library, which is the base for _wxMaxima_ (therefore the `wx` in the name).  (Since the filename starts with a dot, `.wxMaxima` or `.config` will be hidden)."
+#, no-wrap
+msgid ""
+"If you are using Unix/Linux, the configuration information will be saved in a file `.wxMaxima` in your home directory (if you are using wxWidgets \\< 3.1.1), or `.config/wxMaxima.conf` ((XDG-Standard) if wxWidgets >= 3.1.1 is used). You can retrieve the wxWidgets version from the command `wxbuild_info();` or by using the menu option Help->About. [wxWidgets](https://www.wxwidgets.org/) is the cross-platform GUI library, which is the base for _wxMaxima_ (therefore the `wx` in the name).\n"
+"(Since the filename starts with a dot, `.wxMaxima` or `.config` will be hidden).\n"
 msgstr ""
 
 #. type: Plain text
@@ -9391,9 +13879,10 @@ msgstr ""
 msgid "If you are using Windows, the configuration will be stored in the registry. You will find the entries for _wxMaxima_ at the following position in the registry: `HKEY_CURRENT_USER\\Software\\wxMaxima`"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:428
-msgid "# Extensions to _Maxima_"
+#. type: Title #
+#: ../../info/wxmaxima.md:427
+#, no-wrap
+msgid "Extensions to _Maxima_"
 msgstr ""
 
 #. type: Plain text
@@ -9401,12 +13890,11 @@ msgstr ""
 msgid "_WxMaxima_ is primarily a graphical user interface for _Maxima_. As such, its main purpose is to pass along commands to _Maxima_ and to report the results of executing those commands. In some cases, however, _wxMaxima_ adds functionality to _Maxima_. _WxMaxima_’s ability to generate reports by exporting a workbook’s contents to HTML and LaTeX files has been mentioned. This section considers some ways that _wxMaxima_ enhances the inclusion of graphics in a session."
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:432
-#, fuzzy
-#| msgid "Show defined variables"
-msgid "## Subscripted variables"
-msgstr "Vis definerte variabler"
+#. type: Title ##
+#: ../../info/wxmaxima.md:431
+#, no-wrap
+msgid "Subscripted variables"
+msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:434
@@ -9450,12 +13938,14 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:449
-msgid "You can use the menu \"View->Autosubscript\" to set these values."
+#, no-wrap
+msgid "You can use the menu \"View->Autosubscript\" to set these values.\n"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:451
-msgid "## User feedback in the status bar"
+#. type: Title ##
+#: ../../info/wxmaxima.md:450
+#, no-wrap
+msgid "User feedback in the status bar"
 msgstr ""
 
 #. type: Plain text
@@ -9463,11 +13953,10 @@ msgstr ""
 msgid "Long-running commands can provide user feedback in the status bar. This user feedback is replaced by any new feedback that is placed there (allowing to use it as a progress indicator) and is deleted as soon as the current command sent to _Maxima_ is finished. It is safe to use `wxstatusbar()` even in libraries that might be used with plain _Maxima_ (as opposed to _wxMaxima_): If _wxMaxima_ isn’t present the `wxstatusbar()` command will just be left unevaluated."
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:464
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:454
 #, no-wrap
 msgid ""
-"```maxima\n"
 "for i:1 thru 10 do (\n"
 "    /* Tell the user how far we got */\n"
 "    wxstatusbar(concat(\"Pass \",i)),\n"
@@ -9476,12 +13965,12 @@ msgid ""
 "    /* program execution (here: for 3 seconds) */\n"
 "    ?sleep(3)\n"
 ")$\n"
-"```\n"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:466
-msgid "## Exporting the worksheet from within Maxima"
+#. type: Title ##
+#: ../../info/wxmaxima.md:465
+#, no-wrap
+msgid "Exporting the worksheet from within Maxima"
 msgstr ""
 
 #. type: Plain text
@@ -9489,9 +13978,12 @@ msgstr ""
 msgid "The command `wxworksheettohtml()` exports the current worksheet to an HTML file from within a running _Maxima_ session, which is convenient for scripted or batch export. Like `wxstatusbar()` it is safe to use in code that might also run in plain (console) _Maxima_: if _wxMaxima_ isn’t present the command is simply left unevaluated."
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:473
-msgid "```maxima wxworksheettohtml(\"report.html\")$ wxworksheettohtml(\"report.html\", flavor=\"svg\", wxmx=true)$ ```"
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:469
+#, no-wrap
+msgid ""
+"wxworksheettohtml(\"report.html\")$\n"
+"wxworksheettohtml(\"report.html\", flavor=\"svg\", wxmx=true)$\n"
 msgstr ""
 
 #. type: Plain text
@@ -9519,9 +14011,12 @@ msgstr ""
 msgid "The companion command `wxworksheettotex()` exports to a LaTeX (`.tex`) file the same way:"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:489
-msgid "```maxima wxworksheettotex(\"report.tex\")$ wxworksheettotex(\"report.tex\", documentclass=\"report\", documentclassoptions=\"12pt,a4paper\")$ ```"
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:485
+#, no-wrap
+msgid ""
+"wxworksheettotex(\"report.tex\")$\n"
+"wxworksheettotex(\"report.tex\", documentclass=\"report\", documentclassoptions=\"12pt,a4paper\")$\n"
 msgstr ""
 
 #. type: Plain text
@@ -9539,9 +14034,10 @@ msgstr ""
 msgid "Support for `wxworksheettopdf()` is planned."
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:498
-msgid "## Plotting"
+#. type: Title ##
+#: ../../info/wxmaxima.md:497
+#, no-wrap
+msgid "Plotting"
 msgstr ""
 
 #. type: Plain text
@@ -9549,9 +14045,10 @@ msgstr ""
 msgid "Plotting (having fundamentally to do with graphics) is a place where a graphical user interface will have to provide some extensions to the original program."
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:502
-msgid "### Embedding a plot into the worksheet"
+#. type: Title ###
+#: ../../info/wxmaxima.md:501
+#, no-wrap
+msgid "Embedding a plot into the worksheet"
 msgstr ""
 
 #. type: Plain text
@@ -9593,9 +14090,10 @@ msgstr ""
 msgid "If you got problems with one of these functions, please check, if the problem exists in the the Maxima function too (e.g. you got an error with `wxplot2d()`, check the same plot in the Maxima command `plot2d()` (which opens the plot in a separate Window)). If the problem does not disappear, it is most likely a Maxima issue and should be reported in the [Maxima bugtracker](https://sourceforge.net/p/maxima/bugs/). Or maybe a Gnuplot issue."
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:526
-msgid "### Making embedded plots bigger or smaller"
+#. type: Title ###
+#: ../../info/wxmaxima.md:525
+#, no-wrap
+msgid "Making embedded plots bigger or smaller"
 msgstr ""
 
 #. type: Plain text
@@ -9603,11 +14101,10 @@ msgstr ""
 msgid "As noted above, the configure dialog provides a way to change the default size plots created which sets the starting value of `wxplot_size`. The plotting routines of _wxMaxima_ respect this variable that specifies the size of a plot in pixels. It can always be queried or used to set the size of the following plots:"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:538
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:529
 #, no-wrap
 msgid ""
-"```maxima\n"
 "wxplot_size:[1200,800]$\n"
 "wxdraw2d(\n"
 "    explicit(\n"
@@ -9615,7 +14112,6 @@ msgid ""
 "        x,1,10\n"
 "    )\n"
 ")$\n"
-"```\n"
 msgstr ""
 
 #. type: Plain text
@@ -9623,18 +14119,16 @@ msgstr ""
 msgid "If the size of only one plot is to be changed _Maxima_ provides a canonical way to change an attribute only for the current cell. In this usage the specification `wxplot_size = [value1, value2]` is appended to the `wxdraw2d( )` command, and is not part of the `wxdraw2d` command."
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:549
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:541
 #, no-wrap
 msgid ""
-"```maxima\n"
 "wxdraw2d(\n"
 "    explicit(\n"
 "        sin(x),\n"
 "        x,1,10\n"
 "    )\n"
 "),wxplot_size=[1600,800]$\n"
-"```\n"
 msgstr ""
 
 #. type: Plain text
@@ -9642,9 +14136,10 @@ msgstr ""
 msgid "Setting the size of embedded plot with `wxplot_size` works for embedded plots using e.g. `wxplot`, `wxdraw`, `wxcontour_plot` and `wximplicit_plot` commands and for embedded animations with `with_slider_draw` and `wxanimate` commands."
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:553
-msgid "### Better quality plots"
+#. type: Title ###
+#: ../../info/wxmaxima.md:552
+#, no-wrap
+msgid "Better quality plots"
 msgstr ""
 
 #. type: Plain text
@@ -9652,9 +14147,10 @@ msgstr ""
 msgid "_Gnuplot_ doesn’t seem to provide a portable way of determining whether it supports the high-quality bitmap output that the Cairo library provides. On systems where _Gnuplot_ is compiled to use this library the pngCairo option from the configuration menu (that can be overridden by the variable `wxplot_pngcairo`) enables support for antialiasing and additional line styles. If `wxplot_pngCairo` is set without _Gnuplot_ supporting this the result will be error messages instead of graphics."
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:557
-msgid "### Opening embedded plots in interactive _Gnuplot_ windows"
+#. type: Title ###
+#: ../../info/wxmaxima.md:556
+#, no-wrap
+msgid "Opening embedded plots in interactive _Gnuplot_ windows"
 msgstr ""
 
 #. type: Plain text
@@ -9662,9 +14158,10 @@ msgstr ""
 msgid "If a plot was generated using the `wxdraw`-type commands (`wxplot2d` and `wxplot3d` isn’t supported by this feature) and the file size of the underlying _Gnuplot_ project isn’t way too high _wxMaxima_ offers a right-click menu that allows to open the plot in an interactive _Gnuplot_ window."
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:561
-msgid "### Opening Gnuplot’s command console in `plot` windows"
+#. type: Title ###
+#: ../../info/wxmaxima.md:560
+#, no-wrap
+msgid "Opening Gnuplot’s command console in `plot` windows"
 msgstr ""
 
 #. type: Plain text
@@ -9672,9 +14169,10 @@ msgstr ""
 msgid "On MS Windows, there are two Gnuplot programs, `gnuplot.exe` and `wgnuplot.exe`.  You can configure, which command should be used using the configuration menu. `wgnuplot.exe` offers the possibility to open a console window, where _gnuplot_ commands can be entered into, `gnuplot.exe` does not offer this possibility. Unfortunately, `wgnuplot.exe` causes _Gnuplot_ to \"steal\" the keyboard focus for a short time every time a plot is prepared."
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:566
-msgid "### Embedding animations into the spreadsheet"
+#. type: Title ###
+#: ../../info/wxmaxima.md:565
+#, no-wrap
+msgid "Embedding animations into the spreadsheet"
 msgstr ""
 
 #. type: Plain text
@@ -9687,11 +14185,10 @@ msgstr ""
 msgid "The first two arguments for `with_slider_draw` are the name of the variable that is stepped between the plots and a list of the values of these variable. The arguments that follow are the ordinary arguments for `wxdraw2d`:"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:581
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:571
 #, no-wrap
 msgid ""
-"```maxima\n"
 "with_slider_draw(\n"
 "    f,[1,2,3,4,5,6,7,10],\n"
 "    title=concat(\"f=\",f,\"Hz\"),\n"
@@ -9700,7 +14197,6 @@ msgid ""
 "        x,0,1\n"
 "    ),grid=true\n"
 ");\n"
-"```\n"
 msgstr ""
 
 #. type: Plain text
@@ -9708,11 +14204,10 @@ msgstr ""
 msgid "The same functionality for 3D plots is accessible as `with_slider_draw3d`, which allows for rotating 3d plots:"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:600
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:584
 #, no-wrap
 msgid ""
-"```maxima\n"
 "wxanimate_autoplay:true;\n"
 "wxanimate_framerate:20;\n"
 "with_slider_draw3d(\n"
@@ -9727,7 +14222,6 @@ msgid ""
 "        y,-π,π\n"
 "    )\n"
 ")$\n"
-"```\n"
 msgstr ""
 
 #. type: Plain text
@@ -9735,11 +14229,10 @@ msgstr ""
 msgid "If the general shape of the plot is what matters it might suffice to move the plot just a little bit in order to make its 3D nature available to the intuition:"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:619
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:603
 #, no-wrap
 msgid ""
-"```maxima\n"
 "wxanimate_autoplay:true;\n"
 "wxanimate_framerate:20;\n"
 "with_slider_draw3d(\n"
@@ -9754,7 +14247,6 @@ msgid ""
 "        y,-2*π,2*π\n"
 "    )\n"
 ")$\n"
-"```\n"
 msgstr ""
 
 #. type: Plain text
@@ -9777,14 +14269,12 @@ msgstr ""
 msgid "Normally the animations are played back or exported with the frame rate chosen in the configuration of _wxMaxima_. To set the speed at an individual animation is played back the variable `wxanimate_framerate` can be used:"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:631
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:627
 #, no-wrap
 msgid ""
-"```maxima\n"
 "wxanimate(a, 10,\n"
 "    sin(a*x), [x,-5,5]), wxanimate_framerate=6$\n"
-"```\n"
 msgstr ""
 
 #. type: Plain text
@@ -9792,11 +14282,10 @@ msgstr ""
 msgid "The animation functions use _Maxima_’s `makelist` command and therefore share the pitfall that the slider variable’s value is substituted into the expression only if the variable is directly visible in the expression. Therefore the following example will fail:"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:643
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:634
 #, no-wrap
 msgid ""
-"```maxima\n"
 "f:sin(a*x);\n"
 "with_slider_draw(\n"
 "    a,makelist(i/2,i,1,10),\n"
@@ -9804,7 +14293,6 @@ msgid ""
 "    grid=true,\n"
 "    explicit(f,x,0,10)\n"
 ")$\n"
-"```\n"
 msgstr ""
 
 #. type: Plain text
@@ -9812,11 +14300,10 @@ msgstr ""
 msgid "If _Maxima_ is explicitly asked to substitute the slider’s value plotting works fine instead:"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:658
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:646
 #, no-wrap
 msgid ""
-"```maxima\n"
 "f:sin(a*x);\n"
 "with_slider_draw(\n"
 "    b,makelist(i/2,i,1,10),\n"
@@ -9827,12 +14314,12 @@ msgid ""
 "        x,0,10\n"
 "    )\n"
 ")$\n"
-"```\n"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:660
-msgid "### Opening multiple plots in contemporaneous windows"
+#. type: Title ###
+#: ../../info/wxmaxima.md:659
+#, no-wrap
+msgid "Opening multiple plots in contemporaneous windows"
 msgstr ""
 
 #. type: Plain text
@@ -9840,24 +14327,20 @@ msgstr ""
 msgid "While not being provided by _wxMaxima_ this feature of _Maxima_ (on setups that support it) sometimes comes in handily. The following example comes from a post from Mario Rodriguez to the _Maxima_ mailing list:"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:665
-msgid "```maxima load(draw);"
-msgstr ""
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:668
-msgid "/* Parabola in window #1 */ draw2d(terminal=[wxt,1],explicit(x^2,x,-1,1));"
-msgstr ""
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:671
-msgid "/* Parabola in window #2 */ draw2d(terminal=[wxt,2],explicit(x^2,x,-1,1));"
-msgstr ""
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:675
-msgid "/* Paraboloid in window #3 */ draw3d(terminal=[wxt,3],explicit(x^2+y^2,x,-1,1,y,-1,1)); ```"
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:663
+#, no-wrap
+msgid ""
+"load(draw);\n"
+"\n"
+"/* Parabola in window #1 */\n"
+"draw2d(terminal=[wxt,1],explicit(x^2,x,-1,1));\n"
+"\n"
+"/* Parabola in window #2 */\n"
+"draw2d(terminal=[wxt,2],explicit(x^2,x,-1,1));\n"
+"\n"
+"/* Paraboloid in window #3 */\n"
+"draw3d(terminal=[wxt,3],explicit(x^2+y^2,x,-1,1,y,-1,1));\n"
 msgstr ""
 
 #. type: Plain text
@@ -9865,11 +14348,10 @@ msgstr ""
 msgid "Plotting multiple plots in the same window is possible, too (the same is possible in command line Maxima with the standard `draw()` command):"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:688
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:678
 #, no-wrap
 msgid ""
-"```maxima\n"
 "wxdraw(\n"
 "  gr2d(\n"
 "    key=\"sin (x)\",grid=[2,2],\n"
@@ -9878,22 +14360,17 @@ msgid ""
 "    key=\"cos (x)\",grid=[2,2],\n"
 "    explicit(cos(x),x,0,2*%pi))\n"
 ");\n"
-"```\n"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:690
-msgid "### The \"Plot using draw\" side pane"
+#. type: Title ###
+#: ../../info/wxmaxima.md:689
+#, no-wrap
+msgid "The \"Plot using draw\" side pane"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:692
 msgid "The \"Plot using draw\" sidebar hides a simple code generator that allows generating scenes that make use of some of the flexibility of the _draw_ package _maxima_ comes with."
-msgstr ""
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:694
-msgid "#### 2D"
 msgstr ""
 
 #. type: Plain text
@@ -9907,30 +14384,19 @@ msgid "One helpful feature of the 2D button is that it allows to set up the scen
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:700
-msgid "#### 3D"
-msgstr ""
-
-#. type: Plain text
 #: ../../info/wxmaxima.md:702
 msgid "Generates the skeleton of a `draw()` command that draws a 3D scene. If neither a 2D nor a 3D scene is set up, all of the other buttons set up a 2D scene that contains the command the button generates."
 msgstr ""
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:704
-#, fuzzy
-#| msgid "Expression"
-msgid "#### Expression"
-msgstr "Uttrykk"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:706
 msgid "Appends a standard plot of an expression like `sin(x)`, `x*sin(x)` or `x^2+2*x-4` to the `draw()` command the cursor currently is in. If there is no draw command a 2D scene with the plot is generated. Each scene can be filled with any number of plots."
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:708
-msgid "#### Implicit plot"
+#. type: Title ####
+#: ../../info/wxmaxima.md:707
+#, no-wrap
+msgid "Implicit plot"
 msgstr ""
 
 #. type: Plain text
@@ -9939,31 +14405,13 @@ msgid "Tries to find all points an expression like `y=sin(x)`, `y*sin(x)=3` or `
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:712
-#, fuzzy
-#| msgid "Parametric plot"
-msgid "#### Parametric plot"
-msgstr "Parametrisk Plott"
-
-#. type: Plain text
 #: ../../info/wxmaxima.md:714
 msgid "Steps a variable from a lower limit to an upper limit and uses two expressions like `t*sin(t)` and `t*cos(t)` for generating the x, y (and in 3D plots also z) coordinates of a curve that is put into the current draw command."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:716
-#, fuzzy
-msgid "#### Points"
-msgstr "Punkt:"
-
-#. type: Plain text
 #: ../../info/wxmaxima.md:718
 msgid "Draws many points that can optionally be joined. The coordinates of the points are taken from a list of lists, a 2D array or one list or array for each axis."
-msgstr ""
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:720
-msgid "#### Diagram title"
 msgstr ""
 
 #. type: Plain text
@@ -9972,18 +14420,8 @@ msgid "Draws a title on the upper end of the diagram,"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:724
-msgid "#### Axis"
-msgstr ""
-
-#. type: Plain text
 #: ../../info/wxmaxima.md:726
 msgid "Sets up the axis."
-msgstr ""
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:728
-msgid "#### Contour"
 msgstr ""
 
 #. type: Plain text
@@ -9992,19 +14430,14 @@ msgid "(Only for 3D plots): Adds contour lines similar to the ones one can find 
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:732
-#, fuzzy
-msgid "#### Plot name"
-msgstr "Liste:"
-
-#. type: Plain text
 #: ../../info/wxmaxima.md:734
 msgid "Adds a legend entry showing the next plot’s name to the legend of the diagram. An empty name disables generating legend entries for the following plots."
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:736
-msgid "#### Line colour"
+#. type: Title ####
+#: ../../info/wxmaxima.md:735
+#, no-wrap
+msgid "Line colour"
 msgstr ""
 
 #. type: Plain text
@@ -10012,9 +14445,10 @@ msgstr ""
 msgid "Sets the line colour for the following plots the current draw command contains."
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:740
-msgid "#### Fill colour"
+#. type: Title ####
+#: ../../info/wxmaxima.md:739
+#, no-wrap
+msgid "Fill colour"
 msgstr ""
 
 #. type: Plain text
@@ -10023,19 +14457,8 @@ msgid "Sets the fill colour for the following plots the current draw command con
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:744
-#, fuzzy
-msgid "#### Grid"
-msgstr "Rutenett:"
-
-#. type: Plain text
 #: ../../info/wxmaxima.md:746
 msgid "Pops up a wizard that allows to set up grid lines."
-msgstr ""
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:748
-msgid "#### Accuracy"
 msgstr ""
 
 #. type: Plain text
@@ -10043,9 +14466,10 @@ msgstr ""
 msgid "Allows to select an adequate point in the speed vs. accuracy tradeoff that is part of any plot program."
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:752
-msgid "### Modify font and font size for plots"
+#. type: Title ###
+#: ../../info/wxmaxima.md:751
+#, no-wrap
+msgid "Modify font and font size for plots"
 msgstr ""
 
 #. type: Plain text
@@ -10053,16 +14477,14 @@ msgstr ""
 msgid "Especially when you use a high resolution display, the default font size might be very small. For the `draw`-based commands, you can set the font / font size using options like `font=...`, `font_size=...`, e.g.:"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:761
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:755
 #, no-wrap
 msgid ""
-"~~~maxima\n"
 "wxdraw2d(\n"
 "     font=\"Helvetica\",\n"
 "     font_size=30,\n"
 "     explicit(sin(x),x,1,10));\n"
-"~~~\n"
 msgstr ""
 
 #. type: Plain text
@@ -10070,14 +14492,12 @@ msgstr ""
 msgid "For the `plot`-commands (e.g. `wxplot2d`, `wxplot3d`) font sizes and fonts can be set using the `gnuplot_preamble` command, e.g.:"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:768
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:764
 #, no-wrap
 msgid ""
-"~~~maxima\n"
 "wxplot2d(sin(x),[x,1,10],\n"
 "         [gnuplot_preamble, \"set tics font \\\"Arial, 30\\\"; set xlabel font \\\",20\\\"; set ylabel font \\\",20\\\";\"]);\n"
-"~~~\n"
 msgstr ""
 
 #. type: Plain text
@@ -10090,9 +14510,10 @@ msgstr ""
 msgid "Read the Maxima and Gnuplot documentation for further information.  Note: Gnuplot seems to have issues with larger font sizes, see [wxMaxima issue 1966](https://github.com/wxMaxima-developers/wxmaxima/issues/1966)."
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:775
-msgid "## Embedding graphics"
+#. type: Title ##
+#: ../../info/wxmaxima.md:774
+#, no-wrap
+msgid "Embedding graphics"
 msgstr ""
 
 #. type: Plain text
@@ -10100,14 +14521,16 @@ msgstr ""
 msgid "If the `.wxmx` file format is being used embedding files in a _wxMaxima_ project can be done as easily as per drag-and-drop. But sometimes (for example if an image’s contents might change later on in a session) it is better to tell the file to load the image on evaluation:"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:781
-msgid "```maxima show_image(\"man.png\"); ```"
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:778
+#, no-wrap
+msgid "show_image(\"man.png\");\n"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:783
-msgid "## Startup files"
+#. type: Title ##
+#: ../../info/wxmaxima.md:782
+#, no-wrap
+msgid "Startup files"
 msgstr ""
 
 #. type: Plain text
@@ -10135,303 +14558,340 @@ msgstr ""
 msgid "These files are in the Maxima user directory (usually `%USERPROFILE%/maxima` in Windows, `$HOME/.maxima` otherwise). The location can be found out with the command: `maxima_userdir;`"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:794
-#, fuzzy
-msgid "## Special variables wx..."
-msgstr "Slett en variabel"
+#. type: Title ##
+#: ../../info/wxmaxima.md:793
+#, no-wrap
+msgid "Special variables wx..."
+msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:805
+#: ../../info/wxmaxima.md:811
 msgid "`wxsubscripts` tells _Maxima_ if it should convert variable names that contain an underscore (`R_150` or the like) into subscripted variables. See `wxdeclare_subscript` for details which variable names are automatically converted."
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:805
+#: ../../info/wxmaxima.md:811
 msgid "`wxfilename`: This variable contains the name of the file currently opened in _wxMaxima_."
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:805
+#: ../../info/wxmaxima.md:811
 msgid "`wxdirname`: This variable contains the name the directory, in which the file currently opened in _wxMaxima_ is."
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:805
+#: ../../info/wxmaxima.md:811
 msgid "`wxplot_pngcairo` tells whether _wxMaxima_ tries to use _Gnuplot_’s pngcairo terminal that provides more line styles and a better overall graphics quality."
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:805
+#: ../../info/wxmaxima.md:811
 msgid "`wxplot_size` defines the resolution of embedded plots."
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:805
+#: ../../info/wxmaxima.md:811
 msgid "`wxchangedir`: On most operating systems _wxMaxima_ automatically sets _Maxima_’s working directory to the directory of the current file. This allows file I/O (e.g. by `read_matrix`) to work without specifying the whole path to the file that has to be read or written. On Windows this feature sometimes causes error messages and therefore can be set to `false` from the config dialogue."
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:805
+#: ../../info/wxmaxima.md:811
 msgid "`wxanimate_framerate`: The number of frames per second the following animations have to be played back with."
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:805
+#: ../../info/wxmaxima.md:811
 msgid "`wxanimate_autoplay`: Automatically play animations by default?"
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:805
+#: ../../info/wxmaxima.md:811
 msgid "`wxmaximaversion`: Returns the version number of _wxMaxima_."
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:805
+#: ../../info/wxmaxima.md:811
 msgid "`wxwidgetsversion`: Returns the wxWidgets version _wxMaxima_ is using."
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:807
-msgid "## Pretty-printing 2D output"
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:811
+msgid "`wxdirs`: A struct holding the paths _wxMaxima_ itself uses, since these differ by maintainer, distribution and operating system:"
+msgstr ""
+
+#. type: Bullet: '  - '
+#: ../../info/wxmaxima.md:811
+msgid "`wxdirs@userconfdir`: The directory the user's configuration is stored in. Same directory as `maxima_userdir` (see above) - both point at the same place, `wxdirs@userconfdir` is only useful if that is more convenient to reach from a `.mac` file than the Maxima-side variable."
+msgstr ""
+
+#. type: Bullet: '  - '
+#: ../../info/wxmaxima.md:811
+msgid "`wxdirs@datadir`: The directory _wxMaxima_'s own data (icons, the built-in autocompletion list, ...) is installed in."
+msgstr ""
+
+#. type: Bullet: '  - '
+#: ../../info/wxmaxima.md:811
+msgid "`wxdirs@helpdir`: The directory the offline copy of this manual is installed in."
+msgstr ""
+
+#. type: Bullet: '  - '
+#: ../../info/wxmaxima.md:811
+msgid "`wxdirs@localedir`: The directory _wxMaxima_'s translation files are installed in."
+msgstr ""
+
+#. type: Bullet: '  - '
+#: ../../info/wxmaxima.md:811
+msgid "`wxdirs@maximalocation`: The path to the _Maxima_ executable _wxMaxima_ is configured to start."
+msgstr ""
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:812
+#, no-wrap
+msgid "Pretty-printing 2D output"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:809
+#: ../../info/wxmaxima.md:815
 msgid "The function `table_form()` displays a 2D list in a form that is more readable than the output from _Maxima_’s default output routine. The input is a list of one or more lists. Like the \"print\" command, this command displays output even when ended with a dollar sign. Ending the command with a semicolon results in the same table along with a \"done\" statement."
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:818
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:816
 #, no-wrap
 msgid ""
-"```maxima\n"
 "table_form(\n"
 "    [\n"
 "        [1,2],\n"
 "        [3,4]\n"
 "    ]\n"
 ")$\n"
-"```\n"
-msgstr ""
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:820
-msgid "As the next example shows, the lists that are assembled by the `table_form` command can be created before the command is executed."
-msgstr ""
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:822
-msgid "![A third table example](./MatrixTableExample.png){ id=img_MatrixTableExample }"
-msgstr ""
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:824
-msgid "Also, because a matrix is a list of lists, matrices can be converted to tables in a similar fashion."
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:826
-msgid "![Another table_form example](./SecondTableExample.png){ id=img_SecondTableExample }"
+msgid "As the next example shows, the lists that are assembled by the `table_form` command can be created before the command is executed."
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:828
-msgid "The function `wx_matrix()` is a wrapper for Maxima's `matrix()` command that allows for more flexible formatting of matrices in wxMaxima:"
+msgid "![A third table example](./MatrixTableExample.png){ id=img_MatrixTableExample }"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:830
+msgid "Also, because a matrix is a list of lists, matrices can be converted to tables in a similar fashion."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:832
+msgid "![Another table_form example](./SecondTableExample.png){ id=img_SecondTableExample }"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:834
+msgid "The function `wx_matrix()` is a wrapper for Maxima's `matrix()` command that allows for more flexible formatting of matrices in wxMaxima:"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:836
 #, no-wrap
 msgid "**`wx_matrix( <matrix>, [options] )`**\n"
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:835
+#: ../../info/wxmaxima.md:841
 msgid "**`lines=true`**: Draws internal separator lines between the cells. This is required to visually separate headings from data."
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:835
+#: ../../info/wxmaxima.md:841
 msgid "**`rownames=true`**: Tells wxMaxima that the first column of the matrix contains labels."
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:835
+#: ../../info/wxmaxima.md:841
 msgid "**`colnames=true`**: Tells wxMaxima that the first row of the matrix contains labels."
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:835
+#: ../../info/wxmaxima.md:841
 msgid "**`parenstyle=<style>`**: Sets the type of parenthesis or brackets to draw around the matrix. Supported styles are: `round` `()`, `square` `[]`, `angled` `<>`, `straight` `||`, or `none`."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:837
+#: ../../info/wxmaxima.md:843
 #, fuzzy
 #| msgid "Example"
 msgid "Example:"
 msgstr "Eksempel"
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:842
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:844
 #, no-wrap
 msgid ""
-"```maxima\n"
 "wx_matrix(matrix([\"Name\", \"Value\"], [\"X\", 10], [\"Y\", 20]),\n"
 "          lines=true, rownames=true, colnames=true, parenstyle=square);\n"
-"```\n"
+msgstr ""
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:849
+#, no-wrap
+msgid "Bug reporting"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:844
-msgid "## Bug reporting"
-msgstr ""
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:846
+#: ../../info/wxmaxima.md:852
 msgid "_WxMaxima_ provides a few functions that gather bug reporting information about the current system:"
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:849
+#: ../../info/wxmaxima.md:855
 msgid "`wxbuild_info()` gathers information about the currently running version of _wxMaxima_"
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:849
+#: ../../info/wxmaxima.md:855
 msgid "`wxbug_report()` tells how and where to file bugs"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:851
-msgid "## Marking output being drawn in red"
-msgstr ""
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:854
-msgid "_Maxima_’s `box()` command causes _wxMaxima_ to print its argument with a red foreground, if the second argument to the command is the text `highlight`."
-msgstr ""
-
-#. type: Plain text
+#. type: Title ##
 #: ../../info/wxmaxima.md:856
-#, fuzzy
-msgid "## Output rendering."
-msgstr "Strenger"
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:858
-msgid "With `set_display()` one can set, how wxMaxima will render the output."
+#, no-wrap
+msgid "Marking output being drawn in red"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:860
+msgid "_Maxima_’s `box()` command causes _wxMaxima_ to print its argument with a red foreground, if the second argument to the command is the text `highlight`."
+msgstr ""
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:861
+#, no-wrap
+msgid "Output rendering."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:864
+msgid "With `set_display()` one can set, how wxMaxima will render the output."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:866
 msgid "`set_display('xml)` is the default value. Here Maxima speaks to wxMaxima using an (machine readable) XML-dialect (can be seen in the \"Raw XML sidebar\") and outputs the resulting formulas nicely rendered, e.g. pretty Matrices, Square root signs, fractions, etc."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:863
-msgid "<!--- Currently that does not work as it should, the line with the output label is shifted right (issue: #2006) --> `set_display('ascii)` causes wxMaxima to output formulas as in command line Maxima - as ASCII-Art."
-msgstr ""
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:865
-msgid "`set_display('none)` causes 'one-line' ASCII results - the same as the command line Maxima command `display2d:false;` does."
-msgstr ""
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:867
-msgid "# Help menu"
-msgstr ""
-
-#. type: Plain text
 #: ../../info/wxmaxima.md:869
-msgid "WxMaxima’s help menu provides access to the Maxima and wxMaxima manual, tips, some example worksheets and in command line Maxima included demos (the `demo()` command)."
+#, no-wrap
+msgid ""
+"<!--- Currently that does not work as it should, the line with the output label is shifted right (issue: #2006) -->\n"
+"`set_display('ascii)` causes wxMaxima to output formulas as in command line Maxima - as ASCII-Art.\n"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:871
-msgid "Please notice, that the demos write:"
+msgid "`set_display('none)` causes 'one-line' ASCII results - the same as the command line Maxima command `display2d:false;` does."
+msgstr ""
+
+#. type: Title #
+#: ../../info/wxmaxima.md:872
+#, no-wrap
+msgid "Help menu"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:875
-msgid "~~~text At the ’_’ prompt, type ’;’ and <enter> to proceed with the demonstration.  ~~~"
+msgid "WxMaxima’s help menu provides access to the Maxima and wxMaxima manual, tips, some example worksheets and in command line Maxima included demos (the `demo()` command)."
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:877
-msgid "That is valid for command-line Maxima, however in wxMaxima by default it is necessary to continue the demonstration with: <kbd>CTRL</kbd>+<kbd>ENTER</kbd>"
+msgid "Please notice, that the demos write:"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:879
-msgid "(That can be configured in the Configure->Worksheet->\"Hotkeys for sending commands to Maxima\" menu.)"
+#. type: Fenced code block (text)
+#: ../../info/wxmaxima.md:878
+#, no-wrap
+msgid "At the ’_’ prompt, type ’;’ and <enter> to proceed with the demonstration.\n"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:883
-msgid "# Troubleshooting"
+#, no-wrap
+msgid "That is valid for command-line Maxima, however in wxMaxima by default it is necessary to continue the demonstration with: <kbd>CTRL</kbd>+<kbd>ENTER</kbd>\n"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:885
-#, fuzzy
-msgid "## Cannot connect to _Maxima_"
-msgstr ""
-"\n"
-"Ikke tilkoblet."
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:887
-msgid "Since _Maxima_ (the program that does the actual mathematics) and _wxMaxima_ (providing the easy-to-use user interface) are separate programs that communicate by the means of a local network connection. Therefore the most probable cause is that this connection is somehow not working. For example, a firewall could be set up in a way that it doesn’t just prevent unauthorized connections from the internet (and perhaps intercept some connections to the internet, too), but also blocks inter-process-communication inside the same computer. Note that since _Maxima_ is being run by a Lisp processor the process communication that is blocked does not necessarily have to be named \"maxima\". Common names of the program that opens the network connection would be sbcl, gcl, ccl, lisp.exe, or similar names."
+#, no-wrap
+msgid "(That can be configured in the Configure->Worksheet->\"Hotkeys for sending commands to Maxima\" menu.)\n"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:889
-msgid "On Unix computers another possible reason would be that the loopback network that provides network connections between two programs in the same computer isn’t properly configured."
+#. type: Title #
+#: ../../info/wxmaxima.md:888
+#, no-wrap
+msgid "Troubleshooting"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:891
-msgid "## How to save data from a broken .wxmx file"
+#. type: Title ##
+#: ../../info/wxmaxima.md:890
+#, no-wrap
+msgid "Cannot connect to _Maxima_"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:893
-msgid "Internally most modern XML-based formats are ordinary zip files. _WxMaxima_ doesn’t turn on compression, so the contents of `.wxmx` files can be viewed in any text editor."
+msgid "Since _Maxima_ (the program that does the actual mathematics) and _wxMaxima_ (providing the easy-to-use user interface) are separate programs that communicate by the means of a local network connection. Therefore the most probable cause is that this connection is somehow not working. For example, a firewall could be set up in a way that it doesn’t just prevent unauthorized connections from the internet (and perhaps intercept some connections to the internet, too), but also blocks inter-process-communication inside the same computer. Note that since _Maxima_ is being run by a Lisp processor the process communication that is blocked does not necessarily have to be named \"maxima\". Common names of the program that opens the network connection would be sbcl, gcl, ccl, lisp.exe, or similar names."
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:895
-msgid "If the zip signature at the end of the file is still intact after renaming a broken `.wxmx` file to `.zip` most operating systems will provide a way to extract any portion of the information that is stored inside it. This can be done when there is a need of recovering the original image files from a text processor document. If the zip signature isn’t intact that does not need to be the end of the world: If _wxMaxima_ during saving detected that something went wrong there will be a `.wxmx~` file whose contents might help."
+msgid "On Unix computers another possible reason would be that the loopback network that provides network connections between two programs in the same computer isn’t properly configured."
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:897
-msgid "And even if there isn’t such a file: The `.wxmx` file is a container format and the XML portion is stored uncompressed. It it is possible to rename the `.wxmx` file to a `.txt` file and to use a text editor to recover the XML portion of the file’s contents (it starts with `<?xml version=\"1.0\" encoding=\"UTF-8\"?>` and ends with `</wxMaximaDocument>`. Before and after that text you will see some unreadable binary contents in the text editor)."
+#. type: Title ##
+#: ../../info/wxmaxima.md:896
+#, no-wrap
+msgid "How to save data from a broken .wxmx file"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:899
-msgid "If a text file containing only these contents (e.g. copy and paste this text into a new file) is saved as a file ending in `.xml`, _wxMaxima_ will know how to recover the text from the document."
+msgid "Internally most modern XML-based formats are ordinary zip files. _WxMaxima_ doesn’t turn on compression, so the contents of `.wxmx` files can be viewed in any text editor."
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:901
-msgid "## I want some debug info to be displayed on the screen before my command has finished"
+msgid "If the zip signature at the end of the file is still intact after renaming a broken `.wxmx` file to `.zip` most operating systems will provide a way to extract any portion of the information that is stored inside it. This can be done when there is a need of recovering the original image files from a text processor document. If the zip signature isn’t intact that does not need to be the end of the world: If _wxMaxima_ during saving detected that something went wrong there will be a `.wxmx~` file whose contents might help."
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:903
-msgid "Normally _wxMaxima_ waits for the whole 2D formula to be transferred before it begins to typeset. This saves time for making many attempts to typeset a only partially completed equation. There is a `disp` command, though, that will provide debug output immediately and without waiting for the current _Maxima_ command to finish:"
+#, no-wrap
+msgid "And even if there isn’t such a file: The `.wxmx` file is a container format and the XML portion is stored uncompressed. It it is possible to rename the `.wxmx` file to a `.txt` file and to use a text editor to recover the XML portion of the file’s contents (it starts with `<?xml version=\"1.0\" encoding=\"UTF-8\"?>` and ends with `</wxMaximaDocument>`. Before and after that text you will see some unreadable binary contents in the text editor).\n"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:913
+#: ../../info/wxmaxima.md:905
+msgid "If a text file containing only these contents (e.g. copy and paste this text into a new file) is saved as a file ending in `.xml`, _wxMaxima_ will know how to recover the text from the document."
+msgstr ""
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:906
+#, no-wrap
+msgid "I want some debug info to be displayed on the screen before my command has finished"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:909
+msgid "Normally _wxMaxima_ waits for the whole 2D formula to be transferred before it begins to typeset. This saves time for making many attempts to typeset a only partially completed equation. There is a `disp` command, though, that will provide debug output immediately and without waiting for the current _Maxima_ command to finish:"
+msgstr ""
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:910
 #, no-wrap
 msgid ""
-"```maxima\n"
 "for i:1 thru 10 do (\n"
 "   disp(i),\n"
 "   /* (sleep n) is a Lisp function, which can be used */\n"
@@ -10439,273 +14899,285 @@ msgid ""
 "   /* program execution (here: for 3 seconds) */\n"
 "   ?sleep(3)\n"
 ")$\n"
-"```\n"
-msgstr ""
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:915
-msgid "Alternatively one can look for the `wxstatusbar()` command above."
-msgstr ""
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:917
-msgid "## Plotting only shows a closed empty envelope with an error message"
-msgstr ""
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:919
-msgid "This means that _wxMaxima_ could not read the file _Maxima_ that was supposed to instruct _Gnuplot_ to create."
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:921
+msgid "Alternatively one can look for the `wxstatusbar()` command above."
+msgstr ""
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:922
+#, no-wrap
+msgid "Plotting only shows a closed empty envelope with an error message"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:925
+msgid "This means that _wxMaxima_ could not read the file _Maxima_ that was supposed to instruct _Gnuplot_ to create."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:927
 msgid "Possible reasons for this error are:"
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:926
+#: ../../info/wxmaxima.md:932
 msgid "The plotting command is part of a third-party package like `implicit_plot` but this package was not loaded by _Maxima_’s `load()` command before trying to plot."
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:926
+#: ../../info/wxmaxima.md:932
 msgid "_Maxima_ tried to do something the currently installed version of _Gnuplot_ isn’t able to understand. In this case, a file ending in `.gnuplot` located in the directory, which _Maxima_’s variable `maxima_userdir` is pointing, contains the instructions from _Maxima_ to _Gnuplot_. Most of the time, this file’s contents therefore are helpful when debugging the problem."
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:926
+#: ../../info/wxmaxima.md:932
 msgid "Gnuplot was instructed to use the pngCairo library that provides antialiasing and additional line styles, but it was not compiled to support this possibility. Solution: Uncheck the \"Use the Cairo terminal for the plot\" checkbox in the configuration dialog and don’t set `wxplot_pngcairo` to true from _Maxima_."
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:926
+#: ../../info/wxmaxima.md:932
 msgid "Gnuplot didn’t output a valid `.png` file."
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:928
-msgid "## Plotting an animation results in “error: undefined variable”"
+#. type: Title ##
+#: ../../info/wxmaxima.md:933
+#, no-wrap
+msgid "Plotting an animation results in “error: undefined variable”"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:930
+#: ../../info/wxmaxima.md:936
 msgid "The value of the slider variable by default is only substituted into the expression that is to be plotted if it is visible there. Using a `subst` command that substitutes the slider variable into the equation to plot resolves this problem. At the end of section [Embedding animations into the spreadsheet](#embedding-animations-into-the-spreadsheet), you can see an example."
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:932
-msgid "## I lost cell content and undo doesn’t remember"
+#. type: Title ##
+#: ../../info/wxmaxima.md:937
+#, no-wrap
+msgid "I lost cell content and undo doesn’t remember"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:934
+#: ../../info/wxmaxima.md:940
 msgid "There are separate undo functions for cell operations and for changes inside of cells so chances are low that this ever happens. If it does there are several methods to recover data:"
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:939
+#: ../../info/wxmaxima.md:945
 msgid "_WxMaxima_ actually has two undo features: The global undo buffer that is active if no cell is selected and a per-cell undo buffer that is active if the cursor is inside a cell. It is worth trying to use both undo options in order to see if an old value can still be accessed."
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:939
+#: ../../info/wxmaxima.md:945
 msgid "If you still have a way to find out what label _Maxima_ has assigned to the cell just type in the cell’s label and its contents will reappear."
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:939
+#: ../../info/wxmaxima.md:945
 msgid "If you don’t: Don’t panic. In the “View” menu there is a way to show a history pane that shows all _Maxima_ commands that have been issued recently."
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:939
+#: ../../info/wxmaxima.md:945
 msgid "If nothing else helps _Maxima_ contains a replay feature:"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:943
-msgid "```maxima playback(); ```"
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:946
+#, no-wrap
+msgid "playback();\n"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:945
-msgid "## _WxMaxima_ starts up with the message “Maxima process terminated.”"
-msgstr ""
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:947
-msgid "One possible reason is that _Maxima_ cannot be found in the location that is set in the “Maxima” tab of _wxMaxima_’s configuration dialog and therefore won’t run at all. Setting the path to a working _Maxima_ binary should fix this problem."
-msgstr ""
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:949
-msgid "## Maxima is forever calculating and not responding to input"
-msgstr ""
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:951
-msgid "It is theoretically possible that _wxMaxima_ doesn’t realize that _Maxima_ has finished calculating and therefore never gets informed it can send new data to _Maxima_. If this is the case “Trigger evaluation” might resynchronize the two programs."
+#. type: Title ##
+#: ../../info/wxmaxima.md:950
+#, no-wrap
+msgid "_WxMaxima_ starts up with the message “Maxima process terminated.”"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:953
-msgid "## My SBCL-based _Maxima_ runs out of memory"
+msgid "One possible reason is that _Maxima_ cannot be found in the location that is set in the “Maxima” tab of _wxMaxima_’s configuration dialog and therefore won’t run at all. Setting the path to a working _Maxima_ binary should fix this problem."
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:955
-msgid "The Lisp compiler SBCL by default comes with a memory limit that allows it to run even on low-end computers. When compiling a big software package like Lapack or dealing with extremely big lists of equations this limit might be too low. In order to extend the limits, SBCL can be provided with the command line parameter `--dynamic-space-size` that tells SBCL how many megabytes it should reserve. A 32bit Windows-SBCL can reserve up to 999 Megabytes. A 64-bit SBCL version running on Windows can be instructed to use more than the about 1280 Megabytes compiling Lapack needs."
+#. type: Title ##
+#: ../../info/wxmaxima.md:954
+#, no-wrap
+msgid "Maxima is forever calculating and not responding to input"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:957
-msgid "One way to provide _Maxima_ (and thus SBCL) with command line parameters is the \"Additional parameters for Maxima\" field of _wxMaxima_’s configuration dialogue."
+msgid "It is theoretically possible that _wxMaxima_ doesn’t realize that _Maxima_ has finished calculating and therefore never gets informed it can send new data to _Maxima_. If this is the case “Trigger evaluation” might resynchronize the two programs."
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:959
-msgid "![sbcl memory](./sbclMemory.png){ id=img_sbclMemory }"
+#. type: Title ##
+#: ../../info/wxmaxima.md:958
+#, no-wrap
+msgid "My SBCL-based _Maxima_ runs out of memory"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:961
-msgid "## Input sometimes is sluggish/ignoring keys on Ubuntu"
+msgid "The Lisp compiler SBCL by default comes with a memory limit that allows it to run even on low-end computers. When compiling a big software package like Lapack or dealing with extremely big lists of equations this limit might be too low. In order to extend the limits, SBCL can be provided with the command line parameter `--dynamic-space-size` that tells SBCL how many megabytes it should reserve. A 32bit Windows-SBCL can reserve up to 999 Megabytes. A 64-bit SBCL version running on Windows can be instructed to use more than the about 1280 Megabytes compiling Lapack needs."
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:963
-msgid "Installing the package `ibus-gtk` should resolve this issue. See ([https://bugs.launchpad.net/ubuntu/+source/wxwidgets3.0/+bug/1421558](https://bugs.launchpad.net/ubuntu/+source/wxwidgets3.0/+bug/1421558)) for details."
+msgid "One way to provide _Maxima_ (and thus SBCL) with command line parameters is the \"Additional parameters for Maxima\" field of _wxMaxima_’s configuration dialogue."
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:965
-msgid "## _WxMaxima_ halts when _Maxima_ processes Greek characters or Umlauts"
+msgid "![sbcl memory](./sbclMemory.png){ id=img_sbclMemory }"
+msgstr ""
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:966
+#, no-wrap
+msgid "Input sometimes is sluggish/ignoring keys on Ubuntu"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:967
-msgid "If your _Maxima_ is based on SBCL the following lines have to be added to your `.sbclrc`:"
+#: ../../info/wxmaxima.md:969
+msgid "Installing the package `ibus-gtk` should resolve this issue. See ([https://bugs.launchpad.net/ubuntu/+source/wxwidgets3.0/+bug/1421558](https://bugs.launchpad.net/ubuntu/+source/wxwidgets3.0/+bug/1421558)) for details."
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:971
-msgid "```commonlisp (setf sb-impl::*default-external-format* :utf-8)  ```"
+#. type: Title ##
+#: ../../info/wxmaxima.md:970
+#, no-wrap
+msgid "_WxMaxima_ halts when _Maxima_ processes Greek characters or Umlauts"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:973
-msgid "The folder where this file has to be placed is system- and installation-specific. But any SBCL-based _Maxima_ that already has evaluated a cell in the current session will happily tell where it can be found after getting the following command:"
+msgid "If your _Maxima_ is based on SBCL the following lines have to be added to your `.sbclrc`:"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:977
-msgid "```maxima :lisp (sb-impl::userinit-pathname)  ```"
+#. type: Fenced code block (commonlisp)
+#: ../../info/wxmaxima.md:974
+#, no-wrap
+msgid "(setf sb-impl::*default-external-format* :utf-8)\n"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:979
-msgid "## Note concerning Wayland (recent Linux/BSD distributions)"
+msgid "The folder where this file has to be placed is system- and installation-specific. But any SBCL-based _Maxima_ that already has evaluated a cell in the current session will happily tell where it can be found after getting the following command:"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:982
-msgid "There seem to be issues with the Wayland Display Server and wxWidgets.  WxMaxima may be affected, e.g. that sidebars are not moveable."
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:980
+#, no-wrap
+msgid ":lisp (sb-impl::userinit-pathname)\n"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:986
-msgid "You can either disable Wayland and use X11 instead (globally)  or just tell, that wxMaxima should use the X Window System by setting: `GDK_BACKEND=x11`"
+#. type: Title ##
+#: ../../info/wxmaxima.md:984
+#, no-wrap
+msgid "Note concerning Wayland (recent Linux/BSD distributions)"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:988
+msgid "There seem to be issues with the Wayland Display Server and wxWidgets.  WxMaxima may be affected, e.g. that sidebars are not moveable."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:992
+msgid "You can either disable Wayland and use X11 instead (globally)  or just tell, that wxMaxima should use the X Window System by setting: `GDK_BACKEND=x11`"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:994
 #, fuzzy
 #| msgid "Restart Maxima"
 msgid "E.g. start wxMaxima with:"
 msgstr "Restart Maxima"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:990
+#: ../../info/wxmaxima.md:996
 msgid "`GDK_BACKEND=x11 wxmaxima`"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:992
-msgid "## The menu bar disappears on KDE Plasma"
-msgstr ""
-
-#. type: Plain text
+#. type: Title ##
 #: ../../info/wxmaxima.md:997
-msgid "On some KDE Plasma installations the global menu bar disappears when clicked.  As this is a bug in the global menu proxy, the only way to avoid it is to tell that wxMaxima should use its own menu bar instead of the global one.  This is done by setting: `UBUNTU_MENUPROXY=0`"
-msgstr ""
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:1001
-msgid "Starting with version 26.05.0, wxMaxima attempts to set this variable automatically if it detects an affected system (KDE, Unity, or Ubuntu with older wxWidgets versions)."
+#, no-wrap
+msgid "The menu bar disappears on KDE Plasma"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:1003
-msgid "If the automatic fix fails, you can manually start wxMaxima with:"
-msgstr ""
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:1005
-msgid "`UBUNTU_MENUPROXY=0 wxmaxima`"
+msgid "On some KDE Plasma installations the global menu bar disappears when clicked.  As this is a bug in the global menu proxy, the only way to avoid it is to tell that wxMaxima should use its own menu bar instead of the global one.  This is done by setting: `UBUNTU_MENUPROXY=0`"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:1007
-msgid "## Why is the integrated manual browser not offered on my Windows PC?"
+msgid "Starting with version 26.05.0, wxMaxima attempts to set this variable automatically if it detects an affected system (KDE, Unity, or Ubuntu with older wxWidgets versions)."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1010
+#: ../../info/wxmaxima.md:1009
+msgid "If the automatic fix fails, you can manually start wxMaxima with:"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1011
+msgid "`UBUNTU_MENUPROXY=0 wxmaxima`"
+msgstr ""
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:1012
+#, no-wrap
+msgid "Why is the integrated manual browser not offered on my Windows PC?"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1016
 msgid "Either wxWidgets wasn’t compiled with support for Microsoft’s webview2 or Microsoft’s webview2 isn’t installed."
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:1012
-msgid "## Why is the external manual browser not working on my Linux box?"
+#. type: Title ##
+#: ../../info/wxmaxima.md:1017
+#, no-wrap
+msgid "Why is the external manual browser not working on my Linux box?"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1018
+#: ../../info/wxmaxima.md:1024
 msgid "The HTML browser might be a snap, flatpack or appimage version. All of these typically cannot access files that are installed on your local system. Another reason might be that maxima or wxMaxima is installed as a snap, flatpack or something else that doesn’t give the host system access to its contents. A third reason might be that the maxima HTML manual isn’t installed and the online one cannot be accessed."
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:1020
-msgid "## Can I make _wxMaxima_ output both image files and embedded plots at once?"
+#. type: Title ##
+#: ../../info/wxmaxima.md:1025
+#, no-wrap
+msgid "Can I make _wxMaxima_ output both image files and embedded plots at once?"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1022
+#: ../../info/wxmaxima.md:1028
 msgid "The worksheet embeds `.png files. _WxMaxima_ allows the user to specify where they should be generated:"
 msgstr ""
 
-#. type: Plain text
+#. type: Fenced code block (maxima)
 #: ../../info/wxmaxima.md:1029
 #, no-wrap
 msgid ""
-"```maxima\n"
 "wxdraw2d(\n"
 "    file_name=\"test\",  /* extension .png automatically added */\n"
 "    explicit(sin(x),x,1,10)\n"
 ");\n"
-"```\n"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1031
+#: ../../info/wxmaxima.md:1037
 msgid "If a different format is to be used, it is easier to generate the images and then import them into the worksheet again:"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:1050
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:1038
 #, no-wrap
 msgid ""
-"```maxima\n"
 "load(\"draw\");\n"
 "pngdraw(name,[contents]):=\n"
 "(\n"
@@ -10723,217 +15195,234 @@ msgid ""
 ");\n"
 "pngdraw2d(name,[contents]):=\n"
 "    pngdraw(name,gr2d(contents));\n"
-msgstr ""
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:1055
-#, no-wrap
-msgid ""
+"\n"
 "pngdraw2d(\"Test\",\n"
 "        explicit(sin(x),x,1,10)\n"
 ");\n"
-"```\n"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:1057
-msgid "## Can I set the aspect ratio of an embedded plot?"
-msgstr ""
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:1059
-msgid "Use the variable `wxplot_size`:"
+#. type: Title ##
+#: ../../info/wxmaxima.md:1062
+#, no-wrap
+msgid "Can I set the aspect ratio of an embedded plot?"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:1065
+msgid "Use the variable `wxplot_size`:"
+msgstr ""
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:1066
 #, no-wrap
 msgid ""
-"```maxima\n"
 "wxdraw2d(\n"
 "    explicit(sin(x),x,1,10)\n"
 "),wxplot_size=[1000,1000];\n"
-"```\n"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:1067
-msgid "## After upgrading to MacOS 13.1 plot and/or draw commands output error messages like"
+#. type: Title ##
+#: ../../info/wxmaxima.md:1072
+#, no-wrap
+msgid "After upgrading to MacOS 13.1 plot and/or draw commands output error messages like"
 msgstr ""
 
-#. type: Plain text
+#. type: Fenced code block (text)
 #: ../../info/wxmaxima.md:1074
-msgid "```text 1 HIToolbox 0x00007ff80cd91726 _ZN15MenuBarInstance22EnsureAutoShowObserverEv + 102 2 HIToolbox 0x00007ff80cd912b8 _ZN15MenuBarInstance14EnableAutoShowEv + 52 3 HIToolbox 0x00007ff80cd35908 SetMenuBarObscured + 408 ...  ```"
-msgstr ""
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:1076
-msgid "This might be an issue with the operating system. Disable the hiding of the menu bar (SystemSettings => Desktop & Dock => Menu Bar) might solve the issue. See [wxMaxima issue #1746](https://github.com/wxMaxima-developers/wxmaxima/issues/1746) for more information."
-msgstr ""
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:1078
-msgid "## Logging"
+#, no-wrap
+msgid ""
+"1 HIToolbox 0x00007ff80cd91726 _ZN15MenuBarInstance22EnsureAutoShowObserverEv + 102\n"
+"2 HIToolbox 0x00007ff80cd912b8 _ZN15MenuBarInstance14EnableAutoShowEv + 52\n"
+"3 HIToolbox 0x00007ff80cd35908 SetMenuBarObscured + 408\n"
+"...\n"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:1082
-msgid "Log messages might be helpful to debug problems. WxMaxima can log many events. Most log entries will be helpful for developers, especially in case of problems or bugs. If you run a \"Release\"-Build, the log windows is not shown by default, if you run a development version, it is shown by default as a second window. You can enable and disable this window using the \"View->Toggle log window\" menu entry."
+#, no-wrap
+msgid "This might be an issue with the operating system. Disable the hiding of the menu bar (SystemSettings => Desktop & Dock => Menu Bar) might solve the issue. See [wxMaxima issue #1746](https://github.com/wxMaxima-developers/wxmaxima/issues/1746) for more information.\n"
+msgstr ""
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:1083
+#, no-wrap
+msgid "Logging"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1084
+#: ../../info/wxmaxima.md:1088
+#, no-wrap
+msgid ""
+"Log messages might be helpful to debug problems. WxMaxima can log many events. Most log entries will be helpful for developers, especially in case of problems or bugs. If you run a \"Release\"-Build,\n"
+"the log windows is not shown by default, if you run a development version, it is shown by default as a second window. You can enable and disable\n"
+"this window using the \"View->Toggle log window\" menu entry.\n"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1090
 msgid "Messages are not 'lost', if the log window is not shown, if you select to show the log window later, you will see past log messages (if you did not clear the messages)."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1086
+#: ../../info/wxmaxima.md:1092
 msgid "Such messages may be helpful, when you create bug reports (or trying to find a bug by yourself)."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1089
+#: ../../info/wxmaxima.md:1095
 msgid "Log messages can (additionally) be printed to STDERR, when using the command line option \"--logtostderr\". On Windows a separate text console will be opened, as a Windows GUI application does not have the standard IO connected."
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:1093
-msgid "# FAQ"
+#. type: Title #
+#: ../../info/wxmaxima.md:1098
+#, no-wrap
+msgid "FAQ"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:1095
-msgid "## Is there a way to make more text fit on a LaTeX page?"
-msgstr ""
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:1097
-msgid "Yes. Use the [LaTeX package \"geometry\"](https://ctan.org/pkg/geometry) to specify the size of the borders."
-msgstr ""
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:1099
-msgid "You can add the following line to the LaTeX preamble (for example by using the respective field in the config dialogue (\"Export\"->\"Additional lines for the TeX preamble\"), to set borders of 1cm):"
+#. type: Title ##
+#: ../../info/wxmaxima.md:1100
+#, no-wrap
+msgid "Is there a way to make more text fit on a LaTeX page?"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:1103
-msgid "```latex \\usepackage[left=1cm,right=1cm,top=1cm,bottom=1cm]{geometry} ```"
+msgid "Yes. Use the [LaTeX package \"geometry\"](https://ctan.org/pkg/geometry) to specify the size of the borders."
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:1105
-msgid "## Is there a dark mode?"
+#, no-wrap
+msgid "You can add the following line to the LaTeX preamble (for example by using the respective field in the config dialogue (\"Export\"->\"Additional lines for the TeX preamble\"), to set borders of 1cm):\n"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:1107
-msgid "If wxWidgets is new enough, _wxMaxima_ will automatically be in dark mode if the rest of the operating system is. The worksheet itself is by default equipped with a bright background. But it can be configured otherwise. Alternatively, there is a `View/Invert worksheet brightness` menu entry that allows to quickly convert the worksheet from dark to bright and vice versa."
+#. type: Fenced code block (latex)
+#: ../../info/wxmaxima.md:1106
+#, no-wrap
+msgid "\\usepackage[left=1cm,right=1cm,top=1cm,bottom=1cm]{geometry}\n"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:1109
-msgid "## _WxMaxima_ sometimes hangs for several seconds once in the first minute"
-msgstr ""
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:1111
-msgid "_WxMaxima_ delegates some big tasks like parsing _Maxima_’s >1000-page-manual to background tasks, which normally goes totally unnoticed. At the moment the result of such a task is needed, though, it is possible that _wxMaxima_ needs to wait a couple of seconds before it can continue its work."
+#. type: Title ##
+#: ../../info/wxmaxima.md:1110
+#, no-wrap
+msgid "Is there a dark mode?"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:1113
-msgid "## Especially when testing new locale settings, a message box \"locale ’xx_YY’ can not be set\" occurs"
+msgid "If wxWidgets is new enough, _wxMaxima_ will automatically be in dark mode if the rest of the operating system is. The worksheet itself is by default equipped with a bright background. But it can be configured otherwise. Alternatively, there is a `View/Invert worksheet brightness` menu entry that allows to quickly convert the worksheet from dark to bright and vice versa."
+msgstr ""
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:1114
+#, no-wrap
+msgid "_WxMaxima_ sometimes hangs for several seconds once in the first minute"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1115
+#: ../../info/wxmaxima.md:1117
+#, no-wrap
+msgid "_WxMaxima_ delegates some big tasks like parsing _Maxima_’s >1000-page-manual to background tasks, which normally goes totally unnoticed. At the moment the result of such a task is needed, though, it is possible that _wxMaxima_ needs to wait a couple of seconds before it can continue its work.\n"
+msgstr ""
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:1118
+#, no-wrap
+msgid "Especially when testing new locale settings, a message box \"locale ’xx_YY’ can not be set\" occurs"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1121
 msgid "![Locale warning](./locale-warning.png){ id=img_locale_warning}"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1119
+#: ../../info/wxmaxima.md:1125
 msgid "(The same problem can occur with other applications too). The translations seem okay after you click on ’OK’. WxMaxima does not only use its own translations but the translations of the wxWidgets framework too."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1122
+#: ../../info/wxmaxima.md:1128
 msgid "These locales maybe not present in the system. On Ubuntu/Debian systems they can be generated using: `dpkg-reconfigure locales`"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:1124
-msgid "## How can I use symbols for real numbers, natural numbers (ℝ, ℕ), etc.?"
-msgstr ""
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:1126
-msgid "You can find these symbols in the Unicode sidebar (search for ’double-struck capital’). But the selected font must also support these symbols. If they do not display properly, select another font."
-msgstr ""
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:1128
-msgid "## How can a Maxima script determine, if it is running under wxMaxima or command line Maxima?"
-msgstr ""
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:1130
-msgid "If wxMaxima is used, the Maxima variable `maxima_frontend` is set to `wxmaxima`. The Maxima variable `maxima_frontend_version` contains the wxMaxima version in this case."
+#. type: Title ##
+#: ../../info/wxmaxima.md:1129
+#, no-wrap
+msgid "How can I use symbols for real numbers, natural numbers (ℝ, ℕ), etc.?"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:1132
-msgid "If no frontend is used (you are using command line Maxima), these variables are `false`."
+msgid "You can find these symbols in the Unicode sidebar (search for ’double-struck capital’). But the selected font must also support these symbols. If they do not display properly, select another font."
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:1134
-msgid "## Help! I can not save my document!"
+#. type: Title ##
+#: ../../info/wxmaxima.md:1133
+#, no-wrap
+msgid "How can a Maxima script determine, if it is running under wxMaxima or command line Maxima?"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:1136
-msgid "If saving as wxmx file does not work, try saving the document as wxm file (and vice versa). And you can also try to remove all output (Menu Cell->Remove all output) and save that file, maybe some unexpected output causes issues during the save process."
+msgid "If wxMaxima is used, the Maxima variable `maxima_frontend` is set to `wxmaxima`. The Maxima variable `maxima_frontend_version` contains the wxMaxima version in this case."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1140
-#, fuzzy
-msgid "# Command-line arguments"
-msgstr "Kommaseparerte x-koordinater"
+#: ../../info/wxmaxima.md:1138
+msgid "If no frontend is used (you are using command line Maxima), these variables are `false`."
+msgstr ""
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:1139
+#, no-wrap
+msgid "Help! I can not save my document!"
+msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:1142
+#, no-wrap
+msgid "If saving as wxmx file does not work, try saving the document as wxm file (and vice versa). And you can also try to remove all output (Menu Cell->Remove all output) and save that file, maybe some unexpected output causes issues during the save process.\n"
+msgstr ""
+
+#. type: Title #
+#: ../../info/wxmaxima.md:1145
+#, no-wrap
+msgid "Command-line arguments"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1148
 msgid "Usually you can start programs with a graphical user interface just by clicking on a desktop icon or desktop menu entry. WxMaxima - if started from the command line - still provides some command-line switches, though."
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:1158
+#: ../../info/wxmaxima.md:1164
 msgid "`-v` or `--version`: Output the version information"
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:1158
+#: ../../info/wxmaxima.md:1164
 msgid "`-h` or `--help`: Output a short help text"
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:1158
+#: ../../info/wxmaxima.md:1164
 msgid "`-o` or `--open=<str>`: Open the filename given as an argument to this command-line switch"
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:1158
+#: ../../info/wxmaxima.md:1164
 msgid "`-e` or `--eval`: Evaluate the file after opening it."
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:1158
+#: ../../info/wxmaxima.md:1164
 msgid "`-b` or `--batch`: If the command-line opens a file all cells in this file are evaluated and the file is saved afterward. This is for example useful if the session described in the file makes _Maxima_ generate output files. Batch-processing will be stopped if _wxMaxima_ detects that _Maxima_ has output an error and will pause if _Maxima_ has a question: Mathematics is somewhat interactive by nature so a completely interaction-free batch processing cannot always be guaranteed."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1158
+#: ../../info/wxmaxima.md:1164
 #, no-wrap
 msgid ""
 "- `--logtostderr`:                 Log all \"debug messages\" sidebar messages to stderr, too.\n"
@@ -10949,44 +15438,169 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1160
+#: ../../info/wxmaxima.md:1166
 msgid "Instead of a minus, some operating systems might use a dash in front of the command-line switches."
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:1164
-msgid "# About the program, contributing to wxMaxima"
-msgstr ""
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:1166
-msgid "wxMaxima is mainly developed using the programming language C++ using the [wxWidgets framework](https://www.wxwidgets.org), as build system we use [CMake](https://www.cmake.org), a small part is written in Lisp. You can contribute to wxMaxima, join the wxMaxima project at <https://github.com/wxMaxima-developers/wxmaxima>, if you have knowledge of these programming languages and want to help and contribute to the open source project wxMaxima."
-msgstr ""
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:1168
-msgid "But not only programmers are necessary! You can also contribute to wxMaxima, if you help to improve the documentation, find and report bugs (and maybe bugfixes), suggest new features, help to translate wxMaxima or the manual to your language (read the README.md in the [locale subdirectory](https://github.com/wxMaxima-developers/wxmaxima/tree/main/locales) how wxMaxima and the manual can be translated)."
-msgstr ""
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:1170
-msgid "Or answer questions of other users in the discussion forum."
+#. type: Title #
+#: ../../info/wxmaxima.md:1169
+#, no-wrap
+msgid "About the program, contributing to wxMaxima"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:1172
-msgid "The source code of wxMaxima is documented using Doxygen [here](https://wxmaxima-developers.github.io/wxmaxima/Doxygen-documentation/)."
+msgid "wxMaxima is mainly developed using the programming language C++ using the [wxWidgets framework](https://www.wxwidgets.org), as build system we use [CMake](https://www.cmake.org), a small part is written in Lisp. You can contribute to wxMaxima, join the wxMaxima project at <https://github.com/wxMaxima-developers/wxmaxima>, if you have knowledge of these programming languages and want to help and contribute to the open source project wxMaxima."
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:1174
+msgid "But not only programmers are necessary! You can also contribute to wxMaxima, if you help to improve the documentation, find and report bugs (and maybe bugfixes), suggest new features, help to translate wxMaxima or the manual to your language (read the README.md in the [locale subdirectory](https://github.com/wxMaxima-developers/wxmaxima/tree/main/locales) how wxMaxima and the manual can be translated)."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1176
+msgid "Or answer questions of other users in the discussion forum."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1178
+msgid "The source code of wxMaxima is documented using Doxygen [here](https://wxmaxima-developers.github.io/wxmaxima/Doxygen-documentation/)."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1180
 msgid "The program is nearly self-contained, so except for system libraries (and the wxWidgets library), no external dependencies (like graphic files or the Lisp part (the `wxmathML.lisp`-file) is needed, these files are included in the executable."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1175
-msgid "If you are a developer, you might want to try out a modified `wxmathML.lisp`-file without recompiling everything, one can use the command line option `--wxmathml-lisp=<str>` to use another Lisp file, not the included one."
+#: ../../info/wxmaxima.md:1181
+#, no-wrap
+msgid "If you are a developer, you might want to try out a modified `wxmathML.lisp`-file without recompiling everything, one can use the command line option `--wxmathml-lisp=<str>` to use another Lisp file, not the included one.\n"
 msgstr ""
+
+#, fuzzy
+#~ msgid "1×n Matrix b:"
+#~ msgstr "Matrise:"
+
+#, fuzzy
+#~ msgid "Calculate variation"
+#~ msgstr "Kalkuler produkter"
+
+#, fuzzy
+#~ msgid "Hide All Toolbars\tAlt+Shift+-"
+#~ msgstr "Gjem Alt\tAlt+Shift+-"
+
+#, fuzzy
+#~ msgid "Integrate numerically"
+#~ msgstr "Integrer (risch)"
+
+#, fuzzy
+#~ msgid "Load a list from a csv file"
+#~ msgstr "Last en Maxima-pakkefil"
+
+#, fuzzy
+#~ msgid "Main Toolbar\tAlt+Shift+B"
+#~ msgstr "Verktøylinje\tAlt+Shift+T"
+
+#, fuzzy
+#~ msgid "Multivariate linear regression"
+#~ msgstr "Lineær Regresjon..."
+
+#~ msgid "Parts of the document will not be loaded correctly!"
+#~ msgstr "Deler av dokumentet vil ikke bli lastet riktig!"
+
+#, fuzzy
+#~ msgid "Read List from csv file..."
+#~ msgstr "Last en stil fra fil"
+
+#, fuzzy, c-format
+#~ msgid ""
+#~ "You have version %s. The newest version source code is available for is %s.\n"
+#~ "\n"
+#~ "Select OK to visit the wxMaxima webpage."
+#~ msgstr ""
+#~ "Du har versjon %s. Aktuell versjon er %s.\n"
+#~ "\n"
+#~ "Velg OK for å besøke wxMaxima-nettsiden."
+
+#, fuzzy
+#~| msgid "Welcome to wxMaxima"
+#~ msgid "# Introduction to wxMaxima"
+#~ msgstr "Velkommen til wxMaxima"
+
+#, fuzzy
+#~| msgid "&Maxima"
+#~ msgid "### _Maxima_"
+#~ msgstr "&Maxima"
+
+#, fuzzy
+#~| msgid "&Maxima"
+#~ msgid "### WxMaxima"
+#~ msgstr "&Maxima"
+
+#, fuzzy
+#~| msgid "Merge Cells"
+#~ msgid "### Cells"
+#~ msgstr "Slå Sammen Celler"
+
+#, fuzzy
+#~ msgid "#### Greek characters"
+#~ msgstr "Greske konstanter"
+
+#, fuzzy
+#~ msgid "## File Formats"
+#~ msgstr "Fant ikke fil"
+
+#, fuzzy
+#~| msgid "Set fixed font in text controls."
+#~ msgid "### Match parenthesis in text controls"
+#~ msgstr "Set fast font i tekstkontroller."
+
+#, fuzzy
+#~| msgid "Show defined variables"
+#~ msgid "## Subscripted variables"
+#~ msgstr "Vis definerte variabler"
+
+#, fuzzy
+#~| msgid "Expression"
+#~ msgid "#### Expression"
+#~ msgstr "Uttrykk"
+
+#, fuzzy
+#~| msgid "Parametric plot"
+#~ msgid "#### Parametric plot"
+#~ msgstr "Parametrisk Plott"
+
+#, fuzzy
+#~ msgid "#### Points"
+#~ msgstr "Punkt:"
+
+#, fuzzy
+#~ msgid "#### Plot name"
+#~ msgstr "Liste:"
+
+#, fuzzy
+#~ msgid "#### Grid"
+#~ msgstr "Rutenett:"
+
+#, fuzzy
+#~ msgid "## Special variables wx..."
+#~ msgstr "Slett en variabel"
+
+#, fuzzy
+#~ msgid "## Output rendering."
+#~ msgstr "Strenger"
+
+#, fuzzy
+#~ msgid "## Cannot connect to _Maxima_"
+#~ msgstr ""
+#~ "\n"
+#~ "Ikke tilkoblet."
+
+#, fuzzy
+#~ msgid "# Command-line arguments"
+#~ msgstr "Kommaseparerte x-koordinater"
 
 #, fuzzy
 #~ msgid "Killing Maxima."
@@ -11024,22 +15638,6 @@ msgstr ""
 #~ "Vennligst sørg for at du har\n"
 #~ "nettverkstilgang og prøv igjen!"
 
-#, fuzzy
-#~ msgid "Maxima version: "
-#~ msgstr ""
-#~ "\n"
-#~ "Maxima-versjon: "
-
-#, fuzzy
-#~ msgid "Maxima was compiled using: "
-#~ msgstr ""
-#~ "\n"
-#~ "Maxima-versjon: "
-
-#, fuzzy
-#~ msgid "wxMaxima is a cross-platform graphical user interface for the computer algebra system Maxima based on wxWidgets.\n"
-#~ msgstr "wxMaxima er et grafisk brukergrensesnitt til Computer Algebra System-et Maxima basert på wxWidgets."
-
 #~ msgid ""
 #~ "\n"
 #~ "\n"
@@ -11055,42 +15653,8 @@ msgstr ""
 #~ msgstr "ja"
 
 #, fuzzy
-#~ msgid "\"Numpad Enter\" always evaluates cells"
-#~ msgstr "Enter utfører celler"
-
-#~ msgid "(Use default language)"
-#~ msgstr "(Bruk forhåndsvalgt språk)"
-
-#~ msgid "A 'horizontal cursor' was introduced in wxMaxima 0.8.0. It looks like a horizontal line between cells. It indicates where a new cell will appear if you type or paste text or execute a menu command."
-#~ msgstr "En \"sidelengs peker\" ble introdusert i wxMaxima 0.8.0. Den ser ut som en horisontal linje mellom celler. Den indikerer hvor en ny celle vil dukke opp om du skriver eller limer inn tekst, eller kjører en kommando fra menyen."
-
-#, fuzzy
-#~ msgid "A new document format has been introduced in wxMaxima 0.8.2 that saves not only your input and text commentaries, but also the outputs of your calculations. When saving your document, select 'Whole document (*.wxmx)' format."
-#~ msgstr "Et nytt dokumentformat ble introdusert i wxMaxima 0.8.2, som ikke bare lagrer dine uttrykk og kommentarer, men også resultatene av dine utregninger. Når du lagrer dokument, velg 'wxMaxima XML-dokument' som format."
-
-#~ msgid "Additional parameters for Maxima (e.g. -l clisp)."
-#~ msgstr "Øvrige parametre for Maxima (f.eks. -l clisp)."
-
-#, fuzzy
 #~ msgid "Additional parameters for maxima"
 #~ msgstr "Øvrige parametre:"
-
-#, fuzzy
-#~ msgid "All variable names"
-#~ msgstr "Forrige variabel:"
-
-#~ msgid "All|*"
-#~ msgstr "Alle|*"
-
-#~ msgid "Ask to save untitled documents"
-#~ msgstr "Spør om å lagre ulagrede dokument"
-
-#, fuzzy
-#~ msgid "Auto-insert closing parenthesis"
-#~ msgstr "Samsvar parenteser i tekstkontroller"
-
-#~ msgid "Barsplot..."
-#~ msgstr "Søylediagram..."
 
 #~ msgid "Bat files (*.bat)|*.bat|All|*"
 #~ msgstr "Batchfiler (*.bat)|*.bat|Alle|*"
@@ -11098,230 +15662,6 @@ msgstr ""
 #, fuzzy
 #~ msgid "Bat files (*.bat)|*.bat|Exe files (*.exe)||All|*"
 #~ msgstr "Batchfiler (*.bat)|*.bat|Alle|*"
-
-#~ msgid "Bold"
-#~ msgstr "Fet"
-
-#~ msgid "Boxplot..."
-#~ msgstr "Boksdiagram..."
-
-#, fuzzy
-#~ msgid "By default, Shift-Enter is used to evaluate commands, while Enter is used for multiline input. This behaviour can be changed in 'Edit->Configure' dialog by checking 'Enter evaluates cells'. This switches the roles of these two key commands."
-#~ msgstr "Forhåndsvalgt brukes Shift+Enter for å utføre kommandoer, mens Enter brukes for ny linje. Dette kan endres i dialogen 'Endre->Konfigurer' ved å huke av 'Enter utfører celler'. Dette bytter om disse to kommandoenes roller."
-
-#~ msgid "Canonical (tr)"
-#~ msgstr "Kanonisk (tr)"
-
-#~ msgid "Catalan"
-#~ msgstr "Katalan"
-
-#, fuzzy
-#~ msgid "ChangeLog"
-#~ msgstr "Endre variabel"
-
-#~ msgid "Choose font"
-#~ msgstr "Velg font"
-
-#, fuzzy
-#~ msgid "Choose the %s Font"
-#~ msgstr "Velg font"
-
-#, fuzzy
-#~ msgid "Clear the selection"
-#~ msgstr "Klipp Ut Utvalg"
-
-#~ msgid "Config file (*.ini)|*.ini"
-#~ msgstr "Konfigurasjonsfil (*.ini)|*.ini"
-
-#, fuzzy
-#~ msgid "Convert to Heading 5"
-#~ msgstr "Omgjør til &Gamma"
-
-#, fuzzy
-#~ msgid "Convert to Heading 6"
-#~ msgstr "Omgjør til &Gamma"
-
-#, fuzzy
-#~ msgid "Convert to Section"
-#~ msgstr "Omgjør til &Rektangulær Form"
-
-#, fuzzy
-#~ msgid "Convert to Sub-Subsection"
-#~ msgstr "Sett Inn Underseksjoncelle"
-
-#, fuzzy
-#~ msgid "Convert to Subsection"
-#~ msgstr "Omgjør til &Rektangulær Form"
-
-#, fuzzy
-#~ msgid "Convert to Title"
-#~ msgstr "Omgjør til &Fakulteter"
-
-#~ msgid "Czech"
-#~ msgstr "Tsjekkisk"
-
-#~ msgid "Danish"
-#~ msgstr "Dansk"
-
-#, fuzzy
-#~ msgid "Default port for communication with wxMaxima:"
-#~ msgstr "Forhåndsvalgt port til kommunikasjon mellom Maxima og wxMaxima."
-
-#~ msgid "Deviation..."
-#~ msgstr "Avvik..."
-
-#~ msgid "Diff..."
-#~ msgstr "Deriver..."
-
-#, fuzzy
-#~ msgid "Display"
-#~ msgstr "Veksle &Tidsvisning"
-
-#, fuzzy
-#~ msgid "Display all digits"
-#~ msgstr "Vis algoritme"
-
-#~ msgid "English"
-#~ msgstr "Engelsk"
-
-#~ msgid "Enter Matrix..."
-#~ msgstr "Oppgi Matrise..."
-
-#, fuzzy
-#~ msgid "Enter adds newlines, Ctrl+Enter evaluates cells"
-#~ msgstr "Enter utfører celler"
-
-#, fuzzy
-#~ msgid "Enter evaluates cells, Ctrl+Enter adds newlines"
-#~ msgstr "Enter utfører celler"
-
-#~ msgid "Enter the path to the Maxima executable."
-#~ msgstr "Oppgi banen til Maxima-programfilen."
-
-#, fuzzy
-#~ msgid "Environment variables for maxima"
-#~ msgstr "Øvrige parametre:"
-
-#, fuzzy
-#~ msgid "Epsilon"
-#~ msgstr "Epsilon:"
-
-#, fuzzy
-#~ msgid "Evaluate"
-#~ msgstr "&Utfør Celler"
-
-#~ msgid "Example text"
-#~ msgstr "Eksempeltekst"
-
-#~ msgid "Expand"
-#~ msgstr "Utvid"
-
-#~ msgid "Expand (tr)"
-#~ msgstr "Utvid (tr)"
-
-#, fuzzy
-#~ msgid "Export As"
-#~ msgstr "Eksporter"
-
-#, fuzzy
-#~ msgid "Export all settings"
-#~ msgstr "Fold alle seksjoner"
-
-#, fuzzy
-#~ msgid "Export equations to HTML as:"
-#~ msgstr "Eksport til HTML feilet!"
-
-#, fuzzy
-#~ msgid "Export the style settings"
-#~ msgstr "Fold alle seksjoner"
-
-#, fuzzy
-#~ msgid "Exporting to .mac file failed!"
-#~ msgstr "Eksport til TeX feilet!"
-
-#~ msgid "Factor"
-#~ msgstr "Faktoriser"
-
-#, fuzzy
-#~ msgid "Find:"
-#~ msgstr "Finn"
-
-#, fuzzy
-#~ msgid "Finnish"
-#~ msgstr "Dansk"
-
-#~ msgid "Fix reordered reference indices (of %i, %o) before saving"
-#~ msgstr "Fiks omstokkede referanseindekser (av %i, %o) før lagring"
-
-#~ msgid "Fixed font in text controls"
-#~ msgstr "Fast font i tekstkontroller"
-
-#~ msgid "Fonts"
-#~ msgstr "Fonter"
-
-#~ msgid "French"
-#~ msgstr "Fransk"
-
-#~ msgid "Galician"
-#~ msgstr "Galisisk"
-
-#~ msgid "German"
-#~ msgstr "Tysk"
-
-#~ msgid "Greek"
-#~ msgstr "Gresk"
-
-#, fuzzy
-#~ msgid "Hide"
-#~ msgstr "Divider Celle"
-
-#, fuzzy
-#~ msgid "Highlight the matching parenthesis"
-#~ msgstr "Samsvar parenteser i tekstkontroller"
-
-#~ msgid "Histogram..."
-#~ msgstr "Histogram..."
-
-#~ msgid "Horizontal cursor works like a normal cursor, but it operates on cells: press up or down arrow to move it, holding down Shift while moving will select cells, pressing backspace or delete twice will delete a cell next to it."
-#~ msgstr "Horisontal peker fungerer som en vanlig peker, men den betjener celler: trykk opp- eller nedpil for å flytte den; hold inne Shift mens du flytter den for å velge celler; trykk tilbaketast eller Delete to ganger for å slette celler."
-
-#~ msgid "Hungarian"
-#~ msgstr "Ungarsk"
-
-#~ msgid "If you type an operator (one of +*/^=,) as the first symbol in an input cell, % will be automatically inserted before the operator, as on a graphing calculator. You can disable this feature from the 'Edit->Configure' dialog."
-#~ msgstr "Om du bruker en operator (en av +*/^=,) som det første symbolet i en inndatacelle, vil % automatisk bli plassert før operatoren, som på en grafisk kalkulator. Du kan slå av denne funksjonen i dialogen 'Endre->Konfigurer'."
-
-#~ msgid "If your calculation is taking too long to evaluate, you can try 'Maxima->Interrupt' or 'Maxima->Restart Maxima' menu commands."
-#~ msgstr "Om kalkulasjonen din tar for lang tid å utføre, kan du prøve 'Maxima->Avbryt' eller 'Maxima->Restart Maxima' fra menyen."
-
-#~ msgid "Image"
-#~ msgstr "Bilde"
-
-#, fuzzy
-#~ msgid "Import+Export"
-#~ msgstr "Eksporter"
-
-#~ msgid "Infinity"
-#~ msgstr "Uendelig"
-
-#~ msgid "Insert % before an operator at the beginning of a cell"
-#~ msgstr "Sett inn % før en operator ved begynnelsen av celler"
-
-#, fuzzy
-#~ msgid "Integral sign"
-#~ msgstr "Integrer uttrykk"
-
-#, fuzzy
-#~ msgid "Intelligently hide cell brackets"
-#~ msgstr "Klammer rundt aktiv celle"
-
-#, fuzzy
-#~ msgid "Interaction"
-#~ msgstr "Retning:"
-
-#, fuzzy
-#~ msgid "Internal"
-#~ msgstr "Integrer"
 
 #~ msgid ""
 #~ "Invalid entry for Maxima program.\n"
@@ -11332,386 +15672,12 @@ msgstr ""
 #~ "\n"
 #~ "Vennligst oppgi banen til Maxima-programmet igjen."
 
-#~ msgid "Italian"
-#~ msgstr "Italiensk"
-
-#~ msgid "Italic"
-#~ msgstr "Kursiv"
-
-#~ msgid "Japanese"
-#~ msgstr "Japansk"
-
-#~ msgid "Keep percent sign with special symbols: %e, %i, etc."
-#~ msgstr "Behold prosenttegn ved spesielle symbol: %e, %i, etc."
-
-#~ msgid "Language used for wxMaxima GUI."
-#~ msgstr "Språk brukt til wxMaxima GUI."
-
-#~ msgid "Language:"
-#~ msgstr "Språk:"
-
-#~ msgid "Least Squares Fit..."
-#~ msgstr "Minste Kvadraters Metode..."
-
-#~ msgid "Limit..."
-#~ msgstr "Grenseverdi..."
-
-#~ msgid "Linear Regression..."
-#~ msgstr "Lineær Regresjon..."
-
-#, fuzzy
-#~ msgid "List of labels"
-#~ msgstr "Inndataetiketter"
-
-#~ msgid "Load"
-#~ msgstr "Last"
-
-#~ msgid "Load style from file"
-#~ msgstr "Last en stil fra fil"
-
-#, fuzzy
-#~ msgid "Match Case"
-#~ msgstr "Batchfil"
-
-#, fuzzy
-#~ msgid "Maxima Location"
-#~ msgstr "Maxima-spørsmål"
-
-#, fuzzy
-#~ msgid "Maxima configuration"
-#~ msgstr "wxMaxima-konfigurasjon"
-
-#~ msgid "Maxima program:"
-#~ msgstr "Maxima-program:"
-
-#, fuzzy
-#~ msgid "Maxima session (*.mac)|*.mac"
-#~ msgstr "Maxima-pakke (*.mac)|*.mac"
-
-#, fuzzy
-#~ msgid "Maxima usage"
-#~ msgstr "wxMaxima-ikon"
-
-#, fuzzy
-#~ msgid ""
-#~ "Maxima uses ':=' to define functions, e.g.:\n"
-#~ "f(x) := x^2;"
-#~ msgstr "Maxima bruker ':' for å sette verdier ( 'a : 3;' ) og ':=' for å definere funksjoner ( 'f(x) := x^2;' )."
-
-# oversetter er ikke kjent med 'mean'-stuff. gi lyd om du vet bedre.
-#~ msgid "Mean Difference Test..."
-#~ msgstr "Mean Difference Test..."
-
-#~ msgid "Mean Test..."
-#~ msgstr "Mean Test..."
-
-#, fuzzy
-#~ msgid "Mean..."
-#~ msgstr "Gjennomsnitt..."
-
-#~ msgid "Median..."
-#~ msgstr "Median..."
-
-#, fuzzy
-#~ msgid "Misc settings"
-#~ msgstr "Fold alle seksjoner"
-
-#~ msgid "Normality Test..."
-#~ msgstr "Normalitetstest..."
-
-#~ msgid "Norwegian"
-#~ msgstr "Norsk"
-
-#~ msgid "Open a cell when Maxima expects input"
-#~ msgstr "Åpne en celle når Maxima forventer inndata"
-
-#, fuzzy
-#~ msgid "Parametric Plot"
-#~ msgstr "Parametrisk Plott"
-
-#~ msgid "Piechart..."
-#~ msgstr "Kakediagram..."
-
-#~ msgid "Please restart wxMaxima for changes to take effect!"
-#~ msgstr "Vennligst restart wxMaxima for at endringene skal tre i kraft!"
-
-#~ msgid "Polish"
-#~ msgstr "Polsk"
-
-#~ msgid "Portuguese (Brazilian)"
-#~ msgstr "Portugisisk (brasiliansk)"
-
-#, fuzzy
-#~ msgid "Print Margins"
-#~ msgstr "Skriv ut"
-
-#, fuzzy
-#~ msgid "Print scale:"
-#~ msgstr "Skriv ut dokument"
-
-#, fuzzy
-#~ msgid "Printout settings"
-#~ msgstr "Fold alle seksjoner"
-
-#, fuzzy
-#~ msgid "Privacy settings"
-#~ msgstr "Fold alle seksjoner"
-
-#, fuzzy
-#~ msgid "Product sign"
-#~ msgstr "Produkt"
-
-#~ msgid "Read Matrix..."
-#~ msgstr "Les Matrise..."
-
-#, fuzzy
-#~ msgid "Read config to file"
-#~ msgstr "Lagre utvalg til fil"
-
-#~ msgid "Rectform"
-#~ msgstr "Rekt. form"
-
-#~ msgid "Reduce (tr)"
-#~ msgstr "Reduser (tr)"
-
-#, fuzzy
-#~ msgid "Reloading the styles from disc"
-#~ msgstr "Last en stil fra fil"
-
-#, fuzzy
-#~ msgid "Replace All"
-#~ msgstr "Velg Alle"
-
-#, fuzzy
-#~ msgid "Revert changes"
-#~ msgstr "Gjør om igjen den siste endringen du angret"
-
-#, fuzzy
-#~ msgid "Right"
-#~ msgstr "høyre"
-
-#~ msgid "Russian"
-#~ msgstr "Russisk"
-
-#, fuzzy
-#~ msgid "Save config to file"
-#~ msgstr "Lagre utvalg til fil"
-
-#~ msgid "Save style to file"
-#~ msgstr "Lagre stil til fil"
-
-#~ msgid "Scatterplot..."
-#~ msgstr "Spredningsplott..."
-
-#, fuzzy
-#~ msgid "Select"
-#~ msgstr "Utvalg"
-
 #~ msgid "Select Maxima program"
 #~ msgstr "Velg Maxima-program"
 
 #, fuzzy
-#~ msgid "Selecting a part of an output and right-clicking on the selection will bring up a menu with convenient functions that will operate on the selection."
-#~ msgstr "Velg en del av utdataen og høyreklikk på utvalget for å vise en meny med nyttige funksjoner som er relevante for utvalget."
-
-#, fuzzy
-#~ msgid "Show labels:"
-#~ msgstr "Vis &Variabler"
-
-#~ msgid "Show long expressions in wxMaxima document."
-#~ msgstr "Vis lange uttrykk i wxMaxima-dokument."
-
-#, fuzzy
-#~ msgid "Show long expressions:"
-#~ msgstr "Vis lange uttrykk"
-
-#, fuzzy
 #~ msgid "Show section numbers"
 #~ msgstr "Vis &Funksjoner"
-
-#, fuzzy
-#~ msgid "Simple"
-#~ msgstr "Måling:"
-
-#~ msgid "Simplify"
-#~ msgstr "Forenkle"
-
-#~ msgid "Simplify (r)"
-#~ msgstr "Forenkle (r)"
-
-#~ msgid "Simplify (tr)"
-#~ msgstr "Forenkle (tr)"
-
-#, fuzzy
-#~ msgid "Since wxMaxima 0.8.2 you can also insert images into your documents. Use 'Cell->Insert Image...' menu command."
-#~ msgstr "Fra wxMaxima 0.8.2 kan du også sette inn bilder i dokumentene dine. Bruk 'Celle->Sett inn bilde' fra menyen. Merk deg at du er nødt til å lagre dokumentet i formatet 'wxMaxima XML-dokument' om du vil at bilder skal lagres i tillegg til dokumentet."
-
-#~ msgid "Solve ODE..."
-#~ msgstr "Løs ODE..."
-
-#~ msgid "Spanish"
-#~ msgstr "Spansk"
-
-#, fuzzy
-#~ msgid "Standard Options"
-#~ msgstr "Valg"
-
-#~ msgid "Style"
-#~ msgstr "Stil"
-
-#~ msgid "Styles"
-#~ msgstr "Stiler"
-
-#~ msgid "Subsample..."
-#~ msgstr "Undermåling..."
-
-#~ msgid "Subst..."
-#~ msgstr "Erstatt..."
-
-#, fuzzy
-#~ msgid "Text Only"
-#~ msgstr "Tekstcelle"
-
-#~ msgid "The default port used for communication between Maxima and wxMaxima."
-#~ msgstr "Forhåndsvalgt port til kommunikasjon mellom Maxima og wxMaxima."
-
-#~ msgid "Title, section and subsection cells can be folded to hide their contents. To fold or unfold, click in the square next to the cell. If you shift-click, all sublevels of that cell will also fold/unfold."
-#~ msgstr "Tittel-, seksjon- og underseksjonceller kan foldes for å gjemme deres innhold. For å folde eller utfolde, klikk i firkanten ved cellen. Hvis du Shift+klikker, vil alle undernivå av cellen også foldes/utfoldes."
-
-#~ msgid "To plot in polar coordinates, select 'set polar' in the Options entry for Plot2d dialog. You can also plot in spherical and cylindrical coordinates in 3D."
-#~ msgstr "For å plotte i polarkoordinater, velg 'set polar' i Valg-feltet til Plott 2d-dialogen. Du kan også plotte sfæriske og sylindriske koordinater i 3D."
-
-#, fuzzy
-#~ msgid "To put parentheses around an expression, select it, and press '(' or ')' depending on where you want the cursor to appear afterwards."
-#~ msgstr "For å sette parenteser rundt et uttrykk, velg det, og trykk '(' eller ')' alt etter hvor du vil at pekeren skal være etterpå."
-
-#~ msgid "To save the size and position of wxMaxima windows between session, use 'Edit->Configure' dialog."
-#~ msgstr "For å lagre størrelse og posisjon til wxMaxima-vinduer mellom økter, bruk dialogen 'Endre->Konfigurer'."
-
-#, fuzzy
-#~ msgid "To start using wxMaxima right away, start typing your command. An input cell should appear. Then press Shift-Enter to evaluate your command."
-#~ msgstr "For å ta i bruk wxMaxima med en gang, kan du bare starte og skrive kommandoer; en inndatacelle hører til å dukke opp. Deretter trykker du Shift+Enter for å utføre kommandoene dine."
-
-#, fuzzy
-#~ msgid "Top"
-#~ msgstr "Til:"
-
-#~ msgid "Turkish"
-#~ msgstr "Tyrkisk"
-
-#~ msgid "Ukrainian"
-#~ msgstr "Ukrainsk"
-
-#, fuzzy
-#~ msgid "Upsilon"
-#~ msgstr "Epsilon:"
-
-#~ msgid "Use centered dot character for multiplication"
-#~ msgstr "Bruk 'midtstilt prikk'-tegn til multiplikasjon"
-
-#, fuzzy
-#~ msgid "Value"
-#~ msgstr "Verdi:"
-
-#~ msgid "Variance..."
-#~ msgstr "Varians..."
-
-# Det kan vist godt formuleres klarere...
-#~ msgid "When applying functions with one argument from menus, the default argument is '%'. To apply the function to some other value, select it in the document before executing a menu command."
-#~ msgstr "Når du anvender funksjoner med ett argument fra menyer, er det forhåndsvalgte argumentet '%'. For å bruke funksjonen på en annen verdi, velg verdien i dokumentet før du utfører menykommandoen."
-
-#, fuzzy
-#~ msgid "Yes"
-#~ msgstr "ja"
-
-#~ msgid "You can access the last output using the variable '%'. You can access the output of previous commands using variables '%on' where n is the number of output."
-#~ msgstr "Du kan bruke siste utdata ved å bruke variabelen '%'. Du kan bruke utdata fra forrige kommandoer ved å bruke variablene '%on', hvor n er utdatanummer."
-
-#~ msgid "You can evaluate your whole document by using 'Cell->Evaluate All Cells' menu command or the appropriate key shortcut. The cells will be evaluated in the order they appear in the document."
-#~ msgstr "Du kan utføre hele dokumentet ved å bruke 'Celle->Utfør alle celler' fra menyen, eller relevant tastsnarvei. Cellene vil utføres i samme rekkefølge som i dokumentet."
-
-#, fuzzy
-#~ msgid "You can get help on a Maxima function by selecting or clicking on the function name and pressing F1. wxMaxima will search the help index for the selection or the word under the cursor."
-#~ msgstr "Du kan få hjelp til en Maxima-funksjon ved å velge eller klikke på funksjonnavnet, og trykke F1. wxMaxima vil søke gjennom hjelpefilene etter utvalget eller ordet under pekeren."
-
-#~ msgid "You can hide output part of cells by clicking in the triangle on the left side of cells. This works on text cells also."
-#~ msgstr "Du kan gjemme utdatadelen av celler ved å klikke i triangelet på den venstre siden av celler. Dette fungerer også på tekstceller."
-
-#, fuzzy
-#~ msgid "You can insert different types of 'cells' in wxMaxima documents using the 'Cell' menu. Note that only 'input cells' can be evaluated, while others are used for commenting and structuring your calculations."
-#~ msgstr "Du kan sette inn forskjellige typer 'celler' i wxMaxima-dokument ved å bruke 'Celle'-menyen. Merk deg at kun 'inndataceller' kan utføres, mens andre brukes til kommentering og strukturering."
-
-#~ msgid "You can select multiple cells either with a mouse - click'n'drag from between cells or from a cell bracket on the left - or with a keyboard - hold down Shift while moving the horizontal cursor - and then operate on selection. This comes in handy when you want to delete or evaluate multiple cells."
-#~ msgstr "Du kan velge flere celler enten med en mus — klikk-og-dra fra mellom celler eller fra en celleklamme til venstre — eller med et tastatur — hold inne Shift mens du flytter den horisontale pekeren — og betjen deretter utvalget. Dette er hendig når du vil slette eller utføre flere celler."
-
-#, fuzzy
-#~ msgid "and"
-#~ msgstr "Utvid"
-
-#, fuzzy
-#~ msgid "epsilon"
-#~ msgstr "Epsilon:"
-
-#, fuzzy
-#~ msgid "greater than or equal"
-#~ msgstr "Underseksjoncelle"
-
-#, fuzzy
-#~ msgid "in"
-#~ msgstr "Finn"
-
-#, fuzzy
-#~ msgid "intersection"
-#~ msgstr "Retning:"
-
-#, fuzzy
-#~ msgid "less or equal"
-#~ msgstr "Underseksjoncelle"
-
-#, fuzzy
-#~ msgid "much greater than"
-#~ msgstr "Underseksjoncelle"
-
-#, fuzzy
-#~ msgid "nor"
-#~ msgstr "nei"
-
-#, fuzzy
-#~ msgid "not"
-#~ msgstr "nei"
-
-#, fuzzy
-#~ msgid "partial sign"
-#~ msgstr "Delbrøker"
-
-#, fuzzy
-#~ msgid "subset"
-#~ msgstr "Underseksjon"
-
-#, fuzzy
-#~ msgid "subset or equal"
-#~ msgstr "Underseksjoncelle"
-
-#, fuzzy
-#~ msgid "upsilon"
-#~ msgstr "Epsilon:"
-
-#~ msgid "wxMaxima configuration"
-#~ msgstr "wxMaxima-konfigurasjon"
-
-#~ msgid "wxMaxima dialogs set default values for inputs entries, one of which is '%'. If you have made a selection in your document, the selection will be used instead of '%'."
-#~ msgstr "wxMaxima-dialoger setter forhåndsvalgte verdier for inndatafelt, hvorav en er '%'. Om du har gjordt et utvalg i dokumentet ditt, vil utvalget bli brukt i stedet for '%'."
-
-#, fuzzy
-#~ msgid "wxMaxima startup file location: "
-#~ msgstr "Start Animasjon"
-
-#, fuzzy
-#~ msgid "xor"
-#~ msgstr "Eksporter"
-
-#~ msgid "Direction:"
-#~ msgstr "Retning:"
 
 #, fuzzy
 #~ msgid "Lisp files (*.lisp)|*.lisp|All|*"
@@ -11806,9 +15772,6 @@ msgstr ""
 
 #~ msgid "At value"
 #~ msgstr "Ved verdi"
-
-#~ msgid "BC2"
-#~ msgstr "BC2"
 
 #~ msgid "Char poly"
 #~ msgstr "charpoly"
@@ -11917,188 +15880,11 @@ msgstr ""
 #~ msgid "Save panes layout between sessions."
 #~ msgstr "Lagre inndelingsvindu-layout mellom økter."
 
-#, fuzzy
-#~ msgid " samples"
-#~ msgstr "Eksempel"
-
-# hvilken kontekst?
-#, fuzzy
-#~ msgid " times"
-#~ msgstr "Antall:"
-
-#~ msgid "&Definite integration"
-#~ msgstr "&Bestemt Integrasjon"
-
-#~ msgid "&Nusum"
-#~ msgstr "&Nusum"
-
-#~ msgid "&Rational"
-#~ msgstr "&Rasjonell"
-
-#~ msgid "&Special"
-#~ msgstr "&Spesiell"
-
-#~ msgid "&Taylor series"
-#~ msgstr "&Taylorrekke"
-
-#~ msgid "&pm3d"
-#~ msgstr "&pm3d"
-
-#~ msgid "- Infinity"
-#~ msgstr "- Uendelig"
-
-#, fuzzy
-#~ msgid "A function f(a,b), named"
-#~ msgstr "Funksjonnavn"
-
-#, fuzzy
-#~ msgid "A page break"
-#~ msgstr "Sideskift"
-
-#, fuzzy
-#~ msgid "A static plot"
-#~ msgstr "Parametrisk Plott"
-
-#, fuzzy
-#~ msgid "A sub-subsection heading"
-#~ msgstr "Underseksjoncelle"
-
-#, fuzzy
-#~ msgid "A subsection heading"
-#~ msgstr "Underseksjoncelle"
-
-#~ msgid "Browse"
-#~ msgstr "Utforsk"
-
-#~ msgid "Choose new plot format:"
-#~ msgstr "Velg nytt plot-format:"
-
-#~ msgid "Comma separated x coordinates"
-#~ msgstr "Kommaseparerte x-koordinater"
-
-#~ msgid "Comma separated y coordinates"
-#~ msgstr "Kommaseparerte y-koordinater"
-
-#~ msgid "Constant"
-#~ msgstr "Konstant"
-
-#, fuzzy
-#~ msgid "Data format"
-#~ msgstr "Plottformat"
-
-#~ msgid "Depth:"
-#~ msgstr "Dybde:"
-
-#~ msgid "Discrete plot"
-#~ msgstr "Diskret Plott"
-
 #~ msgid "Equation %d:"
 #~ msgstr "Likning %d:"
 
-#~ msgid "Figure %d:"
-#~ msgstr "Figur %d:"
-
 #~ msgid "File:"
 #~ msgstr "Fil:"
-
-#~ msgid "Format:"
-#~ msgstr "Format:"
-
-#, fuzzy
-#~ msgid "Frame counter end"
-#~ msgstr "Fant ikke fil"
-
-#~ msgid "Grid:"
-#~ msgstr "Rutenett:"
-
-#~ msgid "Method:"
-#~ msgstr "Metode:"
-
-#~ msgid "New value:"
-#~ msgstr "Ny verdi:"
-
-#~ msgid "Old value:"
-#~ msgstr "Forrige verdi:"
-
-#~ msgid "Options:"
-#~ msgstr "Valg:"
-
-#, fuzzy
-#~ msgid "Plot an explicit expression"
-#~ msgstr "Finn grenseverdi til et uttrykk"
-
-#~ msgid "Plot to file:"
-#~ msgstr "Plott til fil:"
-
-#, fuzzy
-#~ msgid "Point type:"
-#~ msgstr "Punkt:"
-
-#, fuzzy
-#~ msgid "Reuse last"
-#~ msgstr "Lag liste"
-
-#~ msgid "Save plot to file"
-#~ msgstr "Lagre plott til fil"
-
-#~ msgid "Special"
-#~ msgstr "Spesiell"
-
-#, fuzzy
-#~ msgid "Start value of the parameter"
-#~ msgstr "Kalkuler desimalverdien av siste resultat"
-
-# Det er bestemt et dårligt ord, men jeg kan ikke komme på noget bedre.
-# vi norske sliter vi også...
-#~ msgid "Ticks:"
-#~ msgstr "Haker:"
-
-#, fuzzy
-#~ msgid "Type in text"
-#~ msgstr "Kopier som Bilde"
-
-#~ msgid "Use Gosper algorithm"
-#~ msgstr "Bruk Gospers algoritme"
-
-#~ msgid "antisymmetric"
-#~ msgstr "antisymmetrisk"
-
-#~ msgid "both sides"
-#~ msgstr "begge sider"
-
-#~ msgid "default"
-#~ msgstr "forhåndsvalgt"
-
-#~ msgid "diagonal"
-#~ msgstr "diagonalt"
-
-# generelt?
-#~ msgid "general"
-#~ msgstr "generell"
-
-#~ msgid "inline"
-#~ msgstr "inline"
-
-#~ msgid "left"
-#~ msgstr "venstre"
-
-#~ msgid "logscale"
-#~ msgstr "logscale"
-
-#~ msgid "symmetric"
-#~ msgstr "symmetrisk"
-
-#, fuzzy
-#~ msgid "the x and the y coordinate."
-#~ msgstr "Kommaseparerte y-koordinater"
-
-#, fuzzy
-#~ msgid "Complex infinity."
-#~ msgstr "&Kompleks Forenkling"
-
-#, fuzzy
-#~ msgid "The inverse laplace transform."
-#~ msgstr "I&nvers Laplacetransformasjon..."
 
 #~ msgid "Greek constants"
 #~ msgstr "Greske konstanter"
@@ -12144,9 +15930,6 @@ msgstr ""
 #~ msgstr ""
 #~ "\n"
 #~ "Lisp: "
-
-#~ msgid "wxMaxima document (*.wxm, *.wxmx)|*.wxm;*.wxmx"
-#~ msgstr "wxMaxima-dokument (*.wxm, *.wxmx)|*.wxm;*.wxmx"
 
 #~ msgid "&Interrupt\tCtrl+."
 #~ msgstr "&Avbryt\tCtrl+."

--- a/locales/wxMaxima/pl.po
+++ b/locales/wxMaxima/pl.po
@@ -314,7 +314,7 @@ msgstr ""
 
 #: ../../src/wizards/IntegrateWiz.cpp:39
 msgid "&Definite integration"
-msgstr ""
+msgstr "Całka &oznaczona"
 
 #: ../../src/wxMaximaFrame.cpp:1658
 msgid "&Demoivre"
@@ -430,11 +430,11 @@ msgstr ""
 
 #: ../../src/wizards/IntegrateWiz.cpp:52
 msgid "&Numerical integration"
-msgstr ""
+msgstr "Całkowanie &numeryczne"
 
 #: ../../src/wizards/SumWiz.cpp:44
 msgid "&Nusum"
-msgstr ""
+msgstr "&Nusum"
 
 #: ../../src/main.cpp:675
 msgid "&Open\tCtrl+O"
@@ -450,7 +450,7 @@ msgstr ""
 
 #: ../../src/wizards/SeriesWiz.cpp:45
 msgid "&Power series"
-msgstr ""
+msgstr "&Szereg potęgowy"
 
 #: ../../src/wxMaximaFrame.cpp:655
 msgid "&Print...\tCtrl+P"
@@ -458,7 +458,7 @@ msgstr ""
 
 #: ../../src/wizards/SubstituteWiz.cpp:38
 msgid "&Rational"
-msgstr ""
+msgstr "&Wymierne"
 
 #: ../../src/wxMaximaFrame.cpp:1631
 msgid "&Reduce Trigonometric"
@@ -490,11 +490,11 @@ msgstr ""
 
 #: ../../src/wizards/Plot2dWiz.cpp:42
 msgid "&Special"
-msgstr ""
+msgstr "&Specjalny"
 
 #: ../../src/wizards/LimitWiz.cpp:45
 msgid "&Taylor series"
-msgstr ""
+msgstr "Szereg &Taylora"
 
 #: ../../src/wxMaximaFrame.cpp:1069
 msgid "&Time Display"
@@ -514,7 +514,7 @@ msgstr ""
 
 #: ../../src/wizards/Plot3dWiz.cpp:79
 msgid "&pm3d"
-msgstr ""
+msgstr "&pm3d"
 
 #: ../../src/cells/AnimationCell.cpp:475
 msgid "(Animation)"
@@ -550,7 +550,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:183
 msgid "(Use default language)"
-msgstr ""
+msgstr "(Używaj domyślnego języka)"
 
 #: ../../src/MaximaCommandMenus.cpp:440
 msgid "(f(x),x,a,b)), Epsilon algorithm"
@@ -592,7 +592,7 @@ msgstr ""
 #: ../../src/wizards/IntegrateWiz.cpp:217 ../../src/wizards/LimitWiz.cpp:132
 #: ../../src/wizards/LimitWiz.cpp:142
 msgid "- Infinity"
-msgstr ""
+msgstr "- Nieskończoność"
 
 #: ../../src/MaximaOutputAppender.cpp:116
 msgid "... [suppressed additional lines as the output is longer than allowed in the wxMaxima configuration] "
@@ -649,7 +649,7 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:102
 msgid "A 'horizontal cursor' was introduced in wxMaxima 0.8.0. It looks like a horizontal line between cells. It indicates where a new cell will appear if you type or paste text or execute a menu command."
-msgstr ""
+msgstr "Od wxMaxima 0.8.0 został wprowadzony 'kurzor poziomy'. Wygłada jak kreska pozioma pomiędzy komórkami. Wskazuje miejsce, w którym mozna wstawić nową komorkę poprzez zwykły początek wprowadzania nowego polecenia, wklejanie skopiowanej koorki lub uruchomienie polecenia z menu."
 
 #: ../../src/MaximaCommandMenus.cpp:3039
 msgid "A Ctrl-F event"
@@ -916,7 +916,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:389
 msgid "Additional parameters for Maxima (e.g. -l clisp)."
-msgstr ""
+msgstr "Dodatkowe parametry Maximy (np. -l clisp)."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1543
 msgid "Additional parameters for Maxima (restart Maxima after changes)"
@@ -1012,7 +1012,7 @@ msgstr ""
 
 #: ../../src/dialogs/BinaryNameCtrl.cpp:69
 msgid "All|*"
-msgstr ""
+msgstr "Wszystkie|*"
 
 #: ../../src/wxMaximaFrame.cpp:800
 msgid "Always after underscores"
@@ -1189,7 +1189,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1397
 msgid "Ask to save untitled documents"
-msgstr ""
+msgstr "Pytaj o zapis dokumentów bez nazwy"
 
 #: ../../src/dialogs/MaximaNotStartingDialog.cpp:36
 msgid "Asking the user for the location of a working maxima binary"
@@ -1291,7 +1291,7 @@ msgstr ""
 
 #: ../../src/wizards/BC2Wiz.cpp:59
 msgid "BC2"
-msgstr ""
+msgstr "Warunki brzegowe"
 
 #: ../../src/MaximaManual.cpp:559
 msgid "Background task that compiles the Manual anchors scheduled."
@@ -1299,7 +1299,7 @@ msgstr ""
 
 #: ../../src/sidebars/StatSidebar.cpp:91
 msgid "Barsplot..."
-msgstr ""
+msgstr "Wykres słupkowy..."
 
 #: ../../src/wxMaximaFrame.cpp:1384
 msgid "Basic matrix operations"
@@ -1358,7 +1358,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2109
 msgid "Bold"
-msgstr ""
+msgstr "Pogrubienie"
 
 #: ../../src/wxMaxima.cpp:2259
 msgid "Both horizontal and vertical cursor active at the same time"
@@ -1382,13 +1382,13 @@ msgstr ""
 
 #: ../../src/sidebars/StatSidebar.cpp:97
 msgid "Boxplot..."
-msgstr ""
+msgstr "Wykres pudełkowy..."
 
 #: ../../src/dialogs/BinaryNameCtrl.cpp:42 ../../src/wizards/CsvWiz.cpp:57
 #: ../../src/wizards/CsvWiz.cpp:131 ../../src/wizards/Plot2dWiz.cpp:114
 #: ../../src/wizards/Plot3dWiz.cpp:109
 msgid "Browse"
-msgstr ""
+msgstr "Przeglądaj"
 
 #: ../../src/wxMathml.cpp:101
 msgid "Bug: After removing the whitespace wxMathml.lisp is shorter than expected!"
@@ -1767,11 +1767,11 @@ msgstr ""
 
 #: ../../src/sidebars/MathSidebar.cpp:62
 msgid "Canonical (tr)"
-msgstr ""
+msgstr "Postać kanoniczna (tr)"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:188
 msgid "Catalan"
-msgstr ""
+msgstr "Katalonski"
 
 #: ../../src/MaximaCommandMenus.cpp:466
 msgid "Cauchy principal value of f(x)/(x-c), finite interval"
@@ -1941,7 +1941,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2100
 msgid "Choose font"
-msgstr ""
+msgstr "Wybierz czcionkę"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:793
 msgid "Choose how mathematical output is formatted:\n"
@@ -1952,7 +1952,7 @@ msgstr ""
 
 #: ../../src/wizards/PlotFormatWiz.cpp:31
 msgid "Choose new plot format:"
-msgstr ""
+msgstr "Wybierz nowy format wykresów:"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2432
 #, c-format
@@ -2126,7 +2126,7 @@ msgstr ""
 
 #: ../../src/wizards/MatWiz.cpp:155
 msgid "Columns:"
-msgstr ""
+msgstr "Kolumny:"
 
 #: ../../src/wxMaximaFrame.cpp:1621
 msgid "Combine factorials in an expression"
@@ -2142,11 +2142,11 @@ msgstr ""
 
 #: ../../src/wizards/Plot2dWiz.cpp:626
 msgid "Comma separated x coordinates"
-msgstr ""
+msgstr "Przecinek oddziela kolejne współrzędne na osi OX"
 
 #: ../../src/wizards/Plot2dWiz.cpp:627
 msgid "Comma separated y coordinates"
-msgstr ""
+msgstr "Przecinek oddziela kolejne współrzędne na osi OY"
 
 #: ../../src/MaximaCommandMenus.cpp:4071
 msgid "Comma-separated arguments"
@@ -2240,7 +2240,7 @@ msgstr ""
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:465
 msgid "Comment Selection"
-msgstr ""
+msgstr "Zakomentuj zaznaczenie"
 
 #: ../../src/wxMaximaFrame.cpp:718
 msgid "Comment out the currently selected text"
@@ -2372,7 +2372,7 @@ msgstr ""
 #: ../../src/dialogs/ConfigDialogue.cpp:2641
 #: ../../src/dialogs/ConfigDialogue.cpp:2647
 msgid "Config file (*.ini)|*.ini"
-msgstr ""
+msgstr "Plik konfiguracyjny (*.ini)|*.ini"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2539
 #, c-format
@@ -2404,7 +2404,7 @@ msgstr ""
 #: ../../src/wizards/IntegrateWiz.cpp:208 ../../src/wizards/LimitWiz.cpp:133
 #: ../../src/wizards/SeriesWiz.cpp:105
 msgid "Constant"
-msgstr ""
+msgstr "Stała"
 
 #: ../../src/MaximaCommandMenus.cpp:1102
 msgid "Construct a fraction"
@@ -2878,7 +2878,7 @@ msgstr ""
 
 #: ../../src/worksheet/Worksheet.cpp:6115
 msgid "Cursor"
-msgstr ""
+msgstr "Kursor"
 
 #: ../../src/Styles.cpp:126
 msgid "Cursor color"
@@ -2900,11 +2900,11 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:193
 msgid "Czech"
-msgstr ""
+msgstr "Czeski"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:194
 msgid "Danish"
-msgstr ""
+msgstr "Duński"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2069
 msgid "Dark"
@@ -3043,7 +3043,7 @@ msgstr ""
 #: ../../src/worksheet/WorksheetContextMenu.cpp:157
 #: ../../src/worksheet/WorksheetContextMenu.cpp:298
 msgid "Delete Selection"
-msgstr ""
+msgstr "Usuń zaznaczenie"
 
 #: ../../src/wxMaximaFrame.cpp:1021
 msgid "Delete V&ariable..."
@@ -3121,7 +3121,7 @@ msgstr ""
 
 #: ../../src/wizards/SeriesWiz.cpp:42
 msgid "Depth:"
-msgstr ""
+msgstr "Stopień:"
 
 #: ../../src/MaximaCommandMenus.cpp:994
 msgid "Derivate of y at that point:"
@@ -3156,7 +3156,7 @@ msgstr ""
 
 #: ../../src/sidebars/StatSidebar.cpp:61
 msgid "Deviation..."
-msgstr ""
+msgstr "Odchylenie..."
 
 #: ../../src/wxMaximaFrame.cpp:1534
 msgid "Di&vide Polynomials..."
@@ -3188,7 +3188,7 @@ msgstr ""
 
 #: ../../src/sidebars/MathSidebar.cpp:80
 msgid "Diff..."
-msgstr ""
+msgstr "Pochodna..."
 
 #: ../../src/dialogs/DiffFrame.cpp:308
 #, c-format
@@ -3205,7 +3205,7 @@ msgstr ""
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:363
 msgid "Differentiate..."
-msgstr ""
+msgstr "Pochodna..."
 
 #: ../../src/MaximaCommandMenus.cpp:264
 msgid "Differentiates an expression n times"
@@ -3217,7 +3217,7 @@ msgstr ""
 
 #: ../../src/wizards/LimitWiz.cpp:41
 msgid "Direction:"
-msgstr ""
+msgstr "Z:"
 
 #: ../../src/wxMaximaFrame.cpp:1246
 msgid "Directory operations"
@@ -3229,7 +3229,7 @@ msgstr ""
 
 #: ../../src/wizards/Plot2dWiz.cpp:418 ../../src/wizards/Plot2dWiz.cpp:619
 msgid "Discrete plot"
-msgstr ""
+msgstr "Dyskretny"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:699
 msgid "Display"
@@ -3571,7 +3571,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:196
 msgid "English"
-msgstr ""
+msgstr "Angielski"
 
 #: ../../src/wizards/DrawWiz.cpp:552
 msgid "Enhanced 3D settings:"
@@ -3583,7 +3583,7 @@ msgstr ""
 
 #: ../../src/sidebars/StatSidebar.cpp:106
 msgid "Enter Matrix..."
-msgstr ""
+msgstr "Wprowadź macierz..."
 
 #: ../../src/MaximaCommandMenus.cpp:2255
 msgid "Enter UUID to jump to:"
@@ -3603,7 +3603,7 @@ msgstr ""
 
 #: ../../src/wizards/SystemWiz.cpp:50
 msgid "Enter comma separated list of variables."
-msgstr ""
+msgstr "Wprowadź listę zmiennych oddzielonych przecinkami"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:921
 msgid "Enter evaluates cells, Ctrl+Enter adds newlines"
@@ -3623,7 +3623,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:388
 msgid "Enter the path to the Maxima executable."
-msgstr ""
+msgstr "Wprowadź ścieżkę do programu Maxima"
 
 #: ../../src/MaximaCommandMenus.cpp:1103
 msgid "Enumerator:"
@@ -3870,7 +3870,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2659
 msgid "Example text"
-msgstr ""
+msgstr "Przykładowy tekst"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1547
 msgid "Examples:"
@@ -3886,15 +3886,15 @@ msgstr ""
 
 #: ../../src/sidebars/MathSidebar.cpp:53
 msgid "Expand"
-msgstr ""
+msgstr "Rozwiń"
 
 #: ../../src/sidebars/MathSidebar.cpp:68
 msgid "Expand (tr)"
-msgstr ""
+msgstr "Rozwiń (tr)"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:356
 msgid "Expand Expression"
-msgstr ""
+msgstr "Rozwiń wyrażenie"
 
 #: ../../src/wxMaximaFrame.cpp:1562
 msgid "Expand an expression"
@@ -4216,7 +4216,7 @@ msgstr ""
 
 #: ../../src/sidebars/MathSidebar.cpp:50
 msgid "Factor"
-msgstr ""
+msgstr "Faktoryzuj"
 
 #: ../../src/wxMaximaFrame.cpp:1558
 msgid "Factor Complex"
@@ -4224,7 +4224,7 @@ msgstr ""
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:354
 msgid "Factor Expression"
-msgstr ""
+msgstr "Faktoryzuj wyrażenie"
 
 #: ../../src/wxMaximaFrame.cpp:1556
 msgid "Factor Expression including subexpressions"
@@ -4291,7 +4291,7 @@ msgstr ""
 #: ../../src/cells/GroupCell.cpp:2115
 #, c-format
 msgid "Figure %d:"
-msgstr ""
+msgstr "Obrazek %d:"
 
 #: ../../src/main.cpp:678
 msgid "File"
@@ -4363,7 +4363,7 @@ msgstr ""
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:349
 msgid "Find Root..."
-msgstr ""
+msgstr "Znajdź pierwiastek..."
 
 #: ../../src/wxMaximaFrame.cpp:1508
 msgid "Find a (unconstrained) minimum of an expression"
@@ -4489,7 +4489,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:873
 msgid "Fixed font in text controls"
-msgstr ""
+msgstr "Czcionka o stałej szerokości w kontrolkach tekstowych"
 
 #: ../../src/MaximaCommandMenus.cpp:4039
 msgid "Flush stream"
@@ -4533,7 +4533,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2047
 msgid "Fonts"
-msgstr ""
+msgstr "Czcionki"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:442
 msgid "For each Text-, Sectioning or code cell wxMaxima can display a bracket showing the extend of the cell and allowing to fold it. This setting now tells if this bracket is to be printed, as well."
@@ -4561,7 +4561,7 @@ msgstr ""
 
 #: ../../src/wizards/Plot2dWiz.cpp:69 ../../src/wizards/Plot3dWiz.cpp:60
 msgid "Format:"
-msgstr ""
+msgstr "Format:"
 
 #: ../../src/worksheet/Worksheet.cpp:301 ../../src/wxMaxima.cpp:3521
 msgid "Forwarding the keyboard focus to a text control"
@@ -4626,7 +4626,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:198
 msgid "French"
-msgstr ""
+msgstr "Francuski"
 
 #: ../../src/wxMaximaFrame.cpp:1447
 msgid "Frobenius Norm sqrt(sum((A(i,j))^2)) (complex)"
@@ -4765,7 +4765,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:201
 msgid "German"
-msgstr ""
+msgstr "Niemiecki"
 
 #: ../../src/wxMaximaFrame.cpp:1656
 msgid "Get &Imaginary Part"
@@ -4853,7 +4853,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:202
 msgid "Greek"
-msgstr ""
+msgstr "Grecki"
 
 #: ../../src/wxMaximaFrame.cpp:281
 msgid "Greek Letters"
@@ -4869,7 +4869,7 @@ msgstr ""
 
 #: ../../src/wizards/Plot3dWiz.cpp:52
 msgid "Grid:"
-msgstr ""
+msgstr "Siatka:"
 
 #: ../../src/wxMaximaFrame.cpp:1852
 msgid "Guess an exact number that could be meant by this float"
@@ -5046,7 +5046,7 @@ msgstr ""
 
 #: ../../src/sidebars/StatSidebar.cpp:85
 msgid "Histogram..."
-msgstr ""
+msgstr "Histogram..."
 
 #: ../../src/wxMaximaFrame.cpp:246
 msgid "History"
@@ -5058,7 +5058,7 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:105
 msgid "Horizontal cursor works like a normal cursor, but it operates on cells: press up or down arrow to move it, holding down Shift while moving will select cells, pressing backspace or delete twice will delete a cell next to it."
-msgstr ""
+msgstr "Kursor pionowy zachowuje się, jak zwykły kursor, ale działa na komórkach. Można go przesuwać za pomocą strzałek. Jednoczesne naciśnięcie Shift pozwala zaznaczać komórki, naciśnięcie Backspace lub Delete (dwukrotnie) usuwa zaznaczone komórki."
 
 #: ../../src/wxMaximaFrame.cpp:1563
 msgid "Horner's rule"
@@ -5078,7 +5078,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:205
 msgid "Hungarian"
-msgstr ""
+msgstr "Węgierski"
 
 #: ../../src/wxMaximaFrame.cpp:1147
 msgid "I/O"
@@ -5189,7 +5189,7 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:122
 msgid "If your calculation is taking too long to evaluate, you can try 'Maxima->Interrupt' or 'Maxima->Restart Maxima' menu commands."
-msgstr ""
+msgstr "Jeśli obliczenia trwają zbyt długo, możesz je przerwać wybierając 'Maxima->Przerwij' albo 'Maxima->Uruchom ponownie'"
 
 #: ../../src/MaximaManual.cpp:420
 msgid "Ignoring the cache version for the manual anchors."
@@ -5197,7 +5197,7 @@ msgstr ""
 
 #: ../../src/sidebars/FormatSidebar.cpp:66
 msgid "Image"
-msgstr ""
+msgstr "Obrazek"
 
 #: ../../src/Image.cpp:110
 msgid "Image data had zero length!"
@@ -5326,7 +5326,7 @@ msgstr ""
 #: ../../src/wizards/IntegrateWiz.cpp:215 ../../src/wizards/LimitWiz.cpp:132
 #: ../../src/wizards/LimitWiz.cpp:140
 msgid "Infinity"
-msgstr ""
+msgstr "Nieskończoność"
 
 #: ../../src/wxMaximaFrame.cpp:1986
 msgid "Info about Maxima build"
@@ -5432,11 +5432,11 @@ msgstr ""
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:435
 msgid "Insert Section Cell"
-msgstr ""
+msgstr "Wstaw komórkę &rozdziału"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:437
 msgid "Insert Subsection Cell"
-msgstr ""
+msgstr "Wstaw komórkę &podrozdziału"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:440
 msgid "Insert Subsubsection Cell"
@@ -5448,11 +5448,11 @@ msgstr ""
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:431
 msgid "Insert Text Cell"
-msgstr ""
+msgstr "Wstaw komórkę t&ekstową"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:433
 msgid "Insert Title Cell"
-msgstr ""
+msgstr "Wstaw komórkę &tytułowa"
 
 #: ../../src/wxMaximaFrame.cpp:947
 msgid "Insert a new heading5 cell"
@@ -5566,7 +5566,7 @@ msgstr ""
 #: ../../src/sidebars/MathSidebar.cpp:83
 #: ../../src/worksheet/WorksheetContextMenu.cpp:361
 msgid "Integrate..."
-msgstr ""
+msgstr "Całkuj..."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:834
 msgid "Intelligently hide cell brackets"
@@ -5804,11 +5804,11 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:207
 msgid "Italian"
-msgstr ""
+msgstr "Włoski"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2111
 msgid "Italic"
-msgstr ""
+msgstr "Kursywa"
 
 #: ../../src/MaximaCommandMenus.cpp:1617 ../../src/MaximaCommandMenus.cpp:1623
 msgid "Item"
@@ -5820,7 +5820,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:208
 msgid "Japanese"
-msgstr ""
+msgstr "Japoński"
 
 #: ../../src/MaximaCommandMenus.cpp:2255
 msgid "Jump to UUID"
@@ -5857,7 +5857,7 @@ msgstr ""
 #: ../../src/dialogs/ConfigDialogue.cpp:864
 #, c-format
 msgid "Keep percent sign with special symbols: %e, %i, etc."
-msgstr ""
+msgstr "Używaj znak procentu dla zmiennych specjalnych: %e, %i, itp."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:212
 msgid "Korean"
@@ -5916,11 +5916,11 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:470
 msgid "Language used for wxMaxima GUI."
-msgstr ""
+msgstr "Język używany w GUI wxMaximy"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1311
 msgid "Language:"
-msgstr ""
+msgstr "Język:"
 
 #: ../../src/MaximaCommandMenus.cpp:251
 msgid "Laplace"
@@ -5979,7 +5979,7 @@ msgstr ""
 
 #: ../../src/sidebars/StatSidebar.cpp:79
 msgid "Least Squares Fit..."
-msgstr ""
+msgstr "Metoda najmniejszych kwadratów..."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2007
 msgid "Left"
@@ -6037,7 +6037,7 @@ msgstr ""
 
 #: ../../src/sidebars/MathSidebar.cpp:86
 msgid "Limit..."
-msgstr ""
+msgstr "Granica..."
 
 #: ../../src/sidebars/DrawSidebar.cpp:88
 msgid "Line color"
@@ -6045,7 +6045,7 @@ msgstr ""
 
 #: ../../src/sidebars/StatSidebar.cpp:76
 msgid "Linear Regression..."
-msgstr ""
+msgstr "Regresja liniowa..."
 
 #: ../../src/MaximaCommandMenus.cpp:4068
 msgid "Lisp format string:"
@@ -6178,7 +6178,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2162
 msgid "Load"
-msgstr ""
+msgstr "Wczytaj"
 
 #: ../../src/MaximaCommandMenus.cpp:2356
 msgid "Load Package"
@@ -6218,7 +6218,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2645
 msgid "Load style from file"
-msgstr ""
+msgstr "Wczytaj styl z pliku"
 
 #: ../../src/wxMaximaFrame.cpp:1232
 msgid "Load the file/dir operations (operatingsystem)"
@@ -6551,7 +6551,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1437
 msgid "Maxima program:"
-msgstr ""
+msgstr "Maxima program:"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:382
 msgid "Maxima provides no \"forget all\" command that flushes all settings a maxima session could make. wxMaxima therefore normally defaults to starting a fresh maxima process every time the worksheet is to be re-evaluated. As this needs a little bit of time this switch allows to disable this behavior."
@@ -6794,7 +6794,7 @@ msgstr ""
 
 #: ../../src/sidebars/StatSidebar.cpp:52
 msgid "Mean..."
-msgstr ""
+msgstr "Średnia..."
 
 #: ../../src/MaximaCommandMenus.cpp:1806
 msgid "Mean:"
@@ -6802,7 +6802,7 @@ msgstr ""
 
 #: ../../src/sidebars/StatSidebar.cpp:55
 msgid "Median..."
-msgstr ""
+msgstr "Mediana..."
 
 #: ../../src/wxMaximaFrame.cpp:1961
 msgid "Memoizing"
@@ -6823,7 +6823,7 @@ msgstr ""
 
 #: ../../src/wizards/IntegrateWiz.cpp:55
 msgid "Method:"
-msgstr ""
+msgstr "Metoda:"
 
 #: ../../src/wxMaximaFrame.cpp:1360
 msgid "Methods of generating a matrix"
@@ -6922,7 +6922,7 @@ msgstr ""
 
 #: ../../src/wizards/MatWiz.cpp:163
 msgid "Name:"
-msgstr ""
+msgstr "Nazwa:"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:216
 msgid "Nepali"
@@ -6998,7 +6998,7 @@ msgstr ""
 
 #: ../../src/wizards/SubstituteWiz.cpp:35
 msgid "New value:"
-msgstr ""
+msgstr "Nowa wartość:"
 
 #: ../../src/MaximaCommandMenus.cpp:151 ../../src/MaximaCommandMenus.cpp:171
 #: ../../src/MaximaCommandMenus.cpp:254 ../../src/MaximaCommandMenus.cpp:259
@@ -7303,7 +7303,7 @@ msgstr ""
 
 #: ../../src/wizards/SubstituteWiz.cpp:32
 msgid "Old value:"
-msgstr ""
+msgstr "Stara wartość:"
 
 #: ../../src/MaximaCommandMenus.cpp:151 ../../src/MaximaCommandMenus.cpp:172
 #: ../../src/MaximaCommandMenus.cpp:253 ../../src/MaximaCommandMenus.cpp:259
@@ -7432,7 +7432,7 @@ msgstr ""
 
 #: ../../src/wizards/Plot2dWiz.cpp:75 ../../src/wizards/Plot3dWiz.cpp:66
 msgid "Options:"
-msgstr ""
+msgstr "Opcje:"
 
 #: ../../src/dialogs/FindReplacePane.cpp:109
 msgid "Output"
@@ -7505,7 +7505,7 @@ msgstr ""
 
 #: ../../src/sidebars/FormatSidebar.cpp:69
 msgid "Pagebreak"
-msgstr ""
+msgstr "Podział strony"
 
 #: ../../src/wxMaximaFrame.cpp:1674
 msgid "Parallel Substitute..."
@@ -7533,7 +7533,7 @@ msgstr ""
 
 #: ../../src/wizards/Plot2dWiz.cpp:417 ../../src/wizards/Plot2dWiz.cpp:523
 msgid "Parametric plot"
-msgstr ""
+msgstr "Wykres parametryczny"
 
 #: ../../src/MaximaCommandMenus.cpp:4211
 msgid "Parse string"
@@ -7603,7 +7603,7 @@ msgstr ""
 
 #: ../../src/sidebars/StatSidebar.cpp:94
 msgid "Piechart..."
-msgstr ""
+msgstr "Diagram kołowy..."
 
 #: ../../src/wxMaxima.cpp:1585
 msgid "Please configure wxMaxima with 'Edit->Configure'."
@@ -7611,7 +7611,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2606
 msgid "Please restart wxMaxima for changes to take effect!"
-msgstr ""
+msgstr "Uruchom ponownie wxMaxime, aby zmiany zaczęły obowiązywać"
 
 #: ../../src/MaximaCommandMenus.cpp:2250
 msgid "Please select exactly 2 or 3 files."
@@ -7638,7 +7638,7 @@ msgstr ""
 #: ../../src/sidebars/MathSidebar.cpp:89
 #: ../../src/worksheet/WorksheetContextMenu.cpp:366
 msgid "Plot 2D..."
-msgstr ""
+msgstr "Wykres 2D..."
 
 #: ../../src/MaximaCommandMenus.cpp:85 ../../src/MaximaCommandMenus.cpp:3508
 #: ../../src/wizards/Plot3dWiz.cpp:103
@@ -7648,7 +7648,7 @@ msgstr ""
 #: ../../src/sidebars/MathSidebar.cpp:92
 #: ../../src/worksheet/WorksheetContextMenu.cpp:368
 msgid "Plot 3D..."
-msgstr ""
+msgstr "Wykres 3D..."
 
 #: ../../src/wizards/DrawWiz.cpp:713
 msgid "Plot a parametric curve"
@@ -7689,7 +7689,7 @@ msgstr ""
 
 #: ../../src/wizards/Plot2dWiz.cpp:84 ../../src/wizards/Plot3dWiz.cpp:80
 msgid "Plot to file:"
-msgstr ""
+msgstr "Zapisz wykres do pliku:"
 
 #: ../../src/wxMaximaFrame.cpp:341 ../../src/wxMaximaFrame.cpp:749
 msgid "Plot using Draw"
@@ -7723,7 +7723,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:219
 msgid "Polish"
-msgstr ""
+msgstr "Polski"
 
 #: ../../src/MaximaCommandMenus.cpp:215 ../../src/MaximaCommandMenus.cpp:220
 #: ../../src/MaximaCommandMenus.cpp:225
@@ -7759,7 +7759,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:221
 msgid "Portuguese (Brazilian)"
-msgstr ""
+msgstr "Portugalski (Brazylia)"
 
 #: ../../src/wxMaximaFrame.cpp:1223
 msgid "Position of a match"
@@ -7775,7 +7775,7 @@ msgstr ""
 
 #: ../../src/wizards/Plot2dWiz.cpp:474 ../../src/wizards/Plot3dWiz.cpp:422
 msgid "Postscript file (*.eps)|*.eps|All|*"
-msgstr ""
+msgstr "Plik Postscript (*.eps)|*.eps|Wszystkie|*"
 
 #: ../../src/MaximaCommandMenus.cpp:190
 msgid "Power series"
@@ -8037,7 +8037,7 @@ msgstr ""
 
 #: ../../src/sidebars/StatSidebar.cpp:103
 msgid "Read Matrix..."
-msgstr ""
+msgstr "Wczytaj macierz..."
 
 #: ../../src/MaximaCommandMenus.cpp:4008
 msgid "Read a structure field"
@@ -8174,7 +8174,7 @@ msgstr ""
 
 #: ../../src/sidebars/MathSidebar.cpp:56
 msgid "Rectform"
-msgstr ""
+msgstr "Forma algebraiczna"
 
 #: ../../src/wxMaximaFrame.cpp:1677
 msgid "Recursive Substitute..."
@@ -8198,7 +8198,7 @@ msgstr ""
 
 #: ../../src/sidebars/MathSidebar.cpp:71
 msgid "Reduce (tr)"
-msgstr ""
+msgstr "Redukcja (tr)"
 
 #: ../../src/wxMaximaFrame.cpp:1632
 msgid "Reduce trigonometric expression"
@@ -8586,7 +8586,7 @@ msgstr ""
 
 #: ../../src/wizards/MatWiz.cpp:152
 msgid "Rows:"
-msgstr ""
+msgstr "Wiersze:"
 
 #: ../../src/MaximaCommandMenus.cpp:1391
 msgid "Rule"
@@ -8656,7 +8656,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:223
 msgid "Russian"
-msgstr ""
+msgstr "Rosyjski"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1578
 msgid "SBCL: use <int>Mbytes of heap"
@@ -8709,7 +8709,7 @@ msgstr ""
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:55
 msgid "Save Animation..."
-msgstr ""
+msgstr "Zapisz animację..."
 
 #: ../../src/MaximaFileIO.cpp:779
 msgid "Save As"
@@ -8721,7 +8721,7 @@ msgstr ""
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:50
 msgid "Save Image..."
-msgstr ""
+msgstr "Zapisz obrazek..."
 
 #: ../../src/MaximaCommandMenus.cpp:2866
 msgid "Save Selection to Image"
@@ -8758,7 +8758,7 @@ msgstr ""
 
 #: ../../src/wizards/Plot2dWiz.cpp:473 ../../src/wizards/Plot3dWiz.cpp:421
 msgid "Save plot to file"
-msgstr ""
+msgstr "Zapisz wykres do pliku"
 
 #: ../../src/wxMaximaFrame.cpp:713
 msgid "Save selection from document to an image file"
@@ -8770,7 +8770,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2640
 msgid "Save style to file"
-msgstr ""
+msgstr "Zapisz plik ze stylem"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1384
 msgid "Save the worksheet automatically"
@@ -8802,7 +8802,7 @@ msgstr ""
 
 #: ../../src/sidebars/StatSidebar.cpp:88
 msgid "Scatterplot..."
-msgstr ""
+msgstr "Wykres punktowy...."
 
 #: ../../src/Autocomplete.cpp:157
 msgid "Scheduling a background task that compiles a new list of autocompletable maxima commands."
@@ -8875,7 +8875,7 @@ msgstr ""
 #: ../../src/worksheet/WorksheetContextMenu.cpp:428
 #: ../../src/worksheet/WorksheetContextMenu.cpp:460
 msgid "Select All"
-msgstr ""
+msgstr "Zaznacz wszystko"
 
 #: ../../src/wxMaximaFrame.cpp:710
 msgid "Select All\tCtrl+A"
@@ -8893,7 +8893,7 @@ msgstr ""
 #: ../../src/wizards/IntegrateWiz.cpp:208 ../../src/wizards/LimitWiz.cpp:133
 #: ../../src/wizards/SeriesWiz.cpp:105
 msgid "Select a constant"
-msgstr ""
+msgstr "Wybierz stałą"
 
 #: ../../src/ToolBar.cpp:390 ../../src/ToolBar.cpp:392
 #: ../../src/wxMaximaFrame.cpp:710
@@ -9002,7 +9002,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:479
 msgid "Set fixed font in text controls."
-msgstr ""
+msgstr "Ustaw czcionkę o stałej szerokości w kontrolkach tekstowych."
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:68
 #: ../../src/worksheet/WorksheetContextMenu.cpp:250
@@ -9229,7 +9229,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:465
 msgid "Show long expressions in wxMaxima document."
-msgstr ""
+msgstr "Pokazuj długie wyrażenia w dokumentach wxMaximy"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:722
 msgid "Show long expressions:"
@@ -9334,7 +9334,7 @@ msgstr ""
 
 #: ../../src/sidebars/MathSidebar.cpp:44
 msgid "Simplify"
-msgstr ""
+msgstr "Uprość"
 
 #: ../../src/wxMaximaFrame.cpp:1550
 msgid "Simplify &Radicals..."
@@ -9342,15 +9342,15 @@ msgstr ""
 
 #: ../../src/sidebars/MathSidebar.cpp:47
 msgid "Simplify (r)"
-msgstr ""
+msgstr "Uprość (r)"
 
 #: ../../src/sidebars/MathSidebar.cpp:65
 msgid "Simplify (tr)"
-msgstr ""
+msgstr "Uprość (tr)"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:352
 msgid "Simplify Expression"
-msgstr ""
+msgstr "Uprość wyrażenie"
 
 #: ../../src/wxMaximaFrame.cpp:1605
 msgid "Simplify Logarithms"
@@ -9386,7 +9386,7 @@ msgstr ""
 
 #: ../../src/wizards/SumWiz.cpp:68
 msgid "Simplify the sum"
-msgstr ""
+msgstr "Uprość sumę"
 
 #: ../../src/wxMaximaFrame.cpp:1629
 msgid "Simplify trigonometric expression"
@@ -9451,7 +9451,7 @@ msgstr ""
 
 #: ../../src/wizards/BC2Wiz.cpp:30
 msgid "Solution:"
-msgstr ""
+msgstr "Rozwiązania:"
 
 #: ../../src/MaximaCommandMenus.cpp:3446
 msgid "Solve"
@@ -9491,7 +9491,7 @@ msgstr ""
 
 #: ../../src/sidebars/MathSidebar.cpp:77
 msgid "Solve ODE..."
-msgstr ""
+msgstr "Rozwiąż RRZ..."
 
 #: ../../src/wxMaximaFrame.cpp:1432
 msgid "Solve a linear equation system using dgesv"
@@ -9576,7 +9576,7 @@ msgstr ""
 #: ../../src/sidebars/MathSidebar.cpp:74
 #: ../../src/worksheet/WorksheetContextMenu.cpp:347
 msgid "Solve..."
-msgstr ""
+msgstr "Rozwiąż..."
 
 #: ../../src/wxMaximaFrame.cpp:1953
 msgid "Solving differential equations"
@@ -9618,12 +9618,12 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:227
 msgid "Spanish"
-msgstr ""
+msgstr "Hiszpański"
 
 #: ../../src/wizards/IntegrateWiz.cpp:44 ../../src/wizards/IntegrateWiz.cpp:50
 #: ../../src/wizards/LimitWiz.cpp:38 ../../src/wizards/SeriesWiz.cpp:39
 msgid "Special"
-msgstr ""
+msgstr "Szczególne"
 
 #: ../../src/wizards/DrawWiz.cpp:918
 msgid "Speed versus accuracy"
@@ -9663,7 +9663,7 @@ msgstr ""
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:60
 msgid "Start Animation"
-msgstr ""
+msgstr "Uruchom Animacje"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1622
 msgid "Start a new maxima for each re-evaluation"
@@ -9834,11 +9834,11 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:282
 msgid "Style"
-msgstr ""
+msgstr "Wygląd"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2082
 msgid "Styles"
-msgstr ""
+msgstr "Style"
 
 #: ../../src/sidebars/StatSidebar.cpp:112
 msgid "Subsample..."
@@ -9862,7 +9862,7 @@ msgstr ""
 
 #: ../../src/sidebars/MathSidebar.cpp:59
 msgid "Subst..."
-msgstr ""
+msgstr "Podstaw..."
 
 #: ../../src/MaximaCommandMenus.cpp:715 ../../src/MaximaCommandMenus.cpp:3490
 #: ../../src/MaximaCommandMenus.cpp:4500 ../../src/wizards/SubstituteWiz.cpp:53
@@ -10138,7 +10138,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:492
 msgid "The default port used for communication between Maxima and wxMaxima."
-msgstr ""
+msgstr "Domyślny port używany do komunikacji między Maxima i wxMaxima"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:412
 msgid "The default width for embedded plots. Can be read out or overridden by the maxima variable wxplot_size"
@@ -10520,7 +10520,7 @@ msgstr ""
 
 #: ../../src/wizards/Plot2dWiz.cpp:65 ../../src/wizards/Plot2dWiz.cpp:505
 msgid "Ticks:"
-msgstr ""
+msgstr "Znaczniki:"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1359
 msgid "Time [in Minutes] between autosaves"
@@ -10548,7 +10548,7 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:89
 msgid "Title, section and subsection cells can be folded to hide their contents. To fold or unfold, click in the square next to the cell. If you shift-click, all sublevels of that cell will also fold/unfold."
-msgstr ""
+msgstr "Komórki tytułowa, rozdziału i podrozdziału mogą być zwinięte, żeby ukryć ich zawartość. Do zwinięcia/rozwinięcia wystarczy klikniecie na prostokąt obok komórki. Shift+kliknięcie rozwija/zwija wszystkie poziomy komórki."
 
 #: ../../src/wxMaximaFrame.cpp:1831
 msgid "To &Bigfloat"
@@ -10560,7 +10560,7 @@ msgstr ""
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:344
 msgid "To Float"
-msgstr ""
+msgstr "Wartość zmiennoprzecinkowa"
 
 #: ../../src/wxMaximaFrame.cpp:1834
 msgid "To Numeri&c\tCtrl+Shift+N"
@@ -10576,7 +10576,7 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:124
 msgid "To plot in polar coordinates, select 'set polar' in the Options entry for Plot2d dialog. You can also plot in spherical and cylindrical coordinates in 3D."
-msgstr ""
+msgstr "Aby narysować wykres w biegunowym układzie współrzędnych wybierz 'set polar' w okienku 'Opcje' okna 'Wykres 2D'. W podobny sposób wykresy 3D możesz kreślić w układzie sferycznym lub cylindrycznym."
 
 #: ../../src/dialogs/TipOfTheDay.cpp:131
 msgid "To put parentheses around an expression, select it, and press '(' or ')' depending on where you want the cursor to appear afterwards."
@@ -10584,7 +10584,7 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:137
 msgid "To save the size and position of wxMaxima windows between session, use 'Edit->Configure' dialog."
-msgstr ""
+msgstr "Jeśli chcesz zapisać rozmiar i położenie okna wxMaximy, tak aby przy kolejnym uruchomieniu znajdowało się ono w tym samym miejscu i miało taką samą wielkość, wybierz 'Edycja->Preferencje'."
 
 #: ../../src/dialogs/TipOfTheDay.cpp:51
 msgid "To start using wxMaxima right away, start typing your command. An input cell should appear. Then press Shift-Enter to evaluate your command."
@@ -10804,7 +10804,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:231
 msgid "Ukrainian"
-msgstr ""
+msgstr "Ukraiński"
 
 #: ../../src/wxMaxima.cpp:3164
 msgid "Un-closed parenthesis"
@@ -10835,7 +10835,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2115
 msgid "Underlined"
-msgstr ""
+msgstr "Podkreślenie"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:745
 msgid "Underscore converts to subscripts:"
@@ -10983,7 +10983,7 @@ msgstr ""
 
 #: ../../src/wizards/SumWiz.cpp:69
 msgid "Use Gosper algorithm"
-msgstr ""
+msgstr "Użyj algorytmu Gosper"
 
 #: ../../src/sidebars/RegexCtrl.cpp:133
 msgid "Use RegEx filtering"
@@ -11011,7 +11011,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:849
 msgid "Use centered dot character for multiplication"
-msgstr ""
+msgstr "Używaj kropki jako znaku mnożenia (zamiast *)"
 
 #: ../../src/wxMaximaFrame.cpp:1745
 msgid "Use list"
@@ -11196,7 +11196,7 @@ msgstr ""
 
 #: ../../src/sidebars/StatSidebar.cpp:58
 msgid "Variance..."
-msgstr ""
+msgstr "Wariancja..."
 
 #: ../../src/WXMXformat.cpp:339
 msgid "Verified that we are able to read the whole .zip archive we produced."
@@ -11268,7 +11268,7 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:134
 msgid "When applying functions with one argument from menus, the default argument is '%'. To apply the function to some other value, select it in the document before executing a menu command."
-msgstr ""
+msgstr "Gdy wybierasz pewne jednoargumentowe funkcje z menu programu wxMaxima ich domyślnym argumentem jest '%'. Jeśli chcesz aby było nim inne wyrażenie, wystarczy że wpiszesz je w linii wejścia przed wybraniem funkcji z menu lub zaznaczysz w konsoli wxMaximy."
 
 #: ../../src/wxMaximaFrame.cpp:1092
 msgid "When to invoke the lisp compiler's debugger"
@@ -11355,11 +11355,11 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:64
 msgid "You can access the last output using the variable '%'. You can access the output of previous commands using variables '%on' where n is the number of output."
-msgstr ""
+msgstr "Zmienna '%' przechowuje ostatnie wyjście. Do poprzednich wyjść można odwoływać się za pośrednictwem zmiennych '%on' gdzie n to numer wyjścia."
 
 #: ../../src/dialogs/TipOfTheDay.cpp:118
 msgid "You can evaluate your whole document by using 'Cell->Evaluate All Cells' menu command or the appropriate key shortcut. The cells will be evaluated in the order they appear in the document."
-msgstr ""
+msgstr "Możesz obliczyć wszystkie wyrażenia w dokumencie wybierając 'Edycja->Komórka->Wykonaj wszystkie komórki'. Zostaną one obliczone w kolejności w jakiej pojawiają się w dokumencie"
 
 #: ../../src/dialogs/TipOfTheDay.cpp:98
 msgid "You can get help on a Maxima function by selecting or clicking on the function name and pressing F1. wxMaxima will search the help index for the selection or the word under the cursor."
@@ -11367,7 +11367,7 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:92
 msgid "You can hide output part of cells by clicking in the triangle on the left side of cells. This works on text cells also."
-msgstr ""
+msgstr "Możesz ukryć wyjście wyrażenia w dowolnej komórce klikając na trójkąt w lewym górnym rogu komórki."
 
 #: ../../src/dialogs/TipOfTheDay.cpp:81
 msgid "You can insert different types of 'cells' in wxMaxima documents using the 'Cell' menu. Note that only 'input cells' can be evaluated, while others are used for commenting and structuring your calculations."
@@ -11375,7 +11375,7 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:112
 msgid "You can select multiple cells either with a mouse - click'n'drag from between cells or from a cell bracket on the left - or with a keyboard - hold down Shift while moving the horizontal cursor - and then operate on selection. This comes in handy when you want to delete or evaluate multiple cells."
-msgstr ""
+msgstr "Możesz zaznaczyć kilka komórek albo myszką (kliknij na prostokąt i lub na nawiasy obok komórki i przeciągnij), albo za pomocą Shift+ strałki góra/dól w trybie kursoru poziomego. To się przydaje, jeżeli chceszusunąć lub powtórzyć obliczenia w zaznaczonych komórkach."
 
 #: ../../src/dialogs/TipOfTheDay.cpp:232
 msgid "You found a bug in wxMaxima? Please report it at https://github.com/wxMaxima-developers/wxmaxima/issues\n"
@@ -11451,7 +11451,7 @@ msgstr ""
 
 #: ../../src/wizards/MatWiz.cpp:160
 msgid "antisymmetric"
-msgstr ""
+msgstr "antysymetryczna"
 
 #: ../../src/wxMaximaFrame.cpp:1727
 msgid "apply function to each element"
@@ -11479,7 +11479,7 @@ msgstr ""
 
 #: ../../src/wizards/LimitWiz.cpp:42
 msgid "both sides"
-msgstr ""
+msgstr "obu stron"
 
 #: ../../src/wxMaximaFrame.cpp:1173
 msgid "char to Ascii code..."
@@ -11497,7 +11497,7 @@ msgstr ""
 #: ../../src/wizards/Plot2dWiz.cpp:70 ../../src/wizards/Plot2dWiz.cpp:372
 #: ../../src/wizards/Plot3dWiz.cpp:61 ../../src/wizards/Plot3dWiz.cpp:358
 msgid "default"
-msgstr ""
+msgstr "domyślny"
 
 #: ../../src/sidebars/GreekSidebar.cpp:154
 msgid "delta"
@@ -11505,7 +11505,7 @@ msgstr ""
 
 #: ../../src/wizards/MatWiz.cpp:159
 msgid "diagonal"
-msgstr ""
+msgstr "diagonalna"
 
 #: ../../src/cells/FracCell.cpp:73
 msgid "diff(): Cannot find the multiplication sign I should hide"
@@ -11587,7 +11587,7 @@ msgstr ""
 
 #: ../../src/wizards/MatWiz.cpp:159
 msgid "general"
-msgstr ""
+msgstr "zwykła"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1630
 msgid "gnuplot: Without command console"
@@ -11610,7 +11610,7 @@ msgstr ""
 #: ../../src/wizards/Plot3dWiz.cpp:61 ../../src/wizards/Plot3dWiz.cpp:194
 #: ../../src/wizards/Plot3dWiz.cpp:358 ../../src/wizards/Plot3dWiz.cpp:386
 msgid "inline"
-msgstr ""
+msgstr "wbudowany"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:104
 msgid "intersection"
@@ -11630,7 +11630,7 @@ msgstr ""
 
 #: ../../src/wizards/LimitWiz.cpp:42
 msgid "left"
-msgstr ""
+msgstr "lewej strony"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:117
 msgid "less or equal"
@@ -11642,7 +11642,7 @@ msgstr ""
 
 #: ../../src/wizards/Plot2dWiz.cpp:54 ../../src/wizards/Plot2dWiz.cpp:64
 msgid "logscale"
-msgstr ""
+msgstr "skala logarytmiczna"
 
 #: ../../src/wizards/DrawWiz.cpp:822
 msgid "matrix([x_1,x_2,...],[y_1,y_2,...])"
@@ -11825,7 +11825,7 @@ msgstr ""
 
 #: ../../src/wizards/LimitWiz.cpp:42
 msgid "right"
-msgstr ""
+msgstr "prawej strony"
 
 #: ../../src/wizards/DrawWiz.cpp:310
 msgid "secondary x axis label"
@@ -11877,7 +11877,7 @@ msgstr ""
 
 #: ../../src/wizards/MatWiz.cpp:160
 msgid "symmetric"
-msgstr ""
+msgstr "symetryczna"
 
 #: ../../src/MaximaCommandMenus.cpp:970
 msgid "t:"
@@ -11982,7 +11982,7 @@ msgstr ""
 #: ../../src/dialogs/ConfigDialogue.cpp:142
 #: ../../src/dialogs/ConfigDialogue.cpp:311
 msgid "wxMaxima configuration"
-msgstr ""
+msgstr "wxMaxima preferencje"
 
 #: ../../src/MaximaProcessManager.cpp:209
 msgid "wxMaxima could not start a server.\n\n"
@@ -11992,7 +11992,7 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:127
 msgid "wxMaxima dialogs set default values for inputs entries, one of which is '%'. If you have made a selection in your document, the selection will be used instead of '%'."
-msgstr ""
+msgstr "Domyślnie wxMaxima uzupełnia okna dialogowe (np. 'RRC->Całka'). Przeważnie jedno z nich zostaje uzupełnione przez zmienną '%'. Jeśli chcesz uzupełnić je innym wyrażeniem wystarczy, że wpiszesz je w linii wejścia lub zaznaczysz w konsoli."
 
 #: ../../src/MaximaCommandMenus.cpp:4544
 msgid "wxMaxima document"

--- a/locales/wxMaxima/pt_BR.po
+++ b/locales/wxMaxima/pt_BR.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: wxMaxima\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-30 11:38+0200\n"
+"POT-Creation-Date: 2026-08-10 03:42+0000\n"
 "PO-Revision-Date: 2012-11-15 15:29-0200\n"
 "Last-Translator: Eduardo M Kalinowski <eduardo@kalinowski.com.br>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,7 +17,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: ../../src/StatusBar.cpp:328
+#: ../../src/StatusBar.cpp:447
 #, c-format
 msgid ""
 "\n"
@@ -25,1474 +25,2393 @@ msgid ""
 "Maxima is currently using %3.3f%% of all available CPUs."
 msgstr ""
 
-#: ../../src/Image.cpp:690
+#: ../../src/dialogs/AboutDialog.cpp:59
+#, c-format
+msgid ""
+"\n"
+"\n"
+"Operating System: %s\n"
+msgstr ""
+
+#: ../../src/Image.cpp:773
 msgid ""
 "\n"
 "Image was loaded from a .wxmx file"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:5153
+#: ../../src/dialogs/AboutDialog.cpp:57
+msgid ""
+"\n"
+"Not connected to Maxima."
+msgstr ""
+
+#: ../../src/MaximaEvaluator.cpp:398
+msgid ""
+"\n"
+"Now reads: "
+msgstr ""
+
+#: ../../src/wxMaxima.cpp:1981
 msgid ""
 "\n"
 "Use the menu \"View->Toggle log window\" to show/hide a log window with all debug messages."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:4230
+#: ../../src/dialogs/ConfigDialogue.cpp:1569
+msgid "      -X \"--control-stack-size <int>\""
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1568
+msgid "      -X \"--dynamic-space-size <int>\""
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1572
+msgid "      -X '--control-stack-size <int>'"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1571
+msgid "      -X '--dynamic-space-size <int>'"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1551
+msgid "      -l <name>"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1557
+msgid "      -u <versionnumber>"
+msgstr ""
+
+#: ../../src/Configuration.cpp:1397
+#, c-format
+msgid "  Cells converted to 2D: %ld"
+msgstr ""
+
+#: ../../src/Configuration.cpp:1396
+#, c-format
+msgid "  Cells converted to linear: %ld"
+msgstr ""
+
+#: ../../src/Configuration.cpp:1398
+#, c-format
+msgid "  Cells drawn at the wrong font size: %ld"
+msgstr ""
+
+#: ../../src/Configuration.cpp:1388
+#, c-format
+msgid "  Font cache hits: %ld"
+msgstr ""
+
+#: ../../src/Configuration.cpp:1389
+#, c-format
+msgid "  Font cache misses: %ld"
+msgstr ""
+
+#: ../../src/Configuration.cpp:1400
+#, c-format
+msgid "  Full-window worksheet repaints: %ld"
+msgstr ""
+
+#: ../../src/Configuration.cpp:1384
+#, c-format
+msgid "  Manual anchors from built-in: %ld"
+msgstr ""
+
+#: ../../src/Configuration.cpp:1385
+#, c-format
+msgid "  Manual anchors from cache: %ld"
+msgstr ""
+
+#: ../../src/Configuration.cpp:1386
+#, c-format
+msgid "  Manual anchors self-compiled: %ld"
+msgstr ""
+
+#: ../../src/Configuration.cpp:1387
+#, c-format
+msgid "  Maxima processes spawned: %ld"
+msgstr ""
+
+#: ../../src/Configuration.cpp:1394
+#, c-format
+msgid "  Recalculation needed - Cells appended: %ld"
+msgstr ""
+
+#: ../../src/Configuration.cpp:1393
+#, c-format
+msgid "  Recalculation needed - Config changed: %ld"
+msgstr ""
+
+#: ../../src/Configuration.cpp:1395
+#, c-format
+msgid "  Recalculation needed - Editor dirty: %ld"
+msgstr ""
+
+#: ../../src/Configuration.cpp:1390
+#, c-format
+msgid "  Recalculation needed - Font invalid: %ld"
+msgstr ""
+
+#: ../../src/Configuration.cpp:1392
+#, c-format
+msgid "  Recalculation needed - Font mismatch: %ld"
+msgstr ""
+
+#: ../../src/Configuration.cpp:1391
+#, c-format
+msgid "  Recalculation needed - Size invalid: %ld"
+msgstr ""
+
+#: ../../src/Configuration.cpp:1399
+#, c-format
+msgid "  Worksheet repaints: %ld"
+msgstr ""
+
+#: ../../src/MaximaFileIO.cpp:129
 msgid " (File format (WXM version 1, first line of the file) not recognized)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1559
+#: ../../src/cells/ImgCell.cpp:212 ../../src/cells/ImgCell.cpp:214
+#: ../../src/cells/ImgCell.cpp:216
+msgid " (Graphics) "
+msgstr ""
+
+#: ../../src/cells/EditorCell.cpp:3551 ../../src/cells/EditorCell.cpp:3820
+#: ../../src/cells/EditorCell.cpp:3945
+#, c-format
+msgid " ... + %li hidden lines"
+msgstr ""
+
+#: ../../src/cells/EditorCell.cpp:3553
+msgid " ... + 1 hidden line"
+msgstr ""
+
+#: ../../src/dialogs/TipOfTheDay.cpp:273
+msgid " Did you know? "
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:1607
+msgid " Returns the unique elements of the list"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1596
 msgid " Wrong, if a is complex"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7601
+#: ../../src/wizards/DrawWiz.cpp:964 ../../src/wizards/DrawWiz.cpp:980
+#, fuzzy
+msgid " samples"
+msgstr "Exemplo"
+
+#: ../../src/wizards/DrawWiz.cpp:929 ../../src/wizards/DrawWiz.cpp:945
+msgid " samples, on demand split "
+msgstr ""
+
+#: ../../src/wizards/DrawWiz.cpp:933 ../../src/wizards/DrawWiz.cpp:952
+#, fuzzy
+msgid " times"
+msgstr "Vezes:"
+
+#: ../../src/MaximaCommandMenus.cpp:4473
 msgid ""
 "\".\" = \"The current directory\"\n"
 "\"..\" = \"One directory up\""
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7557 ../../src/wxMaxima.cpp:7563
-#: ../../src/wxMaxima.cpp:7568
+#: ../../src/MaximaCommandMenus.cpp:4429 ../../src/MaximaCommandMenus.cpp:4435
+#: ../../src/MaximaCommandMenus.cpp:4440
 msgid "\"..\" means \"one directory up\"."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:5053
+#: ../../src/dialogs/ConfigDialogue.cpp:1208
+msgid "\"Copy LaTeX\" adds equation markers"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:446
+msgid ""
+"\"MathML (rendered by the browser)\" is the recommended choice: every current browser renders MathML natively and instantly, and the exported page needs no JavaScript and makes no requests to any external server.\n"
+"\"MathML + MathJaX fall-back for old browsers\" behaves the same on current browsers, but additionally downloads MathJaX from an external server (a CDN) as a fall-back on browsers too old to support MathML. Only choose this if you need to support such browsers and accept the external dependency.\n"
+"Bitmaps tend to need more band width than the other options. They lack support for advanced features like drag-and-drop or accessibility. Also they have problems aligning and scaling with the rest of the text and might use fonts that don't match the rest of the document."
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:930
+#, fuzzy
+msgid "\"Numpad Enter\" always evaluates cells"
+msgstr "Enter calcula células"
+
+#: ../../src/sidebars/SymbolsSidebar.cpp:90
+msgid "\"implies\" symbol"
+msgstr ""
+
+#: ../../src/dialogs/DiffFrame.cpp:306
+#, c-format
+msgid "%d differences"
+msgstr ""
+
+#: ../../src/wxMaxima.cpp:1831
 #, c-format
 msgid "%i cells in evaluation queue"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:330
+#: ../../src/sidebars/TableOfContents.cpp:570
+#, c-format
+msgid "%li Levels"
+msgstr ""
+
+#: ../../src/worksheet/Worksheet.cpp:423
 #, c-format
 msgid "%s image, %li×%li, %li ppi"
 msgstr ""
 
-#: ../../src/Autocomplete.cpp:319
+#: ../../src/Autocomplete.cpp:405
 #, c-format
 msgid "%s: Can't interpret line: %s"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1655
+#: ../../src/wxMaxima.cpp:2859
+#, c-format
+msgid ""
+"%sCould not write the setting for:%s\n"
+"(Is the client installed?)"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1692
 #, fuzzy
 msgid "&Algebraic Mode"
 msgstr "Ál&gebra"
 
-#: ../../src/wxMaximaFrame.cpp:1884
+#: ../../src/wxMaximaFrame.cpp:1921
 msgid "&Apropos..."
 msgstr "&Apropos"
 
-#: ../../src/wxMaximaFrame.cpp:615
+#: ../../src/wxMaximaFrame.cpp:646
 msgid "&Batch File...\tCtrl+B"
 msgstr "Carregar arquivo &batch...\tCtrl+B"
 
-#: ../../src/wxMaximaFrame.cpp:1278
+#: ../../src/wxMaximaFrame.cpp:1312
 msgid "&Boundary Value Problem..."
 msgstr "Problema de valor de &fronteira..."
 
-#: ../../src/wxMaximaFrame.cpp:1950
+#: ../../src/wxMaximaFrame.cpp:1987
 msgid "&Bug Report"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1505
+#: ../../src/wxMaximaFrame.cpp:1542
 msgid "&Calculus"
 msgstr "&Cálculo"
 
-#: ../../src/wxMaximaFrame.cpp:1601
+#: ../../src/wxMaximaFrame.cpp:1638
 msgid "&Canonical Form"
 msgstr "Forma &canônica"
 
-#: ../../src/wxMaximaFrame.cpp:1358
+#: ../../src/wxMaximaFrame.cpp:1392
 msgid "&Characteristic Polynomial..."
 msgstr "Polinômio característico..."
 
-#: ../../src/wxMaximaFrame.cpp:990
+#: ../../src/wxMaximaFrame.cpp:1024
 msgid "&Clear Memory"
 msgstr "&Limpar memória"
 
-#: ../../src/wxMaximaFrame.cpp:1583
+#: ../../src/wxMaximaFrame.cpp:1620
 msgid "&Combine Factorials"
 msgstr "&Combinar fatoriais"
 
-#: ../../src/wxMaximaFrame.cpp:1628
+#: ../../src/wxMaximaFrame.cpp:1665
 msgid "&Complex Simplification"
 msgstr "Simplificação &complexa"
 
-#: ../../src/wxMaximaFrame.cpp:1502
+#: ../../src/wxMaximaFrame.cpp:1539
 msgid "&Continued Fraction"
 msgstr "Fração &contínua"
 
-#: ../../src/wxMaximaFrame.cpp:638
+#: ../../src/wxMaximaFrame.cpp:675
 msgid "&Copy\tCtrl+C"
 msgstr "&Copiar\tCtrl+C"
 
-#: ../../src/wxMaximaFrame.cpp:1621
+#: ../../src/wizards/IntegrateWiz.cpp:39
+msgid "&Definite integration"
+msgstr "Integração &definida"
+
+#: ../../src/wxMaximaFrame.cpp:1658
 msgid "&Demoivre"
 msgstr "&Demoivre"
 
-#: ../../src/wxMaximaFrame.cpp:1362
+#: ../../src/wxMaximaFrame.cpp:1396
 msgid "&Determinant"
 msgstr "&Determinante"
 
-#: ../../src/wxMaximaFrame.cpp:1466
+#: ../../src/wxMaximaFrame.cpp:1503
 msgid "&Differentiate..."
 msgstr "&Diferenciar..."
 
-#: ../../src/wxMaximaFrame.cpp:689
+#: ../../src/wxMaximaFrame.cpp:726
 msgid "&Edit"
 msgstr "&Editar"
 
-#: ../../src/wxMaximaFrame.cpp:1246
+#: ../../src/wxMaximaFrame.cpp:1280
 msgid "&Eliminate Variable..."
 msgstr "&Eliminar variável..."
 
-#: ../../src/wxMaximaFrame.cpp:1318
+#: ../../src/wxMaximaFrame.cpp:1352
 msgid "&Enter Matrix..."
 msgstr "&Introduzir matriz..."
 
-#: ../../src/wxMaximaFrame.cpp:1883
+#: ../../src/wxMaximaFrame.cpp:1920
 msgid "&Example..."
 msgstr "&Exemplo..."
 
-#: ../../src/wxMaximaFrame.cpp:1524
+#: ../../src/wxMaximaFrame.cpp:1561
 msgid "&Expand Expression"
 msgstr "&Expandir expressão"
 
-#: ../../src/wxMaximaFrame.cpp:1597
+#: ../../src/wxMaximaFrame.cpp:1634
 msgid "&Expand Trigonometric"
 msgstr "&Expandir trigonométricas"
 
-#: ../../src/wxMaximaFrame.cpp:1626
+#: ../../src/wxMaximaFrame.cpp:1663
 msgid "&Exponentialize"
 msgstr "&Exponencializar"
 
-#: ../../src/wxMaximaFrame.cpp:618
+#: ../../src/wxMaximaFrame.cpp:651
 msgid "&Export..."
 msgstr "&Exportar..."
 
-#: ../../src/wxMaximaFrame.cpp:1516
+#: ../../src/wxMaximaFrame.cpp:1553
 msgid "&Factor Expression"
 msgstr "&Fatorar expressão"
 
-#: ../../src/wxMaximaFrame.cpp:626
+#: ../../src/wxMaximaFrame.cpp:663
 msgid "&File"
 msgstr "&Arquivo"
 
-#: ../../src/wxMaximaFrame.cpp:1019
+#: ../../src/wxMaximaFrame.cpp:1053
 #, fuzzy
 msgid "&Functions"
 msgstr "Função:"
 
-#: ../../src/wxMaximaFrame.cpp:1490
+#: ../../src/wxMaximaFrame.cpp:1527
 msgid "&Greatest Common Divisor..."
 msgstr "Máximo &divisor comum..."
 
-#: ../../src/wxMaximaFrame.cpp:1968
+#: ../../src/wxMaximaFrame.cpp:2021
 msgid "&Help"
 msgstr "Aj&uda"
 
-#: ../../src/wxMaximaFrame.cpp:1453
+#: ../../src/wxMaximaFrame.cpp:1490
 msgid "&Integrate..."
 msgstr "&Integrar..."
 
-#: ../../src/wxMaximaFrame.cpp:964
+#: ../../src/wxMaximaFrame.cpp:998
 msgid "&Interrupt\tCtrl+G"
 msgstr "&Interromper\tCtrl+G"
 
-#: ../../src/wxMaximaFrame.cpp:1355
+#: ../../src/wxMaximaFrame.cpp:1389
 msgid "&Invert Matrix"
 msgstr "&Inverter matriz"
 
-#: ../../src/wxMaximaFrame.cpp:1952
+#: ../../src/wxMaximaFrame.cpp:1995
 msgid "&License"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1763
+#: ../../src/wxMaximaFrame.cpp:1800
 #, fuzzy
 msgid "&List"
 msgstr "Lista:"
 
-#: ../../src/wxMaximaFrame.cpp:610
+#: ../../src/wxMaximaFrame.cpp:641
 msgid "&Load Package...\tCtrl+L"
 msgstr "&Carregar pacote...\tCtrl+L"
 
-#: ../../src/wxMaximaFrame.cpp:1232
+#: ../../src/wxMaximaFrame.cpp:1266
 msgid "&Maxima"
 msgstr "&Maxima"
 
-#: ../../src/wxMaximaFrame.cpp:1882
+#: ../../src/wxMaximaFrame.cpp:1919
 #, fuzzy
 msgid "&Maxima help"
 msgstr "Mostrar ajuda do Maxima"
 
-#: ../../src/wxMaximaFrame.cpp:1660
+#: ../../src/wxMaximaFrame.cpp:1697
 msgid "&Modulus Computation..."
 msgstr "Cálculo com &módulo..."
 
-#: ../../src/main.cpp:435
+#: ../../src/main.cpp:674
 #, fuzzy
 msgid "&New\tCtrl+N"
 msgstr "Novo\tCtrl+N"
 
-#: ../../src/wxMaximaFrame.cpp:1870
+#: ../../src/wxMaximaFrame.cpp:1907
 msgid "&Numeric"
 msgstr "&Numérico"
 
-#: ../../src/wxMaximaFrame.cpp:1785
+#: ../../src/wxMaximaFrame.cpp:1822
 #, fuzzy
 msgid "&Numeric Output"
 msgstr "Alternar saída &numérica"
 
-#: ../../src/main.cpp:436
+#: ../../src/wizards/IntegrateWiz.cpp:52
+msgid "&Numerical integration"
+msgstr "Integração &numérica"
+
+#: ../../src/wizards/SumWiz.cpp:44
+msgid "&Nusum"
+msgstr "&Nusum"
+
+#: ../../src/main.cpp:675
 #, fuzzy
 msgid "&Open\tCtrl+O"
 msgstr "&Abrir\tCtrl+O"
 
-#: ../../src/wxMaximaFrame.cpp:598
+#: ../../src/wxMaximaFrame.cpp:629
 msgid "&Open...\tCtrl+O"
 msgstr "&Abrir...\tCtrl+O"
 
-#: ../../src/wxMaximaFrame.cpp:1780
+#: ../../src/wxMaximaFrame.cpp:1817
 msgid "&Plot"
 msgstr "G&ráfico"
 
-#: ../../src/wxMaximaFrame.cpp:622
+#: ../../src/wizards/SeriesWiz.cpp:45
+msgid "&Power series"
+msgstr "Séries de &potências"
+
+#: ../../src/wxMaximaFrame.cpp:655
 msgid "&Print...\tCtrl+P"
 msgstr "&Imprimir...\tCtrl+P"
 
-#: ../../src/wxMaximaFrame.cpp:1594
+#: ../../src/wizards/SubstituteWiz.cpp:38
+msgid "&Rational"
+msgstr "&Racional"
+
+#: ../../src/wxMaximaFrame.cpp:1631
 msgid "&Reduce Trigonometric"
 msgstr "&Reduzir trigonometricas"
 
-#: ../../src/wxMaximaFrame.cpp:974
+#: ../../src/wxMaximaFrame.cpp:1008
 #, fuzzy
 msgid "&Restart Maxima\tCtrl+Alt+R"
 msgstr "&Reiniciar Maxima"
 
-#: ../../src/wxMaximaFrame.cpp:608
+#: ../../src/wxMaximaFrame.cpp:639
 msgid "&Save\tCtrl+S"
 msgstr "&Salvar\tCtrl+S"
 
-#: ../../src/wxMaximaFrame.cpp:1662
+#: ../../src/wizards/SumWiz.cpp:43 ../../src/wxMaximaFrame.cpp:1699
 msgid "&Simplify"
 msgstr "&Simplificar"
 
-#: ../../src/wxMaximaFrame.cpp:1581
+#: ../../src/wxMaximaFrame.cpp:1618
 msgid "&Simplify Factorials"
 msgstr "&Simplificar fatoriais"
 
-#: ../../src/wxMaximaFrame.cpp:1591
+#: ../../src/wxMaximaFrame.cpp:1628
 msgid "&Simplify Trigonometric"
 msgstr "&Simplificar trigonométricas"
 
-#: ../../src/wxMaximaFrame.cpp:1238
+#: ../../src/wxMaximaFrame.cpp:1272
 msgid "&Solve..."
 msgstr "&Resolver..."
 
-#: ../../src/wxMaximaFrame.cpp:1035
+#: ../../src/wizards/Plot2dWiz.cpp:42
+msgid "&Special"
+msgstr "E&special"
+
+#: ../../src/wizards/LimitWiz.cpp:45
+msgid "&Taylor series"
+msgstr "Série de &Taylor"
+
+#: ../../src/wxMaximaFrame.cpp:1069
 #, fuzzy
 msgid "&Time Display"
 msgstr "Alternar exibição do &tempo"
 
-#: ../../src/wxMaximaFrame.cpp:1375
+#: ../../src/wxMaximaFrame.cpp:1409
 msgid "&Transpose Matrix"
 msgstr "&Transpor matriz"
 
-#: ../../src/wxMaximaFrame.cpp:1605
+#: ../../src/wxMaximaFrame.cpp:1642
 msgid "&Trigonometric Simplification"
 msgstr "Simplificação &trigonométrica"
 
-#: ../../src/wxMaximaFrame.cpp:1021
+#: ../../src/wxMaximaFrame.cpp:1055
 #, fuzzy
 msgid "&Variables"
 msgstr "Variáveis"
 
-#: ../../src/wxMaxima.cpp:2443
+#: ../../src/wizards/Plot3dWiz.cpp:79
+msgid "&pm3d"
+msgstr "&pm3d"
+
+#: ../../src/cells/AnimationCell.cpp:475
+msgid "(Animation)"
+msgstr ""
+
+#: ../../src/MaximaProcessManager.cpp:771
 msgid "(Config tells to suppress the output of long cells)"
 msgstr ""
 
-#: ../../src/MathParser.cpp:1288
+#: ../../src/cells/ImgCell.cpp:284
+msgid "(Image)"
+msgstr ""
+
+#: ../../src/MathParser.cpp:1418
 msgid "(Invalid XML from maxima)"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:4221
+#: ../../src/cells/GroupCell.cpp:652
+msgid "(Layout took too long and was suppressed)"
+msgstr ""
+
+#: ../../src/MaximaFileIO.cpp:120
 msgid "(Maybe a permission problem?)"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:9248
+#: ../../src/sidebars/CharButton.cpp:211
+msgid "(Might not be displayed correctly in at least one of the worksheet fonts)"
+msgstr ""
+
+#: ../../src/sidebars/VariablesPane.cpp:254
+msgid "(Not a valid variable name)"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:183
+msgid "(Use default language)"
+msgstr "(Usar idioma padrão)"
+
+#: ../../src/MaximaCommandMenus.cpp:440
 msgid "(f(x),x,a,b)), Epsilon algorithm"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:9235
+#: ../../src/MaximaCommandMenus.cpp:426
 msgid "(f(x),x,a,b)), Strategy of Aind"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:9258
+#: ../../src/MaximaCommandMenus.cpp:453
 msgid "(f(x),x,a,b), (semi-) infinite interval"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1841
+#: ../../src/wxMaximaFrame.cpp:1878
 msgid "(f(x),x,a,b), Epsilon algorithm"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1843
+#: ../../src/wxMaximaFrame.cpp:1880
 msgid "(f(x),x,a,b), infinite interval"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1839
+#: ../../src/wxMaximaFrame.cpp:1876
 msgid "(f(x),x,a,b), strategy of Aind"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:9361 ../../src/wxMaximaFrame.cpp:1867
+#: ../../src/MaximaCommandMenus.cpp:596 ../../src/wxMaximaFrame.cpp:1904
 msgid "(f(x),x,y) with singularities+discontinuities"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2065
+#: ../../src/wizards/DrawWiz.cpp:274 ../../src/wizards/DrawWiz.cpp:287
+#: ../../src/wizards/DrawWiz.cpp:303 ../../src/wizards/DrawWiz.cpp:320
+#: ../../src/wizards/DrawWiz.cpp:335
+msgid "-"
+msgstr ""
+
+#: ../../src/wizards/IntegrateWiz.cpp:192
+#: ../../src/wizards/IntegrateWiz.cpp:202
+#: ../../src/wizards/IntegrateWiz.cpp:207
+#: ../../src/wizards/IntegrateWiz.cpp:217 ../../src/wizards/LimitWiz.cpp:132
+#: ../../src/wizards/LimitWiz.cpp:142
+msgid "- Infinity"
+msgstr "- Infinito"
+
+#: ../../src/MaximaOutputAppender.cpp:116
 msgid "... [suppressed additional lines as the output is longer than allowed in the wxMaxima configuration] "
 msgstr ""
 
-#: ../../src/Worksheet.cpp:6666
+#: ../../src/worksheet/Worksheet.cpp:4657
 msgid ".wxm clipboard data with unusual header"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8047
-#, fuzzy
-msgid "1×n Matrix b:"
-msgstr "Matriz:"
+#: ../../src/sidebars/TableOfContents.cpp:567
+msgid "1 Level"
+msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1312
+#: ../../src/sidebars/SymbolsSidebar.cpp:77
+msgid "1/2"
+msgstr ""
+
+#: ../../src/sidebars/DrawSidebar.cpp:45
+msgid "2D"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1346
 #, fuzzy
 msgid "2D Array to Matrix..."
 msgstr "Ma&pear a uma matriz..."
 
-#: ../../src/wxMaximaFrame.cpp:743
+#: ../../src/wxMaximaFrame.cpp:780
 msgid "2D equations using ASCII Art"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:746
+#: ../../src/wxMaximaFrame.cpp:783
 msgid "2D equations using ASCII Art with unicode characters, if available"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:5057
+#: ../../src/dialogs/ConfigDialogue.cpp:786
+msgid "2D if it fits on the page width"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:785
+msgid "2D, whenever possible"
+msgstr ""
+
+#: ../../src/sidebars/DrawSidebar.cpp:49
+msgid "3D"
+msgstr ""
+
+#: ../../src/wxMaxima.cpp:1835
 #, c-format
 msgid "; %i commands left in the current cell"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:10617
+#: ../../src/MaximaEvaluator.cpp:500
 msgid "A \":lisp\" as the first command might fail to send a \"finished\" signal."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:6585
+#: ../../src/dialogs/TipOfTheDay.cpp:102
+msgid "A 'horizontal cursor' was introduced in wxMaxima 0.8.0. It looks like a horizontal line between cells. It indicates where a new cell will appear if you type or paste text or execute a menu command."
+msgstr "Um 'cursor horizontal' foi introduzido no wxMaxima 0.8.0. Ele é mostrado como uma linha horizontal entre células. Ele mostra onde uma nova célula vai aparecer se você digitar ou colar texto, ou se executar um comando do menu."
+
+#: ../../src/MaximaCommandMenus.cpp:3099
 msgid "A Ctrl-F event"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1973
+#: ../../src/cells/GroupCell.cpp:2178
+msgid "A Maxima input cell with its output"
+msgstr ""
+
+#: ../../src/worksheet/WorksheetContextMenu.cpp:745
 msgid "A Scalar"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:6653
+#: ../../src/cells/TextCell.cpp:239
+msgid ""
+"A command or number wasn't preceded by a \":\", a \"$\", a \";\" or a \",\".\n"
+"Most probable cause: A missing comma between two list items."
+msgstr ""
+
+#: ../../src/wxMaxima.cpp:2642
 #, c-format
 msgid "A find event, %s"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:2012
+#: ../../src/wizards/ListSortWiz.cpp:63
+#, fuzzy
+msgid "A function f(a,b), named"
+msgstr "Nomes de funções"
+
+#: ../../src/worksheet/WorksheetContextMenu.cpp:784
 msgid "A function returning integers"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:2014
+#: ../../src/worksheet/WorksheetContextMenu.cpp:786
 msgid "A function returning positive numbers"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1965
+#: ../../src/wizards/DrawWiz.cpp:164
+msgid "A good example equation would be x^2+y^2=1"
+msgstr ""
+
+#: ../../src/cells/GroupCell.cpp:2193 ../../src/cells/GroupCell.cpp:2196
+msgid "A heading"
+msgstr ""
+
+#: ../../src/worksheet/WorksheetContextMenu.cpp:737
 #, fuzzy
 msgid "A irrational variable"
 msgstr "Mudar variável"
 
-#: ../../src/Worksheet.cpp:2016
+#: ../../src/worksheet/WorksheetContextMenu.cpp:788
 msgid "A left-associative function"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:2019
+#: ../../src/worksheet/WorksheetContextMenu.cpp:791
 #, fuzzy
 msgid "A linear function"
 msgstr "Apagar uma função"
 
-#: ../../src/wxMaxima.cpp:9590
+#: ../../src/MaximaCommandMenus.cpp:1830
 msgid "A matrix in which each row is a set of variables"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1963
+#: ../../src/dialogs/TipOfTheDay.cpp:84
+#, fuzzy
+msgid "A new document format has been introduced in wxMaxima 0.8.2 that saves not only your input and text commentaries, but also the outputs of your calculations. When saving your document, select 'Whole document (*.wxmx)' format."
+msgstr "Um novo formato de documento foi introduzido no wxMaxima 0.8.2 que salva não só a entrada e os comentários textuais, mas também as saídas dos cálculos. Quando salvar o documento, selecione o formato 'Documento XML do wxMaxima'."
+
+#: ../../src/cells/GroupCell.cpp:2175
+#, fuzzy
+msgid "A page break"
+msgstr "Quebra de página"
+
+#: ../../src/dialogs/TipOfTheDay.cpp:168
+msgid "A plot to be embedded into the work sheet by preceding its name with a \"wx\". \"draw\" can be replaced by \"wxdraw\", plot by \"wxplot\" etc."
+msgstr ""
+
+#: ../../src/worksheet/WorksheetContextMenu.cpp:735
 #, fuzzy
 msgid "A rational variable"
 msgstr "Mudar variável"
 
-#: ../../src/Worksheet.cpp:2018
+#: ../../src/worksheet/WorksheetContextMenu.cpp:790
 msgid "A right-associative function"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1634
+#: ../../src/dialogs/ConfigDialogue.cpp:436
+msgid "A scale factor for the printout. Helpful for printing big equations on small pdf pages."
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1671
 msgid "A search-and-replace for equations"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1636
+#: ../../src/cells/EditorCell.cpp:4522 ../../src/cells/GroupCell.cpp:2184
+msgid "A section heading"
+msgstr ""
+
+#: ../../src/wizards/DrawWiz.cpp:479
+#, fuzzy
+msgid "A static plot"
+msgstr "Gráfico paramétrico"
+
+#: ../../src/cells/EditorCell.cpp:4534
+msgid "A sub-sub-sub-subsection heading"
+msgstr ""
+
+#: ../../src/cells/EditorCell.cpp:4531
+msgid "A sub-sub-subsection heading"
+msgstr ""
+
+#: ../../src/cells/EditorCell.cpp:4528 ../../src/cells/GroupCell.cpp:2190
+#, fuzzy
+msgid "A sub-subsection heading"
+msgstr "Célula de subseção"
+
+#: ../../src/cells/EditorCell.cpp:4525 ../../src/cells/GroupCell.cpp:2187
+#, fuzzy
+msgid "A subsection heading"
+msgstr "Célula de subseção"
+
+#: ../../src/wxMaximaFrame.cpp:1673
 msgid "A subst with basic maths knowledge"
 msgstr ""
 
-#: ../../src/BTextCtrl.cpp:64
+#: ../../src/sidebars/SymbolsSidebar.cpp:239
+msgid "A symbol from the configuration dialogue"
+msgstr ""
+
+#: ../../src/cells/GroupCell.cpp:2181
+msgid "A text cell"
+msgstr ""
+
+#: ../../src/BTextCtrl.cpp:66
 msgid "A text control got the mouse focus"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1442
+#: ../../src/cells/GroupCell.cpp:2199
+msgid "A title"
+msgstr ""
+
+#: ../../src/cells/TextCell.cpp:197
+msgid ""
+"A variable that can be assigned a number to.\n"
+"Often used by solve() and algsys(), if there is an infinite number of results."
+msgstr ""
+
+#: ../../src/cells/GroupCell.cpp:2205
+msgid "A worksheet cell"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1479
 #, fuzzy
 msgid "A&pply function to each Matrix element..."
 msgstr "Aplicar função a uma lista"
 
-#: ../../src/wxMaximaFrame.cpp:1291
+#: ../../src/wxMaximaFrame.cpp:1325
 msgid "A&t Value..."
 msgstr "Valor no pon&to..."
 
-#: ../../src/Configuration.cpp:85
+#: ../../src/Styles.cpp:114
 msgid "ASCII maths"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1963
+#: ../../src/dialogs/ConfigDialogue.cpp:1618
+msgid "Abort evaluation on error"
+msgstr ""
+
+#: ../../src/MaximaEvaluator.cpp:214
+#, c-format
+msgid "Aborting due to --exit-on-error (exit code 1). Cell: %s"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:2016
 msgid "About"
 msgstr "Sobre"
 
-#: ../../src/wxMaximaFrame.cpp:1963 ../../src/wxMaximaFrame.cpp:1965
+#: ../../src/wxMaximaFrame.cpp:2016 ../../src/wxMaximaFrame.cpp:2018
 msgid "About wxMaxima"
 msgstr "Sobre o wxMaxima"
 
-#: ../../src/wxMaxima.cpp:7837
+#: ../../src/MaximaCommandMenus.cpp:1018
 msgid "Accepts one expression or a list in the format [ode1,ode2,...]"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7841
+#: ../../src/MaximaCommandMenus.cpp:1022
 msgid "Accepts one variable or a list in the format [1,4,...]"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7839
+#: ../../src/MaximaCommandMenus.cpp:1020
 msgid "Accepts one variable or a list in the format [var1,var2,...]"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1371
+#: ../../src/dialogs/ConfigDialogue.cpp:292
+msgid "Accessibility"
+msgstr ""
+
+#: ../../src/sidebars/DrawSidebar.cpp:103
+msgid "Accuracy"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1405
 msgid "Ad&joint Matrix"
 msgstr "Matriz ad&junta"
 
-#: ../../src/wxMaximaFrame.cpp:1657
+#: ../../src/wxMaximaFrame.cpp:1694
 msgid "Add Algebraic E&quality..."
 msgstr "Adicionar &igualdade algébrica..."
 
-#: ../../src/wxMaximaFrame.cpp:1015
+#: ../../src/wxMaximaFrame.cpp:1049
 msgid "Add a directory to search path"
 msgstr "Adicionar um diretório ao caminho de busca"
 
-#: ../../src/wxMaximaFrame.cpp:1752
+#: ../../src/wxMaximaFrame.cpp:1789
 msgid "Add a new item to the beginning of the list. Useful for creating stacks."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8602
+#: ../../src/sidebars/VariablesPane.cpp:228
+msgid "Add all"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:1621
 #, fuzzy
 msgid "Add an element to the end of a list"
 msgstr "Abrir um documento"
 
-#: ../../src/wxMaxima.cpp:8597
+#: ../../src/MaximaCommandMenus.cpp:1616
 #, fuzzy
 msgid "Add an element to the start of a list"
 msgstr "Abrir um documento"
 
-#: ../../src/wxMaxima.cpp:7625
+#: ../../src/MaximaCommandMenus.cpp:4497
 msgid "Add dir to path:"
 msgstr "Adicionar diretório ao caminho:"
 
-#: ../../src/wxMaximaFrame.cpp:1658
+#: ../../src/wxMaximaFrame.cpp:1695
 msgid "Add equality to the rational simplifier"
 msgstr "Adicionar igualdade ao simplificador racional"
 
-#: ../../src/wxMaximaFrame.cpp:1015
+#: ../../src/sidebars/SymbolsSidebar.cpp:204
+msgid "Add more symbols"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1262
+msgid "Add the .wxmx file to the HTML export"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1049
 msgid "Add to &Path..."
 msgstr "Adicionar ao &caminho..."
 
-#: ../../src/Worksheet.cpp:1531 ../../src/Worksheet.cpp:1564
-#: ../../src/Worksheet.cpp:1704
+#: ../../src/sidebars/UnicodeSidebar.cpp:105
+msgid "Add to symbols Sidebar"
+msgstr ""
+
+#: ../../src/worksheet/WorksheetContextMenu.cpp:304
+#: ../../src/worksheet/WorksheetContextMenu.cpp:337
+#: ../../src/worksheet/WorksheetContextMenu.cpp:477
 msgid "Add to watchlist"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1562
+#: ../../src/sidebars/XmlInspector.cpp:147
+#, c-format
+msgid "Added much text (%li chars) to the XML inspector."
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1896
+msgid "Additional clipboard formats to put on the clipboard on ordinary copy"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:393
+msgid "Additional commands to be added to the preamble of LaTeX output for pdftex."
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1187
+msgid "Additional lines for the TeX preamble:"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:389
+msgid "Additional parameters for Maxima (e.g. -l clisp)."
+msgstr "Parâmetros adicionais para o Maxima (p.ex. -l clisp)."
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1543
+msgid "Additional parameters for Maxima (restart Maxima after changes)"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1318
+msgid "Additional symbols for the \"symbols\" sidebar:"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1599
 msgid "Additionally: log(a*b)=log(a)+log(b)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1566
+#: ../../src/wxMaximaFrame.cpp:1603
 msgid "Additionally: log(a/b)=log(a)-log(b), a and b positive integers"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1996
+#: ../../src/worksheet/WorksheetContextMenu.cpp:768
 msgid "Additive function: f(a+b)=f(a)+f(b)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1911
+#: ../../src/wxMaximaFrame.cpp:1948
 msgid "Advanced 2d plotting"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1809
+#: ../../src/wxMaximaFrame.cpp:1846
 msgid "Advanced guess (PSLQ algorithm)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1920
+#: ../../src/wxMaximaFrame.cpp:1957
 msgid "Advanced variable names"
 msgstr ""
 
-#: ../../src/ToolBar.cpp:321 ../../src/ToolBar.cpp:589
-msgid "After clicking on animations created with with_slider_draw() or similar this slider allows to change the current frame."
+#: ../../src/dialogs/ConfigDialogue.cpp:184
+msgid "Afrikaans"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1028
+#: ../../src/ToolBar.cpp:536 ../../src/ToolBar.cpp:789
+msgid "After clicking on animations created with with_slider_draw() or similar, this slider allows changing the current frame."
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:185
+msgid "Albanian"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1062
 msgid "Aliases"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1714
+#: ../../src/sidebars/TableOfContents.cpp:572
+msgid "All Levels"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1751
 #, fuzzy
 msgid "All but the 1st n elements"
 msgstr "Aplicar função a uma lista"
 
-#: ../../src/wxMaximaFrame.cpp:1716
+#: ../../src/wxMaximaFrame.cpp:1753
 #, fuzzy
 msgid "All but the last n elements"
 msgstr "Aplicar função a uma lista"
 
-#: ../../src/main.cpp:594 ../../src/wxMaxima.cpp:6075
+#: ../../src/MaximaCommandMenus.cpp:2198 ../../src/main.cpp:883
 msgid "All openable types (*.wxm, *.wxmx, *.mac, *.out, *.xml)|*.wxm;*.wxmx;*.mac;*.out;*.xml|wxMaxima document (*.wxm, *.wxmx)|*.wxm;*.wxmx|Maxima session (*.mac)|*.mac|Xmaxima session (*.out)|*.out|xml from broken .wxmx (*.xml)|*.xml"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:733
+#: ../../src/dialogs/ConfigDialogue.cpp:750
+#, fuzzy
+msgid "All variable names"
+msgstr "Variável antiga:"
+
+#: ../../src/wxMaximaFrame.cpp:770
 #, fuzzy
 msgid "All visible sidebars"
 msgstr "Variável antiga:"
 
-#: ../../src/wxMaximaFrame.cpp:1650
-msgid "Allow to substitute operators"
+#: ../../src/sidebars/HelpBrowser.cpp:48
+msgid "Allow access to an online manual?"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:9040
-msgid "Allows to vary the parameters of a function until it fits experimental data."
+#: ../../src/wxMaximaFrame.cpp:1687
+msgid "Allow substituting operators"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:763
+#: ../../src/wizards/DrawWiz.cpp:722
+msgid "Allows providing separate expressions for calculating"
+msgstr ""
+
+#: ../../src/sidebars/SymbolsSidebar.cpp:182
+msgid "Allows specifying which non-builtin unicode symbols should be displayed in the symbols sidebar along with the built-in symbols."
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:294
+msgid "Allows varying the parameters of a function until it fits experimental data."
+msgstr ""
+
+#: ../../src/dialogs/BinaryNameCtrl.cpp:69
+msgid "All|*"
+msgstr "Todos|*"
+
+#: ../../src/wxMaximaFrame.cpp:800
 msgid "Always after underscores"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:764
+#: ../../src/wxMaximaFrame.cpp:801
 msgid "Always autosubscript after an underscore"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:774
+#: ../../src/wxMaximaFrame.cpp:811
 msgid "Always display this variable with subscript"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1605
+#: ../../src/worksheet/WorksheetContextMenu.cpp:378
 msgid "Always show all digits"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:9241
+#: ../../src/wizards/DrawWiz.cpp:484
+msgid "An animation with multiple frames"
+msgstr ""
+
+#: ../../src/cells/GroupCell.cpp:2202
+msgid "An image cell"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:433
 msgid "An integer between 1..6; Higher numbers work better for oscillating integrands"
 msgstr ""
 
-#: ../../src/MaximaManual.cpp:385
+#: ../../src/cells/TextCell.cpp:202
+msgid "An integration constant."
+msgstr ""
+
+#: ../../src/MaximaManual.cpp:402
 msgid "Anchors file has no top node."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:791
+#: ../../src/wxMaximaFrame.cpp:828
 msgid "Angles"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1775
+#: ../../src/worksheet/WorksheetExport.cpp:1122
+#: ../../src/worksheet/WorksheetExport.cpp:1387
+msgid "Animated Diagram"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1812
 #, fuzzy
 msgid "Animation autoplay"
 msgstr "Salvar animação para arquivo"
 
-#: ../../src/wxMaximaFrame.cpp:1778
+#: ../../src/wxMaximaFrame.cpp:1815
 msgid "Animation framerate..."
 msgstr ""
 
-#: ../../src/Worksheet.cpp:2002
+#: ../../src/dialogs/ConfigDialogue.cpp:1871
+msgid "Announce Maxima's output as MathML"
+msgstr ""
+
+#: ../../src/worksheet/Worksheet.cpp:5467 ../../src/wxMaximaFrame.cpp:1989
+msgid "Anonymize Code for Bug Report"
+msgstr ""
+
+#: ../../src/worksheet/WorksheetContextMenu.cpp:774
 msgid "Antisymmetric function: f(x)=-f(-x)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1739
+#: ../../src/dialogs/ConfigDialogue.cpp:2064
+msgid "Appearance:"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1776
 msgid "Append"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1735
+#: ../../src/wxMaximaFrame.cpp:1772
 msgid "Append a list"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1736
+#: ../../src/wxMaximaFrame.cpp:1773
 #, fuzzy
 msgid "Append a list to an existing list"
 msgstr "Encontrar o limite de uma expressão"
 
-#: ../../src/wxMaxima.cpp:8607
+#: ../../src/MaximaCommandMenus.cpp:1626
 #, fuzzy
 msgid "Append a list to another list"
 msgstr "Encontrar o limite de uma expressão"
 
-#: ../../src/wxMaximaFrame.cpp:1729
+#: ../../src/wxMaximaFrame.cpp:1766
 #, fuzzy
 msgid "Append an element"
 msgstr "Abrir um documento"
 
-#: ../../src/wxMaximaFrame.cpp:1734
+#: ../../src/wxMaximaFrame.cpp:1771
 #, fuzzy
 msgid "Append an element to the beginning an existing list"
 msgstr "Encontrar o limite de uma expressão"
 
-#: ../../src/wxMaximaFrame.cpp:1730
+#: ../../src/wxMaximaFrame.cpp:1767
 #, fuzzy
 msgid "Append an element to the end of an existing list"
 msgstr "Encontrar o limite de uma expressão"
 
-#: ../../src/wxMaxima.cpp:8552
+#: ../../src/MaximaCommandMenus.cpp:1565
 #, fuzzy
 msgid "Apply a function to each list element"
 msgstr "Aplicar função a uma lista"
 
-#: ../../src/wxMaximaFrame.cpp:1810
+#: ../../src/wxMaximaFrame.cpp:1847
 #, c-format
 msgid "Approximate by a fraction using log(), sqrt() and %pi, when needed. Only available in maxima > 5.46.0"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1806
+#: ../../src/wxMaximaFrame.cpp:1843
 msgid "Approximate by nice fraction"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8931
+#: ../../src/MaximaCommandMenus.cpp:182
 msgid ""
 "Approximates a expression around a point as a polynom\n"
 "The trailing \"...\" can be removed by using ratdisrep()"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8939
+#: ../../src/MaximaCommandMenus.cpp:190
 msgid "Approximates a expression as a polynom"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:9474
+#: ../../src/MaximaCommandMenus.cpp:2117
 msgid "Apropos"
 msgstr "Apropos"
 
-#: ../../src/wxMaxima.cpp:7317
+#: ../../src/dialogs/ConfigDialogue.cpp:186
+msgid "Arabic"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:4189
 msgid "Are the chars equal, if case is ignored?"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7312
+#: ../../src/MaximaCommandMenus.cpp:4184
 #, fuzzy
 msgid "Are the chars equal?"
 msgstr "Célula de subseção"
 
-#: ../../src/wxMaxima.cpp:7349
+#: ../../src/MaximaCommandMenus.cpp:4221
 msgid "Are these strings equal if case is ignored?"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7344
+#: ../../src/MaximaCommandMenus.cpp:4216
 msgid "Are these strings equal?"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7259
+#: ../../src/MaximaCommandMenus.cpp:4131
 msgid "Arguments:"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8189
+#: ../../src/MaximaCommandMenus.cpp:1379
 #, fuzzy
 msgid "Array"
 msgstr "Matriz:"
 
-#: ../../src/wxMaximaFrame.cpp:1023
+#: ../../src/wxMaximaFrame.cpp:1057
 #, fuzzy
 msgid "Arrays"
 msgstr "Matriz:"
 
-#: ../../src/wxMaxima.cpp:7308 ../../src/wxMaxima.cpp:7354
+#: ../../src/cells/TextCell.cpp:212
+msgid ""
+"As calculating 0.1^12 demonstrates maxima by default doesn't tend to hide what looks like being the small error using floating-point numbers introduces.\n"
+"If this seems to be the case here the error can be avoided by using exact numbers like 1/10, 1*10^-1 or rat(.1).\n"
+"It also can be hidden by setting fpprintprec to an appropriate value. But be aware in this case that even small errors can add up."
+msgstr ""
+
+#: ../../src/wizards/ListSortWiz.cpp:51
+msgid "Ascending by magnitude (numeric only)"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:4180 ../../src/MaximaCommandMenus.cpp:4226
 msgid "Ascii code to char"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1138
+#: ../../src/wxMaximaFrame.cpp:1172
 msgid "Ascii code to char..."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:10063
+#: ../../src/dialogs/ConfigDialogue.cpp:1397
+msgid "Ask to save untitled documents"
+msgstr "Pedir salvamento de documentos sem título"
+
+#: ../../src/dialogs/MaximaNotStartingDialog.cpp:36
+msgid "Asking the user for the location of a working maxima binary"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:3552
 msgid "Assignment(s):"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:10064
+#: ../../src/MaximaCommandMenus.cpp:3553
 msgid "Assignments of the format a=10,b=20"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:6851
+#: ../../src/MaximaCommandMenus.cpp:1754
 msgid "Assume a value range for a variable"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8545
+#: ../../src/MaximaCommandMenus.cpp:1558
 msgid "Attention: Extracting a random list element isn't efficient for long lists.Iterating over lists using makelist() or for loops is way faster."
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1618
+#: ../../src/dialogs/ConfigDialogue.cpp:897
+msgid "Auto-indent new lines"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:893
+#, fuzzy
+msgid "Auto-insert closing parenthesis"
+msgstr "Parêntesis aos pares nos controles de texto"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1441
+#: ../../src/dialogs/ConfigDialogue.cpp:1472
+#: ../../src/dialogs/MaximaNotStartingDialog.cpp:43
+msgid "Autodetect"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1236
+msgid "Automatic"
+msgstr ""
+
+#: ../../src/worksheet/WorksheetContextMenu.cpp:391
 msgid "Automatic labels"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:952
+#: ../../src/dialogs/ConfigDialogue.cpp:769
+#, c-format
+msgid "Automatic labels (%i1, %o1,...)"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:986
 msgid "Automatically answer questions"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:953
+#: ../../src/wxMaximaFrame.cpp:987
 msgid "Automatically fill in answers known from the last run"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1464 ../../src/Worksheet.cpp:1838
+#: ../../src/dialogs/ConfigDialogue.cpp:460
+msgid "Automatically insert a closing parenthesis the moment the user enters an opening one."
+msgstr ""
+
+#: ../../src/worksheet/WorksheetContextMenu.cpp:235
+#: ../../src/worksheet/WorksheetContextMenu.cpp:610
 msgid "Automatically send known answers"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:6021
+#: ../../src/MaximaFileIO.cpp:902
 #, c-format
 msgid "Autosaving as temp file %s"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:6033
+#: ../../src/MaximaFileIO.cpp:914
 #, c-format
 msgid "Autosaving the .wxmx file as %s"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:781
+#: ../../src/wxMaximaFrame.cpp:818
 msgid "Autosubscript"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:782
+#: ../../src/wxMaximaFrame.cpp:819
 msgid "Autosubscript chars after an underscore"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:767
+#: ../../src/wxMaximaFrame.cpp:804
 msgid "Autosubscript numbers and text following single letters"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:6529
+#: ../../src/MaximaCommandMenus.cpp:3049
 msgid "Autosubscript this variable"
 msgstr ""
 
-#: ../../src/MaximaManual.cpp:536
+#: ../../src/dialogs/ConfigDialogue.cpp:734
+msgid "Autowrap long lines:"
+msgstr ""
+
+#: ../../src/sidebars/DrawSidebar.cpp:75
+msgid "Axis"
+msgstr ""
+
+#: ../../src/wizards/BC2Wiz.cpp:59
+msgid "BC2"
+msgstr "CC2"
+
+#: ../../src/MaximaManual.cpp:559
 msgid "Background task that compiles the Manual anchors scheduled."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1350
+#: ../../src/sidebars/StatSidebar.cpp:91
+msgid "Barsplot..."
+msgstr "Gráfico de barras..."
+
+#: ../../src/wxMaximaFrame.cpp:1384
 msgid "Basic matrix operations"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:6210
+#: ../../src/dialogs/ConfigDialogue.cpp:187
+msgid "Basque"
+msgstr ""
+
+#: ../../src/dialogs/BinaryNameCtrl.cpp:67
+msgid "Bat files (*.bat)|*.bat|Exe files (*.exe)|*.exe|All|*"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:2366
 msgid "Batch File"
 msgstr "Arquivo batch (de lote)"
 
-#: ../../src/wxMaxima.cpp:5318
+#: ../../src/wxMaxima.cpp:2079
+#, c-format
+msgid "Batch mode: %d image(s) could not be loaded at all."
+msgstr ""
+
+#: ../../src/wxMaxima.cpp:2084
+#, c-format
+msgid "Batch mode: %d image(s) failed to decode/render (--debug)."
+msgstr ""
+
+#: ../../src/MaximaResponseReader.cpp:523
+#, c-format
+msgid "Batch mode: Maxima asked a question with no scripted answer available (\"%s\"). Halting, as documented for --batch."
+msgstr ""
+
+#: ../../src/cells/TextCell.cpp:305
+msgid "Besides a division by 0 the reason for this error message can be a calculation that returns +/-infinity."
+msgstr ""
+
+#: ../../src/dialogs/TipOfTheDay.cpp:141
+msgid "Besides the global undo functionality that is active when the cursor is between cells, wxMaxima has a per-cell undo function that is active if the cursor is inside a cell. Pressing Ctrl+Z inside a cell can therefore been used for a fine-pitch undo that doesn't affect latter changes made in other cells."
+msgstr ""
+
+#: ../../src/sidebars/GreekSidebar.cpp:179
+msgid "Beta"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1898
+msgid "Bitmap"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1273
+msgid "Bitmap scale for export:"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1223
+msgid "Bitmaps"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:2109
+msgid "Bold"
+msgstr "Negrito"
+
+#: ../../src/wxMaxima.cpp:2261
 msgid "Both horizontal and vertical cursor active at the same time"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8191
+#: ../../src/dialogs/ConfigDialogue.cpp:1999
+msgid "Bottom"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:1381
 msgid "Bottom end"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7817
+#: ../../src/MaximaCommandMenus.cpp:998
 #, fuzzy
 msgid "Boundary value problem"
 msgstr "Problema de valor de &fronteira..."
+
+#: ../../src/MaximaCommandMenus.cpp:1780
+msgid "Boxplot"
+msgstr ""
+
+#: ../../src/sidebars/StatSidebar.cpp:97
+msgid "Boxplot..."
+msgstr "Gráfico de caixa..."
+
+#: ../../src/dialogs/BinaryNameCtrl.cpp:42 ../../src/wizards/CsvWiz.cpp:57
+#: ../../src/wizards/CsvWiz.cpp:131 ../../src/wizards/Plot2dWiz.cpp:114
+#: ../../src/wizards/Plot3dWiz.cpp:109
+msgid "Browse"
+msgstr "Procurar"
 
 #: ../../src/wxMathml.cpp:101
 msgid "Bug: After removing the whitespace wxMathml.lisp is shorter than expected!"
 msgstr ""
 
-#: ../../src/Autocomplete.cpp:509
+#: ../../src/cells/Cell.cpp:498
+#, c-format
+msgid "Bug: AltCopyTexts not implemented for %s cell"
+msgstr ""
+
+#: ../../src/Autocomplete.cpp:642
 msgid "Bug: Autocompletion requested for unknown type of item."
 msgstr ""
 
-#: ../../src/Worksheet.cpp:2992
+#: ../../src/TreeUndoManager.h:138
 msgid "Bug: Cell left but not entered."
 msgstr ""
 
-#: ../../src/Worksheet.cpp:6203
+#: ../../src/worksheet/Worksheet.cpp:4193
 msgid "Bug: Cell with negative y position!"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:7723
+#: ../../src/worksheet/Worksheet.cpp:5905
 msgid "Bug: Encountered a heading I don't know how to move in one sectioning unit"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:7766
+#: ../../src/worksheet/Worksheet.cpp:5952
 msgid "Bug: Encountered a heading I don't know how to move out one sectioning unit"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:3112
+#: ../../src/worksheet/Worksheet.cpp:2244
 msgid "Bug: Got a question but no cell to answer it in"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:6378
-msgid "Bug: Got a request to change the contents of the cell above the beginning of the worksheet."
-msgstr ""
-
-#: ../../src/Worksheet.cpp:6346
+#: ../../src/worksheet/Worksheet.cpp:4293
 msgid "Bug: Got a request to delete the cell above the beginning of the worksheet."
 msgstr ""
 
-#: ../../src/Worksheet.cpp:6415
+#: ../../src/worksheet/WorksheetDocument.cpp:239
 msgid "Bug: Got a request to first change the contents of a cell and to then undelete it."
 msgstr ""
 
-#: ../../src/Worksheet.cpp:5578
+#: ../../src/worksheet/WorksheetExport.cpp:1576
 msgid "Bug: HTML output is no valid XML"
 msgstr ""
 
-#: ../../src/Configuration.h:615
+#: ../../src/cells/Cell.cpp:289
+msgid "Bug: Math Cell that claims to have no group Cell it belongs to"
+msgstr ""
+
+#: ../../src/Configuration.h:741
 msgid "Bug: Maximum number of digits that is to be displayed is too low!"
 msgstr ""
 
-#: ../../src/MathParser.cpp:523
+#: ../../src/MathParser.cpp:575
 msgid "Bug: Missing contents"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:2597 ../../src/Worksheet.cpp:2711
-#: ../../src/Worksheet.cpp:2753 ../../src/Worksheet.cpp:2787
-#: ../../src/Worksheet.cpp:2816 ../../src/Worksheet.cpp:2828
-#: ../../src/Worksheet.cpp:4442 ../../src/Worksheet.cpp:6650
-#: ../../src/Worksheet.cpp:6863
+#: ../../src/cells/GroupCell.cpp:1498
+msgid "Bug: No image counter to write to!"
+msgstr ""
+
+#: ../../src/cells/AnimationCell.cpp:543 ../../src/cells/EditorCell.cpp:2968
+#: ../../src/cells/ImgCell.cpp:353 ../../src/graphical_io/BitmapOut.cpp:161
+#: ../../src/graphical_io/OutCommon.cpp:264
+#: ../../src/worksheet/Worksheet.cpp:1764
+#: ../../src/worksheet/Worksheet.cpp:1901
+#: ../../src/worksheet/Worksheet.cpp:1943
+#: ../../src/worksheet/Worksheet.cpp:1977
+#: ../../src/worksheet/Worksheet.cpp:2006
+#: ../../src/worksheet/Worksheet.cpp:2018
+#: ../../src/worksheet/Worksheet.cpp:3512
+#: ../../src/worksheet/Worksheet.cpp:4641
+#: ../../src/worksheet/Worksheet.cpp:4866
 msgid "Bug: The clipboard is already opened"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:7763
+#: ../../src/cells/EditorCell.cpp:3051
+msgid "Bug: The clipboard isn't open on pasting into an editor cell"
+msgstr ""
+
+#: ../../src/cells/GroupCell.cpp:2288
+msgid "Bug: The predecessor to a GroupCell is not a GroupCell."
+msgstr ""
+
+#: ../../src/cells/GroupCell.cpp:2286
+msgid "Bug: The successor to a GroupCell is not a GroupCell."
+msgstr ""
+
+#: ../../src/cells/GroupCell.cpp:340
+msgid "Bug: Trying to append NULL to a group cell."
+msgstr ""
+
+#: ../../src/worksheet/Worksheet.cpp:5949
 msgid "Bug: Trying to move a title out by one sectioning unit"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:6934
+#: ../../src/worksheet/Worksheet.cpp:4925
 msgid "Bug: Trying to move the horizontally-drawn cursor to a place inside a GroupCell."
 msgstr ""
 
-#: ../../src/Worksheet.h:247 ../../src/Worksheet.h:252
+#: ../../src/TreeUndoAction.h:52 ../../src/TreeUndoAction.h:57
 msgid "Bug: Trying to record a cell contents change for undo without a cell."
 msgstr ""
 
-#: ../../src/Worksheet.cpp:6417
+#: ../../src/TreeUndoAction.h:73
+msgid "Bug: Trying to record a fold/unfold for undo without a cell."
+msgstr ""
+
+#: ../../src/worksheet/WorksheetDocument.cpp:241
 msgid "Bug: Undo action with both cell contents change and cell addition."
 msgstr ""
 
-#: ../../src/Worksheet.cpp:6383
-msgid "Bug: Undo request for cell outside worksheet."
+#: ../../src/cells/EditorCell.cpp:4541
+msgid "Bug: Unknown type of text"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1948
+#: ../../src/cells/EditorCell.cpp:3981 ../../src/cells/TextCell.cpp:479
+msgid "Bug: dc == NULL"
+msgstr ""
+
+#: ../../src/cells/EditorCell.cpp:2637
+msgid "Bug: x position of cell is unknown!"
+msgstr ""
+
+#: ../../src/cells/EditorCell.cpp:2638
+msgid "Bug: y position of cell is unknown!"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1985
 msgid "Build &Info"
 msgstr "&Informações do build"
 
-#: ../../src/wxMaxima.cpp:7275
+#: ../../src/dialogs/AboutDialog.cpp:45
+#, c-format
+msgid "Build from Git version: %s\n"
+msgstr ""
+
+#: ../../src/dialogs/TipOfTheDay.cpp:54
+#, fuzzy
+msgid "By default, Shift-Enter is used to evaluate commands, while Enter is used for multiline input. This behaviour can be changed in 'Edit->Configure' dialog by checking 'Enter evaluates cells'. This switches the roles of these two key commands."
+msgstr "Por padrão Shift+Enter é usado para avaliar comandos, e Enter é usado para entrada de múltiplas linhas. Ese comportamento pode ser alterado na janela 'Editar->Configurações' marcando 'Enter calcula células'. Essa opção inverte as ações das duas teclas."
+
+#: ../../src/MaximaCommandMenus.cpp:4147
 msgid "Byte:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1458
+#: ../../src/wxMaximaFrame.cpp:1495
 #, fuzzy
 msgid "C&hange Variable in Integrate..."
 msgstr "&Mudar variável..."
 
-#: ../../src/wxMaximaFrame.cpp:687
+#: ../../src/wxMaximaFrame.cpp:724
 msgid "C&onfigure"
 msgstr "C&onfigurações"
 
-#: ../../src/wxMaximaFrame.cpp:1482
+#: ../../src/wizards/CsvWiz.cpp:105
+msgid "CSV export"
+msgstr ""
+
+#: ../../src/wizards/CsvWiz.cpp:34
+msgid "CSV import"
+msgstr ""
+
+#: ../../src/cells/FontVariantCache.cpp:96
+#, c-format
+msgid "Caching font variant: %s"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1519
 msgid "Calculate &Product..."
 msgstr "Calcular &produto..."
 
-#: ../../src/wxMaxima.cpp:8057
+#: ../../src/MaximaCommandMenus.cpp:1243
 msgid "Calculate Singular Value Decomposition of a matrix numerically"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8050
+#: ../../src/MaximaCommandMenus.cpp:1236
 msgid "Calculate Singular Value Decomposition, left and right singular vectors numerically"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1480
+#: ../../src/wxMaximaFrame.cpp:1517
 msgid "Calculate Su&m..."
 msgstr "Calcular &soma..."
 
-#: ../../src/wxMaximaFrame.cpp:1795
+#: ../../src/wxMaximaFrame.cpp:1832
 msgid "Calculate bigfloat value of the last result"
 msgstr "Valor bigfloat do último resultado"
 
-#: ../../src/wxMaximaFrame.cpp:1792
+#: ../../src/wxMaximaFrame.cpp:1829
 msgid "Calculate float value of the last result"
 msgstr "Valor float do último resultado"
 
-#: ../../src/wxMaxima.cpp:9550
+#: ../../src/MaximaCommandMenus.cpp:1788
 #, fuzzy
 msgid "Calculate mean value"
 msgstr "Calcular módulo:"
 
-#: ../../src/wxMaxima.cpp:9554
+#: ../../src/MaximaCommandMenus.cpp:1792
 #, fuzzy
 msgid "Calculate median value"
 msgstr "Calcular módulo:"
 
-#: ../../src/wxMaxima.cpp:8871
+#: ../../src/MaximaCommandMenus.cpp:878
 msgid "Calculate modulus:"
 msgstr "Calcular módulo:"
 
-#: ../../src/wxMaximaFrame.cpp:1798
+#: ../../src/wxMaximaFrame.cpp:1835
 #, fuzzy
 msgid "Calculate numeric value of the last result"
 msgstr "Valor float do último resultado"
 
-#: ../../src/wxMaximaFrame.cpp:1483
+#: ../../src/wxMaximaFrame.cpp:1520
 msgid "Calculate products"
 msgstr "Calcular produtos"
 
-#: ../../src/wxMaxima.cpp:9562
+#: ../../src/MaximaCommandMenus.cpp:1800
 msgid "Calculate standard deviation"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1480
+#: ../../src/wxMaximaFrame.cpp:1517
 msgid "Calculate sums"
 msgstr "Calcular somas"
 
-#: ../../src/wxMaxima.cpp:8025 ../../src/wxMaxima.cpp:8035
+#: ../../src/MaximaCommandMenus.cpp:1209 ../../src/MaximaCommandMenus.cpp:1219
 msgid "Calculate the eigenvalues and eigenvectors numerically"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8020 ../../src/wxMaxima.cpp:8030
+#: ../../src/MaximaCommandMenus.cpp:1204 ../../src/MaximaCommandMenus.cpp:1214
 #, fuzzy
 msgid "Calculate the eigenvalues of a matrix numerically"
 msgstr "Calcular a inversa de uma matriz"
 
-#: ../../src/wxMaxima.cpp:8078 ../../src/wxMaxima.cpp:8099
+#: ../../src/MaximaCommandMenus.cpp:1264 ../../src/MaximaCommandMenus.cpp:1287
 msgid "Calculate the root of the sum of squares of matrix entries"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:9558
-#, fuzzy
-msgid "Calculate variation"
-msgstr "Calcular produtos"
+#: ../../src/MaximaCommandMenus.cpp:1796
+msgid "Calculate variance"
+msgstr ""
 
-#: ../../src/wxMaxima.cpp:8949
+#: ../../src/MaximaCommandMenus.cpp:203
 msgid "Calculates the fourier coefficients for the expression from -p to p"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1968
+#: ../../src/worksheet/WorksheetContextMenu.cpp:740
 msgid "Calls assume() in order to tell maxima about the variable's range"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:2031
+#: ../../src/worksheet/WorksheetContextMenu.cpp:803
 msgid "Can be specified as flag in ev(exp, flag)"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:11125
+#: ../../src/wxMaxima.cpp:3438
 msgid "Can not connect to the web server."
 msgstr "Não é possível se conectar com o servidor web."
 
-#: ../../src/wxMaxima.cpp:11166
+#: ../../src/wxMaxima.cpp:3384 ../../src/wxMaxima.cpp:3420
+#: ../../src/wxMaxima.cpp:3472
 msgid "Can not download version info."
 msgstr "Não foi possível baixar informação de versão."
 
-#: ../../src/wxMaxima.cpp:3016 ../../src/wxMaxima.cpp:4836
+#: ../../src/MaximaProcessManager.cpp:577 ../../src/wxMaxima.cpp:1581
 msgid "Can not start Maxima. The most probable cause is that Maxima isn't installed (it can be downloaded from https://maxima.sourceforge.io) or in wxMaxima's config dialogue the setting for Maxima's location is wrong."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:11203
+#: ../../src/dialogs/MaxSizeChooser.cpp:46
+#: ../../src/dialogs/MaxSizeChooser.cpp:48
+#: ../../src/dialogs/MaximaNotStartingDialog.cpp:71
+#: ../../src/dialogs/MaximaNotStartingDialog.cpp:73
+#: ../../src/dialogs/ResolutionChooser.cpp:41
+#: ../../src/dialogs/ResolutionChooser.cpp:43
+#: ../../src/wizards/ActualValuesStorageWiz.cpp:61
+#: ../../src/wizards/ActualValuesStorageWiz.cpp:63
+#: ../../src/wizards/BC2Wiz.cpp:48 ../../src/wizards/BC2Wiz.cpp:50
+#: ../../src/wizards/CsvWiz.cpp:65 ../../src/wizards/CsvWiz.cpp:139
+#: ../../src/wizards/DrawWiz.cpp:111 ../../src/wizards/DrawWiz.cpp:222
+#: ../../src/wizards/DrawWiz.cpp:354 ../../src/wizards/DrawWiz.cpp:509
+#: ../../src/wizards/DrawWiz.cpp:568 ../../src/wizards/DrawWiz.cpp:665
+#: ../../src/wizards/DrawWiz.cpp:773 ../../src/wizards/DrawWiz.cpp:849
+#: ../../src/wizards/DrawWiz.cpp:987 ../../src/wizards/Gen1Wiz.cpp:44
+#: ../../src/wizards/Gen1Wiz.cpp:46 ../../src/wizards/Gen2Wiz.cpp:47
+#: ../../src/wizards/Gen2Wiz.cpp:49 ../../src/wizards/Gen3Wiz.cpp:55
+#: ../../src/wizards/Gen3Wiz.cpp:57 ../../src/wizards/Gen4Wiz.cpp:62
+#: ../../src/wizards/Gen4Wiz.cpp:64 ../../src/wizards/Gen5Wiz.cpp:70
+#: ../../src/wizards/Gen5Wiz.cpp:72 ../../src/wizards/GenWizPanel.cpp:111
+#: ../../src/wizards/GenWizPanel.cpp:113 ../../src/wizards/IntegrateWiz.cpp:62
+#: ../../src/wizards/IntegrateWiz.cpp:64 ../../src/wizards/LimitWiz.cpp:50
+#: ../../src/wizards/LimitWiz.cpp:52 ../../src/wizards/ListSortWiz.cpp:77
+#: ../../src/wizards/ListSortWiz.cpp:79 ../../src/wizards/MatWiz.cpp:40
+#: ../../src/wizards/MatWiz.cpp:42 ../../src/wizards/MatWiz.cpp:169
+#: ../../src/wizards/MatWiz.cpp:171 ../../src/wizards/Plot2dWiz.cpp:95
+#: ../../src/wizards/Plot2dWiz.cpp:97 ../../src/wizards/Plot2dWiz.cpp:512
+#: ../../src/wizards/Plot2dWiz.cpp:514 ../../src/wizards/Plot2dWiz.cpp:608
+#: ../../src/wizards/Plot2dWiz.cpp:610 ../../src/wizards/Plot3dWiz.cpp:90
+#: ../../src/wizards/Plot3dWiz.cpp:92 ../../src/wizards/PlotFormatWiz.cpp:48
+#: ../../src/wizards/PlotFormatWiz.cpp:50 ../../src/wizards/SeriesWiz.cpp:50
+#: ../../src/wizards/SeriesWiz.cpp:52 ../../src/wizards/SubstituteWiz.cpp:42
+#: ../../src/wizards/SubstituteWiz.cpp:44 ../../src/wizards/SumWiz.cpp:48
+#: ../../src/wizards/SumWiz.cpp:50 ../../src/wizards/SystemWiz.cpp:39
+#: ../../src/wizards/SystemWiz.cpp:41 ../../src/wxMaxima.cpp:3509
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: ../../src/wxMaxima.cpp:3292
+#: ../../src/MaximaResponseReader.cpp:344
 msgid "Cannot authenticate Maxima!"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2677
+#: ../../src/wxMaxima.cpp:1283
+#, c-format
+msgid "Cannot cache the list of known symbols to %s"
+msgstr ""
+
+#: ../../src/cells/FontVariantCache.cpp:85
+#, c-format
+msgid "Cannot create a font based on %s. Falling back to a default font."
+msgstr ""
+
+#: ../../src/MaximaProcessManager.cpp:370
 msgid "Cannot find a maxima binary and no binary chosen in the config dialogue."
 msgstr ""
 
-#: ../../src/Autocomplete.cpp:583
+#: ../../src/Autocomplete.cpp:719
 #, c-format
 msgid "Cannot interpret template %s"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3082
+#: ../../src/MaximaResponseReader.cpp:221
 #, c-format
 msgid "Cannot interpret the numeric value of pid %s"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:11066 ../../src/wxMaxima.cpp:11073
-#: ../../src/wxMaxima.cpp:11080
+#: ../../src/wxMaxima.cpp:3347 ../../src/wxMaxima.cpp:3354
+#: ../../src/wxMaxima.cpp:3361
 #, c-format
 msgid "Cannot interpret version number component %s"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2530
+#: ../../src/cells/EditorCell.cpp:2991
+msgid "Cannot put the copied text on the clipboard"
+msgstr ""
+
+#: ../../src/cells/EditorCell.cpp:2984
+msgid "Cannot put the copied text on the clipboard (1st try)"
+msgstr ""
+
+#: ../../src/cells/EditorCell.cpp:2988
+msgid "Cannot put the copied text on the clipboard (2nd try)"
+msgstr ""
+
+#: ../../src/graphical_io/OutCommon.cpp:98
+#, c-format
+msgid "Cannot remove the file %s"
+msgstr ""
+
+#: ../../src/sidebars/History.cpp:258
+#, c-format
+msgid "Cannot save the command history to %s"
+msgstr ""
+
+#: ../../src/MaximaManual.cpp:386
+#, c-format
+msgid "Cannot save the list of subjects manual contains to the file %s."
+msgstr ""
+
+#: ../../src/MaximaProcessManager.cpp:191
 msgid "Cannot set the communication address to localhost."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2532
+#: ../../src/MaximaProcessManager.cpp:193
 #, c-format
 msgid "Cannot set the communication port to %i."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3656 ../../src/wxMaxima.cpp:6359
+#: ../../src/MaximaCommandMenus.cpp:2795 ../../src/MaximaResponseReader.cpp:880
 #, fuzzy
 msgid "Cannot start gnuplot"
 msgstr "Gráfico paramétrico"
 
-#: ../../src/StatusBar.cpp:216 ../../src/wxMaxima.cpp:2662
+#: ../../src/MaximaCommandMenus.cpp:2844
+msgid "Cannot start the headless gnuplot warnings check"
+msgstr ""
+
+#: ../../src/MaximaProcessManager.cpp:341 ../../src/StatusBar.cpp:254
 msgid "Cannot start the maxima binary"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:9268
+#: ../../src/sidebars/MathSidebar.cpp:62
+msgid "Canonical (tr)"
+msgstr "Forma canônica (tr)"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:188
+msgid "Catalan"
+msgstr "Catalão"
+
+#: ../../src/MaximaCommandMenus.cpp:466
 msgid "Cauchy principal value of f(x)/(x-c), finite interval"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1845
+#: ../../src/wxMaximaFrame.cpp:1882
 msgid "Cauchy principal value, finite interval"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:955
+#: ../../src/wxMaximaFrame.cpp:989
 msgid "Ce&ll"
 msgstr "Cé&lula"
 
-#: ../../src/Configuration.cpp:96
+#: ../../src/Styles.cpp:125
 #, fuzzy
 msgid "Cell bracket fill, Active"
 msgstr "Marcador da célula"
 
-#: ../../src/Configuration.cpp:95
+#: ../../src/Styles.cpp:124
 #, fuzzy
 msgid "Cell bracket fill, Inactive"
 msgstr "Marcador da célula"
 
-#: ../../src/wxMaxima.cpp:10395
+#: ../../src/wxMaxima.cpp:3082
 msgid "Cell ends in a backslash"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1038
+#: ../../src/MaximaCommandMenus.cpp:2262
+#, c-format
+msgid "Cell with UUID %s not found!"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1072
 msgid "Change &2d Display"
 msgstr "Alterar exibição &2d"
 
-#: ../../src/wxMaxima.cpp:10146
+#: ../../src/MaximaCommandMenus.cpp:3641
 #, fuzzy
 msgid "Change Image"
 msgstr "Mudar variável"
 
-#: ../../src/Worksheet.cpp:1324
+#: ../../src/worksheet/WorksheetContextMenu.cpp:86
 #, fuzzy
 msgid "Change Image..."
 msgstr "Salvar imagem..."
 
-#: ../../src/wxMaximaFrame.cpp:1954
+#: ../../src/wxMaximaFrame.cpp:1997
 #, fuzzy
 msgid "Change Log"
 msgstr "Mudar variável"
 
-#: ../../src/wxMaxima.cpp:7555
+#: ../../src/MaximaCommandMenus.cpp:4427
 msgid "Change directory"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1202
+#: ../../src/wxMaximaFrame.cpp:1236
 #, fuzzy
 msgid "Change directory..."
 msgstr "Salvar imagem..."
 
-#: ../../src/wxMaximaFrame.cpp:1039
+#: ../../src/dialogs/ConfigDialogue.cpp:859
+msgid "Change names of greek letters to greek letters"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1073
 msgid "Change the 2d display algorithm used to display math output"
 msgstr "Alterar a algoritmo de exibição 2d usado para mostrar a saída matemática"
 
-#: ../../src/wxMaxima.cpp:8885
+#: ../../src/dialogs/ConfigDialogue.cpp:489
+msgid "Change the text \"alpha\" and \"beta\" to the corresponding greek letter?"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:136
 msgid "Change variable"
 msgstr "Mudar variável"
 
-#: ../../src/wxMaxima.cpp:8905
+#: ../../src/MaximaCommandMenus.cpp:156
 #, fuzzy
 msgid "Change variable and evaluate"
 msgstr "Mudar variável em integral ou soma"
 
-#: ../../src/wxMaximaFrame.cpp:1459
+#: ../../src/wxMaximaFrame.cpp:1496
 msgid "Change variable in integral or sum"
 msgstr "Mudar variável em integral ou soma"
 
-#: ../../src/wxMaximaFrame.cpp:1463
+#: ../../src/wxMaximaFrame.cpp:1500
 #, fuzzy
 msgid "Change variable in integral or sum and evaluate the result"
 msgstr "Mudar variável em integral ou soma"
 
-#: ../../src/wxMaximaFrame.cpp:1026
+#: ../../src/dialogs/ChangeLogDialog.cpp:37
+#, fuzzy
+msgid "ChangeLog"
+msgstr "Mudar variável"
+
+#: ../../src/wxMaximaFrame.cpp:1060
 #, fuzzy
 msgid "Changed option variables"
 msgstr "Mudar variável"
 
-#: ../../src/wxMaxima.cpp:10170
+#: ../../src/MaximaCommandMenus.cpp:3699
 #, c-format
 msgid "Changing image originally loaded from file %s to %s."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7313 ../../src/wxMaxima.cpp:7318
-#: ../../src/wxMaxima.cpp:7323 ../../src/wxMaxima.cpp:7329
-#: ../../src/wxMaxima.cpp:7334 ../../src/wxMaxima.cpp:7340
+#: ../../src/MaximaCommandMenus.cpp:4185 ../../src/MaximaCommandMenus.cpp:4190
+#: ../../src/MaximaCommandMenus.cpp:4195 ../../src/MaximaCommandMenus.cpp:4201
+#: ../../src/MaximaCommandMenus.cpp:4206 ../../src/MaximaCommandMenus.cpp:4212
 msgid "Char #1:"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7314 ../../src/wxMaxima.cpp:7319
-#: ../../src/wxMaxima.cpp:7324 ../../src/wxMaxima.cpp:7329
-#: ../../src/wxMaxima.cpp:7335 ../../src/wxMaxima.cpp:7340
+#: ../../src/MaximaCommandMenus.cpp:4186 ../../src/MaximaCommandMenus.cpp:4191
+#: ../../src/MaximaCommandMenus.cpp:4196 ../../src/MaximaCommandMenus.cpp:4201
+#: ../../src/MaximaCommandMenus.cpp:4207 ../../src/MaximaCommandMenus.cpp:4212
 #, fuzzy
 msgid "Char #2:"
 msgstr "Matriz:"
 
-#: ../../src/wxMaximaFrame.cpp:1140
+#: ../../src/wxMaximaFrame.cpp:1174
 msgid "Char to Unicode code point..."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7358 ../../src/wxMaxima.cpp:7362
+#: ../../src/MaximaCommandMenus.cpp:4230 ../../src/MaximaCommandMenus.cpp:4234
 msgid "Char to unicode code point"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7285 ../../src/wxMaxima.cpp:7289
-#: ../../src/wxMaxima.cpp:7293 ../../src/wxMaxima.cpp:7297
-#: ../../src/wxMaxima.cpp:7301 ../../src/wxMaxima.cpp:7305
-#: ../../src/wxMaxima.cpp:7359 ../../src/wxMaxima.cpp:7363
-#: ../../src/wxMaxima.cpp:7435
+#: ../../src/MaximaCommandMenus.cpp:4157 ../../src/MaximaCommandMenus.cpp:4161
+#: ../../src/MaximaCommandMenus.cpp:4165 ../../src/MaximaCommandMenus.cpp:4169
+#: ../../src/MaximaCommandMenus.cpp:4173 ../../src/MaximaCommandMenus.cpp:4177
+#: ../../src/MaximaCommandMenus.cpp:4231 ../../src/MaximaCommandMenus.cpp:4235
+#: ../../src/MaximaCommandMenus.cpp:4307
 msgid "Char:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1131
+#: ../../src/wxMaximaFrame.cpp:1165
 msgid "Character Tests"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8181
+#: ../../src/MaximaCommandMenus.cpp:1369
 #, fuzzy
 msgid "Characteristic polynom"
 msgstr "Polinômio característico..."
 
-#: ../../src/wxMaxima.cpp:7280
+#: ../../src/MaximaCommandMenus.cpp:4152
 msgid "Chars are strings that are one character long"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1957
+#: ../../src/wxMaximaFrame.cpp:2000
 msgid "Check for Updates"
 msgstr "Procurar por atualizações"
 
-#: ../../src/wxMaximaFrame.cpp:1958
+#: ../../src/wxMaximaFrame.cpp:2001
 #, fuzzy
 msgid "Check if a newer version of wxMaxima is available."
 msgstr "Verificar se existe uma nova versão do wxMaxima/Maxima."
 
-#: ../../src/wxMaximaFrame.cpp:800
+#: ../../src/sidebars/GreekSidebar.cpp:199
+msgid "Chi"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:189
+msgid "Chinese (Simplified)"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:190
+msgid "Chinese (traditional)"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1554
+msgid "Choose a Lisp Maxima was compiled with"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1560
+msgid "Choose between installed Maxima versions"
+msgstr ""
+
+#: ../../src/sidebars/HelpBrowser.cpp:204
+msgid "Choose between the following help topics:"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:2100
+msgid "Choose font"
+msgstr "Escolher fonte"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:793
+msgid ""
+"Choose how mathematical output is formatted:\n"
+"\"2D, whenever possible\" keeps all expressions in two-dimensional form (fractions stacked, matrices drawn as boxes), even if they overflow the page width.\n"
+"\"2D if it fits on the page width\" (default) switches wide objects to linear notation.\n"
+"\"Prefer 1D\" always uses linear notation."
+msgstr ""
+
+#: ../../src/wizards/PlotFormatWiz.cpp:31
+msgid "Choose new plot format:"
+msgstr "Informe novo formato para gráficos:"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:2432
+#, fuzzy, c-format
+msgid "Choose the %s Font"
+msgstr "Escolher fonte"
+
+#: ../../src/wxMaximaFrame.cpp:837
 msgid "Choose the parenthesis type for Matrices"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:9530 ../../src/wxMaxima.cpp:9535
+#: ../../src/MaximaCommandMenus.cpp:1768 ../../src/MaximaCommandMenus.cpp:1773
 msgid "Classes:"
 msgstr "Classes:"
 
-#: ../../src/wxMaximaFrame.cpp:1378
+#: ../../src/wxMaximaFrame.cpp:1412
 msgid "Classic matrix operations"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:998
+#: ../../src/wxMaximaFrame.cpp:1032
 #, fuzzy
 msgid "Clear all aliases"
 msgstr "&Limpar memória"
 
-#: ../../src/wxMaximaFrame.cpp:995
+#: ../../src/wxMaximaFrame.cpp:1029
 #, fuzzy
 msgid "Clear all arrays"
 msgstr "&Limpar memória"
 
-#: ../../src/wxMaximaFrame.cpp:992
+#: ../../src/wxMaximaFrame.cpp:1026
 #, fuzzy
 msgid "Clear all dependencies"
 msgstr "&Limpar memória"
 
-#: ../../src/wxMaximaFrame.cpp:994
+#: ../../src/wxMaximaFrame.cpp:1028
 #, fuzzy
 msgid "Clear all functions"
 msgstr "Apagar uma função"
 
-#: ../../src/wxMaximaFrame.cpp:1001
+#: ../../src/wxMaximaFrame.cpp:1035
 #, fuzzy
 msgid "Clear all gradefs"
 msgstr "&Limpar memória"
 
-#: ../../src/wxMaximaFrame.cpp:1000
+#: ../../src/sidebars/History.cpp:116
+msgid "Clear all history"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1034
 #, fuzzy
 msgid "Clear all labels"
 msgstr "&Limpar memória"
 
-#: ../../src/wxMaximaFrame.cpp:1004
+#: ../../src/wxMaximaFrame.cpp:1038
 msgid "Clear all let rule packages"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1003
+#: ../../src/wxMaximaFrame.cpp:1037
 #, fuzzy
 msgid "Clear all macros"
 msgstr "&Limpar memória"
 
-#: ../../src/wxMaximaFrame.cpp:1002
+#: ../../src/wxMaximaFrame.cpp:1036
 #, fuzzy
 msgid "Clear all props"
 msgstr "&Limpar memória"
 
-#: ../../src/wxMaximaFrame.cpp:997
+#: ../../src/wxMaximaFrame.cpp:1031
 #, fuzzy
 msgid "Clear all rules"
 msgstr "&Limpar memória"
 
-#: ../../src/wxMaximaFrame.cpp:999
+#: ../../src/wxMaximaFrame.cpp:1033
 #, fuzzy
 msgid "Clear all structures"
 msgstr "&Limpar memória"
 
-#: ../../src/wxMaximaFrame.cpp:993
+#: ../../src/wxMaximaFrame.cpp:1027
 #, fuzzy
 msgid "Clear all variables"
 msgstr "Apagar uma variável"
 
-#: ../../src/wxMaximaFrame.cpp:606
+#: ../../src/sidebars/History.cpp:115
+#, fuzzy
+msgid "Clear the selection"
+msgstr "Cortar seleção"
+
+#: ../../src/cells/FontVariantCache.cpp:44
+#, c-format
+msgid "Cleared font cache for font %s"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1926
+msgid "Clipboard format parameters"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:637
 msgid "Close\tCtrl+W"
 msgstr "Fechar\tCtrl+W"
 
-#: ../../src/wxMaxima.cpp:7235
+#: ../../src/MaximaCommandMenus.cpp:4107
 msgid "Close Stream"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:606
+#: ../../src/wxMaximaFrame.cpp:637
 msgid "Close window"
 msgstr "Fechar janela"
 
-#: ../../src/wxMaximaFrame.cpp:1105
+#: ../../src/wxMaximaFrame.cpp:1139
 #, fuzzy
 msgid "Close..."
 msgstr "Resolver..."
 
-#: ../../src/WXMXformat.cpp:301
+#: ../../src/WXMXformat.cpp:303
 msgid "Closed the zip archive"
 msgstr ""
 
-#: ../../src/Configuration.cpp:77
+#: ../../src/Styles.cpp:106
 #, fuzzy
 msgid "Code Default (Maxima input)"
 msgstr "Entrada do Maxima"
 
-#: ../../src/Configuration.cpp:103
+#: ../../src/Styles.cpp:133
 msgid "Code highlighting: Comments"
 msgstr ""
 
-#: ../../src/Configuration.cpp:108
+#: ../../src/Styles.cpp:138
 msgid "Code highlighting: End of line markers"
 msgstr ""
 
-#: ../../src/Configuration.cpp:102
+#: ../../src/Styles.cpp:132
 msgid "Code highlighting: Functions"
 msgstr ""
 
-#: ../../src/Configuration.cpp:107
+#: ../../src/Styles.cpp:137
 msgid "Code highlighting: Lisp"
 msgstr ""
 
-#: ../../src/Configuration.cpp:104
+#: ../../src/Styles.cpp:134
 msgid "Code highlighting: Numbers"
 msgstr ""
 
-#: ../../src/Configuration.cpp:106
+#: ../../src/Styles.cpp:136
 msgid "Code highlighting: Operators"
 msgstr ""
 
-#: ../../src/Configuration.cpp:105
+#: ../../src/Styles.cpp:135
 msgid "Code highlighting: Strings"
 msgstr ""
 
-#: ../../src/Configuration.cpp:101
+#: ../../src/Styles.cpp:131
 msgid "Code highlighting: Variables"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7309 ../../src/wxMaxima.cpp:7355
+#: ../../src/MaximaCommandMenus.cpp:4181 ../../src/MaximaCommandMenus.cpp:4227
 #, fuzzy
 msgid "Code number:"
 msgstr "Colunas:"
 
-#: ../../src/wxMaxima.cpp:7367 ../../src/wxMaxima.cpp:7373
+#: ../../src/MaximaCommandMenus.cpp:4239 ../../src/MaximaCommandMenus.cpp:4245
 #, fuzzy
 msgid "Codepoint number:"
 msgstr "Colunas:"
 
-#: ../../src/wxMaxima.cpp:9590
+#: ../../src/MaximaCommandMenus.cpp:1830
 msgid "Col. names:"
 msgstr "Nomes das colunas:"
 
-#: ../../src/Configuration.cpp:100
+#: ../../src/Styles.cpp:130
 #, fuzzy
 msgid "Color of Outdated cells"
 msgstr "Células desatualizadas"
 
-#: ../../src/Configuration.cpp:99
+#: ../../src/Styles.cpp:128
 #, fuzzy
 msgid "Color of text equal to selection"
 msgstr "Cortar seleção"
 
-#: ../../src/wxMaxima.cpp:7962
+#: ../../src/MaximaCommandMenus.cpp:1142 ../../src/MaximaCommandMenus.cpp:1152
 #, fuzzy
 msgid "Column number:"
 msgstr "Colunas:"
 
-#: ../../src/wxMaxima.cpp:7978
+#: ../../src/MaximaCommandMenus.cpp:1157
 #, fuzzy
 msgid "Column numbers:"
 msgstr "Colunas:"
 
-#: ../../src/wxMaxima.cpp:8202
+#: ../../src/MaximaCommandMenus.cpp:1392
 #, fuzzy
 msgid "Columns"
 msgstr "Colunas:"
 
-#: ../../src/wxMaximaFrame.cpp:1584
+#: ../../src/wizards/MatWiz.cpp:155
+msgid "Columns:"
+msgstr "Colunas:"
+
+#: ../../src/wxMaximaFrame.cpp:1621
 msgid "Combine factorials in an expression"
 msgstr "Combinar fatoriais numa expressão"
 
-#: ../../src/wxMaxima.cpp:10454
+#: ../../src/wizards/CsvWiz.cpp:41 ../../src/wizards/CsvWiz.cpp:112
+msgid "Comma"
+msgstr ""
+
+#: ../../src/wxMaxima.cpp:3141
 msgid "Comma directly followed by a closing parenthesis"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7259
+#: ../../src/wizards/Plot2dWiz.cpp:626
+msgid "Comma separated x coordinates"
+msgstr "Coordenadas x separadas por vírgulas."
+
+#: ../../src/wizards/Plot2dWiz.cpp:627
+msgid "Comma separated y coordinates"
+msgstr "Coordenadas y separadas por vírgulas."
+
+#: ../../src/MaximaCommandMenus.cpp:4131
 #, fuzzy
 msgid "Comma-separated arguments"
 msgstr "Coordenadas x separadas por vírgulas."
 
-#: ../../src/wxMaxima.cpp:7057 ../../src/wxMaxima.cpp:7066
+#: ../../src/MaximaCommandMenus.cpp:3929 ../../src/MaximaCommandMenus.cpp:3938
 #, fuzzy
 msgid "Comma-separated commands"
 msgstr "Coordenadas x separadas por vírgulas."
 
-#: ../../src/wxMaxima.cpp:8458
+#: ../../src/MaximaCommandMenus.cpp:1461
 #, fuzzy
 msgid "Comma-separated elements"
 msgstr "Coordenadas x separadas por vírgulas."
 
-#: ../../src/wxMaxima.cpp:7752 ../../src/wxMaxima.cpp:7766
-#: ../../src/wxMaxima.cpp:10031
+#: ../../src/MaximaCommandMenus.cpp:933 ../../src/MaximaCommandMenus.cpp:947
+#: ../../src/MaximaCommandMenus.cpp:3520
 #, fuzzy
 msgid "Comma-separated equations"
 msgstr "Coordenadas x separadas por vírgulas."
 
-#: ../../src/wxMaxima.cpp:8727 ../../src/wxMaxima.cpp:8735
-#: ../../src/wxMaxima.cpp:8743 ../../src/wxMaxima.cpp:8751
-#: ../../src/wxMaxima.cpp:8760 ../../src/wxMaxima.cpp:8768
+#: ../../src/MaximaCommandMenus.cpp:722 ../../src/MaximaCommandMenus.cpp:732
+#: ../../src/MaximaCommandMenus.cpp:741 ../../src/MaximaCommandMenus.cpp:752
+#: ../../src/MaximaCommandMenus.cpp:764
 #, fuzzy
 msgid "Comma-separated expressions"
 msgstr "Coordenadas x separadas por vírgulas."
 
-#: ../../src/wxMaxima.cpp:7215
+#: ../../src/MaximaCommandMenus.cpp:4087
 #, fuzzy
 msgid "Comma-separated expressions that shall be converted to a string"
 msgstr "Coordenadas x separadas por vírgulas."
 
-#: ../../src/wxMaxima.cpp:7100 ../../src/wxMaxima.cpp:7114
+#: ../../src/MaximaCommandMenus.cpp:3972 ../../src/MaximaCommandMenus.cpp:3986
 #, fuzzy
 msgid "Comma-separated expressions."
 msgstr "Coordenadas x separadas por vírgulas."
 
-#: ../../src/wxMaxima.cpp:7073 ../../src/wxMaxima.cpp:7168
+#: ../../src/MaximaCommandMenus.cpp:3945 ../../src/MaximaCommandMenus.cpp:4040
 #, fuzzy
 msgid "Comma-separated function names"
 msgstr "Coordenadas x separadas por vírgulas."
 
-#: ../../src/wxMaxima.cpp:7086
+#: ../../src/MaximaCommandMenus.cpp:3958
 #, fuzzy
 msgid "Comma-separated function names."
 msgstr "Coordenadas x separadas por vírgulas."
 
-#: ../../src/wxMaxima.cpp:8560 ../../src/wxMaxima.cpp:8567
-#: ../../src/wxMaxima.cpp:8573 ../../src/wxMaxima.cpp:8580
+#: ../../src/MaximaCommandMenus.cpp:1576 ../../src/MaximaCommandMenus.cpp:1585
+#: ../../src/MaximaCommandMenus.cpp:1591 ../../src/MaximaCommandMenus.cpp:1598
 msgid "Comma-separated list entry in the format val1=1,val2=2"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7205
+#: ../../src/MaximaCommandMenus.cpp:4077
 msgid "Comma-separated names of the elements that shall be written"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7099
+#: ../../src/MaximaCommandMenus.cpp:3971
 msgid "Comma-separated names the parameters will be referenced by later."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7488 ../../src/wxMaxima.cpp:7493
+#: ../../src/MaximaCommandMenus.cpp:4360 ../../src/MaximaCommandMenus.cpp:4365
 #, fuzzy
 msgid "Comma-separated numbers from 0 to 255"
 msgstr "Coordenadas x separadas por vírgulas."
 
-#: ../../src/wxMaxima.cpp:8770
-msgid "Comma-separated numbers of the terms to substitute in"
-msgstr ""
-
-#: ../../src/wxMaxima.cpp:7137 ../../src/wxMaxima.cpp:7150
+#: ../../src/MaximaCommandMenus.cpp:4009 ../../src/MaximaCommandMenus.cpp:4022
 msgid "Comma-separated parameter names. A parameter in square brackets [] will be filled with the list of any additional arguments the function gets."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7054
+#: ../../src/MaximaCommandMenus.cpp:776
+msgid "Comma-separated part numbers selecting the subexpression to replace (as in part())"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:3926
 msgid "Comma-separated variable names, can be initialized by the \":\" operator."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7753 ../../src/wxMaxima.cpp:7767
-#: ../../src/wxMaxima.cpp:8719 ../../src/wxMaxima.cpp:8785
-#: ../../src/wxMaxima.cpp:10032
+#: ../../src/MaximaCommandMenus.cpp:711 ../../src/MaximaCommandMenus.cpp:792
+#: ../../src/MaximaCommandMenus.cpp:934 ../../src/MaximaCommandMenus.cpp:948
+#: ../../src/MaximaCommandMenus.cpp:3521
 msgid "Comma-separated variables"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:9469
+#: ../../src/wizards/GenWizPanel.cpp:226
+msgid "Command"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:2112
 msgid "Command:"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1692
+#: ../../src/dialogs/ConfigDialogue.cpp:1145
+msgid "Commands that are executed at every start of maxima."
+msgstr ""
+
+#: ../../src/cells/EditorCell.cpp:4538
+msgid "Comment (ordinary worksheet text that isn't fed to maxima)"
+msgstr ""
+
+#: ../../src/worksheet/WorksheetContextMenu.cpp:465
 msgid "Comment Selection"
 msgstr "Comentar seleção"
 
-#: ../../src/wxMaximaFrame.cpp:681
+#: ../../src/wxMaximaFrame.cpp:718
 msgid "Comment out the currently selected text"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:680
+#: ../../src/wxMaximaFrame.cpp:717
 #, fuzzy
 msgid "Comment selection\tCtrl+/"
 msgstr "Comentar seleção"
 
-#: ../../src/Worksheet.cpp:2004
+#: ../../src/worksheet/WorksheetContextMenu.cpp:776
 msgid "Commutative function"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1396
+#: ../../src/wxMaximaFrame.cpp:649
+msgid "Compare files..."
+msgstr ""
+
+#: ../../src/main.cpp:723
+msgid "Comparing worksheets (the --diff option or the wxmxdiff command) needs 2 or 3 files to compare."
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1430
 msgid "Compile a QR decomposition using dgeqrf"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7162
+#: ../../src/MaximaCommandMenus.cpp:4034
 #, fuzzy
 msgid "Compile a function"
 msgstr "Apagar uma função"
 
-#: ../../src/wxMaximaFrame.cpp:1188
+#: ../../src/wxMaximaFrame.cpp:1222
 #, fuzzy
 msgid "Compile a regular expression"
 msgstr "Apagar uma função"
 
-#: ../../src/wxMaximaFrame.cpp:1385
+#: ../../src/wxMaximaFrame.cpp:1419
 msgid "Compile eigenvalues using dgeev"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1388
+#: ../../src/wxMaximaFrame.cpp:1422
 msgid "Compile eigenvalues using zgeev"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1391
+#: ../../src/wxMaximaFrame.cpp:1425
 msgid "Compile eigenvalues+eigenvectors using dgeev"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1394
+#: ../../src/wxMaximaFrame.cpp:1428
 msgid "Compile eigenvalues+eigenvectors using zgeev"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1076
+#: ../../src/wxMaximaFrame.cpp:1110
 #, fuzzy
 msgid "Compile function..."
 msgstr "Apagar f&unção..."
 
-#: ../../src/wxMaxima.cpp:7511
+#: ../../src/MaximaCommandMenus.cpp:4383
 #, fuzzy
 msgid "Compile regex"
 msgstr "Completar palavra"
@@ -1501,1771 +2420,2405 @@ msgstr "Completar palavra"
 msgid "Compiler-Bug? wxMathml.lisp is shorter than expected!"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2234
+#: ../../src/MaximaOutputAppender.cpp:286
 #, c-format
 msgid "Compiling %s"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7163
+#: ../../src/MaximaCommandMenus.cpp:4035
 msgid "Compiling a function can generate a considerable speed boost if the types of the function parameters are made known to the function before it is compiled. Else the generated code has to be hideously generic."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:892
+#: ../../src/wxMaximaFrame.cpp:926
 #, fuzzy
 msgid "Complete Word\tCtrl+Space"
 msgstr "Completar palavra\tCtrl+K"
 
-#: ../../src/wxMaximaFrame.cpp:893
+#: ../../src/wxMaximaFrame.cpp:927
 msgid "Complete word"
 msgstr "Completar palavra"
 
-#: ../../src/ToolBar.cpp:230
+#: ../../src/ToolBar.cpp:412 ../../src/ToolBar.cpp:418
 msgid "Completely stop maxima and restart it"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1503
+#: ../../src/cells/TextCell.cpp:192
+#, fuzzy
+msgid "Complex infinity."
+msgstr "Simplificação &complexa"
+
+#: ../../src/graphical_io/Printout.cpp:184
+msgid "Composing a list of the line starts we can use as page starts"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1540
 msgid "Compute continued fraction of a value"
 msgstr "Calcular a fração contínua de um valor"
 
-#: ../../src/wxMaximaFrame.cpp:1372
+#: ../../src/wxMaximaFrame.cpp:1406
 msgid "Compute the adjoint matrix"
 msgstr "Calcular a matriz adjunta"
 
-#: ../../src/wxMaximaFrame.cpp:1359
+#: ../../src/wxMaximaFrame.cpp:1393
 msgid "Compute the characteristic polynomial of a matrix"
 msgstr "Calcular o polinômio característico de uma matriz"
 
-#: ../../src/wxMaximaFrame.cpp:1363
+#: ../../src/wxMaximaFrame.cpp:1397
 msgid "Compute the determinant of a matrix"
 msgstr "Calcular o determinante de uma matriz"
 
-#: ../../src/wxMaximaFrame.cpp:1491
+#: ../../src/wxMaximaFrame.cpp:1528
 msgid "Compute the greatest common divisor"
 msgstr "Calcular o máximo divisor comum"
 
-#: ../../src/wxMaximaFrame.cpp:1356
+#: ../../src/wxMaximaFrame.cpp:1390
 msgid "Compute the inverse of a matrix"
 msgstr "Calcular a inversa de uma matriz"
 
-#: ../../src/wxMaximaFrame.cpp:1494
+#: ../../src/wxMaximaFrame.cpp:1531
 msgid "Compute the least common multiple (do load(functs) before using)"
 msgstr "Calcular o mínimo múltiplo comum (faça load(functs) antes de usar)"
 
-#: ../../src/wxMaximaFrame.cpp:1374
+#: ../../src/wxMaximaFrame.cpp:1408
 #, fuzzy
 msgid "Compute the rank of a matrix"
 msgstr "Calcular o determinante de uma matriz"
 
-#: ../../src/wxMaxima.cpp:9629
+#: ../../src/MaximaCommandMenus.cpp:1869
 msgid "Condition:"
 msgstr "Condição:"
 
-#: ../../src/ToolBar.cpp:200 ../../src/wxMaximaFrame.cpp:685
-#: ../../src/wxMaximaFrame.cpp:687
+#: ../../src/dialogs/ConfigDialogue.cpp:2479
+#: ../../src/dialogs/ConfigDialogue.cpp:2489
+#: ../../src/dialogs/ConfigDialogue.cpp:2641
+#: ../../src/dialogs/ConfigDialogue.cpp:2647
+msgid "Config file (*.ini)|*.ini"
+msgstr "Arquivo de configuração (*.ini)|*.ini"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:2539
+#, c-format
+msgid "Config item \"%s\" was of an unknown type"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:2607
+msgid "Configuration warning"
+msgstr ""
+
+#: ../../src/ToolBar.cpp:367 ../../src/ToolBar.cpp:369
+#: ../../src/wxMaximaFrame.cpp:722 ../../src/wxMaximaFrame.cpp:724
 msgid "Configure wxMaxima"
 msgstr "Configurar o wxMaxima"
 
-#: ../../src/wxMaxima.cpp:2504
+#: ../../src/wizards/DrawWiz.cpp:829
+msgid "Connect the dots"
+msgstr ""
+
+#: ../../src/MaximaProcessManager.cpp:165
 msgid "Connection attempt, but connection failed."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2459
+#: ../../src/MaximaProcessManager.cpp:792
 msgid "Connection to Maxima lost."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7921
+#: ../../src/wizards/IntegrateWiz.cpp:193
+#: ../../src/wizards/IntegrateWiz.cpp:208 ../../src/wizards/LimitWiz.cpp:133
+#: ../../src/wizards/SeriesWiz.cpp:105
+msgid "Constant"
+msgstr "Constante"
+
+#: ../../src/MaximaCommandMenus.cpp:1102
 #, fuzzy
 msgid "Construct a fraction"
 msgstr "Fração &contínua"
 
-#: ../../src/wxMaximaFrame.cpp:1305
+#: ../../src/wxMaximaFrame.cpp:1339
 #, fuzzy
 msgid "Construct fraction..."
 msgstr "Fração &contínua"
 
-#: ../../src/wxMaxima.cpp:7158
+#: ../../src/sidebars/VariablesPane.cpp:58
+msgid "Contents"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:4030
 #, fuzzy
 msgid "Contents:"
 msgstr "Constantes gregas"
 
-#: ../../src/wxMaximaFrame.cpp:1877
+#: ../../src/wxMaximaFrame.cpp:1914
 msgid "Context-sensitive &Help\tCtrl+?"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1879
+#: ../../src/wxMaximaFrame.cpp:1916
 msgid "Context-sensitive &Help\tF1"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1542
+#: ../../src/sidebars/DrawSidebar.cpp:80
+msgid "Contour"
+msgstr ""
+
+#: ../../src/sidebars/DrawSidebar.cpp:101
+msgid "Contour lines for 3d plots"
+msgstr ""
+
+#: ../../src/wizards/DrawWiz.cpp:648
+msgid "Contour lines on surface and Bottom"
+msgstr ""
+
+#: ../../src/wizards/DrawWiz.cpp:644
+msgid "Contour lines on the Bottom"
+msgstr ""
+
+#: ../../src/wizards/DrawWiz.cpp:641
+msgid "Contour lines on the Surface"
+msgstr ""
+
+#: ../../src/wizards/DrawWiz.cpp:629
+msgid "Contour lines settings for the following 3d plots"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1579
 msgid "Contract Logarithms"
 msgstr "Contrair logaritmos"
 
-#: ../../src/wxMaximaFrame.cpp:1161
+#: ../../src/wxMaximaFrame.cpp:1195
 #, fuzzy
 msgid "Conversions"
 msgstr "Converter para forma &retangular"
 
-#: ../../src/wxMaximaFrame.cpp:1229
+#: ../../src/wxMaximaFrame.cpp:1263
 #, fuzzy
 msgid "Convert"
 msgstr "Converter para forma &retangular"
 
-#: ../../src/wxMaximaFrame.cpp:1230
+#: ../../src/wxMaximaFrame.cpp:1264
 #, fuzzy
 msgid "Convert + Write to file"
 msgstr "Converter para &fatoriais"
 
-#: ../../src/wxMaximaFrame.cpp:1434
+#: ../../src/wxMaximaFrame.cpp:1471
 #, fuzzy
 msgid "Convert Column to list..."
 msgstr "Converter para &fatoriais"
 
-#: ../../src/wxMaximaFrame.cpp:1430
+#: ../../src/wxMaximaFrame.cpp:1467
 #, fuzzy
 msgid "Convert Row to list..."
 msgstr "Converter para &fatoriais"
 
-#: ../../src/wxMaximaFrame.cpp:1044
+#: ../../src/wxMaximaFrame.cpp:1078
 msgid "Convert a command to maxima code"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1321
+#: ../../src/wxMaximaFrame.cpp:1355
 msgid "Convert a list of lists to a matrix"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1574
+#: ../../src/wxMaximaFrame.cpp:1611
 msgid "Convert binomials, beta and gamma function to factorials"
 msgstr "Converter binômios e as funções beta e gama para fatoriais"
 
-#: ../../src/wxMaximaFrame.cpp:1578
+#: ../../src/wxMaximaFrame.cpp:1615
 msgid "Convert binomials, factorials and beta function to gamma function"
 msgstr "Converter binômios, fatoriais e a função beta para a função gama"
 
-#: ../../src/wxMaximaFrame.cpp:1613
+#: ../../src/wxMaximaFrame.cpp:1650
 msgid "Convert complex expression to polar form"
 msgstr "Converter expressões complexas para a forma polar"
 
-#: ../../src/wxMaximaFrame.cpp:1610
+#: ../../src/wxMaximaFrame.cpp:1647
 msgid "Convert complex expression to rect form"
 msgstr "Converter expressões complexas para a forma retangular"
 
-#: ../../src/wxMaximaFrame.cpp:1622
+#: ../../src/wxMaximaFrame.cpp:1659
 msgid "Convert exponential function of imaginary argument to trigonometric form"
 msgstr "Converter função exponencial de argumento imaginário para a forma trigonométrica"
 
-#: ../../src/wxMaxima.cpp:7411
+#: ../../src/MaximaCommandMenus.cpp:4283
 #, fuzzy
 msgid "Convert string to lowercase"
 msgstr "Converter para &fatoriais"
 
-#: ../../src/wxMaxima.cpp:7543
+#: ../../src/MaximaCommandMenus.cpp:4415
 #, fuzzy
 msgid "Convert string to matching regex"
 msgstr "Converter para &gama"
 
-#: ../../src/wxMaximaFrame.cpp:1543
+#: ../../src/wxMaximaFrame.cpp:1580
 msgid "Convert sum of logarithms to logarithm of product"
 msgstr "Converter soma de logaritmos para logaritmos de um produto"
 
-#: ../../src/wxMaximaFrame.cpp:1573
+#: ../../src/wxMaximaFrame.cpp:1610
 msgid "Convert to &Factorials"
 msgstr "Converter para &fatoriais"
 
-#: ../../src/wxMaximaFrame.cpp:1577
+#: ../../src/wxMaximaFrame.cpp:1614
 msgid "Convert to &Gamma"
 msgstr "Converter para &gama"
 
-#: ../../src/wxMaximaFrame.cpp:1612
+#: ../../src/wxMaximaFrame.cpp:1649
 msgid "Convert to &Polarform"
 msgstr "Converter para forma &polar"
 
-#: ../../src/wxMaximaFrame.cpp:1609
+#: ../../src/wxMaximaFrame.cpp:1646
 msgid "Convert to &Rectform"
 msgstr "Converter para forma &retangular"
 
-#: ../../src/wxMaximaFrame.cpp:1166
+#: ../../src/sidebars/TableOfContents.cpp:522
+#: ../../src/sidebars/TableOfContents.cpp:543
+#, fuzzy
+msgid "Convert to Heading 5"
+msgstr "Converter para &gama"
+
+#: ../../src/sidebars/TableOfContents.cpp:519
+#, fuzzy
+msgid "Convert to Heading 6"
+msgstr "Converter para &gama"
+
+#: ../../src/sidebars/TableOfContents.cpp:531
+#: ../../src/sidebars/TableOfContents.cpp:552
+#, fuzzy
+msgid "Convert to Section"
+msgstr "Converter para forma &retangular"
+
+#: ../../src/sidebars/TableOfContents.cpp:525
+#: ../../src/sidebars/TableOfContents.cpp:546
+#, fuzzy
+msgid "Convert to Sub-Subsection"
+msgstr "Inserir célula de subseção"
+
+#: ../../src/sidebars/TableOfContents.cpp:528
+#: ../../src/sidebars/TableOfContents.cpp:549
+#, fuzzy
+msgid "Convert to Subsection"
+msgstr "Converter para forma &retangular"
+
+#: ../../src/sidebars/TableOfContents.cpp:555
+#, fuzzy
+msgid "Convert to Title"
+msgstr "Converter para &fatoriais"
+
+#: ../../src/wxMaximaFrame.cpp:1200
 #, fuzzy
 msgid "Convert to downcase..."
 msgstr "Converter para &fatoriais"
 
-#: ../../src/wxMaxima.cpp:7016
+#: ../../src/MaximaCommandMenus.cpp:3888
 #, fuzzy
 msgid "Convert to programming language"
 msgstr "Converter para &gama"
 
-#: ../../src/wxMaxima.cpp:7022
+#: ../../src/MaximaCommandMenus.cpp:3894
 msgid "Convert to programming language file"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1602
+#: ../../src/wxMaximaFrame.cpp:1639
 msgid "Convert trigonometric expression to canonical quasilinear form"
 msgstr "Converter expressão trigonométrica para forma canônica quasilinear"
 
-#: ../../src/wxMaximaFrame.cpp:1627
+#: ../../src/wxMaximaFrame.cpp:1664
 msgid "Convert trigonometric functions to exponential form"
 msgstr "Converter funções trigonométricas para a forma exponencial"
 
-#: ../../src/wxMaximaFrame.cpp:1762
+#: ../../src/sidebars/PerformanceSidebar.cpp:46
+msgid "Converted to 2D:"
+msgstr ""
+
+#: ../../src/sidebars/PerformanceSidebar.cpp:45
+msgid "Converted to linear:"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1799
 msgid "Converts a matrix to a list of lists"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1760
+#: ../../src/wxMaximaFrame.cpp:1797
 msgid "Converts a nested list like [[1,2],[3,4]] to a matrix"
 msgstr ""
 
-#: ../../src/ToolBar.cpp:209 ../../src/Worksheet.cpp:1290
-#: ../../src/Worksheet.cpp:1359 ../../src/Worksheet.cpp:1498
-#: ../../src/Worksheet.cpp:1684
+#: ../../src/ToolBar.cpp:380 ../../src/ToolBar.cpp:384
+#: ../../src/dialogs/ConfigDialogue.cpp:285
+#: ../../src/worksheet/WorksheetContextMenu.cpp:48
+#: ../../src/worksheet/WorksheetContextMenu.cpp:122
+#: ../../src/worksheet/WorksheetContextMenu.cpp:269
+#: ../../src/worksheet/WorksheetContextMenu.cpp:457
 msgid "Copy"
 msgstr "Copiar"
 
-#: ../../src/Worksheet.cpp:1296 ../../src/Worksheet.cpp:1375
-#: ../../src/Worksheet.cpp:1514
+#: ../../src/worksheet/WorksheetContextMenu.cpp:58
+#: ../../src/worksheet/WorksheetContextMenu.cpp:140
+#: ../../src/worksheet/WorksheetContextMenu.cpp:287
 #, fuzzy
 msgid "Copy Animation"
 msgstr "Parar animação"
 
-#: ../../src/wxMaximaFrame.cpp:887
+#: ../../src/wxMaximaFrame.cpp:921
 msgid "Copy Previous Input\tCtrl+I"
 msgstr "Copiar entrada anterior\tCtrl+I"
 
-#: ../../src/wxMaximaFrame.cpp:890
+#: ../../src/wxMaximaFrame.cpp:924
 msgid "Copy Previous Output\tCtrl+U"
 msgstr "Copiar saída anterior\tCtrl+U"
 
-#: ../../src/wxMaxima.cpp:7992
+#: ../../src/MaximaCommandMenus.cpp:1176
 #, fuzzy
 msgid "Copy a matrix"
 msgstr "Copiar como imagem"
 
-#: ../../src/Worksheet.cpp:1380 ../../src/Worksheet.cpp:1519
-#: ../../src/wxMaximaFrame.cpp:663
+#: ../../src/worksheet/WorksheetContextMenu.cpp:145
+#: ../../src/worksheet/WorksheetContextMenu.cpp:292
+#: ../../src/wxMaximaFrame.cpp:700
 msgid "Copy as EMF"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1370 ../../src/Worksheet.cpp:1509
-#: ../../src/wxMaximaFrame.cpp:652
+#: ../../src/worksheet/WorksheetContextMenu.cpp:135
+#: ../../src/worksheet/WorksheetContextMenu.cpp:282
+#: ../../src/wxMaximaFrame.cpp:689
 msgid "Copy as Image"
 msgstr "Copiar como imagem"
 
-#: ../../src/Worksheet.cpp:1362 ../../src/Worksheet.cpp:1501
-#: ../../src/wxMaximaFrame.cpp:645
+#: ../../src/worksheet/WorksheetContextMenu.cpp:126
+#: ../../src/worksheet/WorksheetContextMenu.cpp:273
+#: ../../src/wxMaximaFrame.cpp:682
 msgid "Copy as LaTeX"
 msgstr "Copiar como LaTeX"
 
-#: ../../src/wxMaximaFrame.cpp:648
+#: ../../src/wxMaximaFrame.cpp:685
 #, fuzzy
 msgid "Copy as MathML"
 msgstr "Copiar como imagem"
 
-#: ../../src/Worksheet.cpp:1368 ../../src/Worksheet.cpp:1506
+#: ../../src/worksheet/WorksheetContextMenu.cpp:133
+#: ../../src/worksheet/WorksheetContextMenu.cpp:279
 msgid "Copy as MathML (e.g. to word processor)"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1383 ../../src/Worksheet.cpp:1522
-#: ../../src/wxMaximaFrame.cpp:658
+#: ../../src/worksheet/WorksheetContextMenu.cpp:148
+#: ../../src/worksheet/WorksheetContextMenu.cpp:295
+#: ../../src/wxMaximaFrame.cpp:695
 #, fuzzy
 msgid "Copy as RTF"
 msgstr "Copiar como LaTeX"
 
-#: ../../src/Worksheet.cpp:1377 ../../src/Worksheet.cpp:1516
-#: ../../src/wxMaximaFrame.cpp:655
+#: ../../src/worksheet/WorksheetContextMenu.cpp:142
+#: ../../src/worksheet/WorksheetContextMenu.cpp:289
+#: ../../src/wxMaximaFrame.cpp:692
 #, fuzzy
 msgid "Copy as SVG"
 msgstr "Copiar como LaTeX"
 
-#: ../../src/wxMaximaFrame.cpp:640
+#: ../../src/wxMaximaFrame.cpp:677
 msgid "Copy as Text\tCtrl+Shift+C"
 msgstr "&Copiar como texto\tCtrl+Shift+C"
 
-#: ../../src/Worksheet.cpp:1364 ../../src/Worksheet.cpp:1503
+#: ../../src/worksheet/WorksheetContextMenu.cpp:128
+#: ../../src/worksheet/WorksheetContextMenu.cpp:275
 #, fuzzy
 msgid "Copy as plain text"
 msgstr "Copiar como imagem"
 
-#: ../../src/wxMaxima.cpp:7576
+#: ../../src/MaximaCommandMenus.cpp:4448
 #, fuzzy
 msgid "Copy file"
 msgstr "Copiar"
 
-#: ../../src/wxMaximaFrame.cpp:1214
+#: ../../src/wxMaximaFrame.cpp:1248
 #, fuzzy
 msgid "Copy file..."
 msgstr "Resolver..."
 
-#: ../../src/Worksheet.cpp:1360 ../../src/Worksheet.cpp:1499
-#: ../../src/wxMaximaFrame.cpp:643
+#: ../../src/worksheet/WorksheetContextMenu.cpp:124
+#: ../../src/worksheet/WorksheetContextMenu.cpp:271
+#: ../../src/wxMaximaFrame.cpp:680
 msgid "Copy for Octave/Matlab"
 msgstr ""
 
-#: ../../src/ToolBar.cpp:209 ../../src/wxMaximaFrame.cpp:638
+#: ../../src/worksheet/WorksheetContextMenu.cpp:49
+#: ../../src/worksheet/WorksheetContextMenu.cpp:105
+#: ../../src/worksheet/WorksheetContextMenu.cpp:123
+#: ../../src/worksheet/WorksheetContextMenu.cpp:270
+msgid "Copy position (UUID)"
+msgstr ""
+
+#: ../../src/ToolBar.cpp:380 ../../src/ToolBar.cpp:384
+#: ../../src/wxMaximaFrame.cpp:675
 msgid "Copy selection"
 msgstr "Copiar seleção"
 
-#: ../../src/wxMaximaFrame.cpp:664
+#: ../../src/wxMaximaFrame.cpp:701
 msgid "Copy selection from document as an Enhanced Metafile"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:656
+#: ../../src/wxMaximaFrame.cpp:693
 #, fuzzy
 msgid "Copy selection from document as an SVG image"
 msgstr "Copiar seleção do documento como imagem"
 
-#: ../../src/wxMaximaFrame.cpp:653
+#: ../../src/wxMaximaFrame.cpp:690
 msgid "Copy selection from document as an image"
 msgstr "Copiar seleção do documento como imagem"
 
-#: ../../src/wxMaximaFrame.cpp:659
+#: ../../src/wxMaximaFrame.cpp:696
 #, fuzzy
 msgid "Copy selection from document as rtf that a word processor might understand"
 msgstr "Copiar seleção do documento como imagem"
 
-#: ../../src/wxMaximaFrame.cpp:641
+#: ../../src/wxMaximaFrame.cpp:678
 msgid "Copy selection from document as text"
 msgstr "Copiar seleção do documento como texto"
 
-#: ../../src/wxMaximaFrame.cpp:646
+#: ../../src/wxMaximaFrame.cpp:683
 msgid "Copy selection from document in LaTeX format"
 msgstr "Copiar seleção do documento no formato LaTeX"
 
-#: ../../src/wxMaximaFrame.cpp:644
+#: ../../src/wxMaximaFrame.cpp:681
 msgid "Copy selection from document in Matlab format"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:649
+#: ../../src/wxMaximaFrame.cpp:686
 msgid "Copy selection from document in a MathML format many word processors can display as 2d equation"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7403
+#: ../../src/MaximaCommandMenus.cpp:4275
 #, fuzzy
 msgid "Copy string"
 msgstr "Copiar seleção"
 
-#: ../../src/wxMaximaFrame.cpp:1165
+#: ../../src/wxMaximaFrame.cpp:1199
 #, fuzzy
 msgid "Copy string..."
 msgstr "&Introduzir matriz..."
 
-#: ../../src/ToolBar.cpp:623
+#: ../../src/ToolBar.cpp:823
 msgid "Copy, Cut and Paste button"
 msgstr ""
 
-#: ../../src/WXMXformat.cpp:295
+#: ../../src/dialogs/ConfigDialogue.cpp:2523
+#, c-format
+msgid "Copying config bool \"%s\""
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:2533
+#, c-format
+msgid "Copying config float \"%s\""
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:2528
+#, c-format
+msgid "Copying config int \"%s\""
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:2518
+#, c-format
+msgid "Copying config string \"%s\""
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:191
+msgid "Corsican"
+msgstr ""
+
+#: ../../src/WXMXformat.cpp:297
 msgid "Could not create the backup file during saving => aborting."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3294 ../../src/wxMaxima.cpp:3306
+#: ../../src/MaximaResponseReader.cpp:359
 msgid "Could not make sure that we talk to the maxima we started => discarding all data it sends."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2783
+#: ../../src/MaximaProcessManager.cpp:893
 msgid "Could not map view of the file needed in order to send an interrupt signal to maxima."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2763 ../../src/wxMaxima.cpp:2805
+#: ../../src/Image.cpp:1000
+msgid "Could not parse the SVG image data."
+msgstr ""
+
+#: ../../src/MaximaProcessManager.cpp:873
+#: ../../src/MaximaProcessManager.cpp:916
 msgid "Could not send an interrupt signal to maxima."
 msgstr ""
 
-#: ../../src/WXMXformat.cpp:287
+#: ../../src/WXMXformat.cpp:289
 msgid "Could not write the file's contents during saving => aborting."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1325
+#: ../../src/wxMaximaFrame.cpp:1359
 #, fuzzy
 msgid "Create Matrix"
 msgstr "Gerar matriz"
 
-#: ../../src/wxMaximaFrame.cpp:1688
+#: ../../src/wxMaximaFrame.cpp:1725
 #, fuzzy
 msgid "Create a list"
 msgstr "Criar lista"
 
-#: ../../src/wxMaxima.cpp:8487
+#: ../../src/MaximaCommandMenus.cpp:1491
 msgid "Create a list as a storage for the values of variables"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8463 ../../src/wxMaxima.cpp:8476
+#: ../../src/MaximaCommandMenus.cpp:1479
+msgid "Create a list from a list"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:1466
 #, fuzzy
 msgid "Create a list from a rule"
 msgstr "Criar lista de uma expressão"
 
-#: ../../src/wxMaximaFrame.cpp:1670
+#: ../../src/wxMaximaFrame.cpp:1707
 msgid "Create a list from comma-separated elements"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:888
+#: ../../src/wxMaximaFrame.cpp:922
 msgid "Create a new cell with previous input"
 msgstr "Cria uma nova célula com a entrada anterior"
 
-#: ../../src/wxMaximaFrame.cpp:891
+#: ../../src/wxMaximaFrame.cpp:925
 msgid "Create a new cell with previous output"
 msgstr "Cria uma nova célula com a saída anterior"
 
-#: ../../src/wxMaximaFrame.cpp:1348
+#: ../../src/wxMaximaFrame.cpp:1382
 msgid "Create copy, not clone..."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7561
+#: ../../src/MaximaCommandMenus.cpp:4433
 #, fuzzy
 msgid "Create directory"
 msgstr "Criar lista"
 
-#: ../../src/wxMaximaFrame.cpp:1203
+#: ../../src/wxMaximaFrame.cpp:1237
 #, fuzzy
 msgid "Create directory..."
 msgstr "Criar lista"
 
-#: ../../src/wxMaxima.cpp:7419
+#: ../../src/MaximaCommandMenus.cpp:4291
 #, fuzzy
 msgid "Create empty string"
 msgstr "Gerar matriz"
 
-#: ../../src/wxMaximaFrame.cpp:1168
+#: ../../src/wxMaximaFrame.cpp:1202
 #, fuzzy
 msgid "Create empty string..."
 msgstr "Criar lista"
 
-#: ../../src/wxMaximaFrame.cpp:1687
+#: ../../src/wxMaximaFrame.cpp:1724
 #, fuzzy
 msgid "Create list"
 msgstr "Criar lista"
 
-#: ../../src/wxMaxima.cpp:8457
+#: ../../src/MaximaCommandMenus.cpp:1460
 msgid "Create list from comma-separated elements"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1082
+#: ../../src/dialogs/ConfigDialogue.cpp:1389
+msgid "Create scalable plots."
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1116
 #, fuzzy
 msgid "Create struct..."
 msgstr "Criar lista"
 
-#: ../../src/WXMXformat.cpp:80
+#: ../../src/WXMXformat.cpp:81
 msgid "Created a .zip archive (the .wxmx file technically is a .zip file)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1349
+#: ../../src/wxMaximaFrame.cpp:1383
 msgid "Creates an independent matrix with the same contents"
 msgstr ""
 
-#: ../../src/Configuration.cpp:97
+#: ../../src/dialogs/ConfigDialogue.cpp:192
+msgid "Croatian"
+msgstr ""
+
+#: ../../src/wizards/CsvWiz.cpp:93 ../../src/wizards/CsvWiz.cpp:167
+msgid "Csv files (*.csv)|*.csv|Text files (*.txt)|*.txt|All|*"
+msgstr ""
+
+#: ../../src/worksheet/Worksheet.cpp:6125
+msgid "Cursor"
+msgstr "Cursor"
+
+#: ../../src/Styles.cpp:126
 #, fuzzy
 msgid "Cursor color"
 msgstr "Cursor"
 
-#: ../../src/ToolBar.cpp:208 ../../src/Worksheet.cpp:1683
+#: ../../src/ToolBar.cpp:379 ../../src/ToolBar.cpp:383
+#: ../../src/worksheet/WorksheetContextMenu.cpp:456
 msgid "Cut"
 msgstr "Recortar"
 
-#: ../../src/wxMaximaFrame.cpp:636
+#: ../../src/wxMaximaFrame.cpp:673
 msgid "Cut\tCtrl+X"
 msgstr "Cortar\tCtrl+X"
 
-#: ../../src/ToolBar.cpp:208 ../../src/wxMaximaFrame.cpp:636
+#: ../../src/ToolBar.cpp:379 ../../src/ToolBar.cpp:383
+#: ../../src/wxMaximaFrame.cpp:673
 msgid "Cut selection"
 msgstr "Cortar seleção"
 
-#: ../../src/wxMaxima.cpp:9589 ../../src/wxMaxima.cpp:9629
+#: ../../src/dialogs/ConfigDialogue.cpp:193
+msgid "Czech"
+msgstr "Tcheco"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:194
+msgid "Danish"
+msgstr "Dinamarquês"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:2069
+msgid "Dark"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:1829 ../../src/MaximaCommandMenus.cpp:1869
 msgid "Data Matrix:"
 msgstr "Matriz de dados:"
 
-#: ../../src/wxMaxima.cpp:9599
+#: ../../src/MaximaCommandMenus.cpp:1839
 msgid "Data file (*.csv, *.tab, *.txt)|*.csv;*.tab;*.txt"
 msgstr "Arquivo de dados (*.csv, *.tab, *.txt)|*.csv;*.tab;*.txt"
 
-#: ../../src/wxMaxima.cpp:9529 ../../src/wxMaxima.cpp:9534
-#: ../../src/wxMaxima.cpp:9539 ../../src/wxMaxima.cpp:9543
-#: ../../src/wxMaxima.cpp:9547 ../../src/wxMaxima.cpp:9551
-#: ../../src/wxMaxima.cpp:9555 ../../src/wxMaxima.cpp:9559
-#: ../../src/wxMaxima.cpp:9563 ../../src/wxMaxima.cpp:9577
-#: ../../src/wxMaxima.cpp:9582 ../../src/wxMaxima.cpp:10030
+#: ../../src/wizards/DrawWiz.cpp:810
+#, fuzzy
+msgid "Data format"
+msgstr "Formato do gráfico"
+
+#: ../../src/MaximaCommandMenus.cpp:1767 ../../src/MaximaCommandMenus.cpp:1772
+#: ../../src/MaximaCommandMenus.cpp:1777 ../../src/MaximaCommandMenus.cpp:1781
+#: ../../src/MaximaCommandMenus.cpp:1785 ../../src/MaximaCommandMenus.cpp:1789
+#: ../../src/MaximaCommandMenus.cpp:1793 ../../src/MaximaCommandMenus.cpp:1797
+#: ../../src/MaximaCommandMenus.cpp:1801 ../../src/MaximaCommandMenus.cpp:1815
+#: ../../src/MaximaCommandMenus.cpp:1822 ../../src/MaximaCommandMenus.cpp:3519
 msgid "Data:"
 msgstr "Dados:"
 
-#: ../../src/wxMaximaFrame.cpp:1057
+#: ../../src/wxMaximaFrame.cpp:1091
 msgid "Debugger trigger"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:779
+#: ../../src/wxMaximaFrame.cpp:816
 msgid "Declare Text to always be displayed as subscript"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7069
+#: ../../src/MaximaCommandMenus.cpp:3941
 msgid "Declare a function local to a Program"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:6539
+#: ../../src/MaximaCommandMenus.cpp:3059
 msgid "Declare a text snippet to always be displayed as subscript"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:2044
+#: ../../src/worksheet/WorksheetContextMenu.cpp:816
 #, c-format
 msgid "Declare facts about %s"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8800
+#: ../../src/MaximaCommandMenus.cpp:807
 #, fuzzy
 msgid "Declare main variable:"
 msgstr "Apagar uma variável"
 
-#: ../../src/wxMaxima.cpp:7171
+#: ../../src/MaximaCommandMenus.cpp:4043
 msgid "Declare the type of a function parameter"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:2038
+#: ../../src/worksheet/WorksheetContextMenu.cpp:810
 msgid "Declare these chars as ordinary letters"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1500 ../../src/wxMaximaFrame.cpp:1536
+#: ../../src/wxMaximaFrame.cpp:1537 ../../src/wxMaximaFrame.cpp:1573
 msgid "Decompose rational function to partial fractions"
 msgstr "Decompor função racional em frações parciais"
 
-#: ../../src/Worksheet.cpp:2010
+#: ../../src/worksheet/WorksheetContextMenu.cpp:782
 #, fuzzy
 msgid "Decreasing function f(x)<x"
 msgstr "Apagar função(ões):"
 
-#: ../../src/wxMaxima.cpp:7134
+#: ../../src/dialogs/ConfigDialogue.cpp:1336
+msgid "Default animation framerate:"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:717
+msgid "Default plot size for new maxima sessions:"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1534
+#, fuzzy
+msgid "Default port for communication with wxMaxima:"
+msgstr "A porta padrão usada para comunicação entre o Maxima e o wxMaxima."
+
+#: ../../src/MaximaCommandMenus.cpp:4006
 #, fuzzy
 msgid "Define a function"
 msgstr "Apagar uma função"
 
-#: ../../src/wxMaxima.cpp:7147
+#: ../../src/MaximaCommandMenus.cpp:4019
 msgid "Define a macro"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7189
+#: ../../src/MaximaCommandMenus.cpp:4061
 msgid "Define a structure"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7183
+#: ../../src/MaximaCommandMenus.cpp:4055
 msgid "Define a structure type"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7156
+#: ../../src/MaximaCommandMenus.cpp:4028
 #, fuzzy
 msgid "Define a variable"
 msgstr "Apagar uma variável"
 
-#: ../../src/wxMaximaFrame.cpp:1072
+#: ../../src/wxMaximaFrame.cpp:1106
 #, fuzzy
 msgid "Define function..."
 msgstr "Apagar f&unção..."
 
-#: ../../src/wxMaximaFrame.cpp:1079
+#: ../../src/wxMaximaFrame.cpp:1113
 msgid "Define macro..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1077
+#: ../../src/wxMaximaFrame.cpp:1111
 msgid "Define parameter type..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1081
+#: ../../src/wxMaximaFrame.cpp:1115
 msgid "Define struct..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1080
+#: ../../src/dialogs/ConfigDialogue.cpp:404
+msgid "Define the default speed (in frames per second) animations are played back with."
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1114
 #, fuzzy
 msgid "Define variable..."
 msgstr "Apagar uma variável"
 
-#: ../../src/wxMaximaFrame.cpp:1776
+#: ../../src/wxMaximaFrame.cpp:1813
 msgid "Defines if an animation is automatically started or only by clicking on it."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8935
+#: ../../src/MaximaCommandMenus.cpp:186
 msgid "Degree:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:985
+#: ../../src/wxMaximaFrame.cpp:1019
 msgid "Delete F&unction..."
 msgstr "Apagar f&unção..."
 
-#: ../../src/Worksheet.cpp:1386 ../../src/Worksheet.cpp:1525
+#: ../../src/worksheet/WorksheetContextMenu.cpp:157
+#: ../../src/worksheet/WorksheetContextMenu.cpp:298
 msgid "Delete Selection"
 msgstr "Apagar seleção"
 
-#: ../../src/wxMaximaFrame.cpp:987
+#: ../../src/wxMaximaFrame.cpp:1021
 msgid "Delete V&ariable..."
 msgstr "&Apagar variável..."
 
-#: ../../src/wxMaximaFrame.cpp:986
+#: ../../src/wxMaximaFrame.cpp:1020
 msgid "Delete a function"
 msgstr "Apagar uma função"
 
-#: ../../src/wxMaximaFrame.cpp:988
+#: ../../src/wxMaximaFrame.cpp:1022
 msgid "Delete a variable"
 msgstr "Apagar uma variável"
 
-#: ../../src/wxMaximaFrame.cpp:982
+#: ../../src/wxMaximaFrame.cpp:1016
 msgid "Delete all objects with a given name"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:991
+#: ../../src/wxMaximaFrame.cpp:1025
 msgid "Delete all values from memory"
 msgstr "Apagar todos os valores da memória"
 
-#: ../../src/wxMaxima.cpp:7588
+#: ../../src/MaximaCommandMenus.cpp:4460
 #, fuzzy
 msgid "Delete file"
 msgstr "Apagar uma variável"
 
-#: ../../src/wxMaximaFrame.cpp:1216
+#: ../../src/wxMaximaFrame.cpp:1250
 #, fuzzy
 msgid "Delete file..."
 msgstr "&Apagar variável..."
 
-#: ../../src/wxMaxima.cpp:7683
+#: ../../src/MaximaCommandMenus.cpp:4555
 #, fuzzy
 msgid "Delete function(s)"
 msgstr "Apagar função(ões):"
 
-#: ../../src/wxMaxima.cpp:7679
+#: ../../src/MaximaCommandMenus.cpp:4551
 #, fuzzy
 msgid "Delete named object(s)"
 msgstr "Apagar função(ões):"
 
-#: ../../src/wxMaximaFrame.cpp:981
+#: ../../src/wxMaximaFrame.cpp:1015
 #, fuzzy
 msgid "Delete named object..."
 msgstr "Apagar f&unção..."
 
-#: ../../src/wxMaxima.cpp:7674
+#: ../../src/MaximaCommandMenus.cpp:4546
 #, fuzzy
 msgid "Delete variable(s)"
 msgstr "Apagar variável(is):"
 
-#: ../../src/wxMaxima.cpp:7430
+#: ../../src/MaximaCommandMenus.cpp:4302
 #, fuzzy
 msgid "Delimiter:"
 msgstr "Eliminar"
 
-#: ../../src/Worksheet.cpp:1347 ../../src/Worksheet.cpp:1785
+#: ../../src/sidebars/GreekSidebar.cpp:181
+msgid "Delta"
+msgstr ""
+
+#: ../../src/worksheet/WorksheetContextMenu.cpp:110
+#: ../../src/worksheet/WorksheetContextMenu.cpp:558
 #, c-format
 msgid "Demo for \"%s\""
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1930
+#: ../../src/wxMaximaFrame.cpp:1967
 msgid "Demos"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8927
+#: ../../src/MaximaCommandMenus.cpp:178
 msgid "Denom. deg:"
 msgstr "Grau denom.:"
 
-#: ../../src/wxMaxima.cpp:7923
+#: ../../src/MaximaCommandMenus.cpp:1104
 msgid "Denominator:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1030
+#: ../../src/wxMaximaFrame.cpp:1064
 msgid "Dependencies"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7813
+#: ../../src/wizards/SeriesWiz.cpp:42
+msgid "Depth:"
+msgstr "Grau máximo:"
+
+#: ../../src/MaximaCommandMenus.cpp:994
 msgid "Derivate of y at that point:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1497
+#: ../../src/wizards/ListSortWiz.cpp:56
+msgid "Descending by magnitude (numeric only)"
+msgstr ""
+
+#: ../../src/wizards/GenWizPanel.cpp:255
+msgid "Description"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:435 ../../src/MaximaCommandMenus.cpp:448
+#: ../../src/MaximaCommandMenus.cpp:461 ../../src/MaximaCommandMenus.cpp:475
+#: ../../src/MaximaCommandMenus.cpp:486 ../../src/MaximaCommandMenus.cpp:499
+#: ../../src/MaximaCommandMenus.cpp:514 ../../src/MaximaCommandMenus.cpp:528
+#: ../../src/MaximaCommandMenus.cpp:546 ../../src/MaximaCommandMenus.cpp:561
+#: ../../src/MaximaCommandMenus.cpp:576 ../../src/MaximaCommandMenus.cpp:591
+#: ../../src/MaximaCommandMenus.cpp:605
+msgid "Desired absolute error of approximation."
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:434 ../../src/MaximaCommandMenus.cpp:447
+#: ../../src/MaximaCommandMenus.cpp:460 ../../src/MaximaCommandMenus.cpp:474
+#: ../../src/MaximaCommandMenus.cpp:513 ../../src/MaximaCommandMenus.cpp:527
+#: ../../src/MaximaCommandMenus.cpp:545 ../../src/MaximaCommandMenus.cpp:560
+#: ../../src/MaximaCommandMenus.cpp:575 ../../src/MaximaCommandMenus.cpp:590
+#: ../../src/MaximaCommandMenus.cpp:604
+msgid "Desired relative error of approximation."
+msgstr ""
+
+#: ../../src/sidebars/StatSidebar.cpp:61
+msgid "Deviation..."
+msgstr "Desvio..."
+
+#: ../../src/wxMaximaFrame.cpp:1534
 msgid "Di&vide Polynomials..."
 msgstr "Di&vidir polinômios..."
 
-#: ../../src/MaximaManual.cpp:517
+#: ../../src/worksheet/WorksheetExport.cpp:1400
+msgid "Diagram"
+msgstr ""
+
+#: ../../src/sidebars/DrawSidebar.cpp:71
+msgid "Diagram title"
+msgstr ""
+
+#: ../../src/sidebars/HelpBrowser.cpp:51
+msgid "Didn't find an installed offline manual."
+msgstr ""
+
+#: ../../src/MaximaManual.cpp:534
 msgid "Didn't find the maxima HTML manual."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:4907
+#: ../../src/wxMaxima.cpp:1685
 msgid "Didn't get a help browser launch program command line, but can request the system's default help browser."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:9010 ../../src/wxMaxima.cpp:10055
+#: ../../src/Styles.cpp:129
+msgid "Diff viewer: changed text"
+msgstr ""
+
+#: ../../src/sidebars/MathSidebar.cpp:80
+msgid "Diff..."
+msgstr "Derivar..."
+
+#: ../../src/dialogs/DiffFrame.cpp:308
+#, c-format
+msgid "Difference %d / %d"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:264 ../../src/MaximaCommandMenus.cpp:3544
 msgid "Differentiate"
 msgstr "Diferenciar"
 
-#: ../../src/wxMaximaFrame.cpp:1467
+#: ../../src/wxMaximaFrame.cpp:1504
 msgid "Differentiate expression"
 msgstr "Diferenciar expressão"
 
-#: ../../src/Worksheet.cpp:1590
+#: ../../src/worksheet/WorksheetContextMenu.cpp:363
 msgid "Differentiate..."
 msgstr "Diferenciar..."
 
-#: ../../src/wxMaxima.cpp:9010
+#: ../../src/MaximaCommandMenus.cpp:264
 #, fuzzy
 msgid "Differentiates an expression n times"
 msgstr "Diferenciar expressão"
 
-#: ../../src/wxMaxima.cpp:10055
+#: ../../src/MaximaCommandMenus.cpp:3544
 #, fuzzy
 msgid "Differentiates the expression n times"
 msgstr "Diferenciar expressão"
 
-#: ../../src/wxMaximaFrame.cpp:1212
+#: ../../src/wizards/LimitWiz.cpp:41
+msgid "Direction:"
+msgstr "Direção:"
+
+#: ../../src/wxMaximaFrame.cpp:1246
 #, fuzzy
 msgid "Directory operations"
 msgstr "Direção:"
 
-#: ../../src/wxMaximaFrame.cpp:1041
+#: ../../src/main.cpp:315
+msgid "Disabled the console's QuickEdit mode for this batch run so a click into the console cannot suspend wxMaxima."
+msgstr ""
+
+#: ../../src/wizards/Plot2dWiz.cpp:418 ../../src/wizards/Plot2dWiz.cpp:619
+msgid "Discrete plot"
+msgstr "Gráfico discreto"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:699
+#, fuzzy
+msgid "Display"
+msgstr "Alternar exibição do &tempo"
+
+#: ../../src/wxMaximaFrame.cpp:1075
 msgid "Display Te&X Form"
 msgstr "Mostar forma Te&X"
 
-#: ../../src/wxMaxima.cpp:6972
+#: ../../src/MaximaCommandMenus.cpp:3844
 msgid "Display algorithm"
 msgstr "Algoritmo de exibição"
 
-#: ../../src/wxMaximaFrame.cpp:751
+#: ../../src/dialogs/ConfigDialogue.cpp:827
+msgid "Display all and allow linebreaks in long numbers"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:820
+#, fuzzy
+msgid "Display all digits"
+msgstr "Algoritmo de exibição"
+
+#: ../../src/wxMaximaFrame.cpp:788
 msgid "Display an expression as maxima's internal lisp representation"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:754
+#: ../../src/wxMaximaFrame.cpp:791
 msgid "Display an expression as wxMaxima's internal XML representation"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:758
+#: ../../src/wxMaximaFrame.cpp:795
 #, fuzzy
 msgid "Display equations"
 msgstr "Resolver equação(ões)"
 
-#: ../../src/wxMaxima.cpp:6508
+#: ../../src/MaximaCommandMenus.cpp:3028
 msgid "Display expression in maxima's internal representation"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:6514
+#: ../../src/MaximaCommandMenus.cpp:3034
 msgid "Display expression in wxMaxima's internal representation"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1042
+#: ../../src/wxMaximaFrame.cpp:1076
 msgid "Display last result in TeX form"
 msgstr "Exibir último resultado na forma Te&X"
 
-#: ../../src/ToolBar.cpp:360
+#: ../../src/dialogs/ConfigDialogue.cpp:804
+msgid "Display of long numbers"
+msgstr ""
+
+#: ../../src/ToolBar.cpp:580
 #, c-format
 msgid "Display resolution according to wxWidgets: %li x %li ppi"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:802
+#: ../../src/wxMaximaFrame.cpp:839
 #, fuzzy
 msgid "Display string quotation marks"
 msgstr "Resolver equação(ões)"
 
-#: ../../src/wxMaximaFrame.cpp:1036
+#: ../../src/wxMaximaFrame.cpp:1070
 msgid "Display time used for evaluation"
 msgstr "Exibir tempo usado para execução"
 
-#: ../../src/wxMaxima.cpp:9206
+#: ../../src/MaximaCommandMenus.cpp:397
 #, fuzzy
 msgid "Displayed Precision"
 msgstr "Resolver equação(ões)"
 
-#: ../../src/wxMaximaFrame.cpp:1913
+#: ../../src/wxMaximaFrame.cpp:1950
 msgid "Displaying 3d curves"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1462
+#: ../../src/wxMaximaFrame.cpp:1499
 #, fuzzy
 msgid "Dito, and evaluate the result..."
 msgstr "Avaliar formas substa&ntivas"
 
-#: ../../src/wxMaximaFrame.cpp:1445
+#: ../../src/wxMaximaFrame.cpp:1482
 msgid "Dito, but affect all clones of the Matrix..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1255
+#: ../../src/wxMaximaFrame.cpp:1289
 msgid "Dito, but as fraction (real only)..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1532
+#: ../../src/wxMaximaFrame.cpp:1569
 msgid "Dito, including denominator"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1715 ../../src/wxMaximaFrame.cpp:944
+#: ../../src/worksheet/WorksheetContextMenu.cpp:488
+#: ../../src/wxMaximaFrame.cpp:978
 msgid "Divide Cell"
 msgstr "Dividir célula"
 
-#: ../../src/wxMaximaFrame.cpp:1498
+#: ../../src/wxMaximaFrame.cpp:1535
 msgid "Divide numbers or polynomials"
 msgstr "Dividir números ou polinômios"
 
-#: ../../src/wxMaxima.cpp:8578
+#: ../../src/cells/TextCell.cpp:297
+msgid "Division by 0."
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:1596
 #, fuzzy
 msgid "Do for each list element"
 msgstr "Aplicar função a uma lista"
 
-#: ../../src/wxMaxima.cpp:11197
+#: ../../src/wxMaxima.cpp:3503
 #, fuzzy, c-format
 msgid "Do you want to save the changes you made in the document \"%s\"?"
 msgstr "Você quer salvar as mudanças feitas no documento \""
 
-#: ../../src/wxMaximaFrame.cpp:724
+#: ../../src/wxMaximaFrame.cpp:761
 msgid "Dock all Sidebars"
 msgstr ""
 
-#: ../../src/Configuration.cpp:94
+#: ../../src/Styles.cpp:123
 msgid "Document background"
 msgstr "Fundo do documento"
 
-#: ../../src/wxMaxima.cpp:4611
+#: ../../src/MaximaFileIO.cpp:534
 #, fuzzy
 msgid "Document was saved using a newer version of wxMaxima so it may not load correctly. Please update your wxMaxima."
 msgstr " foi salvo com uma versão mais nova do wxMaxima e talvez não seja carregado corretamente. Por favor atualize seu wxMaxima."
 
-#: ../../src/wxMaxima.cpp:4603
+#: ../../src/MaximaFileIO.cpp:526
 #, fuzzy
 msgid "Document was saved using a newer version of wxMaxima. Please update your wxMaxima."
 msgstr " foi salvo com uma versão mais nova do wxMaxima. Por favor atualize seu wxMaxima."
 
-#: ../../src/wxMaximaFrame.cpp:770
+#: ../../src/dialogs/ConfigDialogue.cpp:1170
+msgid "Documentclass for TeX export:"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1178
+msgid "Documentclass options:"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:807
 msgid "Don't autosubscript after an underscore"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1086
+#: ../../src/wxMaximaFrame.cpp:1120
 #, fuzzy
 msgid "Don't evaluate Expression..."
 msgstr "Integrar expressão"
 
-#: ../../src/wxMaxima.cpp:7117
+#: ../../src/MaximaCommandMenus.cpp:3989
 #, fuzzy
 msgid "Don't evaluate one command"
 msgstr "Mostrar um exemplo para o comando:"
 
-#: ../../src/wxMaxima.cpp:7129
+#: ../../src/MaximaCommandMenus.cpp:4001
 #, fuzzy
 msgid "Don't evaluate one whole expression"
 msgstr "Obter a parte eral de uma expressão complexa"
 
-#: ../../src/Worksheet.cpp:1931 ../../src/Worksheet.cpp:2064
+#: ../../src/worksheet/WorksheetContextMenu.cpp:703
+#: ../../src/worksheet/WorksheetContextMenu.cpp:836
 msgid "Don't mark cells that contain tooltips in yellow"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1938 ../../src/Worksheet.cpp:2070
+#: ../../src/worksheet/WorksheetContextMenu.cpp:710
+#: ../../src/worksheet/WorksheetContextMenu.cpp:842
 msgid "Don't mark this message text in yellow"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:11203
+#: ../../src/wxMaxima.cpp:3509
 msgid "Don't save"
 msgstr "Não salvar"
 
-#: ../../src/Worksheet.cpp:1620
+#: ../../src/worksheet/WorksheetContextMenu.cpp:393
 msgid "Don't show labels"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1979
+#: ../../src/worksheet/WorksheetContextMenu.cpp:751
 msgid "Don't use if unassigned"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:797
+#: ../../src/wxMaximaFrame.cpp:834
 msgid "Don't use parenthesis for matrices"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8525
+#: ../../src/dialogs/DiffFrame.cpp:428 ../../src/dialogs/FindReplacePane.cpp:83
+msgid "Down"
+msgstr ""
+
+#: ../../src/sidebars/SymbolsSidebar.cpp:185
+msgid "Drag-and-drop unicode symbols here"
+msgstr ""
+
+#: ../../src/wizards/DrawWiz.cpp:155
+msgid "Draw all points where an equation is true."
+msgstr ""
+
+#: ../../src/wizards/DrawWiz.cpp:802
+msgid "Draw points"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:1536
 #, fuzzy
 msgid "Drop the first n list elements"
 msgstr "Aplicar função a uma lista"
 
-#: ../../src/wxMaxima.cpp:8531 ../../src/wxMaxima.cpp:8537
+#: ../../src/MaximaCommandMenus.cpp:1542
 #, fuzzy
 msgid "Drop the last n list elements"
 msgstr "Aplicar função a uma lista"
 
-#: ../../src/wxMaximaFrame.cpp:1306
+#: ../../src/dialogs/ConfigDialogue.cpp:195
+msgid "Dutch"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1340
 msgid "E&quations"
 msgstr "E&quações"
 
-#: ../../src/wxMaximaFrame.cpp:625
+#: ../../src/wxMaximaFrame.cpp:658
 msgid "E&xit\tCtrl+Q"
 msgstr "Sai&r\tCtrl+Q"
 
-#: ../../src/wxMaximaFrame.cpp:1368
+#: ../../src/wxMaximaFrame.cpp:1402
 msgid "Eige&nvectors"
 msgstr "Autov&etores"
 
-#: ../../src/wxMaximaFrame.cpp:1365
+#: ../../src/wxMaximaFrame.cpp:1399
 msgid "Eigen&values"
 msgstr "Auto&valores"
 
-#: ../../src/wxMaximaFrame.cpp:1387
+#: ../../src/wxMaximaFrame.cpp:1421
 #, fuzzy
 msgid "Eigenvalues (complex)"
 msgstr "Auto&valores"
 
-#: ../../src/wxMaximaFrame.cpp:1384
+#: ../../src/wxMaximaFrame.cpp:1418
 #, fuzzy
 msgid "Eigenvalues (real)"
 msgstr "Auto&valores"
 
-#: ../../src/wxMaximaFrame.cpp:1393
+#: ../../src/wxMaximaFrame.cpp:1427
 msgid "Eigenvalues, left+right eigenvectors (complex)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1390
+#: ../../src/wxMaximaFrame.cpp:1424
 msgid "Eigenvalues, left+right eigenvectors (real)"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8584
+#: ../../src/MaximaCommandMenus.cpp:1602
 msgid "Either a single expression or a comma-separated list of expressions between parenthesis. In the latter case the result of the last expression in the parenthesis is used."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8593
+#: ../../src/cells/TextCell.cpp:176
+msgid ""
+"Either negative or zero.\n"
+"A possible result of sign()."
+msgstr ""
+
+#: ../../src/cells/TextCell.cpp:172
+msgid ""
+"Either positive or zero.\n"
+"A possible result of sign()."
+msgstr ""
+
+#: ../../src/cells/TextCell.cpp:168
+msgid ""
+"Either positive, negative or zero.\n"
+"Normally the result of sign() if the sign cannot be determined."
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:1612
 msgid "Element"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8549
+#: ../../src/MaximaCommandMenus.cpp:1562
 msgid "Element number"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8005
+#: ../../src/MaximaCommandMenus.cpp:1189
 msgid "Element-by-element Product of matrices of the same size (Hadamard product)"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8012
+#: ../../src/MaximaCommandMenus.cpp:1196
 msgid "Element-by-element exponentiation of two matrices"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1342
+#: ../../src/wxMaximaFrame.cpp:1376
 msgid "Element-by-element multiplication"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8510
+#: ../../src/MaximaCommandMenus.cpp:1516
 msgid "Element:"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7204
+#: ../../src/MaximaCommandMenus.cpp:4076
 msgid "Elements:"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7847
+#: ../../src/MaximaCommandMenus.cpp:1028
 #, fuzzy
 msgid "Eliminate a variable"
 msgstr "&Eliminar variável..."
 
-#: ../../src/wxMaximaFrame.cpp:1247
+#: ../../src/wxMaximaFrame.cpp:1281
 msgid "Eliminate a variable from a system of equations"
 msgstr "Eliminar uma variável de um sistema de equações"
 
-#: ../../src/wxMaxima.cpp:10651
+#: ../../src/MaximaEvaluator.cpp:536
 msgid "Empty command => re-triggering evaluation"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:9225
+#: ../../src/MaximaCommandMenus.cpp:416
 #, fuzzy
 msgid "Enable:"
 msgstr "Variável:"
 
-#: ../../src/MathParser.cpp:99
+#: ../../src/MathParser.cpp:94
 #, c-format
 msgid "Encountered an unknown XML tag: <%s>"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2476
+#: ../../src/MaximaProcessManager.cpp:137
 msgid "Encountered an unknown socket event."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7843
+#: ../../src/sidebars/SymbolsSidebar.cpp:129
+msgid "End of proof"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:1024
 msgid "End of t:"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:4097
+#: ../../src/wizards/DrawWiz.cpp:71 ../../src/wizards/DrawWiz.cpp:176
+msgid "End of the x value"
+msgstr ""
+
+#: ../../src/wizards/DrawWiz.cpp:88 ../../src/wizards/DrawWiz.cpp:191
+msgid "End of the y value"
+msgstr ""
+
+#: ../../src/wizards/DrawWiz.cpp:208
+msgid "End of the z value"
+msgstr ""
+
+#: ../../src/wizards/DrawWiz.cpp:760
+msgid "End value of the parameter"
+msgstr ""
+
+#: ../../src/MaximaResponseReader.cpp:432
+#: ../../src/MaximaResponseReader.cpp:586
 msgid "Ended lisp mode after receiving a maxima prompt!"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1828
+#: ../../src/wxMaximaFrame.cpp:1865
 msgid "Engineering format (12.1e6 etc.)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1319
+#: ../../src/dialogs/ConfigDialogue.cpp:196
+msgid "English"
+msgstr "Inglês"
+
+#: ../../src/wizards/DrawWiz.cpp:552
+msgid "Enhanced 3D settings:"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1919
+msgid "Enhanced meta file (emf)"
+msgstr ""
+
+#: ../../src/sidebars/StatSidebar.cpp:106
+msgid "Enter Matrix..."
+msgstr "&Introduzir matriz..."
+
+#: ../../src/MaximaCommandMenus.cpp:2255
+msgid "Enter UUID to jump to:"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1353
 msgid "Enter a matrix"
 msgstr "Introduza uma matriz"
 
-#: ../../src/wxMaxima.cpp:8866
+#: ../../src/dialogs/ConfigDialogue.cpp:925
+#, fuzzy
+msgid "Enter adds newlines, Ctrl+Enter evaluates cells"
+msgstr "Enter calcula células"
+
+#: ../../src/MaximaCommandMenus.cpp:873
 msgid "Enter an equation for rational simplification:"
 msgstr "Informe uma equação para simplificação racional:"
 
-#: ../../src/wxMaxima.cpp:8169
+#: ../../src/wizards/SystemWiz.cpp:50
+msgid "Enter comma separated list of variables."
+msgstr "Informa uma lista de variáveis separadas por vírgulas."
+
+#: ../../src/dialogs/ConfigDialogue.cpp:921
+#, fuzzy
+msgid "Enter evaluates cells, Ctrl+Enter adds newlines"
+msgstr "Enter calcula células"
+
+#: ../../src/MaximaCommandMenus.cpp:1357
 msgid "Enter matrix"
 msgstr "Informe uma matriz"
 
-#: ../../src/wxMaxima.cpp:9095
+#: ../../src/MaximaCommandMenus.cpp:100
 msgid "Enter new animation frame rate [Hz, integer]:"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:9201
+#: ../../src/MaximaCommandMenus.cpp:392
 #, fuzzy
 msgid "Enter new precision for bigfloats:"
 msgstr "Informe a nova precisão:"
 
-#: ../../src/wxMaxima.cpp:7922
+#: ../../src/dialogs/ConfigDialogue.cpp:388
+msgid "Enter the path to the Maxima executable."
+msgstr "Informe o caminho para o executável Maxima."
+
+#: ../../src/MaximaCommandMenus.cpp:1103
 msgid "Enumerator:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1220
+#: ../../src/wxMaximaFrame.cpp:1254
 #, fuzzy
 msgid "Environment variables"
 msgstr "Parâmetros adicionais:"
 
-#: ../../src/wxMaxima.cpp:9045
+#: ../../src/dialogs/ConfigDialogue.cpp:1605
+#, fuzzy
+msgid "Environment variables for maxima"
+msgstr "Parâmetros adicionais:"
+
+#: ../../src/sidebars/GreekSidebar.cpp:182
+#, fuzzy
+msgid "Epsilon"
+msgstr "Epsilon:"
+
+#: ../../src/MaximaCommandMenus.cpp:299
 msgid "Epsilon:"
 msgstr "Epsilon:"
 
-#: ../../src/wxMaximaFrame.cpp:1124 ../../src/wxMaximaFrame.cpp:1135
+#: ../../src/wxMaximaFrame.cpp:1158 ../../src/wxMaximaFrame.cpp:1169
 msgid "Equal, ignoring case?..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1133
+#: ../../src/wxMaximaFrame.cpp:1167
 msgid "Equal?..."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8561
+#: ../../src/MaximaCommandMenus.cpp:1577 ../../src/wizards/DrawWiz.cpp:161
 #, fuzzy
 msgid "Equation"
 msgstr "Equação:"
 
-#: ../../src/wxMaxima.cpp:7751 ../../src/wxMaxima.cpp:7765
+#: ../../src/wizards/SystemWiz.cpp:67
+#, c-format
+msgid "Equation %ld:"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:932 ../../src/MaximaCommandMenus.cpp:946
 #, fuzzy
 msgid "Equation(s)"
 msgstr "Equação(ões):"
 
-#: ../../src/wxMaxima.cpp:7848 ../../src/wxMaxima.cpp:7900
+#: ../../src/MaximaCommandMenus.cpp:1029 ../../src/MaximaCommandMenus.cpp:1081
 msgid "Equation(s):"
 msgstr "Equação(ões):"
 
-#: ../../src/wxMaxima.cpp:7776 ../../src/wxMaxima.cpp:7788
-#: ../../src/wxMaxima.cpp:8899 ../../src/wxMaxima.cpp:8919
-#: ../../src/wxMaxima.cpp:9592 ../../src/wxMaxima.cpp:10039
+#: ../../src/MaximaCommandMenus.cpp:150 ../../src/MaximaCommandMenus.cpp:170
+#: ../../src/MaximaCommandMenus.cpp:957 ../../src/MaximaCommandMenus.cpp:969
+#: ../../src/MaximaCommandMenus.cpp:1832 ../../src/MaximaCommandMenus.cpp:3528
 msgid "Equation:"
 msgstr "Equação:"
 
-#: ../../src/WXMXformat.cpp:258 ../../src/WXMXformat.cpp:288
-#: ../../src/WXMXformat.cpp:296 ../../src/WXMXformat.cpp:311
-#: ../../src/WXMXformat.cpp:332 ../../src/WXMXformat.cpp:362
-#: ../../src/wxMaxima.cpp:3020 ../../src/wxMaxima.cpp:4163
-#: ../../src/wxMaxima.cpp:4222 ../../src/wxMaxima.cpp:4231
-#: ../../src/wxMaxima.cpp:4491 ../../src/wxMaxima.cpp:4502
-#: ../../src/wxMaxima.cpp:4605 ../../src/wxMaxima.cpp:4634
-#: ../../src/wxMaxima.cpp:4645 ../../src/wxMaxima.cpp:11125
-#: ../../src/wxMaxima.cpp:11166
+#: ../../src/dialogs/TipOfTheDay.cpp:196
+msgid "Equations have several advantages over functions. For example they can be manipulated with factor(), expand() and similar functions. They can easily be introduced one into another. Also they are always printed out as 2D maths."
+msgstr ""
+
+#: ../../src/MaximaFileIO.cpp:64 ../../src/MaximaFileIO.cpp:121
+#: ../../src/MaximaFileIO.cpp:130 ../../src/MaximaFileIO.cpp:399
+#: ../../src/MaximaFileIO.cpp:410 ../../src/MaximaFileIO.cpp:528
+#: ../../src/MaximaFileIO.cpp:557 ../../src/MaximaFileIO.cpp:568
+#: ../../src/MaximaProcessManager.cpp:581 ../../src/WXMXformat.cpp:260
+#: ../../src/WXMXformat.cpp:290 ../../src/WXMXformat.cpp:298
+#: ../../src/WXMXformat.cpp:313 ../../src/WXMXformat.cpp:334
+#: ../../src/WXMXformat.cpp:364 ../../src/dialogs/BinaryNameCtrl.cpp:78
+#: ../../src/main.cpp:725 ../../src/wxMaxima.cpp:3384
+#: ../../src/wxMaxima.cpp:3420 ../../src/wxMaxima.cpp:3438
+#: ../../src/wxMaxima.cpp:3472
 msgid "Error"
 msgstr "Erro"
 
-#: ../../src/wxMaxima.cpp:2456
+#: ../../src/MaximaProcessManager.cpp:789
 msgid "Error writing to Maxima"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:6164 ../../src/wxMaxima.cpp:6176
-#: ../../src/wxMaxima.cpp:6187 ../../src/wxMaxima.cpp:7858
-#: ../../src/wxMaxima.cpp:7880 ../../src/wxMaxima.cpp:8163
+#: ../../src/MaximaCommandMenus.cpp:1039 ../../src/MaximaCommandMenus.cpp:1061
+#: ../../src/MaximaCommandMenus.cpp:1351 ../../src/MaximaCommandMenus.cpp:2320
+#: ../../src/MaximaCommandMenus.cpp:2332 ../../src/MaximaCommandMenus.cpp:2343
+#: ../../src/MaximaFileIO.cpp:873 ../../src/sidebars/History.cpp:228
 msgid "Error!"
 msgstr "Erro!"
 
-#: ../../src/Image.cpp:696
+#: ../../src/Image.cpp:779
 #, c-format
 msgid "Error: Cannot render %s."
 msgstr ""
 
-#: ../../src/Image.cpp:699
+#: ../../src/Image.cpp:782
 #, c-format
 msgid ""
 "Error: Cannot render %s:\n"
 "%s"
 msgstr ""
 
-#: ../../src/Image.cpp:704
+#: ../../src/Image.cpp:787
 msgid "Error: Cannot render the image."
 msgstr ""
 
-#: ../../src/Image.cpp:706
+#: ../../src/Image.cpp:789
 #, c-format
 msgid ""
 "Error: Cannot render the image:\n"
 "%s"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7544
+#: ../../src/MaximaCommandMenus.cpp:4416
 msgid "Escapes all special characters in a string. The result is a regex that matches this string exactly."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1652
+#: ../../src/sidebars/GreekSidebar.cpp:184
+msgid "Eta"
+msgstr ""
+
+#: ../../src/sidebars/TableOfContents.cpp:513
+#, fuzzy
+msgid "Evaluate"
+msgstr "Avaliar célula(s)"
+
+#: ../../src/wxMaximaFrame.cpp:1689
 #, fuzzy
 msgid "Evaluate &Noun Forms..."
 msgstr "Avaliar formas substa&ntivas"
 
-#: ../../src/wxMaximaFrame.cpp:856
+#: ../../src/wxMaximaFrame.cpp:890
 #, fuzzy
 msgid "Evaluate All Cells\tCtrl+Shift+R"
 msgstr "Avaliar todas as células\tCtrl+R"
 
-#: ../../src/wxMaximaFrame.cpp:851
+#: ../../src/wxMaximaFrame.cpp:885
 #, fuzzy
 msgid "Evaluate All Visible Cells\tCtrl+R"
 msgstr "Avaliar todas as células\tCtrl+R"
 
-#: ../../src/Worksheet.cpp:1395
+#: ../../src/worksheet/WorksheetContextMenu.cpp:166
 #, fuzzy
 msgid "Evaluate Cell"
 msgstr "Avaliar célula(s)"
 
-#: ../../src/Worksheet.cpp:1398 ../../src/wxMaximaFrame.cpp:844
+#: ../../src/worksheet/WorksheetContextMenu.cpp:169
+#: ../../src/wxMaximaFrame.cpp:878
 msgid "Evaluate Cell(s)"
 msgstr "Avaliar célula(s)"
 
-#: ../../src/Worksheet.cpp:1391 ../../src/Worksheet.cpp:1674
+#: ../../src/worksheet/WorksheetContextMenu.cpp:162
+#: ../../src/worksheet/WorksheetContextMenu.cpp:447
 #, fuzzy
 msgid "Evaluate Cells Above"
 msgstr "Avaliar célula(s)"
 
-#: ../../src/wxMaximaFrame.cpp:866
+#: ../../src/wxMaximaFrame.cpp:900
 #, fuzzy
 msgid "Evaluate Cells Above\tCtrl+Shift+P"
 msgstr "Avaliar todas as células\tCtrl+R"
 
-#: ../../src/Worksheet.cpp:1402 ../../src/Worksheet.cpp:1676
-#: ../../src/wxMaximaFrame.cpp:876
+#: ../../src/worksheet/WorksheetContextMenu.cpp:173
+#: ../../src/worksheet/WorksheetContextMenu.cpp:449
+#: ../../src/wxMaximaFrame.cpp:910
 #, fuzzy
 msgid "Evaluate Cells Below"
 msgstr "Avaliar célula(s)"
 
-#: ../../src/Worksheet.cpp:1451 ../../src/Worksheet.cpp:1756
-#: ../../src/Worksheet.cpp:1890
+#: ../../src/worksheet/WorksheetContextMenu.cpp:222
+#: ../../src/worksheet/WorksheetContextMenu.cpp:529
+#: ../../src/worksheet/WorksheetContextMenu.cpp:662
 msgid "Evaluate Heading 5\tShift+Ctrl+Enter"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1457 ../../src/Worksheet.cpp:1761
-#: ../../src/Worksheet.cpp:1901
+#: ../../src/worksheet/WorksheetContextMenu.cpp:228
+#: ../../src/worksheet/WorksheetContextMenu.cpp:534
+#: ../../src/worksheet/WorksheetContextMenu.cpp:673
 msgid "Evaluate Heading 6\tShift+Ctrl+Enter"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8626
+#: ../../src/MaximaCommandMenus.cpp:618
 #, fuzzy
 msgid "Evaluate Nouns"
 msgstr "Avaliar formas substa&ntivas"
 
-#: ../../src/Worksheet.cpp:1425 ../../src/Worksheet.cpp:1736
+#: ../../src/worksheet/WorksheetContextMenu.cpp:196
+#: ../../src/worksheet/WorksheetContextMenu.cpp:509
 msgid "Evaluate Part\tShift+Ctrl+Enter"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1431 ../../src/Worksheet.cpp:1741
+#: ../../src/worksheet/WorksheetContextMenu.cpp:202
+#: ../../src/worksheet/WorksheetContextMenu.cpp:514
 msgid "Evaluate Section\tShift+Ctrl+Enter"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1445 ../../src/Worksheet.cpp:1751
-#: ../../src/Worksheet.cpp:1879
+#: ../../src/worksheet/WorksheetContextMenu.cpp:216
+#: ../../src/worksheet/WorksheetContextMenu.cpp:524
+#: ../../src/worksheet/WorksheetContextMenu.cpp:651
 msgid "Evaluate Sub-Subsection\tShift+Ctrl+Enter"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1438 ../../src/Worksheet.cpp:1746
-#: ../../src/Worksheet.cpp:1868
+#: ../../src/worksheet/WorksheetContextMenu.cpp:209
+#: ../../src/worksheet/WorksheetContextMenu.cpp:519
+#: ../../src/worksheet/WorksheetContextMenu.cpp:640
 msgid "Evaluate Subsection\tShift+Ctrl+Enter"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:845
+#: ../../src/wxMaximaFrame.cpp:879
 msgid "Evaluate active or selected cell(s)"
 msgstr "Avaliar célula ativa ou selecionada"
 
-#: ../../src/ToolBar.cpp:251
+#: ../../src/ToolBar.cpp:445 ../../src/ToolBar.cpp:457
 msgid "Evaluate all"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:857
+#: ../../src/wxMaximaFrame.cpp:891
 msgid "Evaluate all cells in the document"
 msgstr "Avaliar todas as células no documento"
 
-#: ../../src/wxMaximaFrame.cpp:1653
+#: ../../src/wxMaximaFrame.cpp:1690
 msgid "Evaluate all noun forms in expression"
 msgstr "Avaliar todas as formas substa&ntivas na expressão"
 
-#: ../../src/wxMaximaFrame.cpp:852
+#: ../../src/wxMaximaFrame.cpp:886
 #, fuzzy
 msgid "Evaluate all visible cells in the document"
 msgstr "Avaliar todas as células no documento"
 
-#: ../../src/ToolBar.cpp:248
+#: ../../src/ToolBar.cpp:442 ../../src/ToolBar.cpp:454
 msgid "Evaluate current cell"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7395
+#: ../../src/MaximaCommandMenus.cpp:4267
 #, fuzzy
 msgid "Evaluate string"
 msgstr "Avaliar formas substa&ntivas"
 
-#: ../../src/wxMaximaFrame.cpp:1151
+#: ../../src/wxMaximaFrame.cpp:1185
 #, fuzzy
 msgid "Evaluate string..."
 msgstr "Avaliar formas substa&ntivas"
 
-#: ../../src/ToolBar.cpp:256
+#: ../../src/ToolBar.cpp:449 ../../src/ToolBar.cpp:461
 msgid "Evaluate the file from its beginning to the cell above the cursor"
 msgstr ""
 
-#: ../../src/ToolBar.cpp:259
+#: ../../src/ToolBar.cpp:452 ../../src/ToolBar.cpp:464
 #, fuzzy
 msgid "Evaluate the file from the cursor to its end"
 msgstr "Avaliar todas as células no documento"
 
-#: ../../src/ToolBar.cpp:258
+#: ../../src/ToolBar.cpp:451 ../../src/ToolBar.cpp:463
 #, fuzzy
 msgid "Evaluate the rest"
 msgstr "Avaliar formas substa&ntivas"
 
-#: ../../src/ToolBar.cpp:255
+#: ../../src/ToolBar.cpp:448 ../../src/ToolBar.cpp:460
 #, fuzzy
 msgid "Evaluate to point"
 msgstr "Avaliar formas substa&ntivas"
 
-#: ../../src/wxMaxima.cpp:10518
+#: ../../src/MaximaEvaluator.cpp:351
 msgid "Evaluation ended, since evaluation queue is empty."
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1957
+#: ../../src/worksheet/WorksheetContextMenu.cpp:729
 msgid "Even number"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1703
+#: ../../src/dialogs/ConfigDialogue.cpp:2659
+msgid "Example text"
+msgstr "Texto de exemplo"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1547
+msgid "Examples:"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1740
 msgid "Execute a command for each element of the list"
 msgstr ""
 
-#: ../../src/main.cpp:438
+#: ../../src/main.cpp:677
 msgid "Exit"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:625
-msgid "Exit wxMaxima"
-msgstr ""
+#: ../../src/sidebars/MathSidebar.cpp:53
+msgid "Expand"
+msgstr "Expandir"
 
-#: ../../src/Worksheet.cpp:1583
+#: ../../src/sidebars/MathSidebar.cpp:68
+msgid "Expand (tr)"
+msgstr "Expandir (tr)"
+
+#: ../../src/worksheet/WorksheetContextMenu.cpp:356
 msgid "Expand Expression"
 msgstr "Expandir expressão"
 
-#: ../../src/wxMaximaFrame.cpp:1525
+#: ../../src/wxMaximaFrame.cpp:1562
 msgid "Expand an expression"
 msgstr "Expandir uma expressão"
 
-#: ../../src/wxMaximaFrame.cpp:1531
+#: ../../src/wxMaximaFrame.cpp:1568
 #, fuzzy
 msgid "Expand for given variables"
 msgstr "Mudar variável"
 
-#: ../../src/wxMaxima.cpp:8781
+#: ../../src/MaximaCommandMenus.cpp:788
 msgid "Expand for variable(s) including denominator:"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8716
+#: ../../src/MaximaCommandMenus.cpp:708
 #, fuzzy
 msgid "Expand for variable(s):"
 msgstr "Nova variável:"
 
-#: ../../src/wxMaximaFrame.cpp:1545
+#: ../../src/wxMaximaFrame.cpp:1582
 #, fuzzy
 msgid "Expand log in previous expression"
 msgstr "Expandir uma expressão"
 
-#: ../../src/wxMaximaFrame.cpp:1598
+#: ../../src/wxMaximaFrame.cpp:1635
 msgid "Expand trigonometric expression"
 msgstr "Expandir expressão trigonométrica"
 
-#: ../../src/wxMaximaFrame.cpp:1788
+#: ../../src/wxMaximaFrame.cpp:1825
 msgid "Expect numbers harder to be complex"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1789
+#: ../../src/wxMaximaFrame.cpp:1826
 msgid "Expect variables to contain complex numbers"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:6121
+#: ../../src/MaximaCommandMenus.cpp:2277
+#: ../../src/dialogs/ConfigDialogue.cpp:283
 msgid "Export"
 msgstr "Exportar"
 
-#: ../../src/wxMaximaFrame.cpp:1705
+#: ../../src/sidebars/History.cpp:152
+#, fuzzy
+msgid "Export As"
+msgstr "Exportar"
+
+#: ../../src/wxMaximaFrame.cpp:1742
 #, fuzzy
 msgid "Export List to csv file..."
 msgstr "Exportação para TeX falhou!"
 
-#: ../../src/wxMaximaFrame.cpp:1706
+#: ../../src/wxMaximaFrame.cpp:1743
 #, fuzzy
 msgid "Export a list to a csv file"
 msgstr "Carregar um arquivo de pacote Maxima"
 
-#: ../../src/wxMaximaFrame.cpp:1332
+#: ../../src/wxMaximaFrame.cpp:1366
 #, fuzzy
 msgid "Export a matrix to a csv file"
 msgstr "Carregar um arquivo de pacote Maxima"
 
-#: ../../src/wxMaximaFrame.cpp:619
+#: ../../src/sidebars/History.cpp:102
+msgid "Export all history to a .mac file"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1016
+#, fuzzy
+msgid "Export all settings"
+msgstr "Exportação para TeX falhou!"
+
+#: ../../src/sidebars/History.cpp:105
+msgid "Export commands from the current maxima session to a .mac file"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:652
 #, fuzzy
 msgid "Export document to a HTML or LaTeX file"
 msgstr "Exportar documento para o formato HTML ou pdfLaTeX"
 
-#: ../../src/wxMaximaFrame.cpp:579
+#: ../../src/dialogs/ConfigDialogue.cpp:1218
+#, fuzzy
+msgid "Export equations to HTML as:"
+msgstr "Exportação para HTML falhou!"
+
+#: ../../src/wxMaximaFrame.cpp:600
 #, fuzzy
 msgid "Export failed."
 msgstr "Exportação para TeX falhou!"
 
-#: ../../src/wxMaximaFrame.cpp:567
+#: ../../src/worksheet/WorksheetContextMenu.cpp:154
+msgid "Export output as PNG to a folder..."
+msgstr ""
+
+#: ../../src/worksheet/WorksheetContextMenu.cpp:151
+msgid "Export output as SVG to a folder..."
+msgstr ""
+
+#: ../../src/sidebars/History.cpp:108
+msgid "Export selected commands to a .mac file"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:588
 msgid "Export successful."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:6187
+#: ../../src/MaximaCommandMenus.cpp:3468
+msgid "Export the selected output(s) to this folder"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1022
+#, fuzzy
+msgid "Export the style settings"
+msgstr "Exportação para TeX falhou!"
+
+#: ../../src/sidebars/History.cpp:111
+msgid "Export visible commands to a .mac file"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:3477
+#, c-format
+msgid "Exported %d output image(s) to %s"
+msgstr ""
+
+#: ../../src/wxMaxima.cpp:2200 ../../src/wxMaxima.cpp:2242
+#, c-format
+msgid "Exported the worksheet to %s"
+msgstr ""
+
+#: ../../src/sidebars/History.cpp:228
+#, fuzzy
+msgid "Exporting to .mac file failed!"
+msgstr "Exportação para TeX falhou!"
+
+#: ../../src/MaximaCommandMenus.cpp:2343
 msgid "Exporting to HTML failed!"
 msgstr "Exportação para HTML falhou!"
 
-#: ../../src/wxMaxima.cpp:6164
+#: ../../src/MaximaCommandMenus.cpp:2320
 msgid "Exporting to TeX failed!"
 msgstr "Exportação para TeX falhou!"
 
-#: ../../src/wxMaxima.cpp:6175
+#: ../../src/MaximaCommandMenus.cpp:2331
 #, fuzzy
 msgid "Exporting to maxima batch file failed!"
 msgstr "Exportação para TeX falhou!"
 
-#: ../../src/wxMaximaFrame.cpp:561
+#: ../../src/wxMaximaFrame.cpp:582
 #, fuzzy
 msgid "Exporting..."
 msgstr "&Exportar..."
 
-#: ../../src/wxMaxima.cpp:6510 ../../src/wxMaxima.cpp:6516
-#: ../../src/wxMaxima.cpp:8218 ../../src/wxMaxima.cpp:8633
-#: ../../src/wxMaxima.cpp:8638 ../../src/wxMaxima.cpp:8658
-#: ../../src/wxMaxima.cpp:10065
+#: ../../src/MaximaCommandMenus.cpp:1480
+msgid "Expr:"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:625 ../../src/MaximaCommandMenus.cpp:630
+#: ../../src/MaximaCommandMenus.cpp:650 ../../src/MaximaCommandMenus.cpp:1408
+#: ../../src/MaximaCommandMenus.cpp:3030 ../../src/MaximaCommandMenus.cpp:3036
+#: ../../src/MaximaCommandMenus.cpp:3554 ../../src/sidebars/DrawSidebar.cpp:54
+#: ../../src/wizards/Plot3dWiz.cpp:32
 msgid "Expression"
 msgstr "Expressão"
 
-#: ../../src/wxMaxima.cpp:7019 ../../src/wxMaxima.cpp:7025
+#: ../../src/MaximaCommandMenus.cpp:3891 ../../src/MaximaCommandMenus.cpp:3897
 #, fuzzy
 msgid "Expression or a list of comma-separated expressions"
 msgstr "Coordenadas x separadas por vírgulas."
 
-#: ../../src/wxMaximaFrame.cpp:1088
+#: ../../src/wizards/DrawWiz.cpp:733
+msgid "Expression that calculates the x value"
+msgstr ""
+
+#: ../../src/wizards/DrawWiz.cpp:738
+msgid "Expression that calculates the y value"
+msgstr ""
+
+#: ../../src/wizards/DrawWiz.cpp:744
+msgid "Expression that calculates the z value"
+msgstr ""
+
+#: ../../src/wizards/DrawWiz.cpp:56
+msgid "Expression to plot"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1122
 #, fuzzy
 msgid "Expression to string..."
 msgstr "Expressão"
 
-#: ../../src/wxMaxima.cpp:7113
+#: ../../src/MaximaCommandMenus.cpp:3985
 msgid "Expression whose output is to be used as maxima's input."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7214
+#: ../../src/MaximaCommandMenus.cpp:4086 ../../src/wizards/Plot2dWiz.cpp:39
 msgid "Expression(s):"
 msgstr "Expressão(ões):"
 
-#: ../../src/wxMaxima.cpp:8933 ../../src/wxMaxima.cpp:8941
-#: ../../src/wxMaxima.cpp:8952 ../../src/wxMaxima.cpp:8976
-#: ../../src/wxMaxima.cpp:8981 ../../src/wxMaxima.cpp:8998
-#: ../../src/wxMaxima.cpp:9004 ../../src/wxMaxima.cpp:9011
-#: ../../src/wxMaxima.cpp:9043 ../../src/wxMaxima.cpp:9062
-#: ../../src/wxMaxima.cpp:10056
+#: ../../src/MaximaCommandMenus.cpp:184 ../../src/MaximaCommandMenus.cpp:195
+#: ../../src/MaximaCommandMenus.cpp:206 ../../src/MaximaCommandMenus.cpp:230
+#: ../../src/MaximaCommandMenus.cpp:235 ../../src/MaximaCommandMenus.cpp:252
+#: ../../src/MaximaCommandMenus.cpp:258 ../../src/MaximaCommandMenus.cpp:265
+#: ../../src/MaximaCommandMenus.cpp:297 ../../src/MaximaCommandMenus.cpp:316
+#: ../../src/MaximaCommandMenus.cpp:3545 ../../src/wizards/IntegrateWiz.cpp:33
+#: ../../src/wizards/LimitWiz.cpp:29 ../../src/wizards/SeriesWiz.cpp:30
+#: ../../src/wizards/SubstituteWiz.cpp:29 ../../src/wizards/SumWiz.cpp:31
 msgid "Expression:"
 msgstr "Expressão:"
 
-#: ../../src/wxMaximaFrame.cpp:1423
+#: ../../src/wxMaximaFrame.cpp:1457
 #, fuzzy
 msgid "Extract Column..."
 msgstr "Criar lista de uma expressão"
 
-#: ../../src/wxMaximaFrame.cpp:1726
+#: ../../src/wxMaximaFrame.cpp:1763
 msgid "Extract Elements"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1421
+#: ../../src/wxMaximaFrame.cpp:1455
 #, fuzzy
 msgid "Extract Row..."
 msgstr "Criar lista de uma expressão"
 
-#: ../../src/wxMaximaFrame.cpp:1424
+#: ../../src/wxMaximaFrame.cpp:1458
 msgid "Extract a column from the matrix"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1435
+#: ../../src/wxMaximaFrame.cpp:1472
 msgid "Extract a column from the matrix and convert it to a list"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7960
+#: ../../src/MaximaCommandMenus.cpp:1140
 #, fuzzy
 msgid "Extract a matrix column"
 msgstr "Introduza uma matriz"
 
-#: ../../src/wxMaxima.cpp:7970
+#: ../../src/MaximaCommandMenus.cpp:1150
 #, fuzzy
 msgid "Extract a matrix column as a list"
 msgstr "Introduza uma matriz"
 
-#: ../../src/wxMaximaFrame.cpp:1313
+#: ../../src/wxMaximaFrame.cpp:1347
 #, fuzzy
 msgid "Extract a matrix from a 2-dimensional array"
 msgstr "Gerar uma matriz de uma array bidimensional"
 
-#: ../../src/wxMaxima.cpp:7955
+#: ../../src/MaximaCommandMenus.cpp:1135
 #, fuzzy
 msgid "Extract a matrix row"
 msgstr "Introduza uma matriz"
 
-#: ../../src/wxMaxima.cpp:7965
+#: ../../src/MaximaCommandMenus.cpp:1145
 #, fuzzy
 msgid "Extract a matrix row as a list"
 msgstr "Introduza uma matriz"
 
-#: ../../src/wxMaximaFrame.cpp:1422
+#: ../../src/wxMaximaFrame.cpp:1456
 msgid "Extract a row from the matrix"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1431
+#: ../../src/wxMaximaFrame.cpp:1468
 #, fuzzy
 msgid "Extract a row from the matrix and convert it to a list"
 msgstr "Criar lista de uma expressão"
 
-#: ../../src/wxMaxima.cpp:8564
+#: ../../src/MaximaCommandMenus.cpp:1580
 msgid "Extract a variable's value from a list of variable values"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1723
+#: ../../src/wxMaximaFrame.cpp:1760
 msgid "Extract an actual value for a variable"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1163
+#: ../../src/wxMaximaFrame.cpp:1197
 #, fuzzy
 msgid "Extract char..."
 msgstr "Criar lista de uma expressão"
 
-#: ../../src/wxMaximaFrame.cpp:1207
+#: ../../src/wxMaximaFrame.cpp:1241
 #, fuzzy
 msgid "Extract dir from path..."
 msgstr "Criar lista de uma expressão"
 
-#: ../../src/wxMaxima.cpp:7605
+#: ../../src/MaximaCommandMenus.cpp:4477
 #, fuzzy
 msgid "Extract directory part"
 msgstr "Nomes de funções"
 
-#: ../../src/wxMaxima.cpp:7617
+#: ../../src/MaximaCommandMenus.cpp:4489
 #, fuzzy
 msgid "Extract file type extension"
 msgstr "Criar lista de uma expressão"
 
-#: ../../src/wxMaximaFrame.cpp:1209
+#: ../../src/wxMaximaFrame.cpp:1243
 msgid "Extract filename from path..."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7611
+#: ../../src/MaximaCommandMenus.cpp:4483
 #, fuzzy
 msgid "Extract filename part"
 msgstr "Criar lista de uma expressão"
 
-#: ../../src/wxMaximaFrame.cpp:1211
+#: ../../src/wxMaximaFrame.cpp:1245
 msgid "Extract filetype from path..."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8445
+#: ../../src/MaximaCommandMenus.cpp:1442
 #, fuzzy
 msgid "Extract function arguments"
 msgstr "Nomes de funções"
 
-#: ../../src/wxMaximaFrame.cpp:1727
+#: ../../src/wxMaximaFrame.cpp:1764
 #, fuzzy
 msgid "Extract list Elements"
 msgstr "Criar lista de uma expressão"
 
-#: ../../src/wxMaxima.cpp:8187
+#: ../../src/MaximaCommandMenus.cpp:1375
 #, fuzzy
 msgid "Extract matrix from 2D array"
 msgstr "Introduza uma matriz"
 
-#: ../../src/wxMaximaFrame.cpp:1686
+#: ../../src/wxMaximaFrame.cpp:1723
 #, fuzzy
 msgid "Extract the argument list from a function call"
 msgstr "Criar lista de uma expressão"
 
-#: ../../src/wxMaxima.cpp:8538
+#: ../../src/MaximaCommandMenus.cpp:1551
 #, fuzzy
 msgid "Extract the last n elements from a list"
 msgstr "Criar lista de uma expressão"
 
-#: ../../src/wxMaxima.cpp:7376
+#: ../../src/MaximaCommandMenus.cpp:1550
+msgid "Extract the last n list elements"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:4248
 #, fuzzy
 msgid "Extract the nth char of a string"
 msgstr "Criar lista de uma expressão"
 
-#: ../../src/wxMaxima.cpp:8544
+#: ../../src/MaximaCommandMenus.cpp:1557
 #, fuzzy
 msgid "Extract the nth list elements"
 msgstr "Criar lista de uma expressão"
 
-#: ../../src/wxMaximaFrame.cpp:1724
+#: ../../src/wxMaximaFrame.cpp:1761
 msgid "Extract the value for one variable assigned in a list"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1439
+#: ../../src/wxMaximaFrame.cpp:1476
 msgid "Extract, append or delete rows or columns"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8188
+#: ../../src/MaximaCommandMenus.cpp:1376
 #, fuzzy
 msgid "Extracts a rectangle from a 2D array and converts it to a matrix"
 msgstr "Criar lista de uma expressão"
 
-#: ../../src/wxMaximaFrame.cpp:1521
+#: ../../src/sidebars/MathSidebar.cpp:50
+msgid "Factor"
+msgstr "Fatorar"
+
+#: ../../src/wxMaximaFrame.cpp:1558
 msgid "Factor Complex"
 msgstr "Fatorar complexo"
 
-#: ../../src/Worksheet.cpp:1581
+#: ../../src/worksheet/WorksheetContextMenu.cpp:354
 msgid "Factor Expression"
 msgstr "Fatorar expressão"
 
-#: ../../src/wxMaximaFrame.cpp:1519
+#: ../../src/wxMaximaFrame.cpp:1556
 #, fuzzy
 msgid "Factor Expression including subexpressions"
 msgstr "Fatorar uma expressão em números gaussianos"
 
-#: ../../src/wxMaximaFrame.cpp:1517 ../../src/wxMaximaFrame.cpp:1520
+#: ../../src/wxMaximaFrame.cpp:1554 ../../src/wxMaximaFrame.cpp:1557
 msgid "Factor an expression"
 msgstr "Fatorar uma expressão"
 
-#: ../../src/wxMaximaFrame.cpp:1522
+#: ../../src/wxMaximaFrame.cpp:1559
 msgid "Factor an expression in Gaussian numbers"
 msgstr "Fatorar uma expressão em números gaussianos"
 
-#: ../../src/wxMaximaFrame.cpp:1587
+#: ../../src/wxMaximaFrame.cpp:1624
 msgid "Factorials and &Gamma"
 msgstr "Fatoriais e &gama"
 
-#: ../../src/Image.cpp:137
+#: ../../src/Image.cpp:173
 #, c-format
 msgid "Failed to delete gnuplot data file %s"
 msgstr ""
 
-#: ../../src/Image.cpp:121 ../../src/Image.cpp:128
+#: ../../src/Image.cpp:157 ../../src/Image.cpp:164
 #, c-format
 msgid "Failed to delete gnuplot file %s"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2667
+#: ../../src/MaximaProcessManager.cpp:352
 #, fuzzy
 msgid "Failed to start Maxima"
 msgstr "Reiniciar Maxima"
 
-#: ../../src/wxMaximaFrame.cpp:1418
+#: ../../src/MaximaProcessManager.cpp:628
+msgid "Failed to write to Maxima's stdin (LDB)."
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1452
 msgid "Fast fortran routines that perform numerical tasks"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1922
+#: ../../src/wxMaximaFrame.cpp:1959
 msgid "Fast list access"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2553
+#: ../../src/MaximaProcessManager.cpp:218
 msgid "Fatal error"
 msgstr "Erro fatal"
 
-#: ../../src/wxMaxima.cpp:7191
+#: ../../src/wizards/CsvWiz.cpp:38 ../../src/wizards/CsvWiz.cpp:109
+msgid "Field Separator"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:4063
 #, fuzzy
 msgid "Field contents:"
 msgstr "Constantes gregas"
 
-#: ../../src/wxMaxima.cpp:7198
+#: ../../src/MaximaCommandMenus.cpp:4070
 #, fuzzy
 msgid "Field name:"
 msgstr "Variável antiga:"
 
-#: ../../src/wxMaxima.cpp:7185
+#: ../../src/MaximaCommandMenus.cpp:4057
 msgid "Fields:"
 msgstr ""
 
-#: ../../src/main.cpp:439
+#: ../../src/cells/GroupCell.cpp:2115
+#, c-format
+msgid "Figure %d:"
+msgstr "Figura %d:"
+
+#: ../../src/main.cpp:678
 msgid "File"
 msgstr "Arquivo"
 
-#: ../../src/wxMaximaFrame.cpp:1333
+#: ../../src/wxMaximaFrame.cpp:1367
 #, fuzzy
 msgid "File I/O"
 msgstr "Arquivo"
 
-#: ../../src/wxMaxima.cpp:4165 ../../src/wxMaxima.cpp:4224
-#: ../../src/wxMaxima.cpp:4493 ../../src/wxMaxima.cpp:4504
-#: ../../src/wxMaxima.cpp:4606 ../../src/wxMaxima.cpp:4636
-#: ../../src/wxMaxima.cpp:4647 ../../src/wxMaxima.cpp:5641
+#: ../../src/MaximaFileIO.cpp:66 ../../src/MaximaFileIO.cpp:123
+#: ../../src/MaximaFileIO.cpp:401 ../../src/MaximaFileIO.cpp:412
+#: ../../src/MaximaFileIO.cpp:529 ../../src/MaximaFileIO.cpp:559
+#: ../../src/MaximaFileIO.cpp:570 ../../src/MaximaFileIO.cpp:732
 #, fuzzy
 msgid "File could not be opened"
 msgstr "Arquivo não encontrado"
 
-#: ../../src/wxMaxima.cpp:7241 ../../src/wxMaxima.cpp:7246
-#: ../../src/wxMaxima.cpp:7251
+#: ../../src/MaximaCommandMenus.cpp:4113 ../../src/MaximaCommandMenus.cpp:4118
+#: ../../src/MaximaCommandMenus.cpp:4123
 #, fuzzy
 msgid "File name:"
 msgstr "Variável antiga:"
 
-#: ../../src/wxMaxima.cpp:10225 ../../src/wxMaxima.cpp:10268
+#: ../../src/wxMaxima.cpp:2995 ../../src/wxMaxima.cpp:3038
 msgid "File not found"
 msgstr "Arquivo não encontrado"
 
-#: ../../src/wxMaxima.cpp:5631
+#: ../../src/MaximaFileIO.cpp:730
 #, fuzzy
 msgid "File opened"
 msgstr "Arquivo não encontrado"
 
-#: ../../src/wxMaximaFrame.cpp:1217
+#: ../../src/wxMaximaFrame.cpp:1251
 #, fuzzy
 msgid "File operations"
 msgstr "Arquivo não encontrado"
 
-#: ../../src/wxMaxima.cpp:10224 ../../src/wxMaxima.cpp:10267
+#: ../../src/wxMaxima.cpp:2994 ../../src/wxMaxima.cpp:3037
 msgid "File you tried to open does not exist."
 msgstr "O arquivo que você tentou abrir não existe."
 
-#: ../../src/wxMaximaFrame.cpp:1221
+#: ../../src/wxMaximaFrame.cpp:1255
 #, fuzzy
 msgid "File/directory functions"
 msgstr "Direção:"
 
-#: ../../src/wxMaxima.cpp:7027
+#: ../../src/wizards/CsvWiz.cpp:54 ../../src/wizards/CsvWiz.cpp:128
+msgid "Filename"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:3899
 msgid "Filename or a list of comma-separated file names"
 msgstr ""
 
-#: ../../src/ToolBar.cpp:222
+#: ../../src/sidebars/DrawSidebar.cpp:93
+msgid "Fill color"
+msgstr ""
+
+#: ../../src/ToolBar.cpp:401 ../../src/ToolBar.cpp:403
 msgid "Find"
 msgstr "Localizar"
 
-#: ../../src/wxMaximaFrame.cpp:670
+#: ../../src/wxMaximaFrame.cpp:707
 msgid "Find\tCtrl+F"
 msgstr "Localizar\tCtrl+F"
 
-#: ../../src/wxMaximaFrame.cpp:1468
+#: ../../src/wxMaximaFrame.cpp:1505
 msgid "Find &Limit..."
 msgstr "Encontrar &limite..."
 
-#: ../../src/wxMaximaFrame.cpp:1470
+#: ../../src/wxMaximaFrame.cpp:1507
 msgid "Find Minimum..."
 msgstr "Encontrar mínimo..."
 
-#: ../../src/Worksheet.cpp:1576
+#: ../../src/worksheet/WorksheetContextMenu.cpp:349
 msgid "Find Root..."
 msgstr "Encontrar raiz..."
 
-#: ../../src/wxMaximaFrame.cpp:1471
+#: ../../src/wxMaximaFrame.cpp:1508
 msgid "Find a (unconstrained) minimum of an expression"
 msgstr "Encontrar um mínimo (sem restrição) de uma expressão"
 
-#: ../../src/wxMaximaFrame.cpp:1804
+#: ../../src/wxMaximaFrame.cpp:1841
 msgid "Find a fraction that represents this float exactly"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1469
+#: ../../src/wxMaximaFrame.cpp:1506
 msgid "Find a limit of an expression"
 msgstr "Encontrar o limite de uma expressão"
 
-#: ../../src/wxMaximaFrame.cpp:1807
+#: ../../src/wxMaximaFrame.cpp:1844
 msgid "Find a nice fraction that is similar to this float"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1283
+#: ../../src/wxMaximaFrame.cpp:1317
 #, fuzzy
 msgid "Find a numerical solution for a first degree ODE"
 msgstr "Resolver problema de valor inicial para EDO de primeira ordem"
 
-#: ../../src/wxMaximaFrame.cpp:1252
+#: ../../src/wxMaximaFrame.cpp:1286
 msgid "Find a root of an equation on an interval"
 msgstr "Encontrar uma raíz de uma equação num intervalo"
 
-#: ../../src/wxMaximaFrame.cpp:1259
+#: ../../src/wxMaximaFrame.cpp:1293
 msgid "Find all roots of a polynomial"
 msgstr "Encontrar todas as raízes de um polinômio"
 
-#: ../../src/wxMaximaFrame.cpp:1262
+#: ../../src/wxMaximaFrame.cpp:1296
 msgid "Find all roots of a polynomial (bfloat)"
 msgstr "Encontrar todas as raízes de um polinômio (bfloat)"
 
-#: ../../src/wxMaxima.cpp:6589
+#: ../../src/MaximaCommandMenus.cpp:3103
 msgid "Find and Replace"
 msgstr "Localizar e substituir"
 
-#: ../../src/ToolBar.cpp:222 ../../src/wxMaximaFrame.cpp:670
+#: ../../src/ToolBar.cpp:401 ../../src/ToolBar.cpp:403
+#: ../../src/wxMaximaFrame.cpp:707
 msgid "Find and replace"
 msgstr "Localizar e substituir"
 
-#: ../../src/wxMaxima.cpp:7434
+#: ../../src/MaximaCommandMenus.cpp:4306
 msgid "Find char in string"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1172
+#: ../../src/wxMaximaFrame.cpp:1206
 msgid "Find char in string..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1534
+#: ../../src/wxMaximaFrame.cpp:1571
 msgid "Find common denominator"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1366
+#: ../../src/wxMaximaFrame.cpp:1400
 msgid "Find eigenvalues of a matrix"
 msgstr "Encontrar os autovalores de uma matriz"
 
-#: ../../src/wxMaximaFrame.cpp:1369
+#: ../../src/wxMaximaFrame.cpp:1403
 msgid "Find eigenvectors of a matrix"
 msgstr "Encontrar os autovetores de uma matriz"
 
-#: ../../src/wxMaxima.cpp:7424
+#: ../../src/MaximaCommandMenus.cpp:4296
 msgid "Find first difference"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1170
+#: ../../src/wxMaximaFrame.cpp:1204
 msgid "Find first difference..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1256
+#: ../../src/wxMaximaFrame.cpp:1290
 #, fuzzy
 msgid "Find fractions that real roots of a polynomial and "
 msgstr "Encontrar as raízes reais de um polinômio"
 
-#: ../../src/wxMaxima.cpp:9039
+#: ../../src/MaximaCommandMenus.cpp:293
 msgid "Find minimum"
 msgstr "Encontrar mínimo"
 
-#: ../../src/wxMaximaFrame.cpp:1251
+#: ../../src/wxMaximaFrame.cpp:1285
 msgid "Find numerical solution..."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:10035
+#: ../../src/MaximaCommandMenus.cpp:3524
 msgid "Find root (solve numerically)"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8062 ../../src/wxMaxima.cpp:8083
+#: ../../src/MaximaCommandMenus.cpp:1248 ../../src/MaximaCommandMenus.cpp:1271
 #, fuzzy
 msgid "Find the maximum absolute value of a matrix entry"
 msgstr "Encontrar os autovalores de uma matriz"
 
-#: ../../src/wxMaxima.cpp:8068 ../../src/wxMaxima.cpp:8089
+#: ../../src/MaximaCommandMenus.cpp:1254 ../../src/MaximaCommandMenus.cpp:1277
 msgid "Find the maximum sum of the absolute values of a matrix column"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8073 ../../src/wxMaxima.cpp:8094
+#: ../../src/MaximaCommandMenus.cpp:1259 ../../src/MaximaCommandMenus.cpp:1282
 msgid "Find the maximum sum of the absolute values of a matrix row"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1832
+#: ../../src/dialogs/FindReplacePane.cpp:46
+#, fuzzy
+msgid "Find:"
+msgstr "Localizar"
+
+#: ../../src/wxMaximaFrame.cpp:1869
 msgid "Fine-tune the display of engineering-format numbers"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1712
+#: ../../src/dialogs/ConfigDialogue.cpp:197
+#, fuzzy
+msgid "Finnish"
+msgstr "Dinamarquês"
+
+#: ../../src/wxMaximaFrame.cpp:1749
 msgid "First"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1918
+#: ../../src/wxMaximaFrame.cpp:1955
 msgid "Fitting curves to measurement data"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7227
+#: ../../src/dialogs/ConfigDialogue.cpp:1404
+#, c-format
+msgid "Fix reordered reference indices (of %i, %o) before saving"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:873
+msgid "Fixed font in text controls"
+msgstr "Fonte monoespaçada nos controles de texto"
+
+#: ../../src/MaximaCommandMenus.cpp:4099
 msgid "Flush stream"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1103
+#: ../../src/wxMaximaFrame.cpp:1137
 msgid "Flush..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:922
+#: ../../src/wxMaximaFrame.cpp:956
 #, fuzzy
 msgid "Fold All\tCtrl+Alt+["
 msgstr "Selecionar tudo\tCtrl+A"
 
-#: ../../src/wxMaximaFrame.cpp:923
+#: ../../src/wxMaximaFrame.cpp:957
 msgid "Fold all sections"
 msgstr ""
 
-#: ../../src/ToolBar.cpp:240
+#: ../../src/ToolBar.cpp:424 ../../src/ToolBar.cpp:432
 msgid "Follow"
 msgstr ""
 
-#: ../../src/ToolBar.cpp:285
+#: ../../src/dialogs/ConfigDialogue.cpp:2070
+msgid "Follow system"
+msgstr ""
+
+#: ../../src/wizards/DrawWiz.cpp:341
+msgid "Following plots use secondary x axis"
+msgstr ""
+
+#: ../../src/wizards/DrawWiz.cpp:347
+msgid "Following plots use secondary y axis"
+msgstr ""
+
+#: ../../src/sidebars/PerformanceSidebar.cpp:37
+msgid "Font cache hits:"
+msgstr ""
+
+#: ../../src/sidebars/PerformanceSidebar.cpp:38
+msgid "Font cache misses:"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:2047
+msgid "Fonts"
+msgstr "Fontes"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:442
+msgid "For each Text-, Sectioning or code cell wxMaxima can display a bracket showing the extend of the cell and allowing to fold it. This setting now tells if this bracket is to be printed, as well."
+msgstr ""
+
+#: ../../src/ToolBar.cpp:495
 msgid ""
 "For faster creation of cells the following shortcuts exist:\n"
 "\n"
@@ -3279,429 +4832,634 @@ msgid ""
 "   Ctrl+7: Heading6 cell\n"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7038
+#: ../../src/MaximaCommandMenus.cpp:3910
 msgid "For loop"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1062
+#: ../../src/wxMaximaFrame.cpp:1096
 msgid "For loop..."
 msgstr ""
 
-#: ../../src/Worksheet.cpp:237 ../../src/wxMaxima.cpp:11217
+#: ../../src/wizards/Plot2dWiz.cpp:69 ../../src/wizards/Plot3dWiz.cpp:60
+msgid "Format:"
+msgstr "Formato:"
+
+#: ../../src/worksheet/Worksheet.cpp:301 ../../src/wxMaxima.cpp:3523
 msgid "Forwarding the keyboard focus to a text control"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:11220
+#: ../../src/wxMaxima.cpp:3526
 msgid "Forwarding the keyboard focus to the worksheet"
 msgstr ""
 
-#: ../../src/MaximaManual.cpp:452
+#: ../../src/MaximaManual.cpp:469
 #, c-format
 msgid "Found %li anchors, URLs (individual files): %li, URLs (singlepage): %li"
 msgstr ""
 
-#: ../../src/MaximaManual.cpp:313
+#: ../../src/graphical_io/Printout.cpp:182
+#, c-format
+msgid "Found %li line breaks"
+msgstr ""
+
+#: ../../src/MaximaManual.cpp:326
 #, c-format
 msgid "Found only %li keywords in maxima's manual. Not caching them to disc."
 msgstr ""
 
-#: ../../src/MaximaManual.cpp:513
+#: ../../src/MaximaManual.cpp:530
 #, c-format
 msgid "Found the maxima HTML manual in the folder %s."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8948
+#: ../../src/MaximaCommandMenus.cpp:202
 msgid "Fourier coefficients"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1476
+#: ../../src/wxMaximaFrame.cpp:1513
 msgid "Fourier coefficients..."
 msgstr ""
 
-#: ../../src/ToolBar.cpp:137
+#: ../../src/ToolBar.cpp:132
 #, c-format
 msgid "Frame %li of %li"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:9097
+#: ../../src/wizards/DrawWiz.cpp:488
+msgid "Frame counter"
+msgstr ""
+
+#: ../../src/wizards/DrawWiz.cpp:499
+#, fuzzy
+msgid "Frame counter end"
+msgstr "Arquivo não encontrado"
+
+#: ../../src/wizards/DrawWiz.cpp:494
+msgid "Frame counter start"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:102
 msgid "Frame rate"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1005 ../../src/wxMaximaFrame.cpp:1009
+#: ../../src/wxMaximaFrame.cpp:1039 ../../src/wxMaximaFrame.cpp:1043
 msgid "Free all unused items now"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1413
+#: ../../src/dialogs/ConfigDialogue.cpp:198
+msgid "French"
+msgstr "Francês"
+
+#: ../../src/wxMaximaFrame.cpp:1447
 msgid "Frobenius Norm sqrt(sum((A(i,j))^2)) (complex)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1411
+#: ../../src/wxMaximaFrame.cpp:1445
 msgid "Frobenius Norm sqrt(sum((A(i,j))^2)) (real)"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:9064
+#: ../../src/MaximaCommandMenus.cpp:318 ../../src/wizards/IntegrateWiz.cpp:41
+#: ../../src/wizards/Plot2dWiz.cpp:48 ../../src/wizards/Plot2dWiz.cpp:58
+#: ../../src/wizards/Plot2dWiz.cpp:499 ../../src/wizards/Plot3dWiz.cpp:37
+#: ../../src/wizards/Plot3dWiz.cpp:46 ../../src/wizards/SumWiz.cpp:37
 msgid "From:"
 msgstr "De:"
 
-#: ../../src/wxMaximaFrame.cpp:827
+#: ../../src/wxMaximaFrame.cpp:864
 msgid "Full Screen\tAlt+Enter"
 msgstr "Tela cheia\tAlt+Enter"
 
-#: ../../src/wxMaximaFrame.cpp:824
+#: ../../src/wxMaximaFrame.cpp:861
 msgid "Full Screen\tF11"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7140
+#: ../../src/sidebars/PerformanceSidebar.cpp:48
+msgid "Full-window repaints:"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:4012
 #, fuzzy
 msgid "Function contents:"
 msgstr "Nomes de funções"
 
-#: ../../src/wxMaxima.cpp:7908
+#: ../../src/MaximaCommandMenus.cpp:1089
 #, fuzzy
 msgid "Function f(x):"
 msgstr "Função(ões):"
 
-#: ../../src/wxMaxima.cpp:8572
+#: ../../src/MaximaCommandMenus.cpp:1590
 #, fuzzy
 msgid "Function name"
 msgstr "Nomes de funções"
 
-#: ../../src/wxMaxima.cpp:7167
+#: ../../src/MaximaCommandMenus.cpp:4039
 #, fuzzy
 msgid "Function name(s):"
 msgstr "Nomes de funções"
 
-#: ../../src/wxMaxima.cpp:7135 ../../src/wxMaxima.cpp:7684
+#: ../../src/MaximaCommandMenus.cpp:4007 ../../src/MaximaCommandMenus.cpp:4556
 #, fuzzy
 msgid "Function name:"
 msgstr "Nomes de funções"
 
-#: ../../src/wxMaxima.cpp:8135
+#: ../../src/MaximaCommandMenus.cpp:1323
 msgid "Function:"
 msgstr "Função:"
 
-#: ../../src/wxMaximaFrame.cpp:1630
+#: ../../src/wxMaximaFrame.cpp:1667
 msgid "Functions for complex simplification"
 msgstr "Funções para simplificação complexa"
 
-#: ../../src/wxMaximaFrame.cpp:1588
+#: ../../src/wxMaximaFrame.cpp:1625
 msgid "Functions for simplifying factorials and gamma function"
 msgstr "Funções para simplificar fatoriais e a função gama"
 
-#: ../../src/wxMaximaFrame.cpp:1606
+#: ../../src/wxMaximaFrame.cpp:1643
 msgid "Functions for simplifying trigonometric expressions"
 msgstr "Funções para simplificar expressões trigonométricas"
 
-#: ../../src/wxMaxima.cpp:8965 ../../src/wxMaxima.cpp:8970
+#: ../../src/MaximaCommandMenus.cpp:219 ../../src/MaximaCommandMenus.cpp:224
 msgid "GCD"
 msgstr "MDC"
 
-#: ../../src/wxMaxima.cpp:10186
+#: ../../src/MaximaCommandMenus.cpp:3715
 msgid "GIF image (*.gif)|*.gif"
 msgstr "Imagem GIF (*.gif)|*.gif"
 
-#: ../../src/Worksheet.cpp:103
-msgid "GTK_IM_MODULE is set to \"xim\". Expect the program to hideously flicker and hotkeys to be broken, see for example https://trac.wxwidgets.org/ticket/18462."
+#: ../../src/MaximaCommandMenus.cpp:3615
+msgid "GIF image (*.gif)|*.gif|Portable anymap (*.pnm)|*.pnm|Tagged image file format (*.tif)|*.tif|X pixmap (*.xpm)|*.xpm"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:295
+#: ../../src/worksheet/Worksheet.cpp:117
+msgid "GTK_IM_MODULE is set to \"xim\". Expect the program to hideously flicker and hotkeys to be broken, see for example https://github.com/wxWidgets/wxWidgets/issues/18462."
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:199
+msgid "Galician"
+msgstr "Galego"
+
+#: ../../src/sidebars/GreekSidebar.cpp:180
+msgid "Gamma"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:316
 msgid "General Math"
 msgstr "Matemática Geral"
 
-#: ../../src/wxMaximaFrame.cpp:699
+#: ../../src/wxMaximaFrame.cpp:734
 msgid "General Math\tAlt+Shift+M"
 msgstr "Matemática Geral\tAlt+Shift+M"
 
-#: ../../src/wxMaximaFrame.cpp:1316
+#: ../../src/wxMaximaFrame.cpp:1350
 msgid "Generate Matrix from Expression..."
 msgstr "Gerar matriz da expressão..."
 
-#: ../../src/wxMaximaFrame.cpp:1317
+#: ../../src/wxMaximaFrame.cpp:1351
 msgid "Generate a matrix from a lambda expression"
 msgstr "Gerar uma matriz de uma expressão lambda"
 
-#: ../../src/wxMaximaFrame.cpp:1675
+#: ../../src/wxMaximaFrame.cpp:1712
 msgid "Generate a new list using a lists' elements"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1681
+#: ../../src/wxMaximaFrame.cpp:1718
 msgid "Generate a storage for variable values that can be introduced into equations at any time"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1672
+#: ../../src/wxMaximaFrame.cpp:1709
 msgid "Generate list elements using a rule"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8196
+#: ../../src/MaximaCommandMenus.cpp:1386
 #, fuzzy
 msgid "Generate matrix from a rule"
 msgstr "Criar lista de uma expressão"
 
-#: ../../src/wxMaximaFrame.cpp:1094
+#: ../../src/wxMaximaFrame.cpp:1128
 msgid "Generate unused symbol name"
 msgstr ""
 
-#: ../../src/WXMXformat.cpp:231
+#: ../../src/WXMXformat.cpp:232
 msgid "Generated the XML representation of the document"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8197
+#: ../../src/MaximaCommandMenus.cpp:1387
 msgid "Generates a matrix and fills each element with the result of the expression \"Rule\"."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1619
+#: ../../src/dialogs/ConfigDialogue.cpp:200
+msgid "Georgian"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:201
+msgid "German"
+msgstr "Alemão"
+
+#: ../../src/wxMaximaFrame.cpp:1656
 msgid "Get &Imaginary Part"
 msgstr "Obter parte &imaginária"
 
-#: ../../src/wxMaximaFrame.cpp:1485
+#: ../../src/wxMaximaFrame.cpp:1522
 msgid "Get Laplace transformation of an expression"
 msgstr "Obter transformada de Laplace de uma expressão"
 
-#: ../../src/wxMaximaFrame.cpp:1615
+#: ../../src/wxMaximaFrame.cpp:1652
 msgid "Get Real P&art"
 msgstr "Obter parte re&al"
 
-#: ../../src/wxMaximaFrame.cpp:1201
+#: ../../src/wxMaximaFrame.cpp:1235
 msgid "Get current directory"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1489
+#: ../../src/wxMaximaFrame.cpp:1526
 msgid "Get inverse Laplace transformation of an expression"
 msgstr "Obter transformada inversa de Laplace de uma expressão"
 
-#: ../../src/wxMaxima.cpp:7223
+#: ../../src/MaximaCommandMenus.cpp:4095
 msgid "Get position in stream"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1102
+#: ../../src/wxMaximaFrame.cpp:1136
 #, fuzzy
 msgid "Get position..."
 msgstr "Desvio..."
 
-#: ../../src/wxMaximaFrame.cpp:1620
+#: ../../src/wxMaximaFrame.cpp:1657
 msgid "Get the imaginary part of complex expression"
 msgstr "Obter a parte imaginária de uma expressão complexa"
 
-#: ../../src/wxMaximaFrame.cpp:1616
+#: ../../src/wxMaximaFrame.cpp:1653
 msgid "Get the real part of complex expression"
 msgstr "Obter a parte eral de uma expressão complexa"
 
-#: ../../src/wxMaxima.cpp:3609
+#: ../../src/MaximaProcessManager.cpp:1220
 #, c-format
 msgid "Gnuplot (command line) found at: %s"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3607
+#: ../../src/dialogs/ConfigDialogue.cpp:1629
+msgid "Gnuplot flavour"
+msgstr ""
+
+#: ../../src/MaximaProcessManager.cpp:1218
 #, c-format
 msgid "Gnuplot found at: %s"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2974
+#: ../../src/MaximaProcessManager.cpp:994
 msgid "Gnuplot has closed."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3598 ../../src/wxMaxima.cpp:3603
+#: ../../src/MaximaProcessManager.cpp:1209
+#: ../../src/MaximaProcessManager.cpp:1214
 #, c-format
 msgid "Gnuplot not found, using the default: %s"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:9428 ../../src/wxMaximaFrame.cpp:1887
+#: ../../src/MaximaProcessManager.cpp:1097
+#, c-format
+msgid ""
+"Gnuplot reported the following while preparing the popped-out plot:\n"
+"%s"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:2071 ../../src/wxMaximaFrame.cpp:1924
 msgid "Go to URL"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3989
+#: ../../src/MaximaResponseReader.cpp:396
 #, fuzzy
 msgid "Got a new input prompt!"
 msgstr "Inserir nova célula de entrada"
 
-#: ../../src/Worksheet.cpp:6354
+#: ../../src/worksheet/Worksheet.cpp:4306
 msgid "Got a request to undo an action that involves a delete which isn't possible at this moment."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1031
+#: ../../src/wxMaximaFrame.cpp:1065
 msgid "Gradefs"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1967
+#: ../../src/worksheet/WorksheetContextMenu.cpp:739
 #, fuzzy
 msgid "Greater or less than a value"
 msgstr "Célula de subseção"
 
-#: ../../src/wxMaximaFrame.cpp:1130
+#: ../../src/wxMaximaFrame.cpp:1164
 msgid "Greater, ignoring case?..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:260
+#: ../../src/dialogs/ConfigDialogue.cpp:202
+msgid "Greek"
+msgstr "Grego"
+
+#: ../../src/wxMaximaFrame.cpp:281
 #, fuzzy
 msgid "Greek Letters"
 msgstr "Constantes gregas"
 
-#: ../../src/wxMaximaFrame.cpp:703
+#: ../../src/wxMaximaFrame.cpp:738
 #, fuzzy
 msgid "Greek Letters\tAlt+Shift+G"
 msgstr "Matemática Geral\tAlt+Shift+M"
 
-#: ../../src/wxMaximaFrame.cpp:1815
+#: ../../src/sidebars/DrawSidebar.cpp:97
+msgid "Grid"
+msgstr ""
+
+#: ../../src/wizards/Plot3dWiz.cpp:52
+msgid "Grid:"
+msgstr "Grade:"
+
+#: ../../src/wxMaximaFrame.cpp:1852
 msgid "Guess an exact number that could be meant by this float"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:6123
+#: ../../src/dialogs/ConfigDialogue.cpp:1215
+msgid "HTML"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:2279
 #, fuzzy
 msgid "HTML file (*.html)|*.html|maxima batch file (*.mac)|*.mac|LaTeX file (*.tex)|*.tex"
 msgstr "Arquivo HTML (*.html)|*.html|Arquivo pdfLaTeX (*.tex)|*.tex|Todos|*"
 
-#: ../../src/wxMaximaFrame.cpp:1341
+#: ../../src/wxMaximaFrame.cpp:1375
 msgid "Hadamard (element-by-element) product..."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8004
+#: ../../src/MaximaCommandMenus.cpp:1188
 #, fuzzy
 msgid "Hadamard Product"
 msgstr "Produto"
 
-#: ../../src/wxMaxima.cpp:8011
+#: ../../src/MaximaCommandMenus.cpp:1195
 msgid "Hadamard exponent"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1345
+#: ../../src/wxMaximaFrame.cpp:1379
 #, fuzzy
 msgid "Hadamard exponent..."
 msgstr "Nome da matriz:"
 
-#: ../../src/MaximaManual.cpp:260
+#: ../../src/MaximaManual.cpp:269
 #, c-format
 msgid "Have only %li keyword anchors at the end of parsing the maxima manual => Not caching the result of using the built-in keyword list"
 msgstr ""
 
-#: ../../src/Configuration.cpp:88 ../../src/ToolBar.cpp:276
+#: ../../src/Styles.cpp:117 ../../src/ToolBar.cpp:486
+#: ../../src/sidebars/FormatSidebar.cpp:60
 msgid "Heading 5"
 msgstr ""
 
-#: ../../src/Configuration.cpp:87 ../../src/ToolBar.cpp:277
+#: ../../src/Styles.cpp:116 ../../src/ToolBar.cpp:487
+#: ../../src/sidebars/FormatSidebar.cpp:63
 msgid "Heading 6"
 msgstr ""
 
-#: ../../src/ToolBar.cpp:328 ../../src/wxMaximaFrame.cpp:330
+#: ../../src/dialogs/ConfigDialogue.cpp:203
+msgid "Hebrew"
+msgstr ""
+
+#: ../../src/ToolBar.cpp:544 ../../src/ToolBar.cpp:546
+#: ../../src/wxMaximaFrame.cpp:351
 msgid "Help"
 msgstr "Ajuda"
 
-#: ../../src/ToolBar.cpp:635
+#: ../../src/dialogs/ConfigDialogue.cpp:1461
+msgid "Help browser:"
+msgstr ""
+
+#: ../../src/ToolBar.cpp:835
 msgid "Help button"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1340 ../../src/Worksheet.cpp:1778
+#: ../../src/worksheet/WorksheetContextMenu.cpp:102
+#: ../../src/worksheet/WorksheetContextMenu.cpp:551
 #, c-format
 msgid "Help on \"%s\""
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:729
-#, fuzzy
-msgid "Hide All Toolbars\tAlt+Shift+-"
-msgstr "Esconder todos\tAlt+Shift+-"
+#: ../../src/wizards/GenWizPanel.cpp:248
+#, c-format
+msgid "Help on %s"
+msgstr ""
 
-#: ../../src/ToolBar.cpp:264
+#: ../../src/sidebars/TableOfContents.cpp:510
+#, fuzzy
+msgid "Hide"
+msgstr "Dividir célula"
+
+#: ../../src/ToolBar.cpp:471 ../../src/ToolBar.cpp:473
 #, fuzzy
 msgid "Hide Code"
 msgstr "Dividir célula"
 
-#: ../../src/wxMaximaFrame.cpp:727
+#: ../../src/wxMaximaFrame.cpp:764
 #, fuzzy
 msgid "Hide Code Cells\tAlt+Ctrl+H"
 msgstr "Inserir Célula\tAlt+Shift+C"
 
-#: ../../src/Worksheet.cpp:1896
+#: ../../src/worksheet/WorksheetContextMenu.cpp:668
 msgid "Hide Heading 5"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1907
+#: ../../src/worksheet/WorksheetContextMenu.cpp:679
 msgid "Hide Heading 6"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1855
+#: ../../src/worksheet/WorksheetContextMenu.cpp:627
 #, fuzzy
 msgid "Hide Part"
 msgstr "Dividir célula"
 
-#: ../../src/Worksheet.cpp:1863
+#: ../../src/worksheet/WorksheetContextMenu.cpp:635
 #, fuzzy
 msgid "Hide Section"
 msgstr "Seção"
 
-#: ../../src/Worksheet.cpp:1874
+#: ../../src/worksheet/WorksheetContextMenu.cpp:646
 #, fuzzy
 msgid "Hide Subsection"
 msgstr "Subseção"
 
-#: ../../src/Worksheet.cpp:1885
+#: ../../src/worksheet/WorksheetContextMenu.cpp:657
 #, fuzzy
 msgid "Hide Subsubsection"
 msgstr "Subseção"
 
-#: ../../src/wxMaximaFrame.cpp:730
+#: ../../src/wxMaximaFrame.cpp:766
+msgid "Hide all Sidebars\tAlt+Shift+-"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:487
+msgid "Hide all multiplication signs that aren't really necessary for understanding the equation"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:767
 msgid "Hide all panes"
 msgstr "Esconder todos os painéis"
 
-#: ../../src/Worksheet.cpp:1491
+#: ../../src/worksheet/WorksheetContextMenu.cpp:262
 #, fuzzy
 msgid "Hide cell brackets"
 msgstr "Marcador da célula ativa"
 
-#: ../../src/Worksheet.cpp:1915
+#: ../../src/worksheet/WorksheetContextMenu.cpp:687
 #, fuzzy
 msgid "Hide contents"
 msgstr "Constantes gregas"
 
-#: ../../src/Worksheet.cpp:1552
+#: ../../src/worksheet/WorksheetContextMenu.cpp:325
 msgid "Hide multiplication dots"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1930 ../../src/Worksheet.cpp:2063
+#: ../../src/dialogs/ConfigDialogue.cpp:854
+msgid "Hide multiplication signs, if possible"
+msgstr ""
+
+#: ../../src/wizards/DrawWiz.cpp:555
+msgid "Hide objects behind the surface"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:502
+msgid "Hide the brackets that mark the extend of the worksheet cells at the worksheet's right side and that contain the \"hide\" button of the cell if the cells aren't active."
+msgstr ""
+
+#: ../../src/worksheet/WorksheetContextMenu.cpp:702
+#: ../../src/worksheet/WorksheetContextMenu.cpp:835
 msgid "Hide yellow tooltip marker for this cell"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1937 ../../src/Worksheet.cpp:2069
+#: ../../src/worksheet/WorksheetContextMenu.cpp:709
+#: ../../src/worksheet/WorksheetContextMenu.cpp:841
 msgid "Hide yellow tooltip marker for this message type"
 msgstr ""
 
-#: ../../src/Configuration.cpp:82
+#: ../../src/Styles.cpp:111
 #, fuzzy
 msgid "Highlight (box)"
 msgstr "Destaque (dpart)"
 
-#: ../../src/wxMaxima.cpp:9528
+#: ../../src/dialogs/ConfigDialogue.cpp:869
+#, fuzzy
+msgid "Highlight the matching parenthesis"
+msgstr "Parêntesis aos pares nos controles de texto"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:463
+msgid "Highlight the opening or closing parenthesis for the parenthesis the cursor is at."
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:204
+msgid "Hindi"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:1766
 msgid "Histogram"
 msgstr "Histograma"
 
-#: ../../src/wxMaximaFrame.cpp:232
+#: ../../src/sidebars/StatSidebar.cpp:85
+msgid "Histogram..."
+msgstr "Histograma..."
+
+#: ../../src/wxMaximaFrame.cpp:246
 msgid "History"
 msgstr "Histórico"
 
-#: ../../src/wxMaximaFrame.cpp:709
+#: ../../src/wxMaximaFrame.cpp:744
 #, fuzzy
 msgid "History\tAlt+Shift+I"
 msgstr "Histórico\tAlt+Shift+H"
 
-#: ../../src/wxMaximaFrame.cpp:1526
+#: ../../src/dialogs/TipOfTheDay.cpp:105
+msgid "Horizontal cursor works like a normal cursor, but it operates on cells: press up or down arrow to move it, holding down Shift while moving will select cells, pressing backspace or delete twice will delete a cell next to it."
+msgstr "O cursor horizontal funciona como um cursor normal, mas ele opera em células: pressione as setas para cima ou para baixo para movê-lo; segure Shift enquanto move para selecionar células; pressione Backspace ou Delete duas vezes apaga a célula próxima ao cursor."
+
+#: ../../src/wxMaximaFrame.cpp:1563
 msgid "Horner's rule"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:9207
+#: ../../src/dialogs/ConfigDialogue.cpp:918
+msgid "Hotkeys for sending commands to maxima"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:398
 msgid "How many digits to show:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:759
+#: ../../src/wxMaximaFrame.cpp:796
 msgid "How to display new equations"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1113
+#: ../../src/dialogs/ConfigDialogue.cpp:205
+msgid "Hungarian"
+msgstr "Húngaro"
+
+#: ../../src/wxMaximaFrame.cpp:1147
 msgid "I/O"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7062
-msgid "If a program doesn't need local variables maxima allows to put the commands between parenthesis. The result of the last operation is the return value of the program."
+#: ../../src/sidebars/SymbolsSidebar.cpp:121
+msgid "Identical to"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7172
+#: ../../src/MaximaCommandMenus.cpp:3934
+msgid "If a program doesn't need local variables, Maxima allows putting the commands between parentheses. The result of the last operation is the return value of the program."
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:145
+msgid "If maxima versions compiled with different lisps are installed: The name of the lisp to use by default"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:174
+msgid "If maxima was compiled by GCL: Garbage Collect at minimum allocation past this heapsize"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:171
+msgid "If maxima was compiled by GCL: Minimum allocation fraction between Garbage Collects"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:168
+msgid "If maxima was compiled by GCL: Only garbage collect past this heapsize fraction of working mem"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:180
+msgid "If maxima was compiled by GCL: Share the allocated memory between gcl processes. Allows more than one gcl-compiled maxima to run at the same time, but might provoke crashes."
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:177
+msgid "If maxima was compiled by GCL: The fraction of the total installed RAM to reserve for maxima"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:375
+msgid "If multiple cells are evaluated in one go: Abort evaluation if wxMaxima detects that maxima has encountered any error."
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:727
+msgid "If not extremely long"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:726
+msgid "If not very long"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:418
+msgid "If numbers are getting longer than this number of digits they will be displayed abbreviated by an ellipsis."
+msgstr ""
+
+#: ../../src/dialogs/TipOfTheDay.cpp:181
+msgid "If the \"Autosave\" functionality is enabled in the configuration dialogue wxMaxima acts like mobile apps that backup the file every few minutes and save it on closing."
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:396
+msgid "If the font provides big parenthesis symbols: Use them when big parenthesis are needed for maths display."
+msgstr ""
+
+#: ../../src/cells/TextCell.cpp:327
+msgid "If the thing maxima complains about actually looks like a polynomial you can try running it through ratdisrep() in order to fix that problem."
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:4044
 msgid ""
 "If the type of a function parameter is known when compiling a function the code can vastly be optimized.\n"
 "Known types:\n"
@@ -3709,1280 +5467,2019 @@ msgid ""
 "array, boolean, integer, fixnum (machine-length integer), float (machine-size floating-point numbers), real or any (which is useful for declaring arrays of any)"
 msgstr ""
 
-#: ../../src/MathParser.cpp:890
+#: ../../src/dialogs/ConfigDialogue.cpp:399
+msgid "If this checkbox is checked wxMaxima automatically saves the file closing and every few minutes giving wxMaxima a more cellphone-app-like feel as the file is virtually always saved. If this checkbox is unchecked from time to time a backup is made in the temp folder instead."
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:378
+msgid "If this checkbox is set a new code cell is opened as soon as maxima requests data. If it isn't set a new code cell is opened in this case as soon as the user starts typing in code."
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:372
+msgid "If this checkbox isn't checked the current command is sent to maxima only on pressing Ctrl+Enter"
+msgstr ""
+
+#: ../../src/MathParser.cpp:945
 msgid "If this isn't a function returning a lambda() expression a multiplication sign (*) between closing and opening parenthesis is missing here."
 msgstr ""
 
-#: ../../src/MaximaManual.cpp:403
+#: ../../src/dialogs/ConfigDialogue.cpp:942
+msgid ""
+"If this option is enabled, the filename and path of images inserted with \"Cell\" -> \"Insert Image...\" is stored in the worksheet file on save. This enables reloading of the image file via the context menu after re-opening the worksheet, but storing the filenames and paths may be an undesired data leak. If this option is disabled, reloading still works as long as the worksheet is not closed.\n"
+"\n"
+"Note: Storing the filenames for the reload functionality is independent of the automatically generated image captions."
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:439
+msgid "If this option is set the .wxmx source of the current file is copied to a place a link to is put into the result of an export."
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1873
+msgid "If unset, Maxima's output is announced to the screen reader as maths in a linear text form. Set this option if your screen reader can speak MathML properly."
+msgstr ""
+
+#: ../../src/dialogs/TipOfTheDay.cpp:247
+msgid "If you have ideas, how to improve the design or functionality of wxMaxima, please share your ideas at the issue list or discussion forum at https://github.com/wxMaxima-developers/wxmaxima/."
+msgstr ""
+
+#: ../../src/dialogs/TipOfTheDay.cpp:76
+msgid "If you type an operator (one of +*/^=,) as the first symbol in an input cell, % will be automatically inserted before the operator, as on a graphing calculator. You can disable this feature from the 'Edit->Configure' dialog."
+msgstr ""
+
+#: ../../src/dialogs/TipOfTheDay.cpp:122
+msgid "If your calculation is taking too long to evaluate, you can try 'Maxima->Interrupt' or 'Maxima->Restart Maxima' menu commands."
+msgstr "Se seu cálculo está demorando de mais para executar, você pode tentar os menus 'Maxima->Interromper' ou 'Maxima->Reiniciar o Maxima'."
+
+#: ../../src/MaximaManual.cpp:420
 msgid "Ignoring the cache version for the manual anchors."
 msgstr ""
 
-#: ../../src/Image.cpp:79
+#: ../../src/sidebars/FormatSidebar.cpp:66
+msgid "Image"
+msgstr "Imagem"
+
+#: ../../src/Image.cpp:110
 msgid "Image data had zero length!"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:10147 ../../src/wxMaxima.cpp:10855
-msgid "Image files (*.png, *.jpg, *.bmp, *.xpm, *.gif, *.svg, *.svgz)|*.png;*.jpg;*.bmp;*.xpm;*.gif;*.svg;*.svgz"
+#: ../../src/MaximaCommandMenus.cpp:2564 ../../src/MaximaCommandMenus.cpp:2933
+#: ../../src/MaximaCommandMenus.cpp:3642
+msgid "Image files ("
 msgstr ""
 
-#: ../../src/Worksheet.cpp:5509
+#: ../../src/Image.cpp:74
+#, c-format
+msgid "Image of type %s found."
+msgstr ""
+
+#: ../../src/worksheet/WorksheetExport.cpp:1407
 msgid "ImageCell without image."
 msgstr ""
 
-#: ../../src/MathParser.cpp:347
+#: ../../src/sidebars/DrawSidebar.cpp:60
+msgid "Implicit Plot"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1028
+msgid "Import settings"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1013
+#, fuzzy
+msgid "Import+Export"
+msgstr "Exportar"
+
+#: ../../src/MathParser.cpp:395
 msgid "Importing compressed gnuplot sources for an animation"
 msgstr ""
 
-#: ../../src/MathParser.cpp:334
+#: ../../src/MathParser.cpp:382
 msgid "Importing uncompressed gnuplot sources for an animation"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7993
+#: ../../src/MaximaCommandMenus.cpp:1177
 msgid ""
 "In order to save memory the \":\" operator does clone the matrix, not copy it:\n"
 "If you change an element of one matrix the same element will change in all of its clones. copymatrix() instead generates a copy of a matrix: A new matrix that, if changed in any way, won't change the original."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7404
+#: ../../src/MaximaCommandMenus.cpp:4276
 msgid "In order to save memory the : operator doesn't create an individual copy of the string, but a clone that changes when the original string changes."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:9629
+#: ../../src/dialogs/TipOfTheDay.cpp:175
+msgid ""
+"In order to visualize how a parameter affects an equation wxMaxima provides commands that start with \"with_slider_\" and that create animations. One example would be:\n"
+"\n"
+"    with_slider_draw(\n"
+"        a,[-16,-9,-4,-2,0,1,2,3,4,5,6,7],\n"
+"        title=concat(\"a=\",a),\n"
+"        grid=true,\n"
+"        explicit(\n"
+"            x^2-a*x,\n"
+"            x,-10,10\n"
+"        )\n"
+"    );"
+msgstr ""
+
+#: ../../src/dialogs/TipOfTheDay.cpp:214
+msgid "In text cells bullet lists can be created by beginning a line with \" * \". The number of spaces in front of the \"*\" determines the indentation level; Indentation can be continued in the next line by indenting the line using spaces."
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:421
+msgid "In the LaTeX output: Put exponents after an eventual subscript instead of above it. Might increase readability for some fonts and short subscripts."
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:1869
 msgid "Include columns:"
 msgstr "Incluir colunas:"
 
-#: ../../src/Worksheet.cpp:2008
+#: ../../src/worksheet/WorksheetContextMenu.cpp:780
 msgid "Increasing function f(x)>x"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8470
+#: ../../src/dialogs/ConfigDialogue.cpp:884
+msgid "Incremental Search"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:844
+msgid "Indent equations by the label width"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:512
+msgid "Indent maths so all lines are in par with the first line that starts after the label."
+msgstr ""
+
+#: ../../src/sidebars/TableOfContents.cpp:583
+msgid "Indentation"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:1473
 msgid "Index End:"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8470
+#: ../../src/MaximaCommandMenus.cpp:1473
 msgid "Index Start:"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8471
+#: ../../src/MaximaCommandMenus.cpp:1474
 msgid "Index Step:"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8467 ../../src/wxMaxima.cpp:8480
+#: ../../src/MaximaCommandMenus.cpp:1470 ../../src/MaximaCommandMenus.cpp:1484
 #, fuzzy
 msgid "Index variable:"
 msgstr "Nova variável:"
 
-#: ../../src/wxMaximaFrame.cpp:1949
+#: ../../src/dialogs/ConfigDialogue.cpp:206
+msgid "Indonesian"
+msgstr ""
+
+#: ../../src/cells/TextCell.cpp:186
+msgid "Infinitesimal above zero."
+msgstr ""
+
+#: ../../src/cells/TextCell.cpp:188
+msgid "Infinitesimal below zero."
+msgstr ""
+
+#: ../../src/sidebars/SymbolsSidebar.cpp:91
+#: ../../src/wizards/IntegrateWiz.cpp:192
+#: ../../src/wizards/IntegrateWiz.cpp:200
+#: ../../src/wizards/IntegrateWiz.cpp:207
+#: ../../src/wizards/IntegrateWiz.cpp:215 ../../src/wizards/LimitWiz.cpp:132
+#: ../../src/wizards/LimitWiz.cpp:140
+msgid "Infinity"
+msgstr "Infinito"
+
+#: ../../src/wxMaximaFrame.cpp:1986
 msgid "Info about Maxima build"
 msgstr "Informações sobre a versão do maxima"
 
-#: ../../src/Worksheet.cpp:2046
+#: ../../src/worksheet/WorksheetContextMenu.cpp:818
 msgid "Inform maxima about facts you know for this symbol"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1988
+#: ../../src/worksheet/WorksheetContextMenu.cpp:760
 msgid "Inform maxima about the value of the function at a specific point, e.G. for declaring initial conditions"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7793 ../../src/wxMaxima.cpp:7804
+#: ../../src/MaximaCommandMenus.cpp:974 ../../src/MaximaCommandMenus.cpp:985
 #, fuzzy
 msgid "Initial Condition"
 msgstr "Condição:"
 
-#: ../../src/wxMaximaFrame.cpp:1270
+#: ../../src/wxMaximaFrame.cpp:1304
 msgid "Initial Value Problem (&1)..."
 msgstr "Problema de valor inicial (&1)..."
 
-#: ../../src/wxMaximaFrame.cpp:1274
+#: ../../src/wxMaximaFrame.cpp:1308
 msgid "Initial Value Problem (&2)..."
 msgstr "Problema de valor inicial (&2)..."
 
-#: ../../src/wxMaxima.cpp:9044
+#: ../../src/MaximaCommandMenus.cpp:298
 #, fuzzy
 msgid "Initial estimates:"
 msgstr "Estimativas iniciais:"
 
-#: ../../src/wxMaxima.cpp:7840
+#: ../../src/MaximaCommandMenus.cpp:1021
 #, fuzzy
 msgid "Initial x:"
 msgstr "Estimativas iniciais:"
 
-#: ../../src/Configuration.cpp:78
+#: ../../src/dialogs/FindReplacePane.cpp:107
+msgid "Input"
+msgstr ""
+
+#: ../../src/sidebars/RegexCtrl.cpp:38
+msgid ""
+"Input a RegEx here to filter the results.\n"
+"Right-click for options!"
+msgstr ""
+
+#: ../../src/Styles.cpp:107
 msgid "Input labels"
 msgstr "Rótulos de entrada"
 
-#: ../../src/wxMaximaFrame.cpp:314
+#: ../../src/sidebars/RegexCtrl.cpp:42
+msgid ""
+"Input your filter text here.\n"
+"Right-click for options!"
+msgstr ""
+
+#: ../../src/wizards/GenWizPanel.cpp:103 ../../src/wxMaximaFrame.cpp:335
 msgid "Insert"
 msgstr "Inserir"
 
-#: ../../src/wxMaximaFrame.cpp:905
+#: ../../src/dialogs/ConfigDialogue.cpp:889
+msgid "Insert % before an operator at the beginning of a cell"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:939
 msgid "Insert &Section Cell\tCtrl+3"
 msgstr "Inserir célula de &seleção\tCtrl+3"
 
-#: ../../src/wxMaximaFrame.cpp:901
+#: ../../src/wxMaximaFrame.cpp:935
 msgid "Insert &Text Cell\tCtrl+1"
 msgstr "Inserir célula de &texto\tCtrl+1"
 
-#: ../../src/wxMaximaFrame.cpp:713
+#: ../../src/wxMaximaFrame.cpp:748
 msgid "Insert Cell\tAlt+Shift+C"
 msgstr "Inserir Célula\tAlt+Shift+C"
 
-#: ../../src/Worksheet.cpp:1669
+#: ../../src/worksheet/WorksheetContextMenu.cpp:442
 msgid "Insert Heading5 Cell"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1671
+#: ../../src/worksheet/WorksheetContextMenu.cpp:444
 msgid "Insert Heading6 Cell"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:10854
+#: ../../src/MaximaCommandMenus.cpp:2563
 msgid "Insert Image"
 msgstr "Inserir imagem"
 
-#: ../../src/wxMaximaFrame.cpp:917
+#: ../../src/wxMaximaFrame.cpp:951
 msgid "Insert Image..."
 msgstr "Inserir imagem..."
 
-#: ../../src/wxMaximaFrame.cpp:899
+#: ../../src/wxMaximaFrame.cpp:933
 #, fuzzy
 msgid "Insert Input &Cell\tCtrl+0"
 msgstr "Nova &célula de entrada"
 
-#: ../../src/wxMaximaFrame.cpp:919
+#: ../../src/wxMaximaFrame.cpp:953
 msgid "Insert Page Break"
 msgstr "Inserir quebra de página"
 
-#: ../../src/wxMaximaFrame.cpp:907
+#: ../../src/wxMaximaFrame.cpp:941
 msgid "Insert S&ubsection Cell\tCtrl+4"
 msgstr "Inserir célula de s&ubseção\tCtrl+4"
 
-#: ../../src/wxMaximaFrame.cpp:910
+#: ../../src/wxMaximaFrame.cpp:944
 #, fuzzy
 msgid "Insert S&ubsubsection Cell\tCtrl+5"
 msgstr "Inserir célula de s&ubseção\tCtrl+4"
 
-#: ../../src/Worksheet.cpp:1662
+#: ../../src/worksheet/WorksheetContextMenu.cpp:435
 msgid "Insert Section Cell"
 msgstr "Inserir célula de seleção"
 
-#: ../../src/Worksheet.cpp:1664
+#: ../../src/worksheet/WorksheetContextMenu.cpp:437
 msgid "Insert Subsection Cell"
 msgstr "Inserir célula de subseção"
 
-#: ../../src/Worksheet.cpp:1667
+#: ../../src/worksheet/WorksheetContextMenu.cpp:440
 #, fuzzy
 msgid "Insert Subsubsection Cell"
 msgstr "Inserir célula de subseção"
 
-#: ../../src/wxMaximaFrame.cpp:903
+#: ../../src/wxMaximaFrame.cpp:937
 msgid "Insert T&itle Cell\tCtrl+2"
 msgstr "Inserir célula de tít&ulo\tCtrl+2"
 
-#: ../../src/Worksheet.cpp:1658
+#: ../../src/worksheet/WorksheetContextMenu.cpp:431
 msgid "Insert Text Cell"
 msgstr "Inserir célula de texto"
 
-#: ../../src/Worksheet.cpp:1660
+#: ../../src/worksheet/WorksheetContextMenu.cpp:433
 msgid "Insert Title Cell"
 msgstr "Inserir célula de título"
 
-#: ../../src/wxMaximaFrame.cpp:913
+#: ../../src/wxMaximaFrame.cpp:947
 msgid "Insert a new heading5 cell"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:915
+#: ../../src/wxMaximaFrame.cpp:949
 msgid "Insert a new heading6 cell"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:900
+#: ../../src/wxMaximaFrame.cpp:934
 msgid "Insert a new input cell"
 msgstr "Inserir nova célula de entrada"
 
-#: ../../src/wxMaximaFrame.cpp:906
+#: ../../src/wxMaximaFrame.cpp:940
 msgid "Insert a new section cell"
 msgstr "Inserir nova célula de seleção"
 
-#: ../../src/wxMaximaFrame.cpp:908
+#: ../../src/wxMaximaFrame.cpp:942
 msgid "Insert a new subsection cell"
 msgstr "Inserir nova célula de subseção"
 
-#: ../../src/wxMaximaFrame.cpp:911
+#: ../../src/wxMaximaFrame.cpp:945
 #, fuzzy
 msgid "Insert a new subsubsection cell"
 msgstr "Inserir nova célula de subseção"
 
-#: ../../src/wxMaximaFrame.cpp:902
+#: ../../src/wxMaximaFrame.cpp:936
 msgid "Insert a new text cell"
 msgstr "Inserir nova célula de texto"
 
-#: ../../src/wxMaximaFrame.cpp:904
+#: ../../src/wxMaximaFrame.cpp:938
 msgid "Insert a new title cell"
 msgstr "Inserir nova célula de título"
 
-#: ../../src/wxMaximaFrame.cpp:920
+#: ../../src/wxMaximaFrame.cpp:954
 msgid "Insert a page break"
 msgstr "Inserir uma quebra de página"
 
-#: ../../src/wxMaximaFrame.cpp:1164
+#: ../../src/MaximaCommandMenus.cpp:4261
+msgid "Insert a string into another"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1198
 #, fuzzy
 msgid "Insert char..."
 msgstr "Inserir imagem..."
 
-#: ../../src/wxMaximaFrame.cpp:912
+#: ../../src/wxMaximaFrame.cpp:946
 msgid "Insert heading5 Cell\tCtrl+6"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:914
+#: ../../src/wxMaximaFrame.cpp:948
 msgid "Insert heading6 Cell\tCtrl+7"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:917
+#: ../../src/wxMaximaFrame.cpp:951
 msgid "Insert image"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:916
+#: ../../src/wxMaximaFrame.cpp:950
 #, fuzzy
 msgid "Insert textbased cell"
 msgstr "Inserir célula de texto"
 
-#: ../../src/wxMaxima.cpp:3566
+#: ../../src/worksheet/Worksheet.cpp:6131
+msgid "Insertion point between cells"
+msgstr ""
+
+#: ../../src/sidebars/HelpBrowser.cpp:111
+msgid "Instantiating the HTML manual browser"
+msgstr ""
+
+#: ../../src/MaximaProcessManager.cpp:1177
 msgid "Instructed to prefer gnuplot over wgnuplot"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3554
+#: ../../src/MaximaProcessManager.cpp:1165
 msgid "Instructed to prefer wgnuplot over gnuplot"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8898 ../../src/wxMaxima.cpp:8919
+#: ../../src/dialogs/ConfigDialogue.cpp:749
+msgid "Integers and single letters"
+msgstr ""
+
+#: ../../src/sidebars/SymbolsSidebar.cpp:113
+#, fuzzy
+msgid "Integral sign"
+msgstr "Integrar expressão"
+
+#: ../../src/MaximaCommandMenus.cpp:149 ../../src/MaximaCommandMenus.cpp:170
 msgid "Integral/Sum:"
 msgstr "Integral/soma:"
 
-#: ../../src/wxMaxima.cpp:8986 ../../src/wxMaxima.cpp:10044
+#: ../../src/MaximaCommandMenus.cpp:240 ../../src/MaximaCommandMenus.cpp:3533
+#: ../../src/wizards/IntegrateWiz.cpp:73
 msgid "Integrate"
 msgstr "Integrar"
 
-#: ../../src/wxMaxima.cpp:8980
+#: ../../src/MaximaCommandMenus.cpp:234
 msgid "Integrate (risch)"
 msgstr "Integrar (risch)"
 
-#: ../../src/wxMaximaFrame.cpp:1454
+#: ../../src/wxMaximaFrame.cpp:1491
 msgid "Integrate expression"
 msgstr "Integrar expressão"
 
-#: ../../src/wxMaximaFrame.cpp:1456
+#: ../../src/wxMaximaFrame.cpp:1493
 msgid "Integrate expression with Risch algorithm"
 msgstr "Integrar expressão com o algoritmo Risch"
 
-#: ../../src/wxMaximaFrame.cpp:1869
-#, fuzzy
-msgid "Integrate numerically"
-msgstr "Integrar (risch)"
+#: ../../src/wxMaximaFrame.cpp:1906
+msgid "Integrate numerically (QUADPACK)"
+msgstr ""
 
-#: ../../src/Worksheet.cpp:1588
+#: ../../src/sidebars/MathSidebar.cpp:83
+#: ../../src/worksheet/WorksheetContextMenu.cpp:361
 msgid "Integrate..."
 msgstr "Integrar..."
 
-#: ../../src/wxMaximaFrame.cpp:1737
+#: ../../src/dialogs/ConfigDialogue.cpp:834
+#, fuzzy
+msgid "Intelligently hide cell brackets"
+msgstr "Marcador da célula ativa"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:881
+#, fuzzy
+msgid "Interaction"
+msgstr "Direção:"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1349
+msgid "Interactive popup memory limit [MB/plot]:"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1774
 #, fuzzy
 msgid "Interleave"
 msgstr "Integrar"
 
-#: ../../src/wxMaximaFrame.cpp:1738
+#: ../../src/wxMaximaFrame.cpp:1775
 #, fuzzy
 msgid "Interleave the values of two lists"
 msgstr "Integrar"
 
-#: ../../src/wxMaxima.cpp:8612
+#: ../../src/MaximaCommandMenus.cpp:1631
 #, fuzzy
 msgid "Interleave two lists"
 msgstr "Integrar"
 
-#: ../../src/wxMaximaFrame.cpp:1087
+#: ../../src/dialogs/ConfigDialogue.cpp:1465
+#, fuzzy
+msgid "Internal"
+msgstr "Integrar"
+
+#: ../../src/wxMaximaFrame.cpp:1121
 msgid "Interpret like input..."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7104
+#: ../../src/MaximaCommandMenus.cpp:3976
 msgid "Interpret maxima's output as input"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7502
+#: ../../src/MaximaCommandMenus.cpp:4374
 msgid "Interpret string as maxima code"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1089
+#: ../../src/wxMaximaFrame.cpp:1123
 #, fuzzy
 msgid "Interpret string..."
 msgstr "&Introduzir matriz..."
 
-#: ../../src/ToolBar.cpp:231
+#: ../../src/ToolBar.cpp:413 ../../src/ToolBar.cpp:419
 msgid "Interrupt"
 msgstr "Interromper"
 
-#: ../../src/wxMaximaFrame.cpp:965
+#: ../../src/wxMaximaFrame.cpp:999
 msgid "Interrupt current computation"
 msgstr "Interromper cálculo atual"
 
-#: ../../src/ToolBar.cpp:232
+#: ../../src/ToolBar.cpp:414 ../../src/ToolBar.cpp:420
 msgid "Interrupt current computation. To completely restart maxima press the button left to this one."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2766
+#: ../../src/MaximaProcessManager.cpp:876
 #, c-format
 msgid "Interrupting maxima: %s"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8557
+#: ../../src/MaximaCommandMenus.cpp:1570
 msgid "Introduce a list of actual values into an equation"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1697
+#: ../../src/wxMaximaFrame.cpp:1734
 msgid "Introduce the actual values for variables stored in the list"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:10062
+#: ../../src/MaximaCommandMenus.cpp:3551
 msgid "Introduces one or more assignments into an expression"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:9003
+#: ../../src/sidebars/RegexCtrl.cpp:40
+msgid "Invalid RegEx!"
+msgstr ""
+
+#: ../../src/MathParser.cpp:1338
+#, c-format
+msgid "Invalid XML: %s"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:257
 msgid "Inverse Laplace"
 msgstr "Inversa de Laplace"
 
-#: ../../src/wxMaximaFrame.cpp:1488
+#: ../../src/wxMaximaFrame.cpp:1525
 msgid "Inverse Laplace T&ransform..."
 msgstr "T&ransformada inversa de Laplace..."
 
-#: ../../src/wxMaximaFrame.cpp:832
-msgid "Invert worksheet brightness"
+#: ../../src/sidebars/GreekSidebar.cpp:186
+msgid "Iota"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7338
+#: ../../src/MaximaCommandMenus.cpp:4210
 msgid "Is Char 1 greater than Char2, if case is ignored?"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7333
+#: ../../src/MaximaCommandMenus.cpp:4205
 #, fuzzy
 msgid "Is Char 1 greater than Char2?"
 msgstr "Célula de subseção"
 
-#: ../../src/wxMaxima.cpp:7327
+#: ../../src/MaximaCommandMenus.cpp:4199
 msgid "Is Char 1 less than Char2, if case is ignored?"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7322
+#: ../../src/MaximaCommandMenus.cpp:4194
 msgid "Is Char 1 less than Char2?"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7280
+#: ../../src/MaximaCommandMenus.cpp:4152
 msgid "Is a char?"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1115
+#: ../../src/wxMaximaFrame.cpp:1149
 msgid "Is a char?..."
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1952
+#: ../../src/worksheet/WorksheetContextMenu.cpp:724
 #, fuzzy
 msgid "Is a complex variable"
 msgstr "Nova variável:"
 
-#: ../../src/wxMaxima.cpp:7292
+#: ../../src/MaximaCommandMenus.cpp:4164
 #, fuzzy
 msgid "Is a digit?"
 msgstr "Algoritmo de exibição"
 
-#: ../../src/wxMaximaFrame.cpp:1118
+#: ../../src/wxMaximaFrame.cpp:1152
 msgid "Is a digit?..."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7304
+#: ../../src/MaximaCommandMenus.cpp:4176
 msgid "Is a lowercase char?"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7296
+#: ../../src/MaximaCommandMenus.cpp:4168
 msgid "Is a printable char?"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1949
+#: ../../src/worksheet/WorksheetContextMenu.cpp:721
 #, fuzzy
 msgid "Is a real variable"
 msgstr "Mudar variável"
 
-#: ../../src/wxMaxima.cpp:7300
+#: ../../src/MaximaCommandMenus.cpp:4172
 msgid "Is a uppercase char?"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1116
+#: ../../src/wxMaximaFrame.cpp:1150
 msgid "Is alphabetic?..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1117
+#: ../../src/wxMaximaFrame.cpp:1151
 msgid "Is alphanumeric?..."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7284
+#: ../../src/MaximaCommandMenus.cpp:4156
 msgid "Is an alphabetic char?"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7288
+#: ../../src/MaximaCommandMenus.cpp:4160
 msgid "Is an alphanumeric char?"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1991
+#: ../../src/worksheet/WorksheetContextMenu.cpp:763
 #, fuzzy
 msgid "Is an even function"
 msgstr "Apagar uma função"
 
-#: ../../src/Worksheet.cpp:1955
+#: ../../src/worksheet/WorksheetContextMenu.cpp:727
 #, fuzzy
 msgid "Is an imaginary variable"
 msgstr "Mudar variável"
 
-#: ../../src/Worksheet.cpp:1960
+#: ../../src/worksheet/WorksheetContextMenu.cpp:732
 #, fuzzy
 msgid "Is an integer variable"
 msgstr "Mudar variável"
 
-#: ../../src/Worksheet.cpp:1993
+#: ../../src/worksheet/WorksheetContextMenu.cpp:765
 #, fuzzy
 msgid "Is an odd function"
 msgstr "Apagar uma função"
 
-#: ../../src/wxMaximaFrame.cpp:1122
+#: ../../src/wxMaximaFrame.cpp:1156
 msgid "Is equal?..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1128
+#: ../../src/wxMaximaFrame.cpp:1162
 #, fuzzy
 msgid "Is greater?..."
 msgstr "Criar lista"
 
-#: ../../src/wxMaximaFrame.cpp:1125
+#: ../../src/wxMaximaFrame.cpp:1159
 msgid "Is lower?..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1121
+#: ../../src/wxMaximaFrame.cpp:1155
 msgid "Is lowercase?..."
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1962
+#: ../../src/worksheet/WorksheetContextMenu.cpp:734
 #, fuzzy
 msgid "Is no integer variable"
 msgstr "Mudar variável"
 
-#: ../../src/wxMaximaFrame.cpp:1119
+#: ../../src/wxMaximaFrame.cpp:1153
 msgid "Is printable?..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1120
+#: ../../src/wxMaximaFrame.cpp:1154
 msgid "Is uppercase?..."
 msgstr ""
 
-#: ../../src/Worksheet.cpp:6256
+#: ../../src/dialogs/ConfigDialogue.cpp:498
+msgid "Issue a notification if maxima finishes calculating while the wxMaxima window isn't in focus."
+msgstr ""
+
+#: ../../src/worksheet/Worksheet.cpp:4247
 msgid "Issuing the active cell's undo function"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:6261
+#: ../../src/worksheet/Worksheet.cpp:4251
 msgid "Issuing the worksheet's undo function"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8598 ../../src/wxMaxima.cpp:8604
+#: ../../src/dialogs/TipOfTheDay.cpp:185
+msgid "It is possible to add custom symbols to the \"symbols\" sidebar by copying them into the respective field in the configuration dialogue."
+msgstr ""
+
+#: ../../src/dialogs/TipOfTheDay.cpp:152
+msgid "It is possible to define reusable Maxima libraries with wxMaxima that can be later loaded by using the load() function. All that has to be done is to export a file in the .mac or to save it in the .wxm format. Note, though, that a few special characters like the \"not equal\" symbol for \"#\" are handled by wxMaxima, not by Maxima and therefore cannot be recognized on load()."
+msgstr ""
+
+#: ../../src/wizards/DrawWiz.cpp:476
+msgid "It needs to be filled with objects to draw afterwards."
+msgstr ""
+
+#: ../../src/wizards/ActualValuesStorageWiz.cpp:38
+msgid "It therefore makes sense to apply the known values for variables as late as possible."
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:207
+msgid "Italian"
+msgstr "Italiano"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:2111
+msgid "Italic"
+msgstr "Itálico"
+
+#: ../../src/MaximaCommandMenus.cpp:1617 ../../src/MaximaCommandMenus.cpp:1623
 msgid "Item"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8581
+#: ../../src/MaximaCommandMenus.cpp:1599
 #, fuzzy
 msgid "Iterator name:"
 msgstr "Nome da matriz:"
 
-#: ../../src/wxMaximaFrame.cpp:1048
-msgid "Jump to first error"
+#: ../../src/dialogs/ConfigDialogue.cpp:208
+msgid "Japanese"
+msgstr "Japonês"
+
+#: ../../src/MaximaCommandMenus.cpp:2255
+msgid "Jump to UUID"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1049
-msgid "Jump to the first cell Maxima has reported an error in."
+#: ../../src/wxMaximaFrame.cpp:661
+msgid "Jump to UUID..."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8960
+#: ../../src/wxMaximaFrame.cpp:1082
+msgid "Jump to last error"
+msgstr ""
+
+#: ../../src/dialogs/DiffFrame.cpp:405
+msgid "Jump to next difference"
+msgstr ""
+
+#: ../../src/dialogs/DiffFrame.cpp:404
+msgid "Jump to previous difference"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1083
+msgid "Jump to the last cell Maxima has reported an error in."
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:210
+msgid "Kabyle"
+msgstr ""
+
+#: ../../src/sidebars/GreekSidebar.cpp:187
+msgid "Kappa"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:864
+#, c-format
+msgid "Keep percent sign with special symbols: %e, %i, etc."
+msgstr "Manter símbolo de percentual com símbolos especiais: %e, %i, etc."
+
+#: ../../src/dialogs/ConfigDialogue.cpp:212
+msgid "Korean"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:214
 msgid "LCM"
 msgstr "MMC"
 
-#: ../../src/wxMaximaFrame.cpp:1407
+#: ../../src/wxMaximaFrame.cpp:1441
 msgid "L[1] Norm (complex)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1406
+#: ../../src/wxMaximaFrame.cpp:1440
 msgid "L[1] Norm (real)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1409
+#: ../../src/wxMaximaFrame.cpp:1443
 msgid "L[inf] Norm (complex)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1408
+#: ../../src/wxMaximaFrame.cpp:1442
 msgid "L[inf] Norm (real)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1025
+#: ../../src/dialogs/ConfigDialogue.cpp:1166
+msgid "LaTeX"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1199
+msgid "LaTeX: Place exponents after, instead above subscripts"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1204
+msgid "LaTeX: Use the \"partial derivative\" symbol to represent diff()"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:758
+msgid "Label width:"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1059
 #, fuzzy
 msgid "Labels"
 msgstr "Rótulos de entrada"
 
-#: ../../src/wxMaxima.cpp:7090
+#: ../../src/MaximaCommandMenus.cpp:3962
+#: ../../src/sidebars/GreekSidebar.cpp:188
 msgid "Lambda"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7091
+#: ../../src/MaximaCommandMenus.cpp:3963
 msgid ""
 "Lambda generates a function, but doesn't give it a name.\n"
 "This is useful if you want to use a function only once, perhaps as a parameter to another function and don't need it to be named.\n"
 "Also you can fill a variable with a lambda() construct, effectively generating a function pointer: A variable that can be used as a function, and filled with a different function, if needed."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8997
+#: ../../src/dialogs/ConfigDialogue.cpp:470
+msgid "Language used for wxMaxima GUI."
+msgstr "Idioma usada para a interface do wxMaxima."
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1311
+msgid "Language:"
+msgstr "Idioma:"
+
+#: ../../src/MaximaCommandMenus.cpp:251
 msgid "Laplace"
 msgstr "Laplace"
 
-#: ../../src/wxMaximaFrame.cpp:1484
+#: ../../src/wxMaximaFrame.cpp:1521
 msgid "Laplace &Transform..."
 msgstr "&Transformada de Laplace..."
 
-#: ../../src/wxMaximaFrame.cpp:1718
+#: ../../src/wxMaximaFrame.cpp:1755
 msgid "Last"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3006
+#: ../../src/MaximaProcessManager.cpp:557
 #, c-format
 msgid "Last message from maxima's stderr: %s"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2993
+#: ../../src/MaximaProcessManager.cpp:544
 #, c-format
 msgid "Last message from maxima's stdout: %s"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1720
+#: ../../src/wxMaximaFrame.cpp:1757
 #, fuzzy
 msgid "Last n"
 msgstr "Lista:"
 
-#: ../../src/wxMaxima.cpp:10400
+#: ../../src/wxMaxima.cpp:3087
 msgid "Last non-whitespace is a question mark"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:4899
+#: ../../src/dialogs/ConfigDialogue.cpp:213
+msgid "Latvian"
+msgstr ""
+
+#: ../../src/wxMaxima.cpp:1675
 #, c-format
 msgid "Launching the system's default help browser as %s."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:4909
+#: ../../src/wxMaxima.cpp:1666 ../../src/wxMaxima.cpp:1687
 msgid "Launching the system's default help browser failed."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1493
+#: ../../src/sidebars/SymbolsSidebar.cpp:126
+msgid "Leads to"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1530
 msgid "Least Common Multiple..."
 msgstr "Mínimo múltiplo comum..."
 
-#: ../../src/wxMaxima.cpp:9587
+#: ../../src/MaximaCommandMenus.cpp:1827
 msgid "Least Squares Fit"
 msgstr "Mínimos quadrados"
 
-#: ../../src/wxMaxima.cpp:7982 ../../src/wxMaxima.cpp:7987
-#: ../../src/wxMaxima.cpp:8007 ../../src/wxMaxima.cpp:8013
+#: ../../src/sidebars/StatSidebar.cpp:79
+msgid "Least Squares Fit..."
+msgstr "Mínimos quadrados..."
+
+#: ../../src/dialogs/ConfigDialogue.cpp:2007
+msgid "Left"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:1166 ../../src/MaximaCommandMenus.cpp:1171
+#: ../../src/MaximaCommandMenus.cpp:1191 ../../src/MaximaCommandMenus.cpp:1197
 #, fuzzy
 msgid "Left Matrix:"
 msgstr "Abrir matriz"
 
-#: ../../src/wxMaxima.cpp:8191
+#: ../../src/MaximaCommandMenus.cpp:1381
 msgid "Left end"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1297
+#: ../../src/wxMaximaFrame.cpp:1331
 msgid "Left side to the \"=\""
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1741
+#: ../../src/wxMaximaFrame.cpp:1778
 msgid "Length"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1104 ../../src/wxMaximaFrame.cpp:1167
+#: ../../src/wxMaximaFrame.cpp:1138 ../../src/wxMaximaFrame.cpp:1201
 msgid "Length..."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7421
+#: ../../src/MaximaCommandMenus.cpp:4293
 msgid "Length:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1032
+#: ../../src/wxMaximaFrame.cpp:1066
 msgid "Letrules"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1976
+#: ../../src/dialogs/TipOfTheDay.cpp:163
+msgid "Libraries can be accessed by any wxMaxima process regardless of which directory it runs in, if they are placed in the user directory. This directory can be found by typing maxima_userdir;"
+msgstr ""
+
+#: ../../src/dialogs/LicenseDialog.cpp:63
+#: ../../src/dialogs/LicenseDialog.cpp:77
+msgid "License"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:2068
+msgid "Light"
+msgstr ""
+
+#: ../../src/worksheet/WorksheetContextMenu.cpp:748
 #, fuzzy
 msgid "Likely to be the main variable"
 msgstr "Apagar uma variável"
 
-#: ../../src/wxMaxima.cpp:9028
+#: ../../src/MaximaCommandMenus.cpp:282 ../../src/wizards/LimitWiz.cpp:64
 msgid "Limit"
 msgstr "Limite"
 
-#: ../../src/wxMaxima.cpp:7256
+#: ../../src/sidebars/MathSidebar.cpp:86
+msgid "Limit..."
+msgstr "Limite..."
+
+#: ../../src/sidebars/DrawSidebar.cpp:88
+msgid "Line color"
+msgstr ""
+
+#: ../../src/sidebars/StatSidebar.cpp:76
+msgid "Linear Regression..."
+msgstr "Regressão linear..."
+
+#: ../../src/MaximaCommandMenus.cpp:4128
 #, fuzzy
 msgid "Lisp format string:"
 msgstr "Questões do Maxima"
 
-#: ../../src/wxMaxima.cpp:7258
+#: ../../src/MaximaCommandMenus.cpp:4130
 msgid "Lisp format strings are more powerful than c++ format strings"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:5066
+#: ../../src/wxMaxima.cpp:1874
 msgid "Lisp mode."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1010 ../../src/wxMaximaFrame.cpp:1012
+#: ../../src/wxMaximaFrame.cpp:1044 ../../src/wxMaximaFrame.cpp:1046
 msgid "Lisp normally frees memory only when it has time or runs out of space"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3691
+#: ../../src/MaximaResponseReader.cpp:908
 #, c-format
 msgid "Lisp version: %s"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8435 ../../src/wxMaxima.cpp:8539
-#: ../../src/wxMaxima.cpp:8548 ../../src/wxMaxima.cpp:8565
-#: ../../src/wxMaxima.cpp:8574 ../../src/wxMaxima.cpp:8594
-#: ../../src/wxMaxima.cpp:8599 ../../src/wxMaxima.cpp:8603
+#: ../../src/MaximaCommandMenus.cpp:1432 ../../src/MaximaCommandMenus.cpp:1552
+#: ../../src/MaximaCommandMenus.cpp:1561 ../../src/MaximaCommandMenus.cpp:1583
+#: ../../src/MaximaCommandMenus.cpp:1592 ../../src/MaximaCommandMenus.cpp:1613
+#: ../../src/MaximaCommandMenus.cpp:1618 ../../src/MaximaCommandMenus.cpp:1622
 #, fuzzy
 msgid "List"
 msgstr "Lista:"
 
-#: ../../src/wxMaxima.cpp:8608 ../../src/wxMaxima.cpp:8613
+#: ../../src/MaximaCommandMenus.cpp:1627 ../../src/MaximaCommandMenus.cpp:1632
 #, fuzzy
 msgid "List #1"
 msgstr "Lista:"
 
-#: ../../src/wxMaxima.cpp:8609 ../../src/wxMaxima.cpp:8614
+#: ../../src/MaximaCommandMenus.cpp:1628 ../../src/MaximaCommandMenus.cpp:1633
 #, fuzzy
 msgid "List #2"
 msgstr "Lista:"
 
-#: ../../src/wxMaximaFrame.cpp:1200
+#: ../../src/wxMaximaFrame.cpp:1234
 msgid "List directory"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1205
+#: ../../src/wxMaximaFrame.cpp:1239
 msgid "List directory..."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7385 ../../src/wxMaxima.cpp:7389
+#: ../../src/wizards/ListSortWiz.cpp:34
+msgid "List name:"
+msgstr ""
+
+#: ../../src/sidebars/VariablesPane.cpp:188
+msgid "List of arrays"
+msgstr ""
+
+#: ../../src/sidebars/VariablesPane.cpp:191
+msgid "List of changed options"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:4257
 msgid "List of char to String"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1150
+#: ../../src/wxMaximaFrame.cpp:1184
 #, fuzzy
 msgid "List of chars to string..."
 msgstr "Expressão"
 
-#: ../../src/wxMaxima.cpp:7386
+#: ../../src/MaximaCommandMenus.cpp:4258
 #, fuzzy
 msgid "List of chars:"
 msgstr "Rótulos de entrada"
 
-#: ../../src/wxMaxima.cpp:8559
+#: ../../src/sidebars/VariablesPane.cpp:179
+msgid "List of functional dependencies"
+msgstr ""
+
+#: ../../src/sidebars/VariablesPane.cpp:203
+#, fuzzy
+msgid "List of labels"
+msgstr "Rótulos de entrada"
+
+#: ../../src/sidebars/VariablesPane.cpp:200
+msgid "List of structs"
+msgstr ""
+
+#: ../../src/sidebars/VariablesPane.cpp:197
+msgid "List of user aliases"
+msgstr ""
+
+#: ../../src/sidebars/VariablesPane.cpp:185
+msgid "List of user functions"
+msgstr ""
+
+#: ../../src/sidebars/VariablesPane.cpp:194
+msgid "List of user rules"
+msgstr ""
+
+#: ../../src/sidebars/VariablesPane.cpp:182
+msgid "List of user variables"
+msgstr ""
+
+#: ../../src/sidebars/VariablesPane.cpp:206
+msgid "List of user-defined derivatives"
+msgstr ""
+
+#: ../../src/sidebars/VariablesPane.cpp:216
+msgid "List of user-defined let rule packages"
+msgstr ""
+
+#: ../../src/sidebars/VariablesPane.cpp:212
+msgid "List of user-defined macros"
+msgstr ""
+
+#: ../../src/sidebars/VariablesPane.cpp:209
+msgid "List of user-defined properties"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:1575
 msgid "List with values"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8509 ../../src/wxMaxima.cpp:8527
-#: ../../src/wxMaxima.cpp:8533 ../../src/wxMaxima.cpp:8579
+#: ../../src/MaximaCommandMenus.cpp:1451 ../../src/MaximaCommandMenus.cpp:1510
+#: ../../src/MaximaCommandMenus.cpp:1515 ../../src/MaximaCommandMenus.cpp:1520
+#: ../../src/MaximaCommandMenus.cpp:1524 ../../src/MaximaCommandMenus.cpp:1528
+#: ../../src/MaximaCommandMenus.cpp:1532 ../../src/MaximaCommandMenus.cpp:1538
+#: ../../src/MaximaCommandMenus.cpp:1544 ../../src/MaximaCommandMenus.cpp:1597
+#: ../../src/MaximaCommandMenus.cpp:1608
 msgid "List:"
 msgstr "Lista:"
 
-#: ../../src/wxMaxima.cpp:6200
+#: ../../src/dialogs/ConfigDialogue.cpp:214
+msgid "Lithuanian"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:2162
+msgid "Load"
+msgstr "Carregar"
+
+#: ../../src/MaximaCommandMenus.cpp:2356
 msgid "Load Package"
 msgstr "Carregar pacote"
 
-#: ../../src/wxMaximaFrame.cpp:613
+#: ../../src/wxMaximaFrame.cpp:644
 #, fuzzy
 msgid "Load Recent Package"
 msgstr "Carregar pacote"
 
-#: ../../src/wxMaximaFrame.cpp:616
+#: ../../src/wxMaximaFrame.cpp:647
 msgid "Load a Maxima file using the batch command"
 msgstr "Carregar um arquivo do Maxima usando o comando batch"
 
-#: ../../src/wxMaximaFrame.cpp:611
+#: ../../src/wxMaximaFrame.cpp:642
 msgid "Load a Maxima package file"
 msgstr "Carregar um arquivo de pacote Maxima"
 
-#: ../../src/wxMaximaFrame.cpp:1678
-#, fuzzy
-msgid "Load a list from a csv file"
-msgstr "Carregar um arquivo de pacote Maxima"
-
-#: ../../src/wxMaximaFrame.cpp:1324 ../../src/wxMaximaFrame.cpp:1330
+#: ../../src/wxMaximaFrame.cpp:1358 ../../src/wxMaximaFrame.cpp:1364
 #, fuzzy
 msgid "Load a matrix from a csv file"
 msgstr "Carregar um arquivo de pacote Maxima"
 
-#: ../../src/wxMaximaFrame.cpp:1381 ../../src/wxMaximaFrame.cpp:1382
+#: ../../src/wxMaximaFrame.cpp:1715
+msgid "Load a nested list from a csv file"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1415 ../../src/wxMaximaFrame.cpp:1416
 #, fuzzy
 msgid "Load lapack"
 msgstr "Carregar pacote"
 
-#: ../../src/wxMaxima.cpp:7208
+#: ../../src/MaximaCommandMenus.cpp:4080
 #, fuzzy
 msgid "Load lisp code"
 msgstr "Carregar pacote"
 
-#: ../../src/wxMaximaFrame.cpp:1092
+#: ../../src/wxMaximaFrame.cpp:1126
 #, fuzzy
 msgid "Load lisp..."
 msgstr "Carregar pacote"
 
-#: ../../src/wxMaximaFrame.cpp:1198
+#: ../../src/dialogs/ConfigDialogue.cpp:2645
+msgid "Load style from file"
+msgstr "Ler estilo de um arquivo"
+
+#: ../../src/wxMaximaFrame.cpp:1232
 msgid "Load the file/dir operations (operatingsystem)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1187
+#: ../../src/wxMaximaFrame.cpp:1221
 msgid "Load the regular expression package (sregex)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1224
+#: ../../src/wxMaximaFrame.cpp:1258
 msgid "Load the translation generator (gentran)"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8219
+#: ../../src/sidebars/SymbolsSidebar.cpp:128
+msgid "Long Right arrow"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:1409
 #, fuzzy
 msgid "Loop variable"
 msgstr "Nova variável:"
 
-#: ../../src/wxMaxima.cpp:7778 ../../src/wxMaxima.cpp:10040
+#: ../../src/MaximaCommandMenus.cpp:959 ../../src/MaximaCommandMenus.cpp:3529
 msgid "Lower bound:"
 msgstr "Limite inferior:"
 
-#: ../../src/wxMaximaFrame.cpp:1127
+#: ../../src/wxMaximaFrame.cpp:1161
 msgid "Lower, ignoring case?..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1448
+#: ../../src/wxMaximaFrame.cpp:1485
 #, fuzzy
 msgid "M&atrix"
 msgstr "Matriz"
 
-#: ../../src/wxMaxima.cpp:7153
+#: ../../src/sidebars/XmlInspector.cpp:104
+msgid "MAXIMA RESPONSE:"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:4025
 #, fuzzy
 msgid "Macro contents:"
 msgstr "Constantes gregas"
 
-#: ../../src/wxMaxima.cpp:7148
+#: ../../src/MaximaCommandMenus.cpp:4020
 #, fuzzy
 msgid "Macro name:"
 msgstr "Nome da matriz:"
 
-#: ../../src/wxMaximaFrame.cpp:1024
+#: ../../src/wxMaximaFrame.cpp:1058
 msgid "Macros"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:697
-#, fuzzy
-msgid "Main Toolbar\tAlt+Shift+B"
-msgstr "Barra de ferramentas\tAlt+Shift+T"
+#: ../../src/wxMaximaFrame.cpp:869
+msgid "Main Toolbar\tShift+Alt+B"
+msgstr ""
 
-#: ../../src/wxMaxima.cpp:7906
+#: ../../src/MaximaCommandMenus.cpp:1087
 msgid "Make a function value at a specific point known"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:2028
+#: ../../src/worksheet/WorksheetContextMenu.cpp:800
 msgid "Make an eventual ev() evaluate this"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1070
+#: ../../src/wxMaximaFrame.cpp:1104
 #, fuzzy
 msgid "Make function local..."
 msgstr "Mapear função a uma lista"
 
-#: ../../src/wxMaxima.cpp:8207
+#: ../../src/dialogs/ConfigDialogue.cpp:215
+msgid "Malay"
+msgstr ""
+
+#: ../../src/sidebars/PerformanceSidebar.cpp:33
+msgid "Manual anchors (built-in):"
+msgstr ""
+
+#: ../../src/sidebars/PerformanceSidebar.cpp:34
+msgid "Manual anchors (cache):"
+msgstr ""
+
+#: ../../src/sidebars/PerformanceSidebar.cpp:35
+msgid "Manual anchors (compiled):"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:1397
 msgid "Map"
 msgstr "Mapear"
 
-#: ../../src/wxMaxima.cpp:8215
+#: ../../src/MaximaCommandMenus.cpp:1405
 #, fuzzy
 msgid "Map an expression"
 msgstr "Expandir uma expressão"
 
-#: ../../src/wxMaximaFrame.cpp:1443
+#: ../../src/wxMaximaFrame.cpp:1480
 msgid "Map function to a matrix"
 msgstr "Mapear função a uma matriz"
 
-#: ../../src/wxMaximaFrame.cpp:1446
+#: ../../src/wxMaximaFrame.cpp:1483
 #, fuzzy
 msgid "Map function to a matrix, affecting all of its clones"
 msgstr "Mapear função a uma matriz"
 
-#: ../../src/Configuration.cpp:109
+#: ../../src/dialogs/FindReplacePane.cpp:71
+#, fuzzy
+msgid "Match Case"
+msgstr "Arquivo batch (de lote)"
+
+#: ../../src/Styles.cpp:139
 #, fuzzy
 msgid "Math Default"
 msgstr "Padrão"
 
-#: ../../src/wxMaximaFrame.cpp:286
+#: ../../src/dialogs/ConfigDialogue.cpp:789
+msgid "Math layout strategy"
+msgstr ""
+
+#: ../../src/cells/Cell.cpp:1490
+msgid "Math output"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1221
+msgid "MathML (rendered by the browser)"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1222
+msgid "MathML + MathJaX fall-back for old browsers"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1906
+msgid "MathML as HTML"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1902
+msgid "MathML description"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:307
 msgid "Mathematical Symbols"
 msgstr ""
 
-#: ../../src/ToolBar.cpp:270
+#: ../../src/ToolBar.cpp:480
 msgid "Maths"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7945 ../../src/wxMaxima.cpp:8022
-#: ../../src/wxMaxima.cpp:8027 ../../src/wxMaxima.cpp:8032
-#: ../../src/wxMaxima.cpp:8037 ../../src/wxMaxima.cpp:8041
-#: ../../src/wxMaxima.cpp:8053 ../../src/wxMaxima.cpp:8059
-#: ../../src/wxMaxima.cpp:8064 ../../src/wxMaxima.cpp:8069
-#: ../../src/wxMaxima.cpp:8075 ../../src/wxMaxima.cpp:8080
-#: ../../src/wxMaxima.cpp:8085 ../../src/wxMaxima.cpp:8090
-#: ../../src/wxMaxima.cpp:8096 ../../src/wxMaxima.cpp:8101
-#: ../../src/wxMaxima.cpp:8152 ../../src/wxMaxima.cpp:8182
+#: ../../src/MaximaCommandMenus.cpp:1125 ../../src/MaximaCommandMenus.cpp:1206
+#: ../../src/MaximaCommandMenus.cpp:1211 ../../src/MaximaCommandMenus.cpp:1216
+#: ../../src/MaximaCommandMenus.cpp:1221 ../../src/MaximaCommandMenus.cpp:1225
+#: ../../src/MaximaCommandMenus.cpp:1239 ../../src/MaximaCommandMenus.cpp:1245
+#: ../../src/MaximaCommandMenus.cpp:1250 ../../src/MaximaCommandMenus.cpp:1255
+#: ../../src/MaximaCommandMenus.cpp:1261 ../../src/MaximaCommandMenus.cpp:1266
+#: ../../src/MaximaCommandMenus.cpp:1273 ../../src/MaximaCommandMenus.cpp:1278
+#: ../../src/MaximaCommandMenus.cpp:1284 ../../src/MaximaCommandMenus.cpp:1289
+#: ../../src/MaximaCommandMenus.cpp:1340 ../../src/MaximaCommandMenus.cpp:1370
 msgid "Matrix"
 msgstr "Matriz"
 
-#: ../../src/wxMaxima.cpp:7986
+#: ../../src/MaximaCommandMenus.cpp:1170
 #, fuzzy
 msgid "Matrix Exponent"
 msgstr "Nome da matriz:"
 
-#: ../../src/wxMaximaFrame.cpp:1339
+#: ../../src/wxMaximaFrame.cpp:1373
 #, fuzzy
 msgid "Matrix exponent..."
 msgstr "Nome da matriz:"
 
-#: ../../src/wxMaximaFrame.cpp:1329
+#: ../../src/wxMaximaFrame.cpp:1363
 #, fuzzy
 msgid "Matrix from csv file"
 msgstr "Ler estilo de um arquivo"
 
-#: ../../src/wxMaximaFrame.cpp:1323
+#: ../../src/wxMaximaFrame.cpp:1357
 #, fuzzy
 msgid "Matrix from csv file..."
 msgstr "Ler estilo de um arquivo"
 
-#: ../../src/wxMaxima.cpp:8137
+#: ../../src/MaximaCommandMenus.cpp:1325
 msgid "Matrix map"
 msgstr "Mapear a matriz"
 
-#: ../../src/wxMaxima.cpp:9630
+#: ../../src/MaximaCommandMenus.cpp:1870
 msgid "Matrix name:"
 msgstr "Nome da matriz:"
 
-#: ../../src/wxMaximaFrame.cpp:798
+#: ../../src/wxMaximaFrame.cpp:835
 #, fuzzy
 msgid "Matrix parenthesis"
 msgstr "Parêntesis aos pares nos controles de texto"
 
-#: ../../src/wxMaximaFrame.cpp:1331
+#: ../../src/wxMaximaFrame.cpp:1365
 #, fuzzy
 msgid "Matrix to csv file"
 msgstr "Ler estilo de um arquivo"
 
-#: ../../src/wxMaximaFrame.cpp:1334
+#: ../../src/wxMaximaFrame.cpp:1368
 msgid "Matrix to file or Matrix from file"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1761
+#: ../../src/wxMaximaFrame.cpp:1798
 msgid "Matrix to nested List"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7956 ../../src/wxMaxima.cpp:7961
-#: ../../src/wxMaxima.cpp:7966 ../../src/wxMaxima.cpp:7971
-#: ../../src/wxMaxima.cpp:7976 ../../src/wxMaxima.cpp:8000
-#: ../../src/wxMaxima.cpp:8136
+#: ../../src/MaximaCommandMenus.cpp:1456
+msgid "Matrix to nested list"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:1136 ../../src/MaximaCommandMenus.cpp:1141
+#: ../../src/MaximaCommandMenus.cpp:1146 ../../src/MaximaCommandMenus.cpp:1151
+#: ../../src/MaximaCommandMenus.cpp:1156 ../../src/MaximaCommandMenus.cpp:1161
+#: ../../src/MaximaCommandMenus.cpp:1184 ../../src/MaximaCommandMenus.cpp:1324
+#: ../../src/MaximaCommandMenus.cpp:1457
 msgid "Matrix:"
 msgstr "Matriz:"
 
-#: ../../src/wxMaxima.cpp:8627
-msgid ""
-"Maxima allows to make functions \"nouns\", which means that they aren't automatically evaluated as soon as maxima encounters them.\n"
-"Ways make a function a noun include declaring it a noun, preceding it with a  ' or putting it between the parenthesis of '().\n"
-"\n"
-"This command tells maxima that the nouns in this expression shall now be evaluated, too."
+#: ../../src/dialogs/ConfigDialogue.cpp:1370
+msgid "Max. layout time [s] (0=no limit)"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3473
+#: ../../src/dialogs/ConfigDialogue.cpp:281
+msgid "Maxima"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1433
+#, fuzzy
+msgid "Maxima Location"
+msgstr "Questões do Maxima"
+
+#: ../../src/MaximaCommandMenus.cpp:619
+msgid ""
+"Maxima allows making functions \"nouns\", which means that they aren't automatically evaluated as soon as Maxima encounters them.\n"
+"Ways to make a function a noun include declaring it a noun, preceding it with a single quote or putting it between the parentheses of '().\n"
+"\n"
+"This command tells Maxima that the nouns in this expression shall now be evaluated, too."
+msgstr ""
+
+#: ../../src/MaximaResponseReader.cpp:803
 #, c-format
 msgid "Maxima architecture: %s"
 msgstr ""
 
-#: ../../src/StatusBar.cpp:252
+#: ../../src/StatusBar.cpp:330
 #, fuzzy
 msgid "Maxima asks a question"
 msgstr "Questões do Maxima"
 
-#: ../../src/wxMaxima.cpp:4066
+#: ../../src/MaximaResponseReader.cpp:560
 #, fuzzy
 msgid "Maxima asks a question!"
 msgstr "Questões do Maxima"
 
-#: ../../src/wxMaxima.cpp:7118
+#: ../../src/dialogs/ConfigDialogue.cpp:362
+#, c-format
+msgid "Maxima assigns each command/equation an automatic label (which looks like %i1 or %o1). If a command begins with a descriptive name followed by a : wxMaxima will call the descriptive name a \"user-defined label\" instead. This selection now allows telling wxMaxima whether to show only automatic labels, automatic labels if there aren't user-defined ones or no label at all until a user-defined label can be found by wxMaxima's heuristics. If automatic labels are suppressed extra vertical space is added between equations in order to ease discerning which line starts a new equation and which one only continues the one from the last line."
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:3990
 msgid ""
 "Maxima automatically simplifies expressions it gets as input and then tries to evaluate their value. The ' operator tells maxima that we want a command to be in noun form, which means: stand here as is, and unevaluated.\n"
 "The ' operator can be undone by using the '' operator."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3304
+#: ../../src/cells/EditorCell.cpp:4516
+msgid "Maxima code"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1110
+msgid "Maxima commands to be executed at every start of Maxima"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1063
+msgid "Maxima commands to be executed every time wxMaxima starts Maxima"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1507
+#, fuzzy
+msgid "Maxima configuration"
+msgstr "Configuração do wxMaxima"
+
+#: ../../src/MaximaResponseReader.cpp:346
 msgid "Maxima didn't attempt to authenticate!"
 msgstr ""
 
-#: ../../src/Configuration.cpp:84
+#: ../../src/Styles.cpp:113
 msgid "Maxima errors"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3289
+#: ../../src/MaximaResponseReader.cpp:338
 #, fuzzy
 msgid "Maxima has authenticated!"
 msgstr "Maxima terminado."
 
-#: ../../src/wxMaxima.cpp:10533
+#: ../../src/MaximaEvaluator.cpp:369
 #, fuzzy
 msgid "Maxima has finished calculating."
 msgstr "Maxima está calculando"
 
-#: ../../src/wxMaxima.cpp:5832
+#: ../../src/MaximaEvaluator.cpp:191
 #, fuzzy
 msgid "Maxima has issued an error!"
 msgstr "Questões do Maxima"
 
-#: ../../src/wxMaxima.cpp:3696
+#: ../../src/MaximaResponseReader.cpp:913
 #, c-format
 msgid "Maxima has loaded the file %s."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3382
+#: ../../src/MaximaResponseReader.cpp:761
 msgid "Maxima has sent a new variable value."
 msgstr ""
 
-#: ../../src/MaximaManual.cpp:552
+#: ../../src/StatusBar.cpp:349
+msgid ""
+"Maxima has stopped in a debugger and is waiting for a command.\n"
+"Common commands (type ':h' for the full list):\n"
+"  :bt        show a backtrace of the call stack\n"
+"  :continue  continue the computation\n"
+"  :top       return to the top level (abandon the computation)\n"
+"  :next / :step   step to the next line\n"
+"  :frame     show the current stack frame"
+msgstr ""
+
+#: ../../src/MaximaManual.cpp:576
 #, fuzzy
 msgid "Maxima help file not found!"
 msgstr "Arquivo não encontrado"
 
-#: ../../src/wxMaximaFrame.cpp:1043
+#: ../../src/wxMaximaFrame.cpp:1077
 msgid "Maxima input"
 msgstr "Entrada do Maxima"
 
-#: ../../src/StatusBar.cpp:236
+#: ../../src/StatusBar.cpp:299
 msgid "Maxima is calculating"
 msgstr "Maxima está calculando"
 
-#: ../../src/wxMaxima.cpp:5068
+#: ../../src/wxMaxima.cpp:1876
 #, fuzzy
 msgid "Maxima is ready for input."
 msgstr "Entrada do Maxima"
 
-#: ../../src/Dirstructure.cpp:144
+#: ../../src/Dirstructure.cpp:153
 #, c-format
 msgid "Maxima not found as %s"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:6211
+#: ../../src/MaximaCommandMenus.cpp:2367
 msgid "Maxima package (*.mac)|*.mac"
 msgstr "Pacote Maxima (*.mac)|*.mac"
 
-#: ../../src/wxMaxima.cpp:6202
+#: ../../src/MaximaCommandMenus.cpp:2358
 msgid "Maxima package (*.mac)|*.mac|Lisp package (*.lisp)|*.lisp|All|*"
 msgstr "Pacote Maxima (*.mac)|*.mac|Pacote Lisp (*.lisp)|*.lisp|Todos|*"
 
-#: ../../src/wxMaxima.cpp:3012
+#: ../../src/MaximaProcessManager.cpp:569
 msgid "Maxima process terminated unexpectedly."
 msgstr ""
 
-#: ../../src/Configuration.cpp:79
+#: ../../src/dialogs/ConfigDialogue.cpp:1437
+msgid "Maxima program:"
+msgstr "Programa Maxima:"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:382
+msgid "Maxima provides no \"forget all\" command that flushes all settings a maxima session could make. wxMaxima therefore normally defaults to starting a fresh maxima process every time the worksheet is to be re-evaluated. As this needs a little bit of time this switch allows to disable this behavior."
+msgstr ""
+
+#: ../../src/Styles.cpp:108
 #, fuzzy
 msgid "Maxima question labels"
 msgstr "Questões do Maxima"
 
-#: ../../src/wxMaxima.cpp:3380
+#: ../../src/StatusBar.cpp:339
+msgid "Maxima returned an error message"
+msgstr ""
+
+#: ../../src/MaximaResponseReader.cpp:759
 msgid "Maxima sends a new set of auto-completable symbols."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3908
+#: ../../src/MaximaResponseReader.cpp:1024
 msgid "Maxima sends us a new set of variables for the watch list."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1944
+#: ../../src/sidebars/History.cpp:153
+#, fuzzy
+msgid "Maxima session (*.mac)|*.mac"
+msgstr "Pacote Maxima (*.mac)|*.mac"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1518 ../../src/wxMaximaFrame.cpp:1981
 msgid "Maxima shows help in a browser"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1940
+#: ../../src/dialogs/ConfigDialogue.cpp:1523 ../../src/wxMaximaFrame.cpp:1977
 msgid "Maxima shows help in a sidebar"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1935
+#: ../../src/dialogs/ConfigDialogue.cpp:1511 ../../src/wxMaximaFrame.cpp:1972
 #, fuzzy
 msgid "Maxima shows help in the console"
 msgstr "Arquivo não encontrado"
 
-#: ../../src/StatusBar.cpp:232
+#: ../../src/StatusBar.cpp:290
 #, fuzzy
 msgid "Maxima started. Waiting for authentication..."
 msgstr "Maxima iniciado. Aguardando conexão..."
 
-#: ../../src/StatusBar.cpp:212
+#: ../../src/StatusBar.cpp:245
 msgid "Maxima started. Waiting for connection..."
 msgstr "Maxima iniciado. Aguardando conexão..."
 
-#: ../../src/StatusBar.cpp:228
+#: ../../src/StatusBar.cpp:281
 #, fuzzy
 msgid "Maxima started. Waiting for initial prompt..."
 msgstr "Maxima iniciado. Aguardando conexão..."
 
-#: ../../src/wxMaximaFrame.cpp:1231
+#: ../../src/sidebars/PerformanceSidebar.cpp:36
+msgid "Maxima starts:"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1143
+msgid "Maxima startup file location: "
+msgstr ""
+
+#: ../../src/dialogs/TipOfTheDay.cpp:68
+msgid "Maxima supports three types of numbers: exact fractions (which can be generated for example by typing 1/10), IEEE floating-point numbers (0.2) and arbitrary precision big floats (1b-1). Note that, owing to their nature as binary (not decimal) numbers, there is for example no way to generate an IEEE floating-point number that exactly equals 0.1. If floating-point numbers are used instead of fractions, Maxima will therefore sometimes have to introduce a (very small) error and use things like 3602879701896397/36028797018963968 for 0.1."
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1265
 #, fuzzy
 msgid "Maxima to other language"
 msgstr "Questões do Maxima"
 
-#: ../../src/wxMaxima.cpp:7213
+#: ../../src/MaximaCommandMenus.cpp:4085
 #, fuzzy
 msgid "Maxima to string"
 msgstr "Questões do Maxima"
 
-#: ../../src/wxMaxima.cpp:3397
+#: ../../src/cells/TextCell.cpp:255
+msgid "Maxima tried to find out where between two points a curve crosses the zero line. Since the curve is on the same side of the zero line in both points its algorithms fails here. Set find_root_error to false if you want it to return false instead of an error."
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1615
+#, fuzzy
+msgid "Maxima usage"
+msgstr "Ícone do wxMaxima"
+
+#: ../../src/MaximaResponseReader.cpp:776
 #, c-format
 msgid "Maxima user configuration is located in directory %s"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3443
+#: ../../src/dialogs/TipOfTheDay.cpp:59
+msgid ""
+"Maxima uses ':' to assign values to a variable ('a : 3;'), not '=' as most programming languages do.\n"
+"This allows, that a mathematical equation can be assigned to a variable, e.g.\n"
+" eq1:3*x=4;\n"
+"which may then be solved for x with\n"
+"solve(eq1,x);"
+msgstr ""
+
+#: ../../src/dialogs/TipOfTheDay.cpp:63
+#, fuzzy
+msgid ""
+"Maxima uses ':=' to define functions, e.g.:\n"
+"f(x) := x^2;"
+msgstr "O Maxima usa ':' para atribuir valores ('a : 3;') e ':=' para definir funções ('f(x) := x^2;')."
+
+#: ../../src/MaximaResponseReader.cpp:788
 #, c-format
 msgid "Maxima uses temp directory %s"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3469
+#: ../../src/dialogs/AboutDialog.cpp:50
+#, fuzzy
+msgid "Maxima version: "
+msgstr ""
+"\n"
+"Versão do Maxima: "
+
+#: ../../src/MaximaResponseReader.cpp:799
 #, c-format
 msgid "Maxima version: %s"
 msgstr ""
 
-#: ../../src/MaximaManual.cpp:390
+#: ../../src/MaximaManual.cpp:407
 #, c-format
 msgid "Maxima version: %s, Anchors cache version"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1925
+#: ../../src/wxMaximaFrame.cpp:1962
 #, fuzzy
 msgid "Maxima vs. Programming languages"
 msgstr "Converter para &gama"
 
-#: ../../src/Configuration.cpp:83
+#: ../../src/Styles.cpp:112
 #, fuzzy
 msgid "Maxima warnings"
 msgstr "Entrada do Maxima"
 
-#: ../../src/wxMaxima.cpp:3687
+#: ../../src/MaximaResponseReader.cpp:904
 #, c-format
 msgid "Maxima was compiled using %s"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3487
+#: ../../src/dialogs/AboutDialog.cpp:53
+#, fuzzy
+msgid "Maxima was compiled using: "
+msgstr ""
+"\n"
+"Versão do Maxima: "
+
+#: ../../src/dialogs/TipOfTheDay.cpp:201
+msgid ""
+"Maxima's \"at\" function allows accessing arbitrary variables in a list of results:\n"
+"\n"
+"    g1:a*x+y=0;\n"
+"    g2:b*y+x*x=1;\n"
+"    solve([g1,g2],[a,b]);\n"
+"    %[1];\n"
+"    result_b:b=at(b,%);"
+msgstr ""
+
+#: ../../src/MaximaResponseReader.cpp:817
 #, c-format
 msgid "Maxima's HTML manuals are in directory %s"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3099
+#: ../../src/MaximaResponseReader.cpp:599
+msgid "Maxima's Lisp (sbcl) has stopped in its low-level debugger (LDB). The Lisp cannot continue; you can enter LDB commands - for example \"backtrace\" for a stack trace, or \"exit\" to quit it."
+msgstr ""
+
+#: ../../src/MaximaResponseReader.cpp:597
+msgid "Maxima's Lisp entered sbcl's low-level debugger (LDB)."
+msgstr ""
+
+#: ../../src/MaximaResponseReader.cpp:240
+#: ../../src/MaximaResponseReader.cpp:242
 #, c-format
 msgid "Maxima's PID is %li"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3681
+#: ../../src/MaximaResponseReader.cpp:898
 #, c-format
 msgid "Maxima's demo files are located in directory %s"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3478
+#: ../../src/MaximaResponseReader.cpp:808
 #, c-format
 msgid "Maxima's manual is located in directory %s"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3670
+#: ../../src/wizards/ActualValuesStorageWiz.cpp:34
+msgid "Maxima's power lies in symbolic operations."
+msgstr ""
+
+#: ../../src/StatusBar.cpp:365
+msgid ""
+"Maxima's reader is in Lisp mode (after to_lisp()).\n"
+"Type Lisp forms; enter (to-maxima) to return to Maxima mode."
+msgstr ""
+
+#: ../../src/MaximaResponseReader.cpp:887
 #, fuzzy, c-format
 msgid "Maxima's share files are located in directory %s"
 msgstr "Iniciar animação"
 
-#: ../../src/StatusBar.cpp:66
+#: ../../src/dialogs/TipOfTheDay.cpp:188
+msgid ""
+"Maxima's strengths are manipulating equations and in symbolic calculations. It therefore makes sense to use functions (as opposed to equations with labels) sparingly and to keep the actual values of variables in a list, instead of directly assigning them values. An example session that does do so would be:\n"
+"\n"
+"/* We keep the actual values in a list so we can use them later on */\n"
+"    Values:[a=10,c=100];\n"
+"    Pyth:a^2+b^2=c^2;\n"
+"    solve(%,b);\n"
+"    result:%[2];\n"
+"    at(result,Values);\n"
+"    float(%);"
+msgstr ""
+
+#: ../../src/StatusBar.cpp:73
 msgid "Maxima, the program that does the actual mathematics and wxMaxima, which displays the worksheet are kept in separate processes. This means that even if maxima crashes wxMaxima (and therefore the worksheet) stays intact. Both programs communicate over a local network socket. This time this socket could not be created which might be caused by a firewall that it setup to not only intercepts connections from the outside, but also to intercept connections between two programs that run on the same computer."
 msgstr ""
 
-#: ../../src/StatusBar.cpp:75
+#: ../../src/StatusBar.cpp:82
 msgid "Maxima, the program that does the actual mathematics and wxMaxima, which displays the worksheet are kept in separate processes. This means that even if maxima crashes wxMaxima (and therefore the worksheet) stays intact. Currently the two programs aren't connected to each other which might mean that maxima is still starting up or couldn't be started. Alternatively it can be caused by a firewall that it setup to not only intercepts connections from the outside, but also to intercept connections between two programs that run on the same computer. Another reason for maxima not starting up might be that maxima cannot be found (see wxMaxima's Configuration dialogue for a way to specify maxima's location) or isn't in a working order."
 msgstr ""
 
-#: ../../src/StatusBar.cpp:61
+#: ../../src/StatusBar.cpp:68
 msgid ""
 "Maxima, the program that does the actual mathematics is started as a separate process. This has the advantage that an eventual crash of maxima cannot harm wxMaxima, which displays the worksheet.\n"
 "This icon indicates if data is transferred between maxima and wxMaxima."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:9228
+#: ../../src/dialogs/MaximaNotStartingDialog.cpp:39
+msgid "Maxima, the program that does the actual maths, cannot be started. This might mean that it isn't installed (it can be found at ↗https://maxima.sourceforge.net) or that wxMaxima doesn't know where to search for it. In that case please choose the location of a working maxima binary"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:419
 msgid "Maximum absolute value printed without exponent"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:9230
+#: ../../src/dialogs/ConfigDialogue.cpp:1931
+msgid "Maximum bitmap size on clipboard [Mb]:"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:488 ../../src/MaximaCommandMenus.cpp:501
+#: ../../src/MaximaCommandMenus.cpp:516 ../../src/MaximaCommandMenus.cpp:530
+msgid "Maximum number of Chebyshev moments. Must be greater than 0."
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:421
 msgid "Maximum number of digits to be displayed:"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:9568
+#: ../../src/dialogs/ConfigDialogue.cpp:811
+msgid "Maximum number of displayed digits:"
+msgstr ""
+
+#: ../../src/sidebars/StatSidebar.cpp:70
+msgid "Mean Difference Test..."
+msgstr "Teste de diferença entre médias..."
+
+#: ../../src/sidebars/StatSidebar.cpp:67
+msgid "Mean Test..."
+msgstr "Teste de média..."
+
+#: ../../src/sidebars/StatSidebar.cpp:52
+msgid "Mean..."
+msgstr "Média..."
+
+#: ../../src/MaximaCommandMenus.cpp:1806
 msgid "Mean:"
 msgstr "Média:"
 
-#: ../../src/wxMaximaFrame.cpp:1924
+#: ../../src/sidebars/StatSidebar.cpp:55
+msgid "Median..."
+msgstr "Mediana..."
+
+#: ../../src/wxMaximaFrame.cpp:1961
 msgid "Memoizing"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1013
+#: ../../src/wxMaximaFrame.cpp:1047
 #, fuzzy
 msgid "Memory"
 msgstr "&Limpar memória"
 
-#: ../../src/Worksheet.cpp:1409 ../../src/wxMaximaFrame.cpp:935
+#: ../../src/worksheet/WorksheetContextMenu.cpp:180
+#: ../../src/wxMaximaFrame.cpp:969
 msgid "Merge Cells"
 msgstr "Mesclar células"
 
-#: ../../src/wxMaxima.cpp:5780
+#: ../../src/MaximaResponseReader.cpp:641
 msgid "Message from the stdout of Maxima: "
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1326
+#: ../../src/wizards/IntegrateWiz.cpp:55
+msgid "Method:"
+msgstr "Método:"
+
+#: ../../src/wxMaximaFrame.cpp:1360
 msgid "Methods of generating a matrix"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:6866
+#: ../../src/worksheet/Worksheet.cpp:4869
 #, c-format
 msgid "Middle-click clipboard data: %s"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:9226
+#: ../../src/cells/TextCell.cpp:303
+msgid "Might also indicate a missing multiplication sign (\"*\")."
+msgstr ""
+
+#: ../../src/cells/TextCell.cpp:323
+msgid ""
+"Might be caused by reading an csv file with an empty last line:\n"
+"Technically that line can be described as having the length 0 which differs from the other lines of this file."
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:417
 msgid "Minimum absolute value printed without exponent:"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:10449 ../../src/wxMaxima.cpp:10451
+#: ../../src/dialogs/ConfigDialogue.cpp:1270
+msgid "Misc"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1963
+#, fuzzy
+msgid "Misc settings"
+msgstr "Exportação para TeX falhou!"
+
+#: ../../src/wxMaxima.cpp:3136 ../../src/wxMaxima.cpp:3138
 #, fuzzy
 msgid "Mismatched parenthesis"
 msgstr "Parêntesis aos pares nos controles de texto"
 
-#: ../../src/wxMaximaFrame.cpp:1352
+#: ../../src/cells/VisiblyInvalidCell.cpp:43
+msgid "Missing contents. Bug?"
+msgstr ""
+
+#: ../../src/cells/TextCell.cpp:245
+msgid "Most probable cause: A dot instead a comma between two list items containing assignments."
+msgstr ""
+
+#: ../../src/cells/TextCell.cpp:308
+msgid "Most probable cause: A function was called with a parameter that causes it to return infinity and/or -infinity."
+msgstr ""
+
+#: ../../src/cells/TextCell.cpp:249
+msgid "Most probable cause: Two commas or similar separators in a row."
+msgstr ""
+
+#: ../../src/cells/TextCell.cpp:251
+msgid "Most probable cause: an operator was directly followed by a closing parenthesis."
+msgstr ""
+
+#: ../../src/cells/TextCell.cpp:318
+msgid ""
+"Most probably it was attempted to append something to a list that isn't a list.\n"
+"Enclosing the new element for the list in brackets ([]) converts it to a list and makes it appendable."
+msgstr ""
+
+#: ../../src/cells/TextCell.cpp:155
+msgid "Most questions can be avoided using the assume() and the declare() command. If that isn't possible the \"Automatically answer questions\" button makes wxMaxima automatically fill in all answers it still remembers from a previous run."
+msgstr ""
+
+#: ../../src/sidebars/GreekSidebar.cpp:189
+msgid "Mu"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1386
 msgid "Multiplication, exponent and similar"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1998
+#: ../../src/worksheet/WorksheetContextMenu.cpp:770
 msgid "Multiplicative function: f(a*b)=f(a)*f(b)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1338
+#: ../../src/wxMaximaFrame.cpp:1372
 msgid "Multiply matrices..."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7981
+#: ../../src/MaximaCommandMenus.cpp:1165
 msgid "Multiply two matrices"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:9581
-#, fuzzy
-msgid "Multivariate linear regression"
-msgstr "Regressão linear..."
-
-#: ../../src/wxMaxima.cpp:7842
+#: ../../src/MaximaCommandMenus.cpp:1023
 #, fuzzy
 msgid "Name of t:"
 msgstr "Nome:"
 
-#: ../../src/wxMaxima.cpp:7838
+#: ../../src/wizards/DrawWiz.cpp:750
+msgid "Name of the parameter"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:1019
 #, fuzzy
 msgid "Name of x:"
 msgstr "Nome:"
 
-#: ../../src/wxMaximaFrame.cpp:1320 ../../src/wxMaximaFrame.cpp:1759
+#: ../../src/wizards/MatWiz.cpp:163
+msgid "Name:"
+msgstr "Nome:"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:216
+msgid "Nepali"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1354 ../../src/wxMaximaFrame.cpp:1796
 msgid "Nested list to Matrix"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:769 ../../src/wxMaximaFrame.cpp:1053
+#: ../../src/MaximaCommandMenus.cpp:1450
+msgid "Nested list to matrix"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:748
+#: ../../src/dialogs/ConfigDialogue.cpp:772 ../../src/wxMaximaFrame.cpp:806
+#: ../../src/wxMaximaFrame.cpp:1087
 msgid "Never"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:6534
+#: ../../src/MaximaCommandMenus.cpp:3054
 msgid "Never autosubscript this variable"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:776
+#: ../../src/wxMaximaFrame.cpp:813
 msgid "Never display this variable with subscript"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1469 ../../src/Worksheet.cpp:1843
+#: ../../src/worksheet/WorksheetContextMenu.cpp:240
+#: ../../src/worksheet/WorksheetContextMenu.cpp:615
 msgid "Never offer known answers"
 msgstr ""
 
-#: ../../src/ToolBar.cpp:174
+#: ../../src/ToolBar.cpp:324 ../../src/ToolBar.cpp:326
 msgid "New"
 msgstr "Novo"
 
-#: ../../src/wxMaximaFrame.cpp:597
+#: ../../src/wxMaximaFrame.cpp:628
 msgid "New\tCtrl+N"
 msgstr "Novo\tCtrl+N"
 
-#: ../../src/ToolBar.cpp:611
+#: ../../src/ToolBar.cpp:811
 msgid "New button"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2483
+#: ../../src/MaximaProcessManager.cpp:144
 msgid "New connection attempt whilst already connected."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2491
+#: ../../src/MaximaProcessManager.cpp:152
 msgid "New connection attempt, but no currently no socket maxima could connect to."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2487
+#: ../../src/MaximaProcessManager.cpp:148
 msgid "New connection attempt, but no currently running maxima process."
 msgstr ""
 
-#: ../../src/ToolBar.cpp:174
+#: ../../src/ToolBar.cpp:324 ../../src/ToolBar.cpp:326
 msgid "New document"
 msgstr "Novo documento"
 
-#: ../../src/wxMaxima.cpp:3899
+#: ../../src/dialogs/ConfigDialogue.cpp:901
+msgid "New lines: Jump to text"
+msgstr ""
+
+#: ../../src/MaximaResponseReader.cpp:1015
 #, c-format
 msgid "New maxima Operators detected: %s"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7390
+#: ../../src/MaximaCommandMenus.cpp:4262
 #, fuzzy
 msgid "New part:"
 msgstr "Nova variável:"
 
-#: ../../src/wxMaxima.cpp:8900 ../../src/wxMaxima.cpp:8920
-#: ../../src/wxMaxima.cpp:9000 ../../src/wxMaxima.cpp:9005
+#: ../../src/wizards/SubstituteWiz.cpp:35
+msgid "New value:"
+msgstr "Valor novo:"
+
+#: ../../src/MaximaCommandMenus.cpp:151 ../../src/MaximaCommandMenus.cpp:171
+#: ../../src/MaximaCommandMenus.cpp:254 ../../src/MaximaCommandMenus.cpp:259
 msgid "New variable:"
 msgstr "Nova variável:"
 
-#: ../../src/wxMaximaFrame.cpp:929
+#: ../../src/wxMaximaFrame.cpp:963
 msgid "Next Command\tAlt+Down"
 msgstr "Próximo comando\tAlt+Down"
 
-#: ../../src/wxMaximaFrame.cpp:748
+#: ../../src/dialogs/DiffFrame.cpp:405
+msgid "Next Difference"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:785
 msgid "Nice Graphical Equations"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1550
+#: ../../src/dialogs/ConfigDialogue.cpp:725
+#: ../../src/dialogs/ConfigDialogue.cpp:737 ../../src/wxMaximaFrame.cpp:1587
 msgid "No"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1972
+#: ../../src/worksheet/WorksheetContextMenu.cpp:744
 #, fuzzy
 msgid "No Array"
 msgstr "Matriz:"
 
-#: ../../src/Worksheet.cpp:1974
+#: ../../src/worksheet/WorksheetContextMenu.cpp:746
 msgid "No Scalar"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:10482
+#: ../../src/worksheet/Worksheet.cpp:5466
+msgid "No cells are selected. Anonymize the code in the whole document?"
+msgstr ""
+
+#: ../../src/wizards/DrawWiz.cpp:636
+msgid "No contour lines"
+msgstr ""
+
+#: ../../src/dialogs/DiffFrame.cpp:304
+msgid "No differences"
+msgstr ""
+
+#: ../../src/wxMaxima.cpp:3169
 msgid "No dollar ($) or semicolon (;) at the end of command"
 msgstr ""
 
-#: ../../src/MaximaManual.cpp:406
+#: ../../src/MaximaManual.cpp:423
 msgid "No entries in the caches for the subjects the manual contains."
 msgstr ""
 
@@ -4990,726 +7487,1091 @@ msgstr ""
 msgid "No file with the subjects the manual contained in the last wxMaxima run."
 msgstr ""
 
-#: ../../src/Image.cpp:495
+#: ../../src/Image.cpp:547
 msgid "No gnuplot data!"
 msgstr ""
 
-#: ../../src/Image.cpp:530
+#: ../../src/Image.cpp:582
 msgid "No gnuplot source!"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:6662 ../../src/wxMaxima.cpp:6668
-#: ../../src/wxMaxima.cpp:6687 ../../src/wxMaxima.cpp:6697
+#: ../../src/cells/GroupCell.cpp:1500
+msgid "No image to export"
+msgstr ""
+
+#: ../../src/wxMaxima.cpp:2653 ../../src/wxMaxima.cpp:2661
+#: ../../src/wxMaxima.cpp:2682 ../../src/wxMaxima.cpp:2694
 msgid "No matches found!"
 msgstr "Nenhuma correspondência encontrada!"
 
-#: ../../src/wxMaxima.cpp:3240
+#: ../../src/wizards/DrawWiz.cpp:651
+msgid "No plot, only contour lines"
+msgstr ""
+
+#: ../../src/wizards/DrawWiz.cpp:837
+msgid "No points"
+msgstr ""
+
+#: ../../src/MaximaResponseReader.cpp:145
 msgid "No topics found in topic flag"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3227
+#: ../../src/MaximaResponseReader.cpp:130
 msgid "No topics found in topic tag"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:797
+#: ../../src/Image.cpp:1037
+msgid "No usable image data was found."
+msgstr ""
+
+#: ../../src/sidebars/SymbolsSidebar.cpp:179
+msgid "Non-builtin symbols"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:834
 msgid "None"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8163
+#: ../../src/sidebars/StatSidebar.cpp:73
+msgid "Normality Test..."
+msgstr "Teste de normalidade..."
+
+#: ../../src/cells/TextCell.cpp:271
+msgid ""
+"Normally computers use floating-point numbers that can be handled incredibly fast while being accurate to dozens of digits. They will, though, introduce a small error into some common numbers. For example 0.1 is represented as 3602879701896397/36028797018963968.\n"
+"As mathematics is based on the fact that numbers that are exactly equal cancel each other out small errors can quickly add up to big errors (see Wilkinson's Polynomials or Rump's Polynomials). Some maxima commands therefore use rat() in order to automatically convert floats to exact numbers (like 1/10 or sqrt(2)/2) where floating-point errors might add up.\n"
+"\n"
+"This error message doesn't occur if exact numbers (1/10 instead of 0.1) are used.\n"
+"The info that numbers have automatically been converted can be suppressed by setting ratprint to false."
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:431
+msgid "Normally html expects images to be rather low-res but space saving. These images tend to look rather blurry when viewed on modern screens. Therefore this setting was introduces that selects the factor by which the HTML export increases the resolution in respect to the default value."
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:217
+msgid "Norwegian"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:1351
 msgid "Not a valid matrix dimension!"
 msgstr "Dimensão inválida para matriz!"
 
-#: ../../src/wxMaxima.cpp:7858 ../../src/wxMaxima.cpp:7880
+#: ../../src/MaximaCommandMenus.cpp:1039 ../../src/MaximaCommandMenus.cpp:1061
 msgid "Not a valid number of equations!"
 msgstr "Número de equações inválido!"
 
-#: ../../src/StatusBar.cpp:256
+#: ../../src/StatusBar.cpp:375
 msgid "Not connected to Maxima"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:10496
+#: ../../src/MaximaResponseReader.cpp:841
+msgid "Not re-querying gnuplot's graphics drivers: same gnuplot as before."
+msgstr ""
+
+#: ../../src/MaximaFileIO.cpp:768
+msgid "Not saving: running non-interactively and no file name is set."
+msgstr ""
+
+#: ../../src/MaximaEvaluator.cpp:329
 msgid "Not triggering evaluation as maxima is still busy!"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:10503
+#: ../../src/MaximaEvaluator.cpp:336
 msgid "Not triggering evaluation as maxima still asks a question!"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:10511
+#: ../../src/MaximaEvaluator.cpp:344
 msgid "Not triggering evaluation as there is no working maxima process"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8926
+#: ../../src/sidebars/GreekSidebar.cpp:190
+msgid "Nu"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:177
 msgid "Num. deg:"
 msgstr "Grau num.:"
 
-#: ../../src/wxMaxima.cpp:8540
+#: ../../src/MaximaCommandMenus.cpp:1553
 #, fuzzy
 msgid "Number of elements"
 msgstr "Número de equações:"
 
-#: ../../src/wxMaxima.cpp:7852 ../../src/wxMaxima.cpp:7874
+#: ../../src/MaximaCommandMenus.cpp:1033 ../../src/MaximaCommandMenus.cpp:1055
 msgid "Number of equations:"
 msgstr "Número de equações:"
 
-#: ../../src/wxMaxima.cpp:7481
+#: ../../src/MaximaCommandMenus.cpp:4353
 #, fuzzy
 msgid "Number to octets"
 msgstr "Número de equações:"
 
-#: ../../src/wxMaximaFrame.cpp:1154
+#: ../../src/wxMaximaFrame.cpp:1188
 #, fuzzy
 msgid "Number to octets..."
 msgstr "Número de equações:"
 
-#: ../../src/wxMaximaFrame.cpp:1906
+#: ../../src/wxMaximaFrame.cpp:1943
 msgid "Number types"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7482
+#: ../../src/MaximaCommandMenus.cpp:4354
 #, fuzzy
 msgid "Number:"
 msgstr "Números"
 
-#: ../../src/wxMaximaFrame.cpp:1786
+#: ../../src/wxMaximaFrame.cpp:1823
 #, fuzzy
 msgid "Numeric output"
 msgstr "Alternar saída numérica"
 
-#: ../../src/wxMaxima.cpp:8040
+#: ../../src/MaximaCommandMenus.cpp:1224
 msgid "Numerical QR decomposition of a matrix"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1417
+#: ../../src/wxMaximaFrame.cpp:1451
 #, fuzzy
 msgid "Numerical operations (lapack)"
 msgstr "Integração &numérica"
 
-#: ../../src/wxMaxima.cpp:7831
+#: ../../src/MaximaCommandMenus.cpp:1012
 #, fuzzy
 msgid "Numerical solution for 1st degree ODE"
 msgstr "Resolver problema de valor inicial para EDO de primeira ordem"
 
-#: ../../src/wxMaximaFrame.cpp:1282
+#: ../../src/wxMaximaFrame.cpp:1316
 #, fuzzy
 msgid "Numerical solution..."
 msgstr "Alternar saída numérica"
 
-#: ../../src/wxMaximaFrame.cpp:1261
+#: ../../src/wxMaximaFrame.cpp:1295
 #, fuzzy
 msgid "Numerical solutions of polynomial (bfloat)..."
 msgstr "Encontrar todas as raízes de um polinômio"
 
-#: ../../src/wxMaximaFrame.cpp:1258
+#: ../../src/wxMaximaFrame.cpp:1292
 #, fuzzy
 msgid "Numerical solutions of polynomial..."
 msgstr "Encontrar todas as raízes de um polinômio"
 
-#: ../../src/wxMaxima.cpp:9802 ../../src/wxMaxima.cpp:10161
+#: ../../src/MaximaCommandMenus.cpp:3265 ../../src/MaximaCommandMenus.cpp:3690
+#: ../../src/dialogs/ChangeLogDialog.cpp:131
+#: ../../src/dialogs/LicenseDialog.cpp:90
+#: ../../src/dialogs/MaxSizeChooser.cpp:44
+#: ../../src/dialogs/MaxSizeChooser.cpp:49
+#: ../../src/dialogs/MaximaNotStartingDialog.cpp:68
+#: ../../src/dialogs/MaximaNotStartingDialog.cpp:74
+#: ../../src/dialogs/ResolutionChooser.cpp:39
+#: ../../src/dialogs/ResolutionChooser.cpp:44
+#: ../../src/dialogs/TipOfTheDay.cpp:295
+#: ../../src/wizards/ActualValuesStorageWiz.cpp:60
+#: ../../src/wizards/ActualValuesStorageWiz.cpp:64
+#: ../../src/wizards/BC2Wiz.cpp:47 ../../src/wizards/BC2Wiz.cpp:51
+#: ../../src/wizards/CsvWiz.cpp:64 ../../src/wizards/CsvWiz.cpp:138
+#: ../../src/wizards/DrawWiz.cpp:110 ../../src/wizards/DrawWiz.cpp:221
+#: ../../src/wizards/DrawWiz.cpp:353 ../../src/wizards/DrawWiz.cpp:508
+#: ../../src/wizards/DrawWiz.cpp:567 ../../src/wizards/DrawWiz.cpp:664
+#: ../../src/wizards/DrawWiz.cpp:772 ../../src/wizards/DrawWiz.cpp:848
+#: ../../src/wizards/DrawWiz.cpp:986 ../../src/wizards/Gen1Wiz.cpp:43
+#: ../../src/wizards/Gen1Wiz.cpp:47 ../../src/wizards/Gen2Wiz.cpp:46
+#: ../../src/wizards/Gen2Wiz.cpp:50 ../../src/wizards/Gen3Wiz.cpp:54
+#: ../../src/wizards/Gen3Wiz.cpp:58 ../../src/wizards/Gen4Wiz.cpp:61
+#: ../../src/wizards/Gen4Wiz.cpp:65 ../../src/wizards/Gen5Wiz.cpp:69
+#: ../../src/wizards/Gen5Wiz.cpp:73 ../../src/wizards/GenWizPanel.cpp:106
+#: ../../src/wizards/GenWizPanel.cpp:114 ../../src/wizards/IntegrateWiz.cpp:61
+#: ../../src/wizards/IntegrateWiz.cpp:65 ../../src/wizards/LimitWiz.cpp:49
+#: ../../src/wizards/LimitWiz.cpp:53 ../../src/wizards/ListSortWiz.cpp:76
+#: ../../src/wizards/ListSortWiz.cpp:80 ../../src/wizards/MatWiz.cpp:39
+#: ../../src/wizards/MatWiz.cpp:43 ../../src/wizards/MatWiz.cpp:168
+#: ../../src/wizards/MatWiz.cpp:172 ../../src/wizards/Plot2dWiz.cpp:94
+#: ../../src/wizards/Plot2dWiz.cpp:98 ../../src/wizards/Plot2dWiz.cpp:511
+#: ../../src/wizards/Plot2dWiz.cpp:515 ../../src/wizards/Plot2dWiz.cpp:607
+#: ../../src/wizards/Plot2dWiz.cpp:611 ../../src/wizards/Plot3dWiz.cpp:89
+#: ../../src/wizards/Plot3dWiz.cpp:93 ../../src/wizards/PlotFormatWiz.cpp:47
+#: ../../src/wizards/PlotFormatWiz.cpp:51 ../../src/wizards/SeriesWiz.cpp:49
+#: ../../src/wizards/SeriesWiz.cpp:53 ../../src/wizards/SubstituteWiz.cpp:41
+#: ../../src/wizards/SubstituteWiz.cpp:45 ../../src/wizards/SumWiz.cpp:47
+#: ../../src/wizards/SumWiz.cpp:51 ../../src/wizards/SystemWiz.cpp:38
+#: ../../src/wizards/SystemWiz.cpp:42 ../../src/wizards/WizardHelp.cpp:37
 msgid "OK"
 msgstr "OK"
 
-#: ../../src/wxMaximaFrame.cpp:122
+#: ../../src/wxMaximaFrame.cpp:130
 #, c-format
 msgid "OS: %s Version %li.%li"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8211 ../../src/wxMaxima.cpp:8221
+#: ../../src/MaximaCommandMenus.cpp:1401 ../../src/MaximaCommandMenus.cpp:1411
 #, fuzzy
 msgid "Object composed of elements"
 msgstr "Número de equações:"
 
-#: ../../src/wxMaxima.cpp:7680
+#: ../../src/MaximaCommandMenus.cpp:4552
 #, fuzzy
 msgid "Object name:"
 msgstr "Lista:"
 
-#: ../../src/wxMaxima.cpp:7281
+#: ../../src/MaximaCommandMenus.cpp:4153
 #, fuzzy
 msgid "Object:"
 msgstr "Lista:"
 
-#: ../../src/wxMaxima.cpp:7486
+#: ../../src/MaximaCommandMenus.cpp:4358
 msgid "Octets to Number"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7491
+#: ../../src/MaximaCommandMenus.cpp:4363
 msgid "Octets to String"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1156
+#: ../../src/wxMaximaFrame.cpp:1190
 msgid "Octets to number..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1158
+#: ../../src/wxMaximaFrame.cpp:1192
 #, fuzzy
 msgid "Octets to string..."
 msgstr "Expressão"
 
-#: ../../src/wxMaxima.cpp:7487 ../../src/wxMaxima.cpp:7492
+#: ../../src/MaximaCommandMenus.cpp:4359 ../../src/MaximaCommandMenus.cpp:4364
 msgid "Octets:"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1958
+#: ../../src/worksheet/WorksheetContextMenu.cpp:730
 msgid "Odd number"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8900 ../../src/wxMaxima.cpp:8921
-#: ../../src/wxMaxima.cpp:8999 ../../src/wxMaxima.cpp:9005
+#: ../../src/dialogs/ConfigDialogue.cpp:910
+msgid "Offer answers for questions known from previous runs"
+msgstr ""
+
+#: ../../src/cells/TextCell.cpp:332
+msgid "Often caused by recursive function calls. Some lisps allow increasing the control stack size using command-line arguments."
+msgstr ""
+
+#: ../../src/wizards/SubstituteWiz.cpp:32
+msgid "Old value:"
+msgstr "Valor antigo:"
+
+#: ../../src/MaximaCommandMenus.cpp:151 ../../src/MaximaCommandMenus.cpp:172
+#: ../../src/MaximaCommandMenus.cpp:253 ../../src/MaximaCommandMenus.cpp:259
 msgid "Old variable:"
 msgstr "Variável antiga:"
 
-#: ../../src/wxMaximaFrame.cpp:1055
+#: ../../src/sidebars/GreekSidebar.cpp:201
+msgid "Omega"
+msgstr ""
+
+#: ../../src/sidebars/GreekSidebar.cpp:192
+msgid "Omicron"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1089
 #, fuzzy
 msgid "On all errors"
 msgstr "Erro fatal"
 
-#: ../../src/wxMaximaFrame.cpp:1054
+#: ../../src/wxMaximaFrame.cpp:1088
 msgid "On lisp errors"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:9566
+#: ../../src/MaximaCommandMenus.cpp:1804
 msgid "One sample t-test"
 msgstr "Teste t com uma amostra"
 
-#: ../../src/wxMaximaFrame.cpp:1927
+#: ../../src/wxMaximaFrame.cpp:1964
 msgid "Online tutorials"
 msgstr "Tutoriais online"
 
-#: ../../src/wxMaximaFrame.cpp:766
+#: ../../src/wxMaximaFrame.cpp:803
 msgid "Only Integers and single letters"
 msgstr ""
 
-#: ../../src/ToolBar.cpp:176 ../../src/main.cpp:593 ../../src/wxMaxima.cpp:6074
+#: ../../src/dialogs/ConfigDialogue.cpp:771
+msgid "Only user-defined labels"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:2197 ../../src/ToolBar.cpp:330
+#: ../../src/ToolBar.cpp:333 ../../src/main.cpp:882
 msgid "Open"
 msgstr "Abrir"
 
-#: ../../src/wxMaximaFrame.cpp:598
+#: ../../src/dialogs/ConfigDialogue.cpp:905
+msgid "Open a cell when Maxima expects input"
+msgstr "Abrir uma célula quando o Maxima espera entrada"
+
+#: ../../src/wxMaximaFrame.cpp:629
 msgid "Open a document"
 msgstr "Abrir um documento"
 
-#: ../../src/wxMaximaFrame.cpp:597
+#: ../../src/wxMaximaFrame.cpp:628
 msgid "Open a new window"
 msgstr "Abrir uma nova janela"
 
-#: ../../src/ToolBar.cpp:617
+#: ../../src/ToolBar.cpp:817
 msgid "Open and save button"
 msgstr ""
 
-#: ../../src/ToolBar.cpp:176
+#: ../../src/ToolBar.cpp:330 ../../src/ToolBar.cpp:333
 msgid "Open document"
 msgstr "Abrir documento"
 
-#: ../../src/wxMaxima.cpp:7239
+#: ../../src/MaximaCommandMenus.cpp:4111
 msgid "Open for appending"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1099
+#: ../../src/wxMaximaFrame.cpp:1133
 msgid "Open for appending..."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7244
+#: ../../src/MaximaCommandMenus.cpp:4116
 msgid "Open for reading"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1098
+#: ../../src/wxMaximaFrame.cpp:1132
 #, fuzzy
 msgid "Open for reading..."
 msgstr "Expressão"
 
-#: ../../src/wxMaxima.cpp:7249
+#: ../../src/MaximaCommandMenus.cpp:4121
 msgid "Open for writing"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1100
+#: ../../src/wxMaximaFrame.cpp:1134
 #, fuzzy
 msgid "Open for writing..."
 msgstr "&Exportar..."
 
-#: ../../src/wxMaxima.cpp:9598
+#: ../../src/MaximaCommandMenus.cpp:1838
 msgid "Open matrix"
 msgstr "Abrir matriz"
 
-#: ../../src/wxMaximaFrame.cpp:600
+#: ../../src/wxMaximaFrame.cpp:631
 #, fuzzy
 msgid "Open recent"
 msgstr "Abrir recente"
 
-#: ../../src/wxMaxima.cpp:4309
+#: ../../src/MaximaFileIO.cpp:231
 msgid "Opening a wxmx file"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:4153 ../../src/wxMaxima.cpp:4214
-#: ../../src/wxMaxima.cpp:4313 ../../src/wxMaxima.cpp:4622
+#: ../../src/MaximaFileIO.cpp:54 ../../src/MaximaFileIO.cpp:113
+#: ../../src/MaximaFileIO.cpp:235 ../../src/MaximaFileIO.cpp:545
 msgid "Opening file"
 msgstr "Abrindo arquivo"
 
-#: ../../src/wxMaxima.cpp:5030
+#: ../../src/sidebars/HelpBrowser.cpp:175 ../../src/wxMaxima.cpp:1808
 #, c-format
 msgid "Opening help file %s"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1530
+#: ../../src/wxMaximaFrame.cpp:1567
 msgid "Optimize for CPU time"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1529
+#: ../../src/wxMaximaFrame.cpp:1566
 msgid "Optimize for memory"
 msgstr ""
 
-#: ../../src/ToolBar.cpp:199
+#: ../../src/wizards/DrawWiz.cpp:97
+msgid "Optional: A 2nd expression that defines a region to fill"
+msgstr ""
+
+#: ../../src/ToolBar.cpp:367 ../../src/ToolBar.cpp:369
+#: ../../src/dialogs/ConfigDialogue.cpp:284
 msgid "Options"
 msgstr "Opções"
 
-#: ../../src/wxMaximaFrame.cpp:1225
+#: ../../src/wizards/Plot2dWiz.cpp:75 ../../src/wizards/Plot3dWiz.cpp:66
+msgid "Options:"
+msgstr "Opções:"
+
+#: ../../src/dialogs/FindReplacePane.cpp:109
+msgid "Output"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1259
 #, fuzzy
 msgid "Output C"
 msgstr "Rótulos de saída"
 
-#: ../../src/wxMaximaFrame.cpp:1226
+#: ../../src/wxMaximaFrame.cpp:1260
 msgid "Output Fortran"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1228
+#: ../../src/wxMaximaFrame.cpp:1262
 msgid "Output Rational Fortran"
 msgstr ""
 
-#: ../../src/Configuration.cpp:80
+#: ../../src/Styles.cpp:109
 msgid "Output labels"
 msgstr "Rótulos de saída"
 
-#: ../../src/Configuration.cpp:73
+#: ../../src/Styles.cpp:102
 #, fuzzy
 msgid "Output: Function names"
 msgstr "Nomes de funções"
 
-#: ../../src/Configuration.cpp:75
+#: ../../src/Styles.cpp:104
 msgid "Output: Latin names as greek symbols"
 msgstr ""
 
-#: ../../src/Configuration.cpp:72
+#: ../../src/Styles.cpp:101
 msgid "Output: Numbers and Digits"
 msgstr ""
 
-#: ../../src/Configuration.cpp:71
+#: ../../src/Styles.cpp:100
 #, fuzzy
 msgid "Output: Operators"
 msgstr "Rótulos de saída"
 
-#: ../../src/Configuration.cpp:74
+#: ../../src/Styles.cpp:103
 #, fuzzy, c-format
 msgid "Output: Special constants (%e,%i)"
 msgstr "Constantes especiais"
 
-#: ../../src/Configuration.cpp:76
+#: ../../src/Styles.cpp:105
 #, fuzzy
 msgid "Output: Strings"
 msgstr "Cadeias de caracteres"
 
-#: ../../src/Configuration.cpp:70
+#: ../../src/Styles.cpp:99
 #, fuzzy
 msgid "Output: Variable names"
 msgstr "Variável antiga:"
 
-#: ../../src/wxMaxima.cpp:6442
-msgid "PNG image (*.png)|*.png|JPEG image (*.jpg)|*.jpg|GIF image (*.gif)|*.gif|Scaleable vector graphics (*.svg)|*.svg|Windows bitmap (*.bmp)|*.bmp|Portable anymap (*.pnm)|*.pnm|Tagged image file format (*.tif)|*.tif|X pixmap (*.xpm)|*.xpm"
+#: ../../src/dialogs/ConfigDialogue.cpp:839
+msgid "Overlay scrollbars (slow: repaints the worksheet while they fade)"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:10117
-msgid "PNG image (*.png)|*.png|JPEG image (*.jpg)|*.jpg|Windows bitmap (*.bmp)|*.bmp|GIF image (*.gif)|*.gif|Portable anymap (*.pnm)|*.pnm|Tagged image file format (*.tif)|*.tif|X pixmap (*.xpm)|*.xpm"
+#: ../../src/MaximaCommandMenus.cpp:3609
+msgid "PNG image (*.png)|*.png|JPEG image (*.jpg)|*.jpg|Windows bitmap (*.bmp)|*.bmp|"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8924
+#: ../../src/dialogs/ConfigDialogue.cpp:458
+msgid "PNG images can be read by old wxMaxima versions - but aren't really scalable."
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:175
 msgid "Pade approximation"
 msgstr "Aproximação de Padé"
 
-#: ../../src/wxMaximaFrame.cpp:1478
+#: ../../src/wxMaximaFrame.cpp:1515
 msgid "Pade approximation of a Taylor series"
 msgstr "Aproximação de Padé de uma série de Taylor"
 
-#: ../../src/wxMaximaFrame.cpp:1637
+#: ../../src/sidebars/FormatSidebar.cpp:69
+msgid "Pagebreak"
+msgstr "Quebra de página"
+
+#: ../../src/wxMaximaFrame.cpp:1674
 #, fuzzy
 msgid "Parallel Substitute..."
 msgstr "Substituir..."
 
-#: ../../src/wxMaxima.cpp:8738
+#: ../../src/MaximaCommandMenus.cpp:735
 msgid "Parallel substitution"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7179
+#: ../../src/sidebars/SymbolsSidebar.cpp:124
+msgid "Parallel to"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:4051
 #, fuzzy
 msgid "Parameter name:"
 msgstr "Nome da matriz:"
 
-#: ../../src/wxMaxima.cpp:7136 ../../src/wxMaxima.cpp:7149
+#: ../../src/MaximaCommandMenus.cpp:4008 ../../src/MaximaCommandMenus.cpp:4021
 #, fuzzy
 msgid "Parameter(s):"
 msgstr "Variável(is):"
 
-#: ../../src/wxMaxima.cpp:7399
+#: ../../src/sidebars/DrawSidebar.cpp:64
+#, fuzzy
+msgid "Parametric Plot"
+msgstr "Gráfico paramétrico"
+
+#: ../../src/wizards/Plot2dWiz.cpp:417 ../../src/wizards/Plot2dWiz.cpp:523
+msgid "Parametric plot"
+msgstr "Gráfico paramétrico"
+
+#: ../../src/MaximaCommandMenus.cpp:4271
 msgid "Parse string"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1152
+#: ../../src/wxMaximaFrame.cpp:1186
 #, fuzzy
 msgid "Parse string only..."
 msgstr "&Introduzir matriz..."
 
-#: ../../src/StatusBar.cpp:240
+#: ../../src/StatusBar.cpp:308
 msgid "Parsing output"
 msgstr "Interpretando saída"
 
-#: ../../src/wxMaxima.cpp:7464
+#: ../../src/MaximaCommandMenus.cpp:4336
 msgid "Part:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1499 ../../src/wxMaximaFrame.cpp:1535
+#: ../../src/wxMaximaFrame.cpp:1536 ../../src/wxMaximaFrame.cpp:1572
 msgid "Partial &Fractions..."
 msgstr "&Frações parciais..."
 
-#: ../../src/wxMaxima.cpp:8975
+#: ../../src/MaximaCommandMenus.cpp:229
 #, fuzzy
 msgid "Partial Fractions"
 msgstr "Frações parciais"
 
-#: ../../src/wxMaxima.cpp:4702
-msgid "Parts of the document will not be loaded correctly!"
-msgstr "Partes do documento não serão carregadas corretamente!"
-
-#: ../../src/ToolBar.cpp:210 ../../src/Worksheet.cpp:1654
-#: ../../src/Worksheet.cpp:1685
+#: ../../src/ToolBar.cpp:381 ../../src/ToolBar.cpp:385
+#: ../../src/worksheet/WorksheetContextMenu.cpp:427
+#: ../../src/worksheet/WorksheetContextMenu.cpp:458
 msgid "Paste"
 msgstr "Colar"
 
-#: ../../src/wxMaximaFrame.cpp:667
+#: ../../src/wxMaximaFrame.cpp:704
 msgid "Paste\tCtrl+V"
 msgstr "Colar\tCtrl+V"
 
-#: ../../src/ToolBar.cpp:211
+#: ../../src/ToolBar.cpp:381 ../../src/ToolBar.cpp:385
 msgid "Paste from clipboard"
 msgstr "Colar da área de transferência"
 
-#: ../../src/wxMaximaFrame.cpp:668
+#: ../../src/wxMaximaFrame.cpp:705
 msgid "Paste text from clipboard"
 msgstr "Colar texto da área de transferência"
 
-#: ../../src/wxMaxima.cpp:4841
+#: ../../src/wxMaximaFrame.cpp:272 ../../src/wxMaximaFrame.cpp:759
+msgid "Performance Monitor"
+msgstr ""
+
+#: ../../src/Configuration.cpp:1383
+msgid "Performance Statistics:"
+msgstr ""
+
+#: ../../src/sidebars/SymbolsSidebar.cpp:125
+msgid "Perpendicular to"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:218
+msgid "Persian"
+msgstr ""
+
+#: ../../src/sidebars/GreekSidebar.cpp:198
+msgid "Phi"
+msgstr ""
+
+#: ../../src/sidebars/GreekSidebar.cpp:193
+msgid "Pi"
+msgstr ""
+
+#: ../../src/sidebars/StatSidebar.cpp:94
+msgid "Piechart..."
+msgstr "Gráfico de torta..."
+
+#: ../../src/wxMaxima.cpp:1587
 msgid "Please configure wxMaxima with 'Edit->Configure'."
 msgstr "Queira configurar o wxMaxima com 'Editar->Configurações'."
 
-#: ../../src/wxMaximaFrame.cpp:1768
+#: ../../src/dialogs/ConfigDialogue.cpp:2606
+msgid "Please restart wxMaxima for changes to take effect!"
+msgstr "Queira reiniciar o wxMaxima para as mudanças terem efeito!"
+
+#: ../../src/MaximaCommandMenus.cpp:2250
+msgid "Please select exactly 2 or 3 files."
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1805
 msgid "Plot &2d..."
 msgstr "Gráfico &2d..."
 
-#: ../../src/wxMaximaFrame.cpp:1770
+#: ../../src/wxMaximaFrame.cpp:1807
 msgid "Plot &3d..."
 msgstr "Gráfico &3d..."
 
-#: ../../src/wxMaximaFrame.cpp:1772
+#: ../../src/wxMaximaFrame.cpp:1809
 msgid "Plot &Format..."
 msgstr "&Formato do gráfico..."
 
-#: ../../src/wxMaxima.cpp:9101 ../../src/wxMaxima.cpp:10068
+#: ../../src/MaximaCommandMenus.cpp:107 ../../src/MaximaCommandMenus.cpp:3557
+#: ../../src/wizards/Plot2dWiz.cpp:108 ../../src/wizards/Plot2dWiz.cpp:428
+#: ../../src/wizards/Plot2dWiz.cpp:441
 msgid "Plot 2D"
 msgstr "Gráfico 2D"
 
-#: ../../src/Worksheet.cpp:1593
+#: ../../src/sidebars/MathSidebar.cpp:89
+#: ../../src/worksheet/WorksheetContextMenu.cpp:366
 msgid "Plot 2D..."
 msgstr "Gráfico 2D..."
 
-#: ../../src/wxMaxima.cpp:9078 ../../src/wxMaxima.cpp:10079
+#: ../../src/MaximaCommandMenus.cpp:85 ../../src/MaximaCommandMenus.cpp:3568
+#: ../../src/wizards/Plot3dWiz.cpp:103
 msgid "Plot 3D"
 msgstr "Gráfico 3D"
 
-#: ../../src/Worksheet.cpp:1595
+#: ../../src/sidebars/MathSidebar.cpp:92
+#: ../../src/worksheet/WorksheetContextMenu.cpp:368
 msgid "Plot 3D..."
 msgstr "Gráfico 3D..."
 
-#: ../../src/wxMaxima.cpp:9538
+#: ../../src/wizards/DrawWiz.cpp:713
+msgid "Plot a parametric curve"
+msgstr ""
+
+#: ../../src/wizards/DrawWiz.cpp:45 ../../src/wizards/DrawWiz.cpp:148
+#: ../../src/wizards/DrawWiz.cpp:255
+#, fuzzy
+msgid "Plot an explicit expression"
+msgstr "Encontrar o limite de uma expressão"
+
+#: ../../src/wizards/DrawWiz.cpp:53
+msgid "Plot an expression, for example sin(x) or (x+1)^2."
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:1776
 msgid "Plot as bars"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:9542
-msgid "Plot as error bars"
-msgstr ""
-
-#: ../../src/wxMaxima.cpp:9546
+#: ../../src/MaximaCommandMenus.cpp:1784
 msgid "Plot as pie chart"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:9112
+#: ../../src/MaximaCommandMenus.cpp:118
 msgid "Plot format"
 msgstr "Formato do gráfico"
 
-#: ../../src/wxMaximaFrame.cpp:1768
+#: ../../src/wxMaximaFrame.cpp:1805
 msgid "Plot in 2 dimensions"
 msgstr "Gráfico bidimensional"
 
-#: ../../src/wxMaximaFrame.cpp:1770
+#: ../../src/wxMaximaFrame.cpp:1807
 msgid "Plot in 3 dimensions"
 msgstr "Gráfico tridimensional"
 
-#: ../../src/wxMaximaFrame.cpp:320 ../../src/wxMaximaFrame.cpp:714
+#: ../../src/sidebars/DrawSidebar.cpp:83
+msgid "Plot name"
+msgstr ""
+
+#: ../../src/wizards/Plot2dWiz.cpp:84 ../../src/wizards/Plot3dWiz.cpp:80
+msgid "Plot to file:"
+msgstr "Gráfico para arquivo:"
+
+#: ../../src/wxMaximaFrame.cpp:341 ../../src/wxMaximaFrame.cpp:749
 msgid "Plot using Draw"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7824
+#: ../../src/MaximaCommandMenus.cpp:1005
 msgid "Point #1 with known value:"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7826
+#: ../../src/MaximaCommandMenus.cpp:1007
 msgid "Point #2 with known value:"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7800 ../../src/wxMaxima.cpp:7811
+#: ../../src/MaximaCommandMenus.cpp:981 ../../src/MaximaCommandMenus.cpp:992
 msgid "Point the value is known at:"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7909 ../../src/wxMaxima.cpp:8935
+#: ../../src/wizards/DrawWiz.cpp:842
+#, fuzzy
+msgid "Point type:"
+msgstr "Ponto:"
+
+#: ../../src/MaximaCommandMenus.cpp:186 ../../src/MaximaCommandMenus.cpp:1090
+#: ../../src/wizards/BC2Wiz.cpp:33 ../../src/wizards/BC2Wiz.cpp:39
+#: ../../src/wizards/LimitWiz.cpp:35 ../../src/wizards/SeriesWiz.cpp:36
 msgid "Point:"
 msgstr "Ponto:"
 
-#: ../../src/wxMaxima.cpp:8961 ../../src/wxMaxima.cpp:8966
-#: ../../src/wxMaxima.cpp:8971
+#: ../../src/sidebars/DrawSidebar.cpp:67
+msgid "Points"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:219
+msgid "Polish"
+msgstr "Polonês"
+
+#: ../../src/MaximaCommandMenus.cpp:215 ../../src/MaximaCommandMenus.cpp:220
+#: ../../src/MaximaCommandMenus.cpp:225
 msgid "Polynomial 1:"
 msgstr "Polinômio 1:"
 
-#: ../../src/wxMaxima.cpp:8961 ../../src/wxMaxima.cpp:8966
-#: ../../src/wxMaxima.cpp:8971
+#: ../../src/MaximaCommandMenus.cpp:215 ../../src/MaximaCommandMenus.cpp:220
+#: ../../src/MaximaCommandMenus.cpp:225
 msgid "Polynomial 2:"
 msgstr "Polinômio 2:"
 
-#: ../../src/wxMaxima.cpp:7713 ../../src/wxMaxima.cpp:7724
-#: ../../src/wxMaxima.cpp:7739
+#: ../../src/MaximaCommandMenus.cpp:896 ../../src/MaximaCommandMenus.cpp:906
+#: ../../src/MaximaCommandMenus.cpp:920
 #, fuzzy
 msgid "Polynomial:"
 msgstr "Polinômio 1:"
 
-#: ../../src/wxMaximaFrame.cpp:1754
+#: ../../src/wxMaximaFrame.cpp:1791
 msgid "Pop"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1331 ../../src/Worksheet.cpp:1485
+#: ../../src/worksheet/WorksheetContextMenu.cpp:93
+#: ../../src/worksheet/WorksheetContextMenu.cpp:256
 msgid "Popout interactively"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1189
+#: ../../src/MaximaCommandMenus.cpp:3605
+msgid "Portable anymap (*.pnm)|*.pnm|Tagged image file format (*.tif)|*.tif|X pixmap (*.xpm)|*.xpm"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:220
+msgid "Portuguese"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:221
+msgid "Portuguese (Brazilian)"
+msgstr "Português (Brasileiro)"
+
+#: ../../src/wxMaximaFrame.cpp:1223
 msgid "Position of a match"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7220 ../../src/wxMaxima.cpp:7391
+#: ../../src/MaximaCommandMenus.cpp:4092 ../../src/MaximaCommandMenus.cpp:4263
 #, fuzzy
 msgid "Position:"
 msgstr "Condição:"
 
-#: ../../src/wxMaxima.cpp:8939
+#: ../../src/dialogs/DiffFrame.cpp:51
+msgid "Positions of the differences. Click to jump to one."
+msgstr ""
+
+#: ../../src/wizards/Plot2dWiz.cpp:474 ../../src/wizards/Plot3dWiz.cpp:422
+msgid "Postscript file (*.eps)|*.eps|All|*"
+msgstr "Arquivo Postscript (*.eps)|*.eps|Todos|*"
+
+#: ../../src/MaximaCommandMenus.cpp:190
 #, fuzzy
 msgid "Power series"
 msgstr "Séries de &potências"
 
-#: ../../src/wxMaximaFrame.cpp:1475
+#: ../../src/wxMaximaFrame.cpp:1512
 #, fuzzy
 msgid "Power series..."
 msgstr "Séries de &potências"
 
-#: ../../src/wxMaxima.cpp:9202
+#: ../../src/MaximaCommandMenus.cpp:393
 msgid "Precision"
 msgstr "Precisão"
 
-#: ../../src/Worksheet.cpp:1616
+#: ../../src/dialogs/ConfigDialogue.cpp:787
+msgid "Prefer 1D"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1492
+msgid "Prefer the all-in-one-file >1000 page manual"
+msgstr ""
+
+#: ../../src/worksheet/WorksheetContextMenu.cpp:389
 msgid "Prefer user labels"
 msgstr ""
 
-#: ../../src/main.cpp:437
+#: ../../src/main.cpp:676
 #, fuzzy
 msgid "Preferences"
 msgstr "Preferências...\tCTRL+,"
 
-#: ../../src/ToolBar.cpp:626
+#: ../../src/ToolBar.cpp:826
 msgid "Preferences button"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:685
+#: ../../src/wxMaximaFrame.cpp:722
 #, fuzzy
 msgid "Preferences...\tCtrl+,"
 msgstr "Preferências...\tCTRL+,"
 
-#: ../../src/wxMaximaFrame.cpp:1733
+#: ../../src/wxMaximaFrame.cpp:1770
 #, fuzzy
 msgid "Prepend an element"
 msgstr "Abrir um documento"
 
-#: ../../src/wxMaximaFrame.cpp:927
+#: ../../src/ToolBar.cpp:266 ../../src/sidebars/CharButton.cpp:137
+msgid "Press"
+msgstr ""
+
+#: ../../src/dialogs/TipOfTheDay.cpp:146
+msgid "Pressing Ctrl+Space or Ctrl+Tab starts an autocomplete function that can not only complete all functions that are integrated into the Maxima core and their parameters: It also knows about parameters from currently loaded packages and from functions that are defined in the current file."
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:961
 msgid "Previous Command\tAlt+Up"
 msgstr "Comando anterior\tAlt+Up"
 
-#: ../../src/ToolBar.cpp:184
+#: ../../src/dialogs/DiffFrame.cpp:404
+msgid "Previous Difference"
+msgstr ""
+
+#: ../../src/ToolBar.cpp:343 ../../src/ToolBar.cpp:345
 msgid "Print"
 msgstr "Imprimir"
 
-#: ../../src/ToolBar.cpp:620
+#: ../../src/dialogs/ConfigDialogue.cpp:1988
+#, fuzzy
+msgid "Print Margins"
+msgstr "Imprimir"
+
+#: ../../src/ToolBar.cpp:820
 msgid "Print button"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1493
+#: ../../src/worksheet/WorksheetContextMenu.cpp:264
 #, fuzzy
 msgid "Print cell brackets"
 msgstr "Marcador da célula ativa"
 
-#: ../../src/ToolBar.cpp:184 ../../src/wxMaximaFrame.cpp:622
+#: ../../src/ToolBar.cpp:343 ../../src/ToolBar.cpp:345
+#: ../../src/wxMaximaFrame.cpp:655
 msgid "Print document"
 msgstr "Imprimir documento"
 
-#: ../../src/wxMaximaFrame.cpp:1829
+#: ../../src/wxMaximaFrame.cpp:1866
 msgid "Print floating-point numbers with exponents dividable by 3"
 msgstr ""
 
-#: ../../src/WXMXformat.cpp:255
-msgid "Produced invalid XML. The erroneous XML data has therefore not been saved but has been put on the clipboard in order to allow to debug it."
+#: ../../src/dialogs/ConfigDialogue.cpp:1968
+#, fuzzy
+msgid "Print scale:"
+msgstr "Imprimir documento"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1981
+msgid "Print the cell brackets [drawn to their left]"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:9061
+#: ../../src/dialogs/ConfigDialogue.cpp:287
+#, fuzzy
+msgid "Printout settings"
+msgstr "Exportação para TeX falhou!"
+
+#: ../../src/graphical_io/Printout.cpp:208
+msgid "Printout: Cannot find a suitable point for a page break!"
+msgstr ""
+
+#: ../../src/graphical_io/Printout.cpp:162
+msgid "Printout: Composing a list of all line starts as possible locations for page breaks"
+msgstr ""
+
+#: ../../src/graphical_io/Printout.cpp:279
+msgid "Printout: Layouting the whole worksheet as a endless scroll of the width of the paper"
+msgstr ""
+
+#: ../../src/graphical_io/Printout.cpp:201
+#, c-format
+msgid "Printout: PageStart=%li, PageHeight=%li, canvasSize=%li"
+msgstr ""
+
+#: ../../src/graphical_io/Printout.cpp:235
+#, c-format
+msgid "Printout: Print ppi: %lix%li"
+msgstr ""
+
+#: ../../src/graphical_io/Printout.cpp:134
+#, c-format
+msgid "Printout: Printing the region %li-%li"
+msgstr ""
+
+#: ../../src/graphical_io/Printout.cpp:76
+#, c-format
+msgid "Printout: Request to print page %li"
+msgstr ""
+
+#: ../../src/graphical_io/Printout.cpp:240
+#, c-format
+msgid "Printout: Scalefactor: %ex%e"
+msgstr ""
+
+#: ../../src/graphical_io/Printout.cpp:112
+#, c-format
+msgid "Printout: Setting the device origin to %lix%li"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:936
+#, fuzzy
+msgid "Privacy settings"
+msgstr "Exportação para TeX falhou!"
+
+#: ../../src/WXMXformat.cpp:256
+msgid ""
+"Produced invalid XML. The erroneous XML data has therefore not been saved but has been put on the clipboard in order to allow debugging it.\n"
+"Try saving the document in wxm format. Or maybe it helps to remove all output before saving the file, if the conversion of the output causes the problem."
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:315
 msgid "Product"
 msgstr "Produto"
 
-#: ../../src/wxMaximaFrame.cpp:1095
+#: ../../src/sidebars/SymbolsSidebar.cpp:123
+#, fuzzy
+msgid "Product sign"
+msgstr "Produto"
+
+#: ../../src/wxMaximaFrame.cpp:1129
 #, fuzzy
 msgid "Program"
 msgstr "Histograma"
 
-#: ../../src/wxMaxima.cpp:7061
+#: ../../src/MaximaCommandMenus.cpp:3933
 #, fuzzy
 msgid "Program (no local variables)"
 msgstr "Mudar variável"
 
-#: ../../src/wxMaxima.cpp:7052
+#: ../../src/MaximaCommandMenus.cpp:3924
 msgid "Program block"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1066
+#: ../../src/wxMaximaFrame.cpp:1100
 msgid "Program block with local variables..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1068
+#: ../../src/wxMaximaFrame.cpp:1102
 msgid "Program block, no local variables..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1751
+#: ../../src/sidebars/GreekSidebar.cpp:200
+msgid "Psi"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1788
 msgid "Push"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8508
+#: ../../src/MaximaCommandMenus.cpp:1514
 #, fuzzy
 msgid "Push an element to a list"
 msgstr "Criar lista de uma expressão"
 
-#: ../../src/wxMaximaFrame.cpp:1395
+#: ../../src/wxMaximaFrame.cpp:1429
 msgid "QR decomposition"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3621
+#: ../../src/MaximaResponseReader.cpp:845
 msgid "Querying gnuplot which graphics drivers it supports."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8953
+#: ../../src/wxMaximaFrame.cpp:658
+msgid "Quit wxMaxima"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1910
+msgid "RTF with OMML maths"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:207
 msgid "Range radius:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1374
+#: ../../src/wxMaximaFrame.cpp:1408
 msgid "Rank"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:246 ../../src/wxMaximaFrame.cpp:722
+#: ../../src/wxMaximaFrame.cpp:260 ../../src/wxMaximaFrame.cpp:757
 msgid "Raw XML monitor"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:2117
+#: ../../src/wxMaximaFrame.cpp:2168
 #, c-format
 msgid "Re-Reading the config from %s."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:2114
+#: ../../src/wxMaximaFrame.cpp:2165
 msgid "Re-Reading the config from the default location."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:867
+#: ../../src/wxMaximaFrame.cpp:901
 #, fuzzy
 msgid "Re-evaluate all cells above the one the cursor is in"
 msgstr "Avaliar todas as células no documento"
 
-#: ../../src/wxMaximaFrame.cpp:877
+#: ../../src/wxMaximaFrame.cpp:911
 #, fuzzy
 msgid "Re-evaluate all cells below the one the cursor is in"
 msgstr "Avaliar todas as células no documento"
 
-#: ../../src/main.cpp:366
+#: ../../src/main.cpp:605
 msgid "Re-opening STDERR failed."
 msgstr ""
 
-#: ../../src/main.cpp:367
+#: ../../src/main.cpp:606
 #, fuzzy
 msgid "Re-opening STDIN failed."
 msgstr "Abrindo arquivo"
 
-#: ../../src/main.cpp:365
+#: ../../src/main.cpp:604
 msgid "Re-opening STDOUT failed."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7512
+#: ../../src/wxMaxima.cpp:2889
+#, c-format
+msgid "Re-pointed the .wxmx file association at %s"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:4384
 msgid "Re-using a compiled regex is faster that using the same regex string multiple times."
 msgstr ""
 
-#: ../../src/Worksheet.cpp:6668
+#: ../../src/worksheet/Worksheet.cpp:4659
 #, fuzzy
 msgid "Read .wxm data from clipboard"
 msgstr "Colar texto da área de transferência"
 
-#: ../../src/wxMaxima.cpp:7599
+#: ../../src/MaximaCommandMenus.cpp:4471
 msgid "Read Directory"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1677
-#, fuzzy
-msgid "Read List from csv file..."
-msgstr "Ler estilo de um arquivo"
+#: ../../src/sidebars/StatSidebar.cpp:103
+msgid "Read Matrix..."
+msgstr "Ler matriz..."
 
-#: ../../src/wxMaxima.cpp:7196
+#: ../../src/MaximaCommandMenus.cpp:4068
 msgid "Read a structure field"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7270 ../../src/wxMaxima.cpp:7274
+#: ../../src/MaximaCommandMenus.cpp:4142 ../../src/MaximaCommandMenus.cpp:4146
 msgid "Read byte"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7266
+#: ../../src/MaximaCommandMenus.cpp:4138
 #, fuzzy
 msgid "Read char"
 msgstr "Ler matriz..."
 
-#: ../../src/wxMaxima.cpp:7593
+#: ../../src/dialogs/ConfigDialogue.cpp:2488
+#, fuzzy
+msgid "Read config to file"
+msgstr "Salvar seleção para arquivo"
+
+#: ../../src/MaximaCommandMenus.cpp:4465
 #, fuzzy
 msgid "Read environment variable"
 msgstr "Parâmetros adicionais:"
 
-#: ../../src/wxMaximaFrame.cpp:1219
+#: ../../src/wxMaximaFrame.cpp:1253
 #, fuzzy
 msgid "Read environment variable..."
 msgstr "Apagar uma variável"
 
-#: ../../src/wxMaxima.cpp:7262
+#: ../../src/MaximaCommandMenus.cpp:4134
 msgid "Read line"
 msgstr ""
 
-#: ../../src/MaximaManual.cpp:113
+#: ../../src/wxMaximaFrame.cpp:1714
+msgid "Read nested list from csv file..."
+msgstr ""
+
+#: ../../src/MaximaManual.cpp:114
 #, c-format
 msgid "Read the entries the maxima manual offers from %s"
 msgstr ""
 
-#: ../../src/StatusBar.cpp:245
+#: ../../src/StatusBar.cpp:318
 msgid "Reading Maxima output"
 msgstr "Lendo saída do Maxima"
 
-#: ../../src/StatusBar.cpp:247
+#: ../../src/StatusBar.cpp:320
 #, c-format
 msgid "Reading Maxima output: %li bytes"
 msgstr ""
@@ -5723,527 +8585,794 @@ msgstr ""
 msgid "Reading the Lisp part of wxMaxima from the included header file."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:148
+#: ../../src/wxMaximaFrame.cpp:156
 #, c-format
 msgid "Reading the config from %s."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:151
+#: ../../src/wxMaximaFrame.cpp:159
 msgid "Reading the config from the default location."
 msgstr ""
 
-#: ../../src/StatusBar.cpp:224
+#: ../../src/StatusBar.cpp:272
 msgid "Ready for user input"
 msgstr "Pronto para entrada do usuário"
 
-#: ../../src/Worksheet.cpp:960
-msgid "Recalculated the whole worksheet at once => Updating its size"
+#: ../../src/sidebars/PerformanceSidebar.cpp:43
+msgid "Recalc (Cells appended):"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:946
-msgid "Recalculation hit the end of the worksheet => Updating its size"
+#: ../../src/sidebars/PerformanceSidebar.cpp:42
+msgid "Recalc (Config changed):"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:930
+#: ../../src/sidebars/PerformanceSidebar.cpp:44
+msgid "Recalc (Editor dirty):"
+msgstr ""
+
+#: ../../src/sidebars/PerformanceSidebar.cpp:39
+msgid "Recalc (Font invalid):"
+msgstr ""
+
+#: ../../src/sidebars/PerformanceSidebar.cpp:41
+msgid "Recalc (Font mismatch):"
+msgstr ""
+
+#: ../../src/sidebars/PerformanceSidebar.cpp:40
+msgid "Recalc (Size invalid):"
+msgstr ""
+
+#: ../../src/worksheet/WorksheetLayout.cpp:162
+#, c-format
+msgid "Recalculated the whole worksheet at once => Updating its size (Visited %d cells, recalculated %d, in %ld ms)"
+msgstr ""
+
+#: ../../src/worksheet/WorksheetLayout.cpp:125
+#, c-format
+msgid "Recalculation covered the whole dirty range => stopping early (Visited %d cells, recalculated %d, in %ld ms)"
+msgstr ""
+
+#: ../../src/worksheet/WorksheetLayout.cpp:146
+#, c-format
+msgid "Recalculation hit the end of the worksheet => Updating its size (Visited %d cells, recalculated %d, in %ld ms)"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:964
 msgid "Recall next command from history"
 msgstr "Recuperar o próximo comando do histórico"
 
-#: ../../src/wxMaximaFrame.cpp:928
+#: ../../src/wxMaximaFrame.cpp:962
 msgid "Recall previous command from history"
 msgstr "Recuperar o comando anterior do histórico"
 
-#: ../../src/wxMaxima.cpp:3235
+#: ../../src/MaximaResponseReader.cpp:138
 #, c-format
 msgid "Received manual topic request: %s"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3097
+#: ../../src/MaximaResponseReader.cpp:237
 #, c-format
 msgid "Received maxima's first prompt: %s"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:603
+#: ../../src/dialogs/ConfigDialogue.cpp:1327
+msgid "Recent files list length:"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:634
 #, fuzzy
 msgid "Recover unsaved"
 msgstr "não salvo"
 
-#: ../../src/wxMaximaFrame.cpp:1640
+#: ../../src/sidebars/MathSidebar.cpp:56
+msgid "Rectform"
+msgstr "Forma ret"
+
+#: ../../src/wxMaximaFrame.cpp:1677
 #, fuzzy
 msgid "Recursive Substitute..."
 msgstr "Substituir..."
 
-#: ../../src/wxMaxima.cpp:8746
+#: ../../src/MaximaCommandMenus.cpp:744
 msgid "Recursive substitution"
 msgstr ""
 
-#: ../../src/ToolBar.cpp:192
+#: ../../src/ToolBar.cpp:355 ../../src/ToolBar.cpp:358
 msgid "Redo"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:633
+#: ../../src/wxMaximaFrame.cpp:670
 #, fuzzy
 msgid "Redo\tCtrl+Y"
 msgstr "&Desfazer\tCtrl+Z"
 
-#: ../../src/wxMaximaFrame.cpp:633
+#: ../../src/wxMaximaFrame.cpp:670
 msgid "Redo last change"
 msgstr "Desfazer última alteração"
 
-#: ../../src/wxMaximaFrame.cpp:1595
+#: ../../src/sidebars/MathSidebar.cpp:71
+msgid "Reduce (tr)"
+msgstr "Reduzir (tr)"
+
+#: ../../src/wxMaximaFrame.cpp:1632
 msgid "Reduce trigonometric expression"
 msgstr "Reduzir expressão trigonométrica"
 
-#: ../../src/wxMaxima.cpp:2366 ../../src/wxMaxima.cpp:10630
+#: ../../src/MaximaEvaluator.cpp:395
+msgid ""
+"Refusing to evaluate cell: its text changed between being queued and being evaluated (see GH #2196).\n"
+"Queued as: "
+msgstr ""
+
+#: ../../src/MaximaEvaluator.cpp:123 ../../src/MaximaEvaluator.cpp:515
 msgid "Refusing to send cell to maxima: "
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7523
+#: ../../src/dialogs/FindReplacePane.cpp:85
+msgid "Regex"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:4395
 msgid "Regex match"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7518
+#: ../../src/MaximaCommandMenus.cpp:4390
 msgid "Regex match position"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1195
+#: ../../src/wxMaximaFrame.cpp:2009
+msgid "Register wxMaxima as the tool that compares .wxmx files in TortoiseSVN and TortoiseGit"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1229
 #, fuzzy
 msgid "Regular expression that matches a string"
 msgstr "Coordenadas x separadas por vírgulas."
 
-#: ../../src/wxMaximaFrame.cpp:1196
+#: ../../src/wxMaximaFrame.cpp:1230
 #, fuzzy
 msgid "Regular expressions"
 msgstr "Integrar expressão"
 
-#: ../../src/Worksheet.cpp:1314
+#: ../../src/worksheet/WorksheetContextMenu.cpp:76
 #, fuzzy
 msgid "Reload Image"
 msgstr "Copiar como imagem"
 
-#: ../../src/Worksheet.cpp:1320
+#: ../../src/worksheet/WorksheetContextMenu.cpp:82
 #, c-format
 msgid "Reload Image \"%s\""
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:9809
+#: ../../src/dialogs/ConfigDialogue.cpp:997
+msgid "Reload all GUI settings from disc"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1004
+msgid "Reload the style settings from disc"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:3272
 #, c-format
 msgid "Reloading image file %s."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:883
+#: ../../src/dialogs/ConfigDialogue.cpp:2573
+msgid "Reloading the configuration from disc"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:2581
+#, fuzzy
+msgid "Reloading the styles from disc"
+msgstr "Ler estilo de um arquivo"
+
+#: ../../src/sidebars/VariablesPane.cpp:220
+msgid "Remove"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:917
 msgid "Remove All Output"
 msgstr "Remover todas as saídas"
 
-#: ../../src/wxMaximaFrame.cpp:1426
-msgid "Remove Rows or Columns..."
+#: ../../src/wxMaximaFrame.cpp:1463
+msgid "Remove Columns..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1748
+#: ../../src/wxMaximaFrame.cpp:1460
+msgid "Remove Rows..."
+msgstr ""
+
+#: ../../src/sidebars/VariablesPane.cpp:225
+msgid "Remove all"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1785
 msgid "Remove all list elements that appear twice in a row. Normally used in conjunction with sort."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1174
+#: ../../src/wxMaximaFrame.cpp:1208
 msgid "Remove all occurrences of a word..."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7439
+#: ../../src/MaximaCommandMenus.cpp:4311
 msgid "Remove all occurrences of part"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8592
+#: ../../src/MaximaCommandMenus.cpp:1611
 #, fuzzy
 msgid "Remove an element from a list"
 msgstr "Criar lista de uma expressão"
 
-#: ../../src/wxMaxima.cpp:7566
+#: ../../src/MaximaCommandMenus.cpp:1519
+msgid "Remove and return the first element of a list"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1464
+msgid "Remove columns from a matrix"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:4438
 msgid "Remove directory"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1204
+#: ../../src/wxMaximaFrame.cpp:1238
 msgid "Remove directory..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1747
+#: ../../src/wxMaximaFrame.cpp:1784
 msgid "Remove duplicates"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1176
+#: ../../src/wxMaximaFrame.cpp:1210
 msgid "Remove first occurrence of a word..."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7444
+#: ../../src/MaximaCommandMenus.cpp:4316
 msgid "Remove first occurrence of part"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:884
+#: ../../src/MaximaCommandMenus.cpp:1155
+msgid "Remove matrix columns"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:1160
+msgid "Remove matrix rows"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:918
 msgid "Remove output from input cells"
 msgstr "Remover saídas das células de entrada"
 
-#: ../../src/wxMaxima.cpp:7975
-msgid "Remove rows and/or columns"
+#: ../../src/wxMaximaFrame.cpp:1461
+msgid "Remove rows from the a matrix"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1427
-msgid "Remove rows and/or columns from the matrix"
-msgstr ""
-
-#: ../../src/wxMaxima.cpp:7582
+#: ../../src/MaximaCommandMenus.cpp:4454
 #, fuzzy
 msgid "Rename file"
 msgstr "Abrindo arquivo"
 
-#: ../../src/wxMaximaFrame.cpp:1215
+#: ../../src/wxMaximaFrame.cpp:1249
 #, fuzzy
 msgid "Rename file..."
 msgstr "Apagar uma variável"
 
-#: ../../src/wxMaximaFrame.cpp:1527
+#: ../../src/wxMaximaFrame.cpp:1564
 #, fuzzy
 msgid "Reorganize an expression using horner's rule"
 msgstr "Fatorar uma expressão em números gaussianos"
 
-#: ../../src/wxMaximaFrame.cpp:1346
+#: ../../src/wxMaximaFrame.cpp:1380
 msgid "Repetitive element-by-element multiplication"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7538
+#: ../../src/dialogs/FindReplacePane.cpp:117
+#, fuzzy
+msgid "Replace All"
+msgstr "Selecionar tudo"
+
+#: ../../src/MaximaCommandMenus.cpp:4410
 msgid "Replace all regex matches"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7533
+#: ../../src/MaximaCommandMenus.cpp:4405
 msgid "Replace first regex match"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7463
+#: ../../src/wxMaximaFrame.cpp:1990
+msgid "Replace non-builtin variable and function names in the selected code cells (or the whole document) with random names, so a worksheet can be shared without revealing its original names"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:4335
 #, fuzzy
 msgid "Replace the first occurrence of Part"
 msgstr "Substituídas %d ocorrências."
 
-#: ../../src/wxMaximaFrame.cpp:1180
+#: ../../src/wxMaximaFrame.cpp:1214
 #, fuzzy
 msgid "Replace..."
 msgstr "Selecionar tudo"
 
-#: ../../src/wxMaxima.cpp:6719
+#: ../../src/wxMaxima.cpp:2720
 #, fuzzy, c-format
 msgid "Replaced %li occurrences."
 msgstr "Substituídas %d ocorrências."
 
-#: ../../src/wxMaximaFrame.cpp:1950
+#: ../../src/dialogs/FindReplacePane.cpp:62
+msgid "Replacement:"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:768
+msgid "Replaces the subexpression that part(expr, n_1, n_2, ...) would select by a new value. The part numbers form a path: n_1 selects a part of the expression, n_2 a part of that, and so on."
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1987
 msgid "Report bug"
 msgstr "Relatar bug"
 
-#: ../../src/wxMaximaFrame.cpp:996
+#: ../../src/dialogs/ConfigDialogue.cpp:983
+msgid "Reset all GUI settings"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1030
 #, fuzzy
 msgid "Reset option variables"
 msgstr "Mudar variável"
 
-#: ../../src/ToolBar.cpp:229 ../../src/wxMaximaFrame.cpp:974
+#: ../../src/dialogs/ConfigDialogue.cpp:990
+msgid "Reset the Style settings"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:2557
+#: ../../src/dialogs/ConfigDialogue.cpp:2565
+msgid "Resetting all configuration settings"
+msgstr ""
+
+#: ../../src/ToolBar.cpp:411 ../../src/ToolBar.cpp:417
+#: ../../src/wxMaximaFrame.cpp:1008
 msgid "Restart Maxima"
 msgstr "Reiniciar Maxima"
 
-#: ../../src/Worksheet.cpp:1304 ../../src/Worksheet.cpp:1477
+#: ../../src/worksheet/WorksheetContextMenu.cpp:66
+#: ../../src/worksheet/WorksheetContextMenu.cpp:248
 #, fuzzy
 msgid "Restrict Maximum size"
 msgstr "Reiniciar Maxima"
 
-#: ../../src/wxMaxima.cpp:10031
+#: ../../src/MaximaCommandMenus.cpp:3520
 #, fuzzy
 msgid "Result variables:"
 msgstr "Apagar variável(is):"
 
-#: ../../src/wxMaxima.cpp:8135
+#: ../../src/MaximaCommandMenus.cpp:1323
 msgid "Resulting Matrix name (may be empty):"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1190
+#: ../../src/wxMaximaFrame.cpp:1224
 msgid "Return a match"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7077
+#: ../../src/MaximaCommandMenus.cpp:3949
 msgid "Return from a block or loop"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1069
+#: ../../src/wxMaximaFrame.cpp:1103
 msgid "Return from current block/loop..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1755
+#: ../../src/wxMaximaFrame.cpp:1792
 msgid "Return the first item of the list and remove it from the list. Useful for creating stacks."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8526
+#: ../../src/MaximaCommandMenus.cpp:1537
 msgid "Return the list without its first n elements"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8532
+#: ../../src/MaximaCommandMenus.cpp:1543
 msgid "Return the list without its last n elements"
 msgstr ""
 
-#: ../../src/ToolBar.cpp:241
+#: ../../src/ToolBar.cpp:424 ../../src/ToolBar.cpp:433
 msgid "Return to the cell that is currently being evaluated"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1711
+#: ../../src/wxMaximaFrame.cpp:1748
 msgid "Returns an arbitrary list item"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1713
+#: ../../src/MaximaCommandMenus.cpp:1527
+msgid "Returns the first element of a list"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1750
 msgid "Returns the first item of the list"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1719
+#: ../../src/MaximaCommandMenus.cpp:1531
+msgid "Returns the last element of a list"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1756
 msgid "Returns the last item of the list"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1721
+#: ../../src/wxMaximaFrame.cpp:1758
 msgid "Returns the last n items of the list"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1742
+#: ../../src/wxMaximaFrame.cpp:1779
 msgid "Returns the length of the list"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1715
+#: ../../src/wxMaximaFrame.cpp:1752
 msgid "Returns the list without its first n elements"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1717
+#: ../../src/wxMaximaFrame.cpp:1754
 msgid "Returns the list without its last n elements"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1743
+#: ../../src/MaximaCommandMenus.cpp:1509
+msgid "Returns the number of elements of a list"
+msgstr ""
+
+#: ../../src/wizards/DrawWiz.cpp:836
+#, fuzzy
+msgid "Reuse last"
+msgstr "Criar lista"
+
+#: ../../src/wxMaximaFrame.cpp:1780
 msgid "Reverse"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1744
+#: ../../src/wxMaximaFrame.cpp:1781
 msgid "Reverse the order of the list items"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7983 ../../src/wxMaxima.cpp:7988
-#: ../../src/wxMaxima.cpp:8008 ../../src/wxMaxima.cpp:8014
+#: ../../src/MaximaCommandMenus.cpp:1523
+msgid "Reverses the order of the members of a list"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:295
+msgid "Revert all to defaults"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:980
+#, fuzzy
+msgid "Revert changes"
+msgstr "Desfazer última alteração"
+
+#: ../../src/sidebars/GreekSidebar.cpp:194
+msgid "Rho"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:2015
+#, fuzzy
+msgid "Right"
+msgstr "direita"
+
+#: ../../src/MaximaCommandMenus.cpp:1167 ../../src/MaximaCommandMenus.cpp:1172
+#: ../../src/MaximaCommandMenus.cpp:1192 ../../src/MaximaCommandMenus.cpp:1198
 #, fuzzy
 msgid "Right Matrix:"
 msgstr "Informe uma matriz"
 
-#: ../../src/wxMaxima.cpp:8190
+#: ../../src/sidebars/SymbolsSidebar.cpp:127
+msgid "Right arrow"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:1380
 msgid "Right end"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1301
+#: ../../src/wxMaximaFrame.cpp:1335
 msgid "Right side to the \"=\""
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1455
+#: ../../src/wxMaximaFrame.cpp:1492
 msgid "Risch Integration..."
 msgstr "Integração Risch..."
 
-#: ../../src/wxMaximaFrame.cpp:785
+#: ../../src/dialogs/ConfigDialogue.cpp:222
+msgid "Romanian"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:822
 msgid "Rounded"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1437
+#: ../../src/wxMaximaFrame.cpp:1474
 msgid "Row and column operations"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7957 ../../src/wxMaxima.cpp:7967
-#: ../../src/wxMaxima.cpp:7972
+#: ../../src/MaximaCommandMenus.cpp:1137 ../../src/MaximaCommandMenus.cpp:1147
 msgid "Row number:"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7977
+#: ../../src/MaximaCommandMenus.cpp:1162
 #, fuzzy
 msgid "Row numbers:"
 msgstr "Números"
 
-#: ../../src/wxMaxima.cpp:8203
+#: ../../src/MaximaCommandMenus.cpp:1393
 #, fuzzy
 msgid "Rows"
 msgstr "Linas:"
 
-#: ../../src/wxMaxima.cpp:8201
+#: ../../src/wizards/MatWiz.cpp:152
+msgid "Rows:"
+msgstr "Linas:"
+
+#: ../../src/MaximaCommandMenus.cpp:1391
 msgid "Rule"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8464 ../../src/wxMaxima.cpp:8477
+#: ../../src/MaximaCommandMenus.cpp:1467
 msgid "Rule:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1027
+#: ../../src/wxMaximaFrame.cpp:1061
 msgid "Rules"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1693
+#: ../../src/wxMaximaFrame.cpp:1730
 #, fuzzy
 msgid "Run each element through an expression"
 msgstr "Encontrar o limite de uma expressão"
 
-#: ../../src/wxMaxima.cpp:6355
+#: ../../src/MaximaCommandMenus.cpp:2790
 #, c-format
 msgid "Running %s on the file %s: "
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2633
+#: ../../src/MaximaProcessManager.cpp:297
 #, c-format
 msgid "Running maxima as: %s"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:130
+#: ../../src/wxMaximaFrame.cpp:138
 msgid "Running on DirectFB"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:114
+#: ../../src/wxMaximaFrame.cpp:122
 msgid "Running on MS Windows"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:116
+#: ../../src/wxMaximaFrame.cpp:124
 msgid "Running on MS Windows using DirectDraw"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:136
+#: ../../src/wxMaximaFrame.cpp:144
 msgid "Running on Mac OS"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:127
+#: ../../src/wxMaximaFrame.cpp:135
 msgid "Running on Motif"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:133
+#: ../../src/wxMaximaFrame.cpp:141
 msgid "Running on the universal wxWidgets port"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8208
+#: ../../src/MaximaCommandMenus.cpp:1398
 msgid "Runs each element of an object (list, matrix, equation,...) through a function individually"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8216
+#: ../../src/MaximaCommandMenus.cpp:1406
 msgid "Runs each element of an object (list, matrix, equation,...) through an expression individually"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1691
+#: ../../src/wxMaximaFrame.cpp:1728
 msgid "Runs each element through a function"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1694
+#: ../../src/wxMaximaFrame.cpp:1731
 #, fuzzy
 msgid "Runs each element through an expression"
 msgstr "Encontrar o limite de uma expressão"
 
-#: ../../src/wxMaxima.cpp:9572
+#: ../../src/dialogs/ConfigDialogue.cpp:223
+msgid "Russian"
+msgstr "Russo"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1578
+msgid "SBCL: use <int>Mbytes of heap"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1585
+msgid "SBCL: use <int>Mbytes of stack for function calls"
+msgstr ""
+
+#: ../../src/sidebars/XmlInspector.cpp:78
+msgid "SENT TO MAXIMA:"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1224
+msgid "SVG graphics"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:1810
 msgid "Sample 1:"
 msgstr "Amostra 1:"
 
-#: ../../src/wxMaxima.cpp:9573
+#: ../../src/MaximaCommandMenus.cpp:1811
 msgid "Sample 2:"
 msgstr "Amostra 2:"
 
-#: ../../src/wxMaxima.cpp:9567
+#: ../../src/MaximaCommandMenus.cpp:1805
 msgid "Sample:"
 msgstr "Amostra:"
 
-#: ../../src/ToolBar.cpp:177 ../../src/wxMaxima.cpp:11203
+#: ../../src/wizards/DrawWiz.cpp:956
+msgid "Samples for explicit and parametric plots:"
+msgstr ""
+
+#: ../../src/wizards/DrawWiz.cpp:969
+msgid "Samples for implicit plots and regions:"
+msgstr ""
+
+#: ../../src/wizards/DrawWiz.cpp:937
+msgid "Samples for implicit plots:"
+msgstr ""
+
+#: ../../src/wizards/DrawWiz.cpp:924
+msgid "Samples on a line:"
+msgstr ""
+
+#: ../../src/ToolBar.cpp:331 ../../src/ToolBar.cpp:334
+#: ../../src/dialogs/ConfigDialogue.cpp:2163 ../../src/wxMaxima.cpp:3509
 msgid "Save"
 msgstr "Salvar"
 
-#: ../../src/Worksheet.cpp:1294
+#: ../../src/worksheet/WorksheetContextMenu.cpp:55
 msgid "Save Animation..."
 msgstr "Salvar animação..."
 
-#: ../../src/wxMaxima.cpp:5672
+#: ../../src/MaximaFileIO.cpp:779
 msgid "Save As"
 msgstr "Salvar como"
 
-#: ../../src/wxMaximaFrame.cpp:609
+#: ../../src/wxMaximaFrame.cpp:640
 msgid "Save As...\tShift+Ctrl+S"
 msgstr "Salvar como...\tShift+Ctrl+S"
 
-#: ../../src/Worksheet.cpp:1291
+#: ../../src/worksheet/WorksheetContextMenu.cpp:50
 msgid "Save Image..."
 msgstr "Salvar imagem..."
 
-#: ../../src/wxMaxima.cpp:6440
+#: ../../src/MaximaCommandMenus.cpp:2926
 msgid "Save Selection to Image"
 msgstr "Salvar seleção para imagem"
 
-#: ../../src/wxMaximaFrame.cpp:675
+#: ../../src/wxMaximaFrame.cpp:712
 msgid "Save Selection to Image..."
 msgstr "Salvar seleção para imagem..."
 
-#: ../../src/wxMaxima.cpp:10184
+#: ../../src/MaximaCommandMenus.cpp:3713
 msgid "Save animation to file"
 msgstr "Salvar animação para arquivo"
 
-#: ../../src/wxMaxima.cpp:7203
+#: ../../src/MaximaCommandMenus.cpp:4075
 msgid "Save as lisp code"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1091
+#: ../../src/wxMaximaFrame.cpp:1125
 #, fuzzy
 msgid "Save as lisp..."
 msgstr "Carregar pacote"
 
-#: ../../src/ToolBar.cpp:177 ../../src/wxMaximaFrame.cpp:608
+#: ../../src/dialogs/ConfigDialogue.cpp:2478
+#, fuzzy
+msgid "Save config to file"
+msgstr "Salvar seleção para arquivo"
+
+#: ../../src/ToolBar.cpp:331 ../../src/ToolBar.cpp:334
+#: ../../src/wxMaximaFrame.cpp:639
 msgid "Save document"
 msgstr "Salvar documento"
 
-#: ../../src/wxMaximaFrame.cpp:609
+#: ../../src/wxMaximaFrame.cpp:640
 msgid "Save document as"
 msgstr "Salvar documento como"
 
-#: ../../src/wxMaximaFrame.cpp:676
+#: ../../src/wizards/Plot2dWiz.cpp:473 ../../src/wizards/Plot3dWiz.cpp:421
+msgid "Save plot to file"
+msgstr "Salvar gráfico para um arquivo"
+
+#: ../../src/wxMaximaFrame.cpp:713
 msgid "Save selection from document to an image file"
 msgstr "Salvar seleção do documento para uma imagem"
 
-#: ../../src/wxMaxima.cpp:10125
+#: ../../src/MaximaCommandMenus.cpp:3620
 msgid "Save selection to file"
 msgstr "Salvar seleção para arquivo"
 
-#: ../../src/wxMaximaFrame.cpp:573
+#: ../../src/dialogs/ConfigDialogue.cpp:2640
+msgid "Save style to file"
+msgstr "Salvar estilo para um arquivo"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1384
+msgid "Save the worksheet automatically"
+msgstr ""
+
+#: ../../src/MaximaFileIO.cpp:873
+msgid "Saving failed!"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:594
 #, fuzzy
 msgid "Saving failed."
 msgstr "Falha ao iniciar o servidor"
 
-#: ../../src/WXMXformat.cpp:310
+#: ../../src/WXMXformat.cpp:312
 msgid "Saving succeeded, but the resulting files has disappeared ?!?."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:10107
-msgid "Scalable Vector image (*.svg)|*.svg|Compressed Scalable Vector Image (*.svgz)|*.svgz|PNG image (*.png)|*.png|JPEG image (*.jpg)|*.jpg|GIF image (*.gif)|*.gif|Windows bitmap (*.bmp)|*.bmp|Portable anymap (*.pnm)|*.pnm|Tagged image file format (*.tif)|*.tif|X pixmap (*.xpm)|*.xpm"
+#: ../../src/dialogs/ConfigDialogue.cpp:1914
+msgid "Scalable Vector Graphics (svg)"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:9533
+#: ../../src/MaximaCommandMenus.cpp:3596
+msgid "Scalable Vector image (*.svg)|*.svg|Compressed Scalable Vector Image (*.svgz)|*.svgz|PNG image (*.png)|*.png|JPEG image (*.jpg)|*.jpg|GIF image (*.gif)|*.gif|Windows bitmap (*.bmp)|*.bmp|"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:1771
 msgid "Scatterplot"
 msgstr "Gráfico de dispersão"
 
-#: ../../src/Autocomplete.cpp:125
+#: ../../src/sidebars/StatSidebar.cpp:88
+msgid "Scatterplot..."
+msgstr "Gráfico de dispersão..."
+
+#: ../../src/Autocomplete.cpp:157
 msgid "Scheduling a background task that compiles a new list of autocompletable maxima commands."
 msgstr ""
 
-#: ../../src/Autocomplete.cpp:458
+#: ../../src/Autocomplete.cpp:586
 msgid "Scheduling a background task that scans for autocompletable file names."
 msgstr ""
 
-#: ../../src/ToolBar.cpp:632
+#: ../../src/dialogs/ConfigDialogue.cpp:1867
+msgid "Screen reader"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:662
+msgid "Scroll to a cell with a certain UUID"
+msgstr ""
+
+#: ../../src/ToolBar.cpp:832
 msgid "Search button"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7454
+#: ../../src/MaximaCommandMenus.cpp:4326
 msgid "Search first occurrence of part"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1178
+#: ../../src/dialogs/DiffFrame.cpp:420
+msgid "Search input / UUID"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1212
 msgid "Search..."
 msgstr ""
 
-#: ../../src/ToolBar.cpp:273
+#: ../../src/ToolBar.cpp:483 ../../src/sidebars/FormatSidebar.cpp:51
 msgid "Section"
 msgstr "Seção"
 
-#: ../../src/Configuration.cpp:91
+#: ../../src/Styles.cpp:120
 msgid "Section cell (Heading 2)"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7218
+#: ../../src/sidebars/TableOfContents.cpp:585
+msgid "Section numbers"
+msgstr ""
+
+#: ../../src/wizards/DrawWiz.cpp:158
+msgid "See also the speed <-> accuracy button."
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:4090
 #, fuzzy
 msgid "Seek to position"
 msgstr "Aproximação de Padé"
@@ -6252,1147 +9381,1662 @@ msgstr "Aproximação de Padé"
 msgid "Seems like something is broken with a font."
 msgstr ""
 
-#: ../../src/Autocomplete.cpp:350
+#: ../../src/Autocomplete.cpp:438
 msgid "Seems like the package with the maxima share files isn't installed."
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1655 ../../src/Worksheet.cpp:1687
+#: ../../src/sidebars/TableOfContents.cpp:511
+#, fuzzy
+msgid "Select"
+msgstr "Seleção"
+
+#: ../../src/MaximaCommandMenus.cpp:2239
+msgid "Select 2 or 3 files to compare"
+msgstr ""
+
+#: ../../src/worksheet/WorksheetContextMenu.cpp:428
+#: ../../src/worksheet/WorksheetContextMenu.cpp:460
 msgid "Select All"
 msgstr "Selecionar tudo"
 
-#: ../../src/wxMaximaFrame.cpp:673
+#: ../../src/wxMaximaFrame.cpp:710
 msgid "Select All\tCtrl+A"
 msgstr "Selecionar tudo\tCtrl+A"
 
-#: ../../src/ToolBar.cpp:629
+#: ../../src/ToolBar.cpp:829
 msgid "Select All button"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:9631
+#: ../../src/MaximaCommandMenus.cpp:1871
 msgid "Select Subsample"
 msgstr "Selecione a subamostra"
 
-#: ../../src/ToolBar.cpp:214 ../../src/ToolBar.cpp:215
-#: ../../src/wxMaximaFrame.cpp:673
+#: ../../src/wizards/IntegrateWiz.cpp:193
+#: ../../src/wizards/IntegrateWiz.cpp:208 ../../src/wizards/LimitWiz.cpp:133
+#: ../../src/wizards/SeriesWiz.cpp:105
+msgid "Select a constant"
+msgstr "Selecione uma constante"
+
+#: ../../src/ToolBar.cpp:390 ../../src/ToolBar.cpp:392
+#: ../../src/wxMaximaFrame.cpp:710
 msgid "Select all"
 msgstr "Selecionar tudo"
 
-#: ../../src/wxMaxima.cpp:6971
+#: ../../src/dialogs/BinaryNameCtrl.cpp:64
+msgid "Select binary location program"
+msgstr ""
+
+#: ../../src/wizards/CsvWiz.cpp:92 ../../src/wizards/CsvWiz.cpp:166
+msgid "Select csv file to read"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:3843
 msgid "Select math display algorithm"
 msgstr "Selecione o algoritmo de exibição de fórmulas"
 
-#: ../../src/Configuration.cpp:98
+#: ../../src/dialogs/TipOfTheDay.cpp:109
+#, fuzzy
+msgid "Selecting a part of an output and right-clicking on the selection will bring up a menu with convenient functions that will operate on the selection."
+msgstr "Selecionar uma parte da saída e clicar com o botão direito na seleção traz um menu com funções convenientes que operam na seleção."
+
+#: ../../src/Styles.cpp:127
 #, fuzzy
 msgid "Selection color"
 msgstr "Seleção"
 
-#: ../../src/ToolBar.cpp:252
+#: ../../src/wizards/CsvWiz.cpp:40 ../../src/wizards/CsvWiz.cpp:111
+msgid "Semicolon"
+msgstr ""
+
+#: ../../src/ToolBar.cpp:446 ../../src/ToolBar.cpp:458
 msgid "Send all cells to maxima"
 msgstr ""
 
-#: ../../src/ToolBar.cpp:249
+#: ../../src/ToolBar.cpp:443 ../../src/ToolBar.cpp:455
 msgid "Send the current cell to maxima"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2810
+#: ../../src/MaximaProcessManager.cpp:921
 msgid "Sending Maxima a SIGINT signal."
 msgstr ""
 
-#: ../../src/StatusBar.cpp:220
+#: ../../src/StatusBar.cpp:263
 msgid "Sending a command to Maxima"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:10598
+#: ../../src/MaximaEvaluator.cpp:471
 msgid "Sending a new command to Maxima."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2792
+#: ../../src/MaximaProcessManager.cpp:902
 msgid "Sending an interrupt signal to Maxima."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:169
+#: ../../src/wxMaxima.cpp:218
 msgid "Sending configuration data to maxima."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:4718
+#: ../../src/MaximaEvaluator.cpp:558
 msgid "Sending maxima the info how to express 2d maths as XML"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1533
+#: ../../src/wxMaximaFrame.cpp:1570
 #, fuzzy
 msgid "Sequential Comparative Simplification"
 msgstr "Simplificação &complexa"
 
-#: ../../src/wxMaxima.cpp:9016
+#: ../../src/dialogs/ConfigDialogue.cpp:224
+msgid "Serbian"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:270 ../../src/wizards/SeriesWiz.cpp:60
 msgid "Series"
 msgstr "Série"
 
-#: ../../src/wxMaximaFrame.cpp:1479
+#: ../../src/wxMaximaFrame.cpp:1516
 #, fuzzy
 msgid "Series approximation"
 msgstr "Aproximação de Padé"
 
-#: ../../src/wxMaxima.cpp:2561
+#: ../../src/MaximaProcessManager.cpp:227
 msgid "Server started"
 msgstr "Servidor iniciado"
 
-#: ../../src/wxMaximaFrame.cpp:1824
+#: ../../src/wxMaximaFrame.cpp:1861
 #, fuzzy
 msgid "Set &displayed Precision..."
 msgstr "Ajustar &precisão..."
 
-#: ../../src/wxMaximaFrame.cpp:1563
+#: ../../src/wxMaximaFrame.cpp:1600
 msgid "Set Maxima option variable logexpand:all"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1567
+#: ../../src/wxMaximaFrame.cpp:1604
 msgid "Set Maxima option variable logexpand:super"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1560
+#: ../../src/wxMaximaFrame.cpp:1597
 msgid "Set Maxima option variable logexpand:true"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:822
+#: ../../src/wxMaximaFrame.cpp:859
 msgid "Set Zoom"
 msgstr "Ajustar zoom"
 
-#: ../../src/wxMaximaFrame.cpp:1819
+#: ../../src/wxMaximaFrame.cpp:1856
 #, fuzzy
 msgid "Set bigfloat &Precision..."
 msgstr "Ajustar a precisão de ponto flutuante"
 
-#: ../../src/Worksheet.cpp:1306 ../../src/Worksheet.cpp:1479
+#: ../../src/dialogs/ConfigDialogue.cpp:479
+msgid "Set fixed font in text controls."
+msgstr "Usa fonte monoespaçada nos controles de texto."
+
+#: ../../src/worksheet/WorksheetContextMenu.cpp:68
+#: ../../src/worksheet/WorksheetContextMenu.cpp:250
 msgid "Set image resolution"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1510
+#: ../../src/dialogs/ResolutionChooser.cpp:29
+msgid "Set image resolution [in ppi]"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1547
 #, fuzzy
 msgid "Set main variable..."
 msgstr "Apagar uma variável"
 
-#: ../../src/wxMaximaFrame.cpp:1773
+#: ../../src/dialogs/MaxSizeChooser.cpp:29
+msgid "Set maximum image size [in mm]"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1810
 msgid "Set plot format"
 msgstr "Ajustar formato do gráfico"
 
-#: ../../src/wxMaximaFrame.cpp:1101
+#: ../../src/wxMaximaFrame.cpp:1135
 #, fuzzy
 msgid "Set position..."
 msgstr "Salvar animação..."
 
-#: ../../src/wxMaximaFrame.cpp:1656
+#: ../../src/wxMaximaFrame.cpp:1693
 #, fuzzy
 msgid "Set the \"algebraic\" flag"
 msgstr "Alternar flag algébrico"
 
-#: ../../src/wxMaxima.cpp:8314
+#: ../../src/MaximaCommandMenus.cpp:1960
 msgid "Set the diagram title"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1779
+#: ../../src/wxMaximaFrame.cpp:1816
 #, fuzzy
 msgid "Set the frame rate for animations."
 msgstr "Iniciar animação"
 
-#: ../../src/wxMaxima.cpp:8377
+#: ../../src/MaximaCommandMenus.cpp:2023
 msgid "Set the grid density."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8327
+#: ../../src/MaximaCommandMenus.cpp:1973
 msgid "Set the next plot's title. Empty = no title."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1820
+#: ../../src/wxMaximaFrame.cpp:1857
 msgid "Set the precision for numbers that are defined as bigfloat. Such numbers can be generated by entering 1.5b12 or as bfloat(1.234)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:811
+#: ../../src/wxMaximaFrame.cpp:848
 msgid "Set zoom to 100%"
 msgstr "Definir zoom em 100%"
 
-#: ../../src/wxMaximaFrame.cpp:813
+#: ../../src/wxMaximaFrame.cpp:850
 msgid "Set zoom to 120%"
 msgstr "Definir zoom em 120%"
 
-#: ../../src/wxMaximaFrame.cpp:815
+#: ../../src/wxMaximaFrame.cpp:852
 msgid "Set zoom to 150%"
 msgstr "Definir zoom em 150%"
 
-#: ../../src/wxMaximaFrame.cpp:817
+#: ../../src/wxMaximaFrame.cpp:854
 msgid "Set zoom to 200%"
 msgstr "Definir zoom em 200%"
 
-#: ../../src/wxMaximaFrame.cpp:819
+#: ../../src/wxMaximaFrame.cpp:856
 msgid "Set zoom to 300%"
 msgstr "Definir zoom em 300%"
 
-#: ../../src/wxMaximaFrame.cpp:809
+#: ../../src/wxMaximaFrame.cpp:846
 msgid "Set zoom to 80%"
 msgstr "Definir zoom em 80%"
 
-#: ../../src/wxMaxima.cpp:4731
+#: ../../src/dialogs/ConfigDialogue.cpp:163
+msgid "Sets the language, line ending type and charset encoding programs will use"
+msgstr ""
+
+#: ../../src/MaximaEvaluator.cpp:574
 #, c-format
 msgid "Setting gnuplot_binary to %s"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:4804
+#: ../../src/MaximaEvaluator.cpp:642
 #, fuzzy
 msgid "Setting prompt and help format"
 msgstr "Ajustar formato do gráfico"
 
-#: ../../src/wxMaximaFrame.cpp:1292
+#: ../../src/dialogs/ConfigDialogue.cpp:165
+msgid "Setting this to \"cat\" causes gnuplot not to halt if there is much output"
+msgstr ""
+
+#: ../../src/wizards/DrawWiz.cpp:546
+msgid "Settings for the following 3d plots"
+msgstr ""
+
+#: ../../src/wizards/DrawWiz.cpp:462
+#, c-format
+msgid "Setup a %iD scene"
+msgstr ""
+
+#: ../../src/sidebars/DrawSidebar.cpp:48
+msgid "Setup a 2D plot"
+msgstr ""
+
+#: ../../src/sidebars/DrawSidebar.cpp:52
+msgid "Setup a 3D plot"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1326
 msgid "Setup atvalues for solving ODE with Laplace transformation"
 msgstr "Configurar valores em pontos para resolver EDO com transformada de Laplace"
 
-#: ../../src/wxMaximaFrame.cpp:1661
+#: ../../src/wxMaximaFrame.cpp:1698
 msgid "Setup modulus computation"
 msgstr "Configurar cálculos com módulo"
 
-#: ../../src/wxMaxima.cpp:9220
+#: ../../src/sidebars/DrawSidebar.cpp:78
+msgid "Setup the axis"
+msgstr ""
+
+#: ../../src/wizards/DrawWiz.cpp:263
+msgid "Setup the axis for the current plot."
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:411
 msgid "Setup the engineering format"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1831
+#: ../../src/wxMaximaFrame.cpp:1868
 msgid "Setup the engineering format..."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:9576
+#: ../../src/MaximaCommandMenus.cpp:1814
 msgid "Shapiro-Wilk test for normality"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1543
+#: ../../src/worksheet/WorksheetContextMenu.cpp:316
 #, fuzzy
 msgid "Show \"%\" in special constants"
 msgstr "Constantes especiais"
 
-#: ../../src/wxMaximaFrame.cpp:1889
+#: ../../src/wxMaximaFrame.cpp:1926
 msgid "Show &Tips..."
 msgstr "&Mostar dicas..."
 
-#: ../../src/Worksheet.cpp:1556
+#: ../../src/worksheet/WorksheetContextMenu.cpp:329
 msgid "Show * as multiplication dot"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:895
+#: ../../src/wxMaximaFrame.cpp:929
 #, fuzzy
 msgid "Show Template\tCtrl+Shift+Space"
 msgstr "Exibir modelo\tCtrl+Shift+K"
 
-#: ../../src/wxMaximaFrame.cpp:753
+#: ../../src/wxMaximaFrame.cpp:790
 #, fuzzy
 msgid "Show XML representation"
 msgstr "Mostrar expressões longas"
 
-#: ../../src/wxMaximaFrame.cpp:1889
+#: ../../src/wxMaximaFrame.cpp:1926
 msgid "Show a tip"
 msgstr "Mostrar uma dica"
 
-#: ../../src/Worksheet.cpp:1607
+#: ../../src/worksheet/WorksheetContextMenu.cpp:380
 msgid "Show all + allow linebreaks in long numbers"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:9475
+#: ../../src/MaximaCommandMenus.cpp:2118
 msgid "Show all commands similar to:"
 msgstr "Mostrar todos os comandos semelhantes a:"
 
-#: ../../src/wxMaxima.cpp:9468
+#: ../../src/sidebars/SymbolsSidebar.cpp:206
+msgid "Show all unicode symbols"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:2111
 msgid "Show an example for the command:"
 msgstr "Mostrar um exemplo para o comando:"
 
-#: ../../src/wxMaximaFrame.cpp:1883
+#: ../../src/wxMaximaFrame.cpp:1920
 msgid "Show an example of usage"
 msgstr "Mostrar um exemplo de uso"
 
-#: ../../src/wxMaximaFrame.cpp:1884
+#: ../../src/sidebars/History.cpp:121
+msgid "Show commands from current session only"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1921
 msgid "Show commands similar to"
 msgstr "Mostrar os comandos semelhantes a"
 
-#: ../../src/wxMaximaFrame.cpp:1020
+#: ../../src/wxMaximaFrame.cpp:1054
 msgid "Show defined functions"
 msgstr "Mostrar funções definidas"
 
-#: ../../src/wxMaximaFrame.cpp:1022
+#: ../../src/wxMaximaFrame.cpp:1056
 msgid "Show defined variables"
 msgstr "Mostrar variáveis definidas"
 
-#: ../../src/wxMaximaFrame.cpp:1074
+#: ../../src/wxMaximaFrame.cpp:1108
 msgid "Show definition of a function"
 msgstr "Mostrar definição de uma função"
 
-#: ../../src/wxMaximaFrame.cpp:740
+#: ../../src/wxMaximaFrame.cpp:777
 msgid "Show equations in their linear form"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1073
+#: ../../src/wxMaximaFrame.cpp:1107
 #, fuzzy
 msgid "Show function &Definition..."
 msgstr "Mostar &definição..."
 
-#: ../../src/wxMaximaFrame.cpp:896
+#: ../../src/wxMaximaFrame.cpp:930
 msgid "Show function template"
 msgstr "Mostrar modelo de função"
 
-#: ../../src/Worksheet.cpp:1614
+#: ../../src/worksheet/WorksheetContextMenu.cpp:387
 #, fuzzy
 msgid "Show input labels"
 msgstr "Rótulos de entrada"
 
-#: ../../src/wxMaximaFrame.cpp:750
+#: ../../src/dialogs/ConfigDialogue.cpp:766
+#, fuzzy
+msgid "Show labels:"
+msgstr "Mostrar &variáveis"
+
+#: ../../src/wxMaximaFrame.cpp:787
 #, fuzzy
 msgid "Show lisp representation"
 msgstr "Mostrar expressões longas"
 
-#: ../../src/Worksheet.cpp:1604
+#: ../../src/dialogs/ConfigDialogue.cpp:465
+msgid "Show long expressions in wxMaxima document."
+msgstr "Mostrar expressões grandes no documento do wxMaxima."
+
+#: ../../src/dialogs/ConfigDialogue.cpp:722
+#, fuzzy
+msgid "Show long expressions:"
+msgstr "Mostrar expressões longas"
+
+#: ../../src/worksheet/WorksheetContextMenu.cpp:377
 msgid "Show max. 100 digits"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1602
+#: ../../src/worksheet/WorksheetContextMenu.cpp:375
 msgid "Show max. 20 digits"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1603
+#: ../../src/worksheet/WorksheetContextMenu.cpp:376
 msgid "Show max. 50 digits"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:835
+#: ../../src/wxMaximaFrame.cpp:868
 msgid "Show or hide the wxMaxima logging window"
 msgstr ""
 
-#: ../../src/ToolBar.cpp:612
+#: ../../src/ToolBar.cpp:812
 msgid "Show the \"New\" button?"
 msgstr ""
 
-#: ../../src/ToolBar.cpp:636
+#: ../../src/ToolBar.cpp:836
 msgid "Show the \"help\" button?"
 msgstr ""
 
-#: ../../src/ToolBar.cpp:633
+#: ../../src/ToolBar.cpp:833
 msgid "Show the \"search\" button?"
 msgstr ""
 
-#: ../../src/ToolBar.cpp:630
+#: ../../src/ToolBar.cpp:830
 msgid "Show the \"select all\" button?"
 msgstr ""
 
-#: ../../src/ToolBar.cpp:624
+#: ../../src/ToolBar.cpp:824
 msgid "Show the Copy, Cut and the Paste button?"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7033
+#: ../../src/wxMaximaFrame.cpp:650
+msgid "Show the differences between 2 or 3 files"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:3905
 #, fuzzy
 msgid "Show the function's definition"
 msgstr "Mostrar a definição da função:"
 
-#: ../../src/ToolBar.cpp:618
+#: ../../src/ToolBar.cpp:818
 msgid "Show the open and the save button?"
 msgstr ""
 
-#: ../../src/ToolBar.cpp:627
+#: ../../src/ToolBar.cpp:827
 msgid "Show the preferences button?"
 msgstr ""
 
-#: ../../src/ToolBar.cpp:621
+#: ../../src/ToolBar.cpp:821
 msgid "Show the print button?"
 msgstr ""
 
-#: ../../src/ToolBar.cpp:615
+#: ../../src/ToolBar.cpp:815
 #, fuzzy
 msgid "Show the undo and redo button?"
 msgstr "Mostrar a definição da função:"
 
-#: ../../src/wxMaximaFrame.cpp:1006 ../../src/wxMaximaFrame.cpp:1011
+#: ../../src/dialogs/TipOfTheDay.cpp:288
+msgid "Show tips at Startup"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1040 ../../src/wxMaximaFrame.cpp:1045
 msgid "Show used + to-be-freed memory"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1033
+#: ../../src/wxMaximaFrame.cpp:1067
 #, fuzzy
 msgid "Show user definitions"
 msgstr "Mostrar a definição da função:"
 
-#: ../../src/ToolBar.cpp:328 ../../src/wxMaximaFrame.cpp:1877
-#: ../../src/wxMaximaFrame.cpp:1879
+#: ../../src/ToolBar.cpp:544 ../../src/ToolBar.cpp:546
+#: ../../src/wxMaximaFrame.cpp:1914 ../../src/wxMaximaFrame.cpp:1916
 #, fuzzy
 msgid "Show wxMaxima help"
 msgstr "Mostrar ajuda do Maxima"
 
-#: ../../src/wxMaximaFrame.cpp:1825
+#: ../../src/wxMaximaFrame.cpp:1862
 msgid "Shows how many digits of a numbers are displayed"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:732
+#: ../../src/wxMaximaFrame.cpp:769
 msgid "Sidebars"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1513
+#: ../../src/sidebars/GreekSidebar.cpp:195
+msgid "Sigma"
+msgstr ""
+
+#: ../../src/dialogs/FindReplacePane.cpp:88
+#, fuzzy
+msgid "Simple"
+msgstr "Amostra:"
+
+#: ../../src/MaximaCommandMenus.cpp:1819
+msgid "Simple linear regression"
+msgstr ""
+
+#: ../../src/sidebars/MathSidebar.cpp:44
+msgid "Simplify"
+msgstr "Simplificar"
+
+#: ../../src/wxMaximaFrame.cpp:1550
 #, fuzzy
 msgid "Simplify &Radicals..."
 msgstr "Simplificar &radicais"
 
-#: ../../src/Worksheet.cpp:1579
+#: ../../src/sidebars/MathSidebar.cpp:47
+msgid "Simplify (r)"
+msgstr "Simplificar (r)"
+
+#: ../../src/sidebars/MathSidebar.cpp:65
+msgid "Simplify (tr)"
+msgstr "Simplificar (tr)"
+
+#: ../../src/worksheet/WorksheetContextMenu.cpp:352
 msgid "Simplify Expression"
 msgstr "Simplificar expressão"
 
-#: ../../src/wxMaximaFrame.cpp:1568
+#: ../../src/wxMaximaFrame.cpp:1605
 #, fuzzy
 msgid "Simplify Logarithms"
 msgstr "Simplificar a soma"
 
-#: ../../src/wxMaximaFrame.cpp:1582
+#: ../../src/wxMaximaFrame.cpp:1619
 msgid "Simplify an expression containing factorials"
 msgstr "Simplificar uma expressão envolvendo fatoriais"
 
-#: ../../src/wxMaximaFrame.cpp:1539
+#: ../../src/wxMaximaFrame.cpp:1576
 #, fuzzy
 msgid "Simplify equations"
 msgstr "Resolver equação(ões)"
 
-#: ../../src/wxMaximaFrame.cpp:1514
+#: ../../src/wxMaximaFrame.cpp:1551
 msgid "Simplify expression containing radicals"
 msgstr "Simplificar uma expressão envolvendo radicais"
 
-#: ../../src/wxMaxima.cpp:8649
+#: ../../src/MaximaCommandMenus.cpp:641
 #, fuzzy
 msgid "Simplify radicals"
 msgstr "Simplificar &radicais"
 
-#: ../../src/wxMaximaFrame.cpp:1512
+#: ../../src/wxMaximaFrame.cpp:1549
 msgid "Simplify rational expression"
 msgstr "Simplificar uma expressão racional"
 
-#: ../../src/wxMaximaFrame.cpp:1538
+#: ../../src/wxMaximaFrame.cpp:1575
 msgid "Simplify sum() commands..."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8636
+#: ../../src/MaximaCommandMenus.cpp:628
 #, fuzzy
 msgid "Simplify sums"
 msgstr "Simplificar"
 
-#: ../../src/wxMaximaFrame.cpp:1592
+#: ../../src/wizards/SumWiz.cpp:68
+msgid "Simplify the sum"
+msgstr "Simplificar a soma"
+
+#: ../../src/wxMaximaFrame.cpp:1629
 msgid "Simplify trigonometric expression"
 msgstr "Simplificar uma expressão trigonométrica"
 
-#: ../../src/wxMaximaFrame.cpp:1399
+#: ../../src/dialogs/TipOfTheDay.cpp:139
+#, fuzzy
+msgid "Since wxMaxima 0.8.2 you can also insert images into your documents. Use 'Cell->Insert Image...' menu command."
+msgstr "Desde o wxMaxima 0.8.2 você pode inserir imagens nos documentos. Use o menu 'Célula->Inserir imagem...'. Note que você precisa salvar o documento no formato 'Documento XML do wxMaxima' para que a imagem seja salva junto com o documento."
+
+#: ../../src/wxMaximaFrame.cpp:1433
 msgid "Singular Values"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1400 ../../src/wxMaximaFrame.cpp:1403
+#: ../../src/wxMaximaFrame.cpp:1434 ../../src/wxMaximaFrame.cpp:1437
 msgid "Singular values using dgesvd"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1402
+#: ../../src/wxMaximaFrame.cpp:1436
 msgid "Singular values, left + right vectors"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1635
+#: ../../src/MaximaCommandMenus.cpp:487 ../../src/MaximaCommandMenus.cpp:500
+msgid "Size of internal work array. (limit - limlst)/2 is the maximum number of subintervals to use."
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:436 ../../src/MaximaCommandMenus.cpp:449
+#: ../../src/MaximaCommandMenus.cpp:462 ../../src/MaximaCommandMenus.cpp:476
+#: ../../src/MaximaCommandMenus.cpp:547 ../../src/MaximaCommandMenus.cpp:562
+#: ../../src/MaximaCommandMenus.cpp:577 ../../src/MaximaCommandMenus.cpp:592
+#: ../../src/MaximaCommandMenus.cpp:606
+msgid "Size of internal work array. limit is the maximum number of subintervals to use."
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:515 ../../src/MaximaCommandMenus.cpp:529
+msgid "Size of internal work array. limit/2 is the maximum number of subintervals to use."
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:2113
+msgid "Slanted"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:225
+msgid "Slovak"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:226
+msgid "Slovenian"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1672
 #, fuzzy
 msgid "Smart Substitute..."
 msgstr "Substituir..."
 
-#: ../../src/wxMaxima.cpp:8730
+#: ../../src/MaximaCommandMenus.cpp:725
 #, fuzzy
 msgid "Smart substitution"
 msgstr "Substituir"
 
-#: ../../src/wxMaxima.cpp:7799 ../../src/wxMaxima.cpp:7810
-#: ../../src/wxMaxima.cpp:7823
+#: ../../src/MaximaCommandMenus.cpp:980 ../../src/MaximaCommandMenus.cpp:991
+#: ../../src/MaximaCommandMenus.cpp:1004
 #, fuzzy
 msgid "Solution of the ODE:"
 msgstr "Solução:"
 
-#: ../../src/wxMaxima.cpp:10017
+#: ../../src/wizards/BC2Wiz.cpp:30
+msgid "Solution:"
+msgstr "Solução:"
+
+#: ../../src/MaximaCommandMenus.cpp:3506
 msgid "Solve"
 msgstr "Resolver"
 
-#: ../../src/wxMaximaFrame.cpp:1244
+#: ../../src/wxMaximaFrame.cpp:1278
 msgid "Solve &Algebraic System..."
 msgstr "Resolver sistema &algébrico..."
 
-#: ../../src/wxMaximaFrame.cpp:1242
+#: ../../src/wxMaximaFrame.cpp:1276
 msgid "Solve &Linear System..."
 msgstr "Resolver sistema &linear..."
 
-#: ../../src/wxMaximaFrame.cpp:1266
+#: ../../src/wxMaximaFrame.cpp:1300
 msgid "Solve &ODE..."
 msgstr "Resolver ED&O..."
 
-#: ../../src/wxMaximaFrame.cpp:1240
+#: ../../src/wxMaximaFrame.cpp:1274
 msgid "Solve (to_poly)..."
 msgstr "Resolver (to_poly)..."
 
-#: ../../src/wxMaxima.cpp:8045
+#: ../../src/MaximaCommandMenus.cpp:1231
 msgid "Solve A*x=b numerically"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1397
+#: ../../src/wxMaximaFrame.cpp:1431
 #, fuzzy
 msgid "Solve Ax=b"
 msgstr "Resolver"
 
-#: ../../src/wxMaxima.cpp:7783
+#: ../../src/MaximaCommandMenus.cpp:964
 msgid "Solve ODE"
 msgstr "Resolver EDO ..."
 
-#: ../../src/wxMaximaFrame.cpp:1287
+#: ../../src/wxMaximaFrame.cpp:1321
 msgid "Solve ODE with Lapla&ce..."
 msgstr "Resolver EDO com Laplace..."
 
-#: ../../src/wxMaximaFrame.cpp:1398
+#: ../../src/sidebars/MathSidebar.cpp:77
+msgid "Solve ODE..."
+msgstr "Resolver EDO..."
+
+#: ../../src/wxMaximaFrame.cpp:1432
 #, fuzzy
 msgid "Solve a linear equation system using dgesv"
 msgstr "Resolver sistema de equações lineares"
 
-#: ../../src/wxMaxima.cpp:7852 ../../src/wxMaxima.cpp:7863
+#: ../../src/MaximaCommandMenus.cpp:1033 ../../src/MaximaCommandMenus.cpp:1044
 msgid "Solve algebraic system"
 msgstr "Resolver sistema algébrico"
 
-#: ../../src/wxMaximaFrame.cpp:1245
+#: ../../src/wxMaximaFrame.cpp:1279
 msgid "Solve algebraic system of equations"
 msgstr "Resolver sistema de equações algébricas"
 
-#: ../../src/wxMaximaFrame.cpp:1279
+#: ../../src/wxMaximaFrame.cpp:1313
 msgid "Solve boundary value problem for second degree ODE"
 msgstr "Resolver problema de contorno para EDO de segunda ordem"
 
-#: ../../src/wxMaxima.cpp:7895
+#: ../../src/MaximaCommandMenus.cpp:1076
 #, fuzzy
 msgid "Solve differential equations using laplace()"
 msgstr "Resolver equação diferencial ordinário com transformada de Laplace"
 
-#: ../../src/wxMaxima.cpp:7744 ../../src/wxMaximaFrame.cpp:1238
+#: ../../src/MaximaCommandMenus.cpp:925 ../../src/wxMaximaFrame.cpp:1272
 msgid "Solve equation(s)"
 msgstr "Resolver equação(ões)"
 
-#: ../../src/wxMaximaFrame.cpp:1241
+#: ../../src/wxMaximaFrame.cpp:1275
 msgid "Solve equation(s) with to_poly_solve"
 msgstr "Resolver equação(ões) como to_poly_solve"
 
-#: ../../src/wxMaxima.cpp:7773
+#: ../../src/MaximaCommandMenus.cpp:954
 #, fuzzy
 msgid "Solve equations numerically"
 msgstr "Resolver equação(ões)"
 
-#: ../../src/wxMaxima.cpp:7757
+#: ../../src/MaximaCommandMenus.cpp:938
 #, fuzzy
 msgid "Solve equations to polynom"
 msgstr "Resolver equação(ões) como to_poly_solve"
 
-#: ../../src/wxMaximaFrame.cpp:1271
+#: ../../src/wxMaximaFrame.cpp:1305
 msgid "Solve initial value problem for first degree ODE"
 msgstr "Resolver problema de valor inicial para EDO de primeira ordem"
 
-#: ../../src/wxMaximaFrame.cpp:1275
+#: ../../src/wxMaximaFrame.cpp:1309
 msgid "Solve initial value problem for second degree ODE"
 msgstr "Resolver problema de valor inicial para EDO de segunda ordem"
 
-#: ../../src/wxMaxima.cpp:7874 ../../src/wxMaxima.cpp:7884
+#: ../../src/MaximaCommandMenus.cpp:1055 ../../src/MaximaCommandMenus.cpp:1065
 msgid "Solve linear system"
 msgstr "Resolver sistema linear"
 
-#: ../../src/wxMaximaFrame.cpp:1243
+#: ../../src/wxMaximaFrame.cpp:1277
 msgid "Solve linear system of equations"
 msgstr "Resolver sistema de equações lineares"
 
-#: ../../src/wxMaximaFrame.cpp:1263
+#: ../../src/wxMaximaFrame.cpp:1297
 msgid "Solve numerical, 1 Variable"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1267
+#: ../../src/wxMaximaFrame.cpp:1301
 msgid "Solve ordinary differential equation of maximum degree 2"
 msgstr "Resolver equação diferencial ordinário de grau máximo 2"
 
-#: ../../src/wxMaximaFrame.cpp:1288
+#: ../../src/wxMaximaFrame.cpp:1322
 msgid "Solve ordinary differential equations with Laplace transformation"
 msgstr "Resolver equação diferencial ordinário com transformada de Laplace"
 
-#: ../../src/wxMaxima.cpp:7708
+#: ../../src/MaximaCommandMenus.cpp:891
 #, fuzzy
 msgid "Solve polynomials numerically"
 msgstr "Resolver equação(ões)"
 
-#: ../../src/wxMaxima.cpp:7718
+#: ../../src/MaximaCommandMenus.cpp:900
 #, fuzzy
 msgid "Solve polynomials numerically (bfloats)"
 msgstr "Resolver equação(ões)"
 
-#: ../../src/wxMaxima.cpp:7729
+#: ../../src/MaximaCommandMenus.cpp:910
 #, fuzzy
 msgid "Solve polynomials numerically (real roots)"
 msgstr "Resolver equação(ões)"
 
-#: ../../src/wxMaximaFrame.cpp:1249
+#: ../../src/wxMaximaFrame.cpp:1283
 #, fuzzy
 msgid "Solve symbolically"
 msgstr "Resolver equação(ões)"
 
-#: ../../src/Worksheet.cpp:1574
+#: ../../src/sidebars/MathSidebar.cpp:74
+#: ../../src/worksheet/WorksheetContextMenu.cpp:347
 msgid "Solve..."
 msgstr "Resolver..."
 
-#: ../../src/wxMaximaFrame.cpp:1916
+#: ../../src/wxMaximaFrame.cpp:1953
 msgid "Solving differential equations"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1904
+#: ../../src/wxMaximaFrame.cpp:1941
 msgid "Solving equations with Maxima"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7105
+#: ../../src/MaximaCommandMenus.cpp:3977
 #, c-format
 msgid ""
 "Sometimes one wants maxima to loose the information that a function name was used with the ' operator in order to make maxima not evaluate it. In other places one wants % to mean \"the last expression at the time this function was created\", not \"the last expression now\".\n"
 "In both cases the '' operator will do what is requested."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1746
+#: ../../src/wxMaximaFrame.cpp:1783
 msgid "Sort"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8496
+#: ../../src/wizards/ListSortWiz.cpp:41
+msgid "Sort Criterion:"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:1500
 #, fuzzy
 msgid "Sort a list"
 msgstr "Criar lista"
 
-#: ../../src/wxMaxima.cpp:7459
+#: ../../src/MaximaCommandMenus.cpp:4331
 msgid "Sort all characters in string"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1179
+#: ../../src/wxMaximaFrame.cpp:1213
 #, fuzzy
 msgid "Sort the characters..."
 msgstr "Constantes gregas"
 
-#: ../../src/wxMaxima.cpp:8482
+#: ../../src/MaximaCommandMenus.cpp:1486
 #, fuzzy
 msgid "Source list:"
 msgstr "Criar lista"
 
-#: ../../src/wxMaxima.cpp:7429
+#: ../../src/dialogs/ConfigDialogue.cpp:227
+msgid "Spanish"
+msgstr "Espanhol"
+
+#: ../../src/wizards/IntegrateWiz.cpp:44 ../../src/wizards/IntegrateWiz.cpp:50
+#: ../../src/wizards/LimitWiz.cpp:38 ../../src/wizards/SeriesWiz.cpp:39
+msgid "Special"
+msgstr "Especial"
+
+#: ../../src/wizards/DrawWiz.cpp:918
+msgid "Speed versus accuracy"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:4301
 msgid "Split"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1191
+#: ../../src/wxMaximaFrame.cpp:1225
 msgid "Split on match"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7528
+#: ../../src/MaximaCommandMenus.cpp:4400
 msgid "Split on regex match"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7449
+#: ../../src/MaximaCommandMenus.cpp:4321
 msgid "Split string into tokens"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1171
+#: ../../src/wxMaximaFrame.cpp:1205
 #, fuzzy
 msgid "Split..."
 msgstr "Gráfico de caixa..."
 
-#: ../../src/wxMaximaFrame.cpp:788
+#: ../../src/wxMaximaFrame.cpp:825
 msgid "Square"
 msgstr ""
 
-#: ../../src/Configuration.cpp:86
+#: ../../src/dialogs/ConfigDialogue.cpp:1300
+#, fuzzy
+msgid "Standard Options"
+msgstr "Opções"
+
+#: ../../src/Styles.cpp:115
 #, fuzzy
 msgid "Standard Text"
 msgstr "Opções"
 
-#: ../../src/Worksheet.cpp:1298
+#: ../../src/worksheet/WorksheetContextMenu.cpp:60
 msgid "Start Animation"
 msgstr "Iniciar animação"
 
-#: ../../src/wxMaxima.cpp:7842
+#: ../../src/dialogs/ConfigDialogue.cpp:1622
+msgid "Start a new maxima for each re-evaluation"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:1023
 msgid "Start of t:"
 msgstr ""
 
-#: ../../src/ToolBar.cpp:305
+#: ../../src/wizards/DrawWiz.cpp:66 ../../src/wizards/DrawWiz.cpp:171
+msgid "Start of the x value"
+msgstr ""
+
+#: ../../src/wizards/DrawWiz.cpp:83 ../../src/wizards/DrawWiz.cpp:186
+msgid "Start of the y value"
+msgstr ""
+
+#: ../../src/wizards/DrawWiz.cpp:203
+msgid "Start of the z value"
+msgstr ""
+
+#: ../../src/ToolBar.cpp:507 ../../src/ToolBar.cpp:519
 #, fuzzy
 msgid "Start or Stop animation"
 msgstr "Iniciar animação"
 
-#: ../../src/ToolBar.cpp:306
+#: ../../src/ToolBar.cpp:508 ../../src/ToolBar.cpp:520
 msgid "Start or stop the currently selected animation that has been created with the with_slider class of commands"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:386
+#: ../../src/dialogs/ConfigDialogue.cpp:496
+msgid "Start searching while the phrase to search for is still being typed."
+msgstr ""
+
+#: ../../src/wizards/DrawWiz.cpp:755
+#, fuzzy
+msgid "Start value of the parameter"
+msgstr "Valor float do último resultado"
+
+#: ../../src/wxMaxima.cpp:403
 msgid "Starting Maxima process failed"
 msgstr "Falha ao iniciar o Maxima"
 
-#: ../../src/main.cpp:667
+#: ../../src/main.cpp:956
 #, fuzzy
 msgid "Starting a new wxMaxima process for a new window"
 msgstr "Falha ao iniciar o Maxima"
 
-#: ../../src/wxMaxima.cpp:3105 ../../src/wxMaxima.cpp:5633
+#: ../../src/wxMaxima.cpp:1858 ../../src/wxMaxima.cpp:1884
 msgid "Starting evaluation of the document"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2544
+#: ../../src/MaximaProcessManager.cpp:205
 msgid "Starting server failed"
 msgstr "Falha ao iniciar o servidor"
 
-#: ../../src/WXMXformat.cpp:64
-msgid "Starting to save the worksheet as .wxmx"
+#: ../../src/WXMXformat.cpp:65
+#, c-format
+msgid "Starting to save the worksheet as .wxmx. Filename: %s"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:252
+#: ../../src/dialogs/ConfigDialogue.cpp:286
+msgid "Startup commands"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:266
 msgid "Statistics"
 msgstr "Estatísticas"
 
-#: ../../src/wxMaximaFrame.cpp:701
+#: ../../src/wxMaximaFrame.cpp:736
 msgid "Statistics\tAlt+Shift+S"
 msgstr "Estatísticas\tAlt+Shift+S"
 
-#: ../../src/wxMaxima.cpp:7844
+#: ../../src/MaximaCommandMenus.cpp:1025
 #, fuzzy
 msgid "Step width:"
 msgstr "Produto"
 
-#: ../../src/wxMaximaFrame.cpp:794
+#: ../../src/dialogs/ConfigDialogue.cpp:939
+msgid "Store filenames in image cells to enable image reloading after re-opening the worksheet"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:831
 msgid "Straight lines"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1106
+#: ../../src/wxMaximaFrame.cpp:1140
 msgid "Stream"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7231
+#: ../../src/MaximaCommandMenus.cpp:4103
 msgid "Stream length"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7219 ../../src/wxMaxima.cpp:7224
-#: ../../src/wxMaxima.cpp:7228 ../../src/wxMaxima.cpp:7232
-#: ../../src/wxMaxima.cpp:7236 ../../src/wxMaxima.cpp:7240
-#: ../../src/wxMaxima.cpp:7245 ../../src/wxMaxima.cpp:7250
-#: ../../src/wxMaxima.cpp:7256 ../../src/wxMaxima.cpp:7263
-#: ../../src/wxMaxima.cpp:7267 ../../src/wxMaxima.cpp:7271
-#: ../../src/wxMaxima.cpp:7276
+#: ../../src/MaximaCommandMenus.cpp:4091 ../../src/MaximaCommandMenus.cpp:4096
+#: ../../src/MaximaCommandMenus.cpp:4100 ../../src/MaximaCommandMenus.cpp:4104
+#: ../../src/MaximaCommandMenus.cpp:4108 ../../src/MaximaCommandMenus.cpp:4112
+#: ../../src/MaximaCommandMenus.cpp:4117 ../../src/MaximaCommandMenus.cpp:4122
+#: ../../src/MaximaCommandMenus.cpp:4128 ../../src/MaximaCommandMenus.cpp:4135
+#: ../../src/MaximaCommandMenus.cpp:4139 ../../src/MaximaCommandMenus.cpp:4143
+#: ../../src/MaximaCommandMenus.cpp:4148
 msgid "Stream:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1185
+#: ../../src/dialogs/ConfigDialogue.cpp:2117
+msgid "Strike Through"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1219
 #, fuzzy
 msgid "String"
 msgstr "Cadeias de caracteres"
 
-#: ../../src/wxMaxima.cpp:7345 ../../src/wxMaxima.cpp:7350
-#: ../../src/wxMaxima.cpp:7425
+#: ../../src/MaximaCommandMenus.cpp:4217 ../../src/MaximaCommandMenus.cpp:4222
+#: ../../src/MaximaCommandMenus.cpp:4297
 #, fuzzy
 msgid "String #1:"
 msgstr "Cadeias de caracteres"
 
-#: ../../src/wxMaxima.cpp:7346 ../../src/wxMaxima.cpp:7351
-#: ../../src/wxMaxima.cpp:7426
+#: ../../src/MaximaCommandMenus.cpp:4218 ../../src/MaximaCommandMenus.cpp:4223
+#: ../../src/MaximaCommandMenus.cpp:4298
 #, fuzzy
 msgid "String #2:"
 msgstr "Cadeias de caracteres"
 
-#: ../../src/wxMaximaFrame.cpp:1136
+#: ../../src/wxMaximaFrame.cpp:1170
 #, fuzzy
 msgid "String Tests"
 msgstr "Cadeias de caracteres"
 
-#: ../../src/wxMaxima.cpp:7415
+#: ../../src/MaximaCommandMenus.cpp:4287
 #, fuzzy
 msgid "String length"
 msgstr "Cadeias de caracteres"
 
-#: ../../src/wxMaxima.cpp:7381
+#: ../../src/MaximaCommandMenus.cpp:4253
 msgid "String to list of char"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1148
+#: ../../src/wxMaximaFrame.cpp:1182
 msgid "String to list of chars..."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7496
+#: ../../src/MaximaCommandMenus.cpp:4368
 #, fuzzy
 msgid "String to octets"
 msgstr "Cadeias de caracteres"
 
-#: ../../src/wxMaximaFrame.cpp:1160
+#: ../../src/wxMaximaFrame.cpp:1194
 msgid "String to octets..."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7377 ../../src/wxMaxima.cpp:7382
-#: ../../src/wxMaxima.cpp:7391 ../../src/wxMaxima.cpp:7396
-#: ../../src/wxMaxima.cpp:7400 ../../src/wxMaxima.cpp:7407
-#: ../../src/wxMaxima.cpp:7412 ../../src/wxMaxima.cpp:7416
-#: ../../src/wxMaxima.cpp:7420 ../../src/wxMaxima.cpp:7430
-#: ../../src/wxMaxima.cpp:7436 ../../src/wxMaxima.cpp:7441
-#: ../../src/wxMaxima.cpp:7446 ../../src/wxMaxima.cpp:7450
-#: ../../src/wxMaxima.cpp:7456 ../../src/wxMaxima.cpp:7460
-#: ../../src/wxMaxima.cpp:7465 ../../src/wxMaxima.cpp:7470
-#: ../../src/wxMaxima.cpp:7474 ../../src/wxMaxima.cpp:7478
-#: ../../src/wxMaxima.cpp:7497
+#: ../../src/MaximaCommandMenus.cpp:4249 ../../src/MaximaCommandMenus.cpp:4254
+#: ../../src/MaximaCommandMenus.cpp:4263 ../../src/MaximaCommandMenus.cpp:4268
+#: ../../src/MaximaCommandMenus.cpp:4272 ../../src/MaximaCommandMenus.cpp:4279
+#: ../../src/MaximaCommandMenus.cpp:4284 ../../src/MaximaCommandMenus.cpp:4288
+#: ../../src/MaximaCommandMenus.cpp:4292 ../../src/MaximaCommandMenus.cpp:4302
+#: ../../src/MaximaCommandMenus.cpp:4308 ../../src/MaximaCommandMenus.cpp:4313
+#: ../../src/MaximaCommandMenus.cpp:4318 ../../src/MaximaCommandMenus.cpp:4322
+#: ../../src/MaximaCommandMenus.cpp:4328 ../../src/MaximaCommandMenus.cpp:4332
+#: ../../src/MaximaCommandMenus.cpp:4337 ../../src/MaximaCommandMenus.cpp:4342
+#: ../../src/MaximaCommandMenus.cpp:4346 ../../src/MaximaCommandMenus.cpp:4350
+#: ../../src/MaximaCommandMenus.cpp:4369
 #, fuzzy
 msgid "String:"
 msgstr "Cadeias de caracteres"
 
-#: ../../src/wxMaxima.cpp:7197
+#: ../../src/MaximaCommandMenus.cpp:4069
 msgid "Struct :"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7184 ../../src/wxMaxima.cpp:7190
+#: ../../src/MaximaCommandMenus.cpp:4056 ../../src/MaximaCommandMenus.cpp:4062
 msgid "Struct type name:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1029
+#: ../../src/wxMaximaFrame.cpp:1063
 msgid "Structs"
 msgstr ""
 
-#: ../../src/ToolBar.cpp:274
+#: ../../src/dialogs/ConfigDialogue.cpp:282
+msgid "Style"
+msgstr "Estilo"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:2082
+msgid "Styles"
+msgstr "Estilos"
+
+#: ../../src/sidebars/StatSidebar.cpp:112
+msgid "Subsample..."
+msgstr "Subamostra..."
+
+#: ../../src/ToolBar.cpp:484 ../../src/sidebars/FormatSidebar.cpp:54
 msgid "Subsection"
 msgstr "Subseção"
 
-#: ../../src/Configuration.cpp:90
+#: ../../src/Styles.cpp:119
 msgid "Subsection cell (Heading 3)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1643
+#: ../../src/wxMaximaFrame.cpp:1680
 msgid "Subst constant t into eq with diff(x,t)..."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8724
+#: ../../src/MaximaCommandMenus.cpp:716
 msgid "Subst is a better string-search-and-replace for expressions."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7688 ../../src/wxMaxima.cpp:8723
-#: ../../src/wxMaxima.cpp:10061 ../../src/wxMaximaFrame.cpp:1651
+#: ../../src/sidebars/MathSidebar.cpp:59
+msgid "Subst..."
+msgstr "Substituir..."
+
+#: ../../src/MaximaCommandMenus.cpp:715 ../../src/MaximaCommandMenus.cpp:3550
+#: ../../src/MaximaCommandMenus.cpp:4560 ../../src/wizards/SubstituteWiz.cpp:53
+#: ../../src/wxMaximaFrame.cpp:1688
 msgid "Substitute"
 msgstr "Substituir"
 
-#: ../../src/wxMaximaFrame.cpp:1193
+#: ../../src/wxMaximaFrame.cpp:1227
 #, fuzzy
 msgid "Substitute all matches"
 msgstr "Substituir..."
 
-#: ../../src/wxMaximaFrame.cpp:1192
+#: ../../src/wxMaximaFrame.cpp:1226
 msgid "Substitute first match"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1646
+#: ../../src/MaximaCommandMenus.cpp:767
+msgid "Substitute only in a specific part"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1683
 #, fuzzy
 msgid "Substitute only in parts..."
 msgstr "Substituir..."
 
-#: ../../src/wxMaxima.cpp:8763
-msgid "Substitute only in specific parts"
-msgstr ""
-
-#: ../../src/wxMaximaFrame.cpp:1647
+#: ../../src/wxMaximaFrame.cpp:1684
 msgid "Substitute only in the elements n_1, n_2,..."
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1585 ../../src/wxMaximaFrame.cpp:1633
+#: ../../src/worksheet/WorksheetContextMenu.cpp:358
+#: ../../src/wxMaximaFrame.cpp:1670
 msgid "Substitute..."
 msgstr "Substituir..."
 
-#: ../../src/wxMaximaFrame.cpp:1641 ../../src/wxMaximaFrame.cpp:1644
+#: ../../src/wxMaximaFrame.cpp:1678 ../../src/wxMaximaFrame.cpp:1681
 msgid "Substitutes until the equation no more changes"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8747
+#: ../../src/MaximaCommandMenus.cpp:745
 msgid "Substitutes up to lrats_max_iter times, or until the expression stops changing when substituting."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8756
+#: ../../src/MaximaCommandMenus.cpp:757
 #, c-format
 msgid "Substitutes, but makes sure that if substituting t=0 in diff(x,t) the result isn't 0 (as t no more changes), but %at(diff(x,t),t=0)."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8739
+#: ../../src/MaximaCommandMenus.cpp:736
 msgid "Substitutes, but makes sure that nothing is substituted into the other substituents."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1638
+#: ../../src/wxMaximaFrame.cpp:1675
 msgid "Substitutes, but not in the other substituents"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8764
-msgid "Substitutes, but only in the n_1th, n_2th and so on term of the equation."
-msgstr ""
-
-#: ../../src/ToolBar.cpp:275
+#: ../../src/ToolBar.cpp:485 ../../src/sidebars/FormatSidebar.cpp:57
 #, fuzzy
 msgid "Subsubsection"
 msgstr "Subseção"
 
-#: ../../src/Configuration.cpp:89
+#: ../../src/Styles.cpp:118
 msgid "Subsubsection cell (Heading 4)"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1831
+#: ../../src/worksheet/WorksheetContextMenu.cpp:603
 #, fuzzy
 msgid "Suggestion: "
 msgstr "Subseção"
 
-#: ../../src/Worksheet.cpp:2030
+#: ../../src/worksheet/WorksheetContextMenu.cpp:802
 msgid "Suitable as flag for ev()"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:9049
+#: ../../src/MaximaCommandMenus.cpp:303 ../../src/wizards/SumWiz.cpp:60
 msgid "Sum"
 msgstr "Soma"
 
-#: ../../src/wxMaximaFrame.cpp:1551
+#: ../../src/sidebars/SymbolsSidebar.cpp:122
+msgid "Sum sign"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:228
+msgid "Swedish"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1588
 msgid "Switch off simplifications of log(). Set Maxima option variable logexpand:false"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:4090
+#: ../../src/MaximaResponseReader.cpp:569
 msgid "Switched to lisp mode after receiving a lisp debug prompt!"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:4092
+#: ../../src/MaximaResponseReader.cpp:428
+#: ../../src/MaximaResponseReader.cpp:571
 msgid "Switched to lisp mode after receiving a lisp prompt!"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1971
+#: ../../src/worksheet/WorksheetContextMenu.cpp:743
 #, fuzzy
 msgid "Symbolic Constant"
 msgstr "Selecione uma constante"
 
-#: ../../src/wxMaximaFrame.cpp:705
+#: ../../src/wxMaximaFrame.cpp:740
 #, fuzzy
 msgid "Symbols\tAlt+Shift+Y"
 msgstr "Estatísticas\tAlt+Shift+S"
 
-#: ../../src/Worksheet.cpp:2006
+#: ../../src/dialogs/ConfigDialogue.cpp:472
+msgid "Symbols that are entered or copied here will appear in the symbols sidebar so they can be entered into the worksheet easily."
+msgstr ""
+
+#: ../../src/worksheet/WorksheetContextMenu.cpp:778
 msgid "Symmetric function: f(x)=f(-x)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:238
+#: ../../src/dialogs/DiffFrame.cpp:370 ../../src/dialogs/DiffFrame.cpp:387
+msgid "Sync Horizontal"
+msgstr ""
+
+#: ../../src/dialogs/DiffFrame.cpp:382 ../../src/dialogs/DiffFrame.cpp:388
+msgid "Sync Vertical"
+msgstr ""
+
+#: ../../src/wizards/CsvWiz.cpp:42 ../../src/wizards/CsvWiz.cpp:113
+msgid "Tab"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:252
 msgid "Table of Contents"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:711
+#: ../../src/wxMaximaFrame.cpp:746
 #, fuzzy
 msgid "Table of Contents\tAlt+Shift+T"
 msgstr "Barra de ferramentas\tAlt+Shift+T"
 
-#: ../../src/wxMaxima.cpp:8930
+#: ../../src/wizards/DrawWiz.cpp:561
+msgid "Take surface color from steepness"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:229
+msgid "Tamil"
+msgstr ""
+
+#: ../../src/sidebars/GreekSidebar.cpp:196
+msgid "Tau"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:181
 #, fuzzy
 msgid "Taylor series"
 msgstr "Série de Taylor:"
 
-#: ../../src/wxMaximaFrame.cpp:1474
+#: ../../src/wxMaximaFrame.cpp:1511
 #, fuzzy
 msgid "Taylor series..."
 msgstr "Série de Taylor:"
 
-#: ../../src/wxMaxima.cpp:8925
+#: ../../src/MaximaCommandMenus.cpp:176
 msgid "Taylor series:"
 msgstr "Série de Taylor:"
 
-#: ../../src/wxMaxima.cpp:4132
+#: ../../src/wxMaxima.cpp:1488
 msgid "Telling maxima about the new working directory."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7907
+#: ../../src/MaximaCommandMenus.cpp:1088
 msgid "Tells maxima for an f(x), that f(x=t)=a"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1945
+#: ../../src/wxMaximaFrame.cpp:1982
 msgid "Tells maxima to show the help for ?, ?? and describe() in a separate browser window"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1941
+#: ../../src/wxMaximaFrame.cpp:1978
 msgid "Tells maxima to show the help for ?, ?? and describe() in a wxMaxima sidebar"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1936
+#: ../../src/wxMaximaFrame.cpp:1973
 msgid "Tells maxima to show the help for ?, ?? and describe() on the console"
 msgstr ""
 
-#: ../../src/ToolBar.cpp:271
+#: ../../src/dialogs/ConfigDialogue.cpp:148
+msgid "Tells maxima where to store the result of compiling libraries"
+msgstr ""
+
+#: ../../src/ToolBar.cpp:481 ../../src/sidebars/FormatSidebar.cpp:45
 msgid "Text"
 msgstr "Texto"
 
-#: ../../src/Configuration.cpp:93
+#: ../../src/dialogs/ConfigDialogue.cpp:739
+msgid "Text & Code"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:738
+#, fuzzy
+msgid "Text Only"
+msgstr "Célula de texto"
+
+#: ../../src/Styles.cpp:122
 msgid "Text cell background"
 msgstr "Fundo da célula de texto"
 
-#: ../../src/wxMaxima.cpp:6541
+#: ../../src/dialogs/TipOfTheDay.cpp:219
+msgid "Text cells can hold citations that as marked as such by beginning a line with \" > \". The number of spaces in front of the \">\" determines the indentation level, as it does with bullet lists."
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:3061
 msgid "Text snippet"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:4632
+#: ../../src/dialogs/TipOfTheDay.cpp:205
+msgid ""
+"The \"at\" function allows introducing one equation into another:\n"
+"\n"
+"    ohm:U=R*I;\n"
+"    r_parallel:R=R_1*R_2/(R_1+R_2);\n"
+"    result:at(ohm,r_parallel);"
+msgstr ""
+
+#: ../../src/MaximaFileIO.cpp:555
 msgid "The .xml file doesn't seem to be valid xml or isn't a content.xml extracted from a .wxmx zip archive"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2734
+#: ../../src/MaximaProcessManager.cpp:844
 msgid "The Maxima process doesn't offer a shared memory segment we can send an interrupt signal to."
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:392
+msgid "The URL MathJaX.js should be downloaded from by our HTML export."
+msgstr ""
+
+#: ../../src/cells/TextCell.cpp:336
+msgid "The [] or the part() command tried to access a list or matrix element that doesn't exist."
+msgstr ""
+
+#: ../../src/sidebars/DrawSidebar.cpp:106
+msgid "The accuracy versus speed tradeoff"
+msgstr ""
+
+#: ../../src/cells/TextCell.cpp:357
+msgid "The argument of a function was of the wrong type. Most probably an equation was expected but was lacking an \"=\"."
 msgstr ""
 
 #: ../../src/MaximaManual.cpp:107
 msgid "The cache for the subjects the manual contains cannot be read."
 msgstr ""
 
-#: ../../src/MaximaManual.cpp:378
+#: ../../src/MaximaManual.cpp:395
 msgid "The cache for the subjects the manual contains has no head node."
 msgstr ""
 
-#: ../../src/MaximaManual.cpp:396
+#: ../../src/MaximaManual.cpp:413
 msgid "The cache for the subjects the manual contains is from a different Maxima version."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1379
+#: ../../src/wxMaximaFrame.cpp:1413
 msgid "The classic operations one typically uses matrices for"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7193
+#: ../../src/sidebars/DrawSidebar.cpp:91
+msgid "The color of the next line to draw"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:4065
 msgid "The comma-separated contents of the struct fields"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7186
+#: ../../src/MaximaCommandMenus.cpp:4058
 #, fuzzy
 msgid "The comma-separated names of the struct fields"
 msgstr "Informa uma lista de variáveis separadas por vírgulas."
 
-#: ../../src/wxMaxima.cpp:7070
-msgid "The command local() allows to tell maxima which functions to make local to the current program when defined."
+#: ../../src/MaximaCommandMenus.cpp:3942
+msgid "The command local() allows telling Maxima which functions to make local to the current program when defined."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:303
+#: ../../src/wxMaximaFrame.cpp:324
 msgid "The current Wizard"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:9592
+#: ../../src/dialogs/ConfigDialogue.cpp:415
+msgid "The default height for embedded plots. Can be read out or overridden by the maxima variable wxplot_size."
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:492
+msgid "The default port used for communication between Maxima and wxMaxima."
+msgstr "A porta padrão usada para comunicação entre o Maxima e o wxMaxima."
+
+#: ../../src/dialogs/ConfigDialogue.cpp:412
+msgid "The default width for embedded plots. Can be read out or overridden by the maxima variable wxplot_size"
+msgstr ""
+
+#: ../../src/sidebars/DrawSidebar.cpp:74
+msgid "The diagram title"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:2401
+#, c-format
+msgid "The directory %s with maxima's startup file doesn't exist. Trying to create it..."
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:150
+msgid "The directory containing the startup files, any user libraries and, if MAXIMA_OBJDIR isn't set the subdirectory with the results from compiling maxima libraries."
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:154
+msgid "The directory maxima places temporary files in, for example plots that are to be included in the worksheet."
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:157
+msgid "The directory the compiled versions of maxima are placed in"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:159
+msgid "The directory the maxima manual can be found in"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:160
+msgid "The directory the user's home directory is in"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:475
+msgid "The document class LaTeX is instructed to use for our documents."
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:1832
 msgid "The equation to fit the data to"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8447
+#: ../../src/MaximaCommandMenus.cpp:774
+msgid "The expression to substitute in"
+msgstr ""
+
+#: ../../src/MaximaFileIO.cpp:444
+#, c-format
+msgid "The file claims %ld watch variables; capping at %ld."
+msgstr ""
+
+#: ../../src/sidebars/DrawSidebar.cpp:96
+msgid "The fill color for the next objects"
+msgstr ""
+
+#: ../../src/cells/TextCell.cpp:354
+msgid "The first argument of subst() isn't an equation or a list of equations. Most probably it was lacking an \"=\"."
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:1444
 msgid "The function call whose arguments to extract"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1298
+#: ../../src/sidebars/DrawSidebar.cpp:100
+msgid "The grid in the background of the diagram"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1332
 msgid "The half of the equation that is to the left of the \"=\""
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1302
+#: ../../src/wxMaximaFrame.cpp:1336
 msgid "The half of the equation that is to the right of the \"=\""
 msgstr ""
 
-#: ../../src/MaximaManual.cpp:399
+#: ../../src/MaximaManual.cpp:416
 msgid "The help dir from the cache differs from the current one."
 msgstr ""
 
-#: ../../src/Image.cpp:985
+#: ../../src/Image.cpp:1136
 msgid ""
 "The image could not be displayed. It may be broken, in a wrong format or be the result of gnuplot not being able to write the image or not being able to understand what maxima wanted to plot.\n"
 "One example of the latter would be: Gnuplot refuses to plot entirely empty images"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:9799 ../../src/wxMaxima.cpp:10158
+#: ../../src/MaximaCommandMenus.cpp:3262 ../../src/MaximaCommandMenus.cpp:3687
 #, c-format
 msgid "The image file \"%s\" cannot be found."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:718
+#: ../../src/wxMaximaFrame.cpp:753
 msgid "The integrated help browser"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:9591
+#: ../../src/cells/TextCell.cpp:397
+#, fuzzy
+msgid "The inverse laplace transform."
+msgstr "T&ransformada inversa de Laplace..."
+
+#: ../../src/dialogs/TipOfTheDay.cpp:223
+msgid "The key combination Shift+Space results in a non-breakable space."
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:162
+msgid "The list of directories the operating system looks for programs in"
+msgstr ""
+
+#: ../../src/cells/TextCell.cpp:293
+msgid "The list of time-dependent variables to solve to doesn't match the time-dependent variables the list of dgls contains."
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:1831
 msgid "The list of variables contained in each matrix row"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:214
+#: ../../src/dialogs/TipOfTheDay.cpp:166
+msgid "The load() command of Maxima versions >5.38 is able to load .wxm files as library of Maxima's commands."
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:228
 msgid "The main toolbar"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1882
+#: ../../src/wxMaximaFrame.cpp:1919
 msgid "The manual of Maxima"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1881
+#: ../../src/wxMaximaFrame.cpp:1918
 #, fuzzy
 msgid "The manual of wxMaxima"
 msgstr "Bem-vindo ao wxMaxima"
 
-#: ../../src/wxMaxima.cpp:7125
+#: ../../src/dialogs/MaxSizeChooser.cpp:59
+msgid "The maximum size for this image. Values <= 0 mean: Unspecified."
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:3997
 msgid "The name of a function we don't want to be evaluated here"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7131
+#: ../../src/MaximaCommandMenus.cpp:4003
 msgid "The name of an expression that we don't want to be evaluated."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7199
+#: ../../src/MaximaCommandMenus.cpp:4071
 msgid "The name of the field to read"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7185
+#: ../../src/MaximaCommandMenus.cpp:4057
 msgid "The name of the new struct type"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7198
+#: ../../src/MaximaCommandMenus.cpp:4070
 msgid "The name of the struct"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7191
+#: ../../src/MaximaCommandMenus.cpp:4063
 msgid "The name of the struct type"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8220
+#: ../../src/MaximaCommandMenus.cpp:1410
 msgid "The name of the variable that shall contain the current element"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8468
+#: ../../src/sidebars/DrawSidebar.cpp:86
+msgid "The next plot's title"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:494
+msgid "The number of recently opened files that is to be remembered."
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:1471
 msgid "The number of the item which is stepped from \"Index Start\" to \"Index End\"."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8465 ../../src/wxMaxima.cpp:8478
+#: ../../src/dialogs/ConfigDialogue.cpp:477
+msgid "The options the document class LaTeX is instructed to use for our documents gets."
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1065
+#: ../../src/dialogs/ConfigDialogue.cpp:1112
+msgid "The part of the output of these commands that isn't declared as \"math\" might be suppressed by wxMaxima. As always maxima commands are required to end in a \";\" or a \"$\""
+msgstr ""
+
+#: ../../src/dialogs/ResolutionChooser.cpp:51
+msgid "The resolution for this image."
+msgstr ""
+
+#: ../../src/cells/TextCell.cpp:182
+msgid "The result was indefinite, which might be infinity, both plus or minus infinity or something additionally potentially involving a complex infinity."
+msgstr ""
+
+#: ../../src/cells/TextCell.cpp:180
+msgid "The result was undefined."
+msgstr ""
+
+#: ../../src/dialogs/TipOfTheDay.cpp:209
+msgid ""
+"The rhs() (\"right hand side\") command allows retrieving the result of an equation in exactly the format a function would have:\n"
+"\n"
+"    Values:[\n"
+"        /* m=1.2 tons */\n"
+"        m=1.2*10^3,\n"
+"        /* 100 km/h*/\n"
+"        v=100*10^3/(60*60)\n"
+"    ];\n"
+"    Energy:W=1/2*m*v^2;\n"
+"    at(Energy,Values);\n"
+"    W_mech:rhs(%);"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:1468
 msgid ""
 "The rule that explains how to generate the value of a list item.\n"
 "Might be something like \"i\", \"i^2\" or \"sin(i)\""
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7785
+#: ../../src/cells/TextCell.cpp:351
+msgid "The second argument of at() isn't an equation or a list of equations. Most probably it was lacking an \"=\"."
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:3481
+msgid "The selection contains no output that could be exported."
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:966
 msgid "The solution of an ODE describes the general shape of the resulting curve. The actual height of that curve is defined by the initial condition or boundary values, later on."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7818
+#: ../../src/MaximaCommandMenus.cpp:999
 msgid ""
 "The solution of an ODE tells the shape, but not the height of the solution.\n"
 "If the ODE's result is known at two points this function fills in the correct values for the  constants"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7794 ../../src/wxMaxima.cpp:7805
+#: ../../src/MaximaCommandMenus.cpp:975 ../../src/MaximaCommandMenus.cpp:986
 msgid ""
 "The solution of an ODE tells the shape, but not the height of the solution.\n"
 "If the ODE's state is known at a point this function fills in the correct values for the constants"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7896
+#: ../../src/MaximaCommandMenus.cpp:1077
 msgid ""
 "The solution variable needs to be in the form\n"
 "   U(t)=1/2*U(t)+3*diff(U(t),t)\n"
 "for this to work; Initial conditions can be specified using atvalue()."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8481 ../../src/wxMaxima.cpp:8582
+#: ../../src/sidebars/DrawSidebar.cpp:58
+msgid "The standard plot command: Plot an equation as a curve"
+msgstr ""
+
+#: ../../src/cells/TextCell.cpp:267
+msgid "The value of few special variables is assigned by Maxima and cannot be changed by the user. Also a few constructs aren't variable names and therefore cannot be written to."
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:1485 ../../src/MaximaCommandMenus.cpp:1600
 msgid "The variable the value of the current source item is stored in."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:9594
+#: ../../src/MaximaCommandMenus.cpp:1834
 msgid "The variables to search the optimum solution for"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:193
+#: ../../src/wxMaximaFrame.cpp:207
 msgid "The worksheet"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:8122
+#: ../../src/worksheet/Worksheet.cpp:6371
 msgid "The worksheet containing maxima's input and output"
 msgstr ""
 
-#: ../../src/MathParser.cpp:629
+#: ../../src/MathParser.cpp:682
 msgid ""
 "The xml data from maxima or from the .wxmx file was missing data here.\n"
 "If you find a way how to reproduce this problem please file a bug report against wxMaxima."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2143
+#: ../../src/MaximaCommandMenus.cpp:1481
+msgid ""
+"The ‘j’th element is equal to ‘ev (<expr>, <x>=<list>[j])’ \n"
+"j are the elements of the source list.\n"
+"Might be something like \"x=i\""
+msgstr ""
+
+#: ../../src/dialogs/TipOfTheDay.cpp:95
+msgid "There are many resources about Maxima and wxMaxima on the internet. Visit https://wxMaxima-developers.github.io/wxmaxima/help.html for more information and to find tutorials on using wxMaxima and Maxima."
+msgstr ""
+
+#: ../../src/dialogs/TipOfTheDay.cpp:251
+msgid ""
+"There is a discussion forum for wxMaxima at https://github.com/wxMaxima-developers/wxmaxima/discussions.\n"
+"You can ask questions there - and please help other users, by answering their questions, if you know an answer."
+msgstr ""
+
+#: ../../src/MaximaResponseReader.cpp:63
+msgid ""
+"There was an error in the XML describing a worksheet-export request.\n"
+"Please report this as a bug to the wxMaxima project."
+msgstr ""
+
+#: ../../src/MaximaOutputAppender.cpp:66 ../../src/MaximaOutputAppender.cpp:194
 #, fuzzy
 msgid ""
 "There was an error in the XML maxima has generated.\n"
@@ -7402,25 +11046,25 @@ msgstr ""
 "\n"
 "Favor relatar isso como um bug."
 
-#: ../../src/wxMaxima.cpp:3911
+#: ../../src/MaximaResponseReader.cpp:1027
 msgid ""
 "There was an error in the XML that should contain a list of watch variables.\n"
 "Please report this as a bug to the wxMaxima project."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3869
+#: ../../src/MaximaResponseReader.cpp:986
 msgid ""
 "There was an error in the XML that should contain the list of operators.\n"
 "Please report this as a bug to the wxMaxima project."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3321
+#: ../../src/MaximaResponseReader.cpp:719
 msgid ""
 "There was an error in the XML that should describe the contents of some variables.\n"
 "Please report this as a bug to the wxMaxima project."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3257
+#: ../../src/MaximaResponseReader.cpp:163
 #, fuzzy
 msgid ""
 "There was an error in the XML that should describe the manual topics.\n"
@@ -7430,141 +11074,234 @@ msgstr ""
 "\n"
 "Favor relatar isso como um bug."
 
-#: ../../src/wxMaxima.cpp:3202
+#: ../../src/MaximaResponseReader.cpp:42
 msgid ""
 "There was an error in the XML that should describe the status bar message.\n"
 "Please report this as a bug to the wxMaxima project."
 msgstr ""
 
-#: ../../src/MaximaManual.cpp:363
+#: ../../src/sidebars/GreekSidebar.cpp:185
+msgid "Theta"
+msgstr ""
+
+#: ../../src/dialogs/LicenseDialog.cpp:85
+msgid "Third-party notices"
+msgstr ""
+
+#: ../../src/cells/TextCell.cpp:312
+msgid ""
+"This error message is most probably caused by a try to assign a value to a number instead of a variable name.\n"
+"One probable cause is using a variable that already has a numeric value as a loop counter."
+msgstr ""
+
+#: ../../src/MaximaManual.cpp:376
 msgid ""
 "This file is generated by wxMaxima\n"
 "It caches the list of subjects maxima's manual offers and is automatically\n"
 "overwritten if maxima's version changes or the file cannot be read"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1992
+#: ../../src/dialogs/ConfigDialogue.cpp:1097
+msgid "This file won't be read by maxima if maxima is used without wxMaxima. In order to add startup commands that are executed in this case, too, please add them to maxima-init.mac, instead."
+msgstr ""
+
+#: ../../src/worksheet/WorksheetContextMenu.cpp:764
 msgid "This function will return even integers"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1994
+#: ../../src/worksheet/WorksheetContextMenu.cpp:766
 msgid "This function will return odd integers"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1950
+#: ../../src/cells/TextCell.cpp:229
+msgid "This message can appear when trying to numerically find an optimum. In this case it might indicate that a starting point lies in a local optimum that fits the data best if one parameter is increased to infinity or decreased to -infinity. It also can indicate that an attempt was made to fit data to an equation that actually matches the data best if one parameter is set to +/- infinity."
+msgstr ""
+
+#: ../../src/worksheet/WorksheetContextMenu.cpp:722
 msgid "This symbol has no imaginary part"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1956
+#: ../../src/worksheet/WorksheetContextMenu.cpp:728
 msgid "This symbol has no real part"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1953
+#: ../../src/worksheet/WorksheetContextMenu.cpp:725
 msgid "This symbol might have both real and imaginary part"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1980
+#: ../../src/cells/TextCell.cpp:300
+msgid "This warning can be deactivated by setting factor_max_degree_print_warning to false."
+msgstr ""
+
+#: ../../src/wizards/DrawWiz.cpp:471
+#, c-format
+msgid "This wizard setups a %iD scene."
+msgstr ""
+
+#: ../../src/worksheet/WorksheetContextMenu.cpp:752
 msgid "Throw an error if this symbol is used before assigning it any contents"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:9013 ../../src/wxMaxima.cpp:10058
+#: ../../src/wizards/Plot2dWiz.cpp:65 ../../src/wizards/Plot2dWiz.cpp:505
+msgid "Ticks:"
+msgstr "Marcações:"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1359
+msgid "Time [in Minutes] between autosaves"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:267 ../../src/MaximaCommandMenus.cpp:3547
 msgid "Times:"
 msgstr "Vezes:"
 
-#: ../../src/ToolBar.cpp:272
+#: ../../src/dialogs/TipOfTheDay.cpp:49 ../../src/dialogs/TipOfTheDay.cpp:267
+msgid "Tip of the day"
+msgstr ""
+
+#: ../../src/ToolBar.cpp:482 ../../src/sidebars/FormatSidebar.cpp:48
 msgid "Title"
 msgstr "Título"
 
-#: ../../src/wxMaxima.cpp:8315 ../../src/wxMaxima.cpp:8328
+#: ../../src/MaximaCommandMenus.cpp:1961 ../../src/MaximaCommandMenus.cpp:1974
 msgid "Title (Sub- and superscripts as x_{10} or x^{10})"
 msgstr ""
 
-#: ../../src/Configuration.cpp:92
+#: ../../src/Styles.cpp:121
 msgid "Title cell (Heading 1)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1794
+#: ../../src/dialogs/TipOfTheDay.cpp:89
+msgid "Title, section and subsection cells can be folded to hide their contents. To fold or unfold, click in the square next to the cell. If you shift-click, all sublevels of that cell will also fold/unfold."
+msgstr "Células de título, seção e subseção podem ser recolhidas para ocultar seu conteúdo. Para recolher ou expandir, clique no quadrado próximo à celula. Se você segurar Shift enquanto clica, todos os subníveis daquela célula também serão recolhidos/expandidos."
+
+#: ../../src/wxMaximaFrame.cpp:1831
 msgid "To &Bigfloat"
 msgstr "Para &bigfloat"
 
-#: ../../src/wxMaximaFrame.cpp:1791
+#: ../../src/wxMaximaFrame.cpp:1828
 msgid "To &Float"
 msgstr "Para &float"
 
-#: ../../src/Worksheet.cpp:1571
+#: ../../src/worksheet/WorksheetContextMenu.cpp:344
 msgid "To Float"
 msgstr "Para float"
 
-#: ../../src/wxMaximaFrame.cpp:1797
+#: ../../src/wxMaximaFrame.cpp:1834
 msgid "To Numeri&c\tCtrl+Shift+N"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1803
+#: ../../src/wxMaximaFrame.cpp:1840
 #, fuzzy
 msgid "To exact fraction"
 msgstr "Frações parciais"
 
-#: ../../src/wxMaximaFrame.cpp:1814
+#: ../../src/wxMaximaFrame.cpp:1851
 #, fuzzy
 msgid "To exact number"
 msgstr "Mostrar &funções"
 
-#: ../../src/wxMaxima.cpp:9064
+#: ../../src/dialogs/TipOfTheDay.cpp:124
+msgid "To plot in polar coordinates, select 'set polar' in the Options entry for Plot2d dialog. You can also plot in spherical and cylindrical coordinates in 3D."
+msgstr "Para fazer gráficos em coordenadas polares, selecione 'Polar' em Opções na janela de gráficos bidimensionais. Você também pode fazer gráficos em coordenadas esféricas e cilíndricas em 3D."
+
+#: ../../src/dialogs/TipOfTheDay.cpp:131
+#, fuzzy
+msgid "To put parentheses around an expression, select it, and press '(' or ')' depending on where you want the cursor to appear afterwards."
+msgstr "Para inserir parêntesis ao redor de uma expressão, selecione-a e pressione '(' ou ')', dependende de onde você quer que o cursor apareça depois."
+
+#: ../../src/dialogs/TipOfTheDay.cpp:137
+msgid "To save the size and position of wxMaxima windows between session, use 'Edit->Configure' dialog."
+msgstr "Para salvar o tamanho e posição da janela do wxMaxima entre sessões, use a janela 'Maxima->Configurações'."
+
+#: ../../src/dialogs/TipOfTheDay.cpp:51
+#, fuzzy
+msgid "To start using wxMaxima right away, start typing your command. An input cell should appear. Then press Shift-Enter to evaluate your command."
+msgstr "Para iniciar a usar o wxMaxima, digite o seu comando. Uma célula de entrada deve aparecer. Aperte Shift+Enter para executar seu comando."
+
+#: ../../src/MaximaCommandMenus.cpp:318 ../../src/wizards/IntegrateWiz.cpp:47
+#: ../../src/wizards/Plot2dWiz.cpp:51 ../../src/wizards/Plot2dWiz.cpp:61
+#: ../../src/wizards/Plot2dWiz.cpp:502 ../../src/wizards/Plot3dWiz.cpp:40
+#: ../../src/wizards/Plot3dWiz.cpp:49 ../../src/wizards/SumWiz.cpp:40
 msgid "To:"
 msgstr "Até:"
 
-#: ../../src/wxMaximaFrame.cpp:825 ../../src/wxMaximaFrame.cpp:828
+#: ../../src/sidebars/TableOfContents.cpp:579
+msgid "Toc levels shown here"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:862 ../../src/wxMaximaFrame.cpp:865
 msgid "Toggle full screen editing"
 msgstr "Alternar edição em tela cheia"
 
-#: ../../src/ToolBar.cpp:265
+#: ../../src/dialogs/DiffFrame.cpp:370 ../../src/dialogs/DiffFrame.cpp:387
+msgid "Toggle horizontal scroll synchronization"
+msgstr ""
+
+#: ../../src/ToolBar.cpp:471 ../../src/ToolBar.cpp:473
 msgid "Toggle the visibility of code cells"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1177
+#: ../../src/dialogs/DiffFrame.cpp:382 ../../src/dialogs/DiffFrame.cpp:388
+msgid "Toggle vertical scroll synchronization"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1211
 msgid "Tokenize..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1909
+#: ../../src/wxMaximaFrame.cpp:1946
 msgid "Tolerance calculations with Maxima"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8192
+#: ../../src/ToolBar.cpp:176
+msgid "Toolbar"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1991
+#, fuzzy
+msgid "Top"
+msgstr "Até:"
+
+#: ../../src/MaximaCommandMenus.cpp:1382
 msgid "Top end"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1078
+#: ../../src/wxMaxima.cpp:2862
+msgid "Tortoise diff tool"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1112
 #, fuzzy
 msgid "Trace a function..."
 msgstr "Apagar uma função"
 
-#: ../../src/wxMaxima.cpp:7084
+#: ../../src/MaximaCommandMenus.cpp:3956
 #, fuzzy
 msgid "Trace function(s)"
 msgstr "Apagar função(ões):"
 
-#: ../../src/wxMaximaFrame.cpp:1184
+#: ../../src/wxMaximaFrame.cpp:1218
 #, fuzzy
 msgid "Transformations"
 msgstr "Transposta de uma matriz"
 
-#: ../../src/wxMaximaFrame.cpp:1376
+#: ../../src/wxMaximaFrame.cpp:1410
 msgid "Transpose a matrix"
 msgstr "Transposta de uma matriz"
 
-#: ../../src/wxMaxima.cpp:7832
+#: ../../src/MaximaCommandMenus.cpp:1013
 msgid "Tries to find a numerical solution for a 1st order ODE (or in other words: a equation of the format depends(x,t);diff(x,t)=(something containing x and t)"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:10036
+#: ../../src/MaximaCommandMenus.cpp:3525
 msgid "Tries to find a solution of the equation that lies between the two bounds."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7774
+#: ../../src/MaximaCommandMenus.cpp:955
 msgid "Tries to find a value of the variable that solves the equation between the two bonds"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7719
+#: ../../src/MaximaCommandMenus.cpp:901
 msgid ""
 "Tries to find all solutions of a polynomial numerically using bfloats.\n"
 "Might be able to detect solutions in non-polynomials, as well, if the expression is approximated by an polynomial, beforehand:\n"
@@ -7572,7 +11309,7 @@ msgid ""
 "    bfallroots(ratdisrep(taylor(expression,0,30)));"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7709
+#: ../../src/MaximaCommandMenus.cpp:892
 msgid ""
 "Tries to find all solutions of a polynomial numerically.\n"
 "Might be able to detect solutions in non-polynomials, as well, if the expression is approximated by an polynomial, beforehand:\n"
@@ -7580,7 +11317,7 @@ msgid ""
 "    allroots(ratdisrep(taylor(expression,0,30)));"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7730
+#: ../../src/MaximaCommandMenus.cpp:911
 #, c-format
 msgid ""
 "Tries to find exact fractions that match the numerical solutions of a polynomial.\n"
@@ -7592,298 +11329,413 @@ msgid ""
 "See also guess_exact_value()"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1181
+#: ../../src/wxMaximaFrame.cpp:1215
 msgid "Trim both ends..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1182
+#: ../../src/wxMaximaFrame.cpp:1216
 #, fuzzy
 msgid "Trim left..."
 msgstr "Limite..."
 
-#: ../../src/wxMaximaFrame.cpp:1183
+#: ../../src/wxMaximaFrame.cpp:1217
 #, fuzzy
 msgid "Trim right..."
 msgstr "Limite..."
 
-#: ../../src/wxMaxima.cpp:7473
+#: ../../src/MaximaCommandMenus.cpp:4345
 msgid "Trim string left"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7469
+#: ../../src/MaximaCommandMenus.cpp:4341
 msgid "Trim string on both ends"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7477
+#: ../../src/MaximaCommandMenus.cpp:4349
 msgid "Trim string right"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1511
+#: ../../src/wxMaximaFrame.cpp:1548
 msgid "Try to guess which form is &simple"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8637
+#: ../../src/MaximaCommandMenus.cpp:629
 msgid "Try to simplify sums that result from sum() commands."
 msgstr ""
 
-#: ../../src/MaximaManual.cpp:369
+#: ../../src/MaximaManual.cpp:382
 #, c-format
 msgid "Trying to cache the list of subjects the manual contains in the file %s."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:4423
+#: ../../src/MaximaFileIO.cpp:357
 msgid "Trying to discard all output."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:4380
+#: ../../src/MaximaFileIO.cpp:326
 msgid "Trying to extract content.xml out of a broken .zip file."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:5519
+#: ../../src/MaximaFileIO.cpp:610
 msgid "Trying to open a file with an empty name!"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:5523
+#: ../../src/MaximaFileIO.cpp:622
 #, c-format
 msgid "Trying to open the non-existing file %s"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:4457
+#: ../../src/MaximaFileIO.cpp:378
 msgid "Trying to reconstruct the xml closing markers."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:4376
+#: ../../src/MaximaFileIO.cpp:322
 msgid "Trying to recover a broken .wxmx file."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:6026
+#: ../../src/MaximaFileIO.cpp:907
 #, c-format
 msgid "Trying to remove the old temp file %s"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2507
+#: ../../src/MaximaProcessManager.cpp:168
 msgid "Trying to restart maxima."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2523
+#: ../../src/MaximaProcessManager.cpp:184
 #, c-format
 msgid "Trying to start the socket a Maxima on the local machine can connect to on port %i"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1928
+#: ../../src/dialogs/ConfigDialogue.cpp:230
+msgid "Turkish"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1965
 msgid "Tutorials"
 msgstr "Tutoriais"
 
-#: ../../src/wxMaxima.cpp:9571
+#: ../../src/MaximaCommandMenus.cpp:1809
 msgid "Two sample t-test"
 msgstr "Teste t com duas amostras"
 
-#: ../../src/Worksheet.cpp:8013
+#: ../../src/worksheet/Worksheet.cpp:6249
 #, fuzzy
 msgid "Type"
 msgstr "Tipo:"
 
-#: ../../src/wxMaxima.cpp:7180
+#: ../../src/cells/EditorCell.cpp:4550
+#, fuzzy
+msgid "Type in text"
+msgstr "Copiar como imagem"
+
+#: ../../src/MaximaCommandMenus.cpp:4052 ../../src/wizards/MatWiz.cpp:158
 msgid "Type:"
 msgstr "Tipo:"
 
-#: ../../src/wxMaxima.cpp:9429
+#: ../../src/MaximaCommandMenus.cpp:2072
 msgid "URL"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1146
+#: ../../src/dialogs/ConfigDialogue.cpp:1231
+msgid "URL MathJaX.js is located at:"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1180
 msgid "UTF8 to Unicode code point..."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:10479
+#: ../../src/dialogs/ConfigDialogue.cpp:231
+msgid "Ukrainian"
+msgstr "Ucraniano"
+
+#: ../../src/wxMaxima.cpp:3166
 msgid "Un-closed parenthesis"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:10467
+#: ../../src/wxMaxima.cpp:3154
 msgid "Un-closed parenthesis on encountering ; or $"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:11160
-msgid "Unable to interpret the version info I got from http://wxMaxima-developers.github.io/wxmaxima/version.txt: "
+#: ../../src/wxMaxima.cpp:3468
+#, c-format
+msgid "Unable to interpret the version info I got from %s: %s"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1007
+#: ../../src/wxMaxima.cpp:3414
+#, c-format
+msgid "Unable to interpret the version info I got: %s"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1041
 #, fuzzy
 msgid "Undefine"
 msgstr "Sublinhado"
 
-#: ../../src/ToolBar.cpp:191
+#: ../../src/sidebars/VariablesPane.cpp:303
+#: ../../src/sidebars/VariablesPane.cpp:386
+msgid "Undefined"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:2115
+msgid "Underlined"
+msgstr "Sublinhado"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:745
+msgid "Underscore converts to subscripts:"
+msgstr ""
+
+#: ../../src/ToolBar.cpp:354 ../../src/ToolBar.cpp:357
 msgid "Undo"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:631
+#: ../../src/wxMaximaFrame.cpp:668
 msgid "Undo\tCtrl+Z"
 msgstr "&Desfazer\tCtrl+Z"
 
-#: ../../src/ToolBar.cpp:614
+#: ../../src/ToolBar.cpp:814
 msgid "Undo and redo button"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:631
+#: ../../src/wxMaximaFrame.cpp:668
 msgid "Undo last change"
 msgstr "Desfazer última alteração"
 
-#: ../../src/wxMaximaFrame.cpp:924
+#: ../../src/cells/TextCell.cpp:115
+#, c-format
+msgid "Unexpected text style %li for TextCell"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:958
 #, fuzzy
 msgid "Unfold All\tCtrl+Alt+]"
 msgstr "Selecionar tudo\tCtrl+A"
 
-#: ../../src/wxMaximaFrame.cpp:925
+#: ../../src/wxMaximaFrame.cpp:959
 msgid "Unfold all folded sections"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1893
+#: ../../src/sidebars/TableOfContents.cpp:507
+msgid "Unhide"
+msgstr ""
+
+#: ../../src/worksheet/WorksheetContextMenu.cpp:665
 msgid "Unhide Heading 5"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1904
+#: ../../src/worksheet/WorksheetContextMenu.cpp:676
 msgid "Unhide Heading 6"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1852
+#: ../../src/worksheet/WorksheetContextMenu.cpp:624
 msgid "Unhide Part"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1860
+#: ../../src/worksheet/WorksheetContextMenu.cpp:632
 #, fuzzy
 msgid "Unhide Section"
 msgstr "Seção"
 
-#: ../../src/Worksheet.cpp:1871
+#: ../../src/worksheet/WorksheetContextMenu.cpp:643
 #, fuzzy
 msgid "Unhide Subsection"
 msgstr "Subseção"
 
-#: ../../src/Worksheet.cpp:1882
+#: ../../src/worksheet/WorksheetContextMenu.cpp:654
 #, fuzzy
 msgid "Unhide Subsubsection"
 msgstr "Subseção"
 
-#: ../../src/Worksheet.cpp:1912
+#: ../../src/worksheet/WorksheetContextMenu.cpp:684
 #, fuzzy
 msgid "Unhide contents"
 msgstr "Constantes gregas"
 
-#: ../../src/wxMaximaFrame.cpp:266
+#: ../../src/wxMaximaFrame.cpp:287
 #, fuzzy
 msgid "Unicode characters"
 msgstr "Constantes gregas"
 
-#: ../../src/wxMaximaFrame.cpp:707
+#: ../../src/wxMaximaFrame.cpp:742
 msgid "Unicode chars\tAlt+Shift+U"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1144
+#: ../../src/wxMaximaFrame.cpp:1178
 msgid "Unicode code point to UTF8..."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7366
+#: ../../src/MaximaCommandMenus.cpp:4238
 msgid "Unicode code point to char"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1142
+#: ../../src/wxMaximaFrame.cpp:1176
 msgid "Unicode code point to char..."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7371
+#: ../../src/MaximaCommandMenus.cpp:4243
 msgid "Unicode code point to utf8 numbers"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7078
+#: ../../src/sidebars/SymbolsSidebar.cpp:180
+msgid "Unicode symbols:"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:3950
 msgid "Unlike in other programming language return() only exits from the current loop or block(), not from the whole function."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:10418
+#: ../../src/wxMaxima.cpp:3105
 msgid "Unterminated comment."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:10461
+#: ../../src/wxMaxima.cpp:3148
 msgid "Unterminated string."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:4786
+#: ../../src/wizards/ActualValuesStorageWiz.cpp:43
+msgid "Until then the actual values for all variables can be kept in a list."
+msgstr ""
+
+#: ../../src/dialogs/DiffFrame.cpp:429 ../../src/dialogs/FindReplacePane.cpp:80
+msgid "Up"
+msgstr ""
+
+#: ../../src/MaximaEvaluator.cpp:629
 msgid "Updating maxima's configuration"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:11150 ../../src/wxMaxima.cpp:11157
-#: ../../src/wxMaxima.cpp:11163
+#: ../../src/wxMaxima.cpp:3407 ../../src/wxMaxima.cpp:3412
+#: ../../src/wxMaxima.cpp:3414 ../../src/wxMaxima.cpp:3461
+#: ../../src/wxMaxima.cpp:3466 ../../src/wxMaxima.cpp:3469
 msgid "Upgrade"
 msgstr "Atualizar"
 
-#: ../../src/wxMaxima.cpp:7779 ../../src/wxMaxima.cpp:10041
+#: ../../src/MaximaCommandMenus.cpp:489 ../../src/MaximaCommandMenus.cpp:502
+#: ../../src/MaximaCommandMenus.cpp:517 ../../src/MaximaCommandMenus.cpp:531
+msgid "Upper bound on the number of cycles. Must be greater than or equal to 3."
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:960 ../../src/MaximaCommandMenus.cpp:3530
 msgid "Upper bound:"
 msgstr "Limite superior:"
 
-#: ../../src/wxMaximaFrame.cpp:792
+#: ../../src/sidebars/GreekSidebar.cpp:197
+#, fuzzy
+msgid "Upsilon"
+msgstr "Epsilon:"
+
+#: ../../src/wxMaximaFrame.cpp:829
 msgid "Use \"<\" and \">\" as parenthesis for matrices"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1708 ../../src/wxMaximaFrame.cpp:1739
+#: ../../src/dialogs/ConfigDialogue.cpp:507
+msgid "Use GTK's overlay scrollbars, which appear over the worksheet and fade out when unused. Looks modern, but GTK repaints the whole worksheet on every frame of the fade animation - which runs after every mouse movement - so classic scrollbars are much faster."
+msgstr ""
+
+#: ../../src/wizards/SumWiz.cpp:69
+msgid "Use Gosper algorithm"
+msgstr "User algoritmo Gosper"
+
+#: ../../src/sidebars/RegexCtrl.cpp:133
+msgid "Use RegEx filtering"
+msgstr ""
+
+#: ../../src/sidebars/RegexCtrl.cpp:134
+msgid "Use Text search filtering"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1745 ../../src/wxMaximaFrame.cpp:1776
 #, fuzzy
 msgid "Use a list"
 msgstr "Criar lista"
 
-#: ../../src/wxMaxima.cpp:8571
+#: ../../src/MaximaCommandMenus.cpp:1589
 msgid "Use a list as parameter list for a function"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1708
+#: ../../src/wxMaximaFrame.cpp:2008
+msgid "Use as TortoiseSVN/Git diff tool"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:485
+msgid "Use centered dot and Minus, not Star and Hyphen"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:849
+msgid "Use centered dot character for multiplication"
+msgstr "Usar um ponto centralizado para indicar multiplicação"
+
+#: ../../src/wxMaximaFrame.cpp:1745
 #, fuzzy
 msgid "Use list"
 msgstr "Criar lista"
 
-#: ../../src/wxMaximaFrame.cpp:1701
+#: ../../src/wxMaximaFrame.cpp:1738
 msgid "Use list as the arguments of a function"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:786
+#: ../../src/wxMaximaFrame.cpp:823
 msgid "Use rounded parenthesis for matrices"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:789
+#: ../../src/wxMaximaFrame.cpp:826
 msgid "Use square parenthesis for matrices"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1083
+#: ../../src/wxMaximaFrame.cpp:1117
 #, fuzzy
 msgid "Use struct field..."
 msgstr "Fração &contínua"
 
-#: ../../src/wxMaximaFrame.cpp:795
+#: ../../src/dialogs/ConfigDialogue.cpp:425
+msgid "Use the \"partial derivative\" symbol to represent the fraction that represents a diff() when exporting LaTeX"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:2052
+msgid "Use unicode Math Symbols, if available"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:832
 msgid "Use vertical lines instead of parenthesis for matrices"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1619
+#: ../../src/worksheet/WorksheetContextMenu.cpp:392
 msgid "User labels only"
 msgstr ""
 
-#: ../../src/Configuration.cpp:81
+#: ../../src/dialogs/ConfigDialogue.cpp:1248
+#: ../../src/dialogs/ConfigDialogue.cpp:1452
+#: ../../src/dialogs/ConfigDialogue.cpp:1480
+#: ../../src/dialogs/MaximaNotStartingDialog.cpp:54
+msgid "User specified"
+msgstr ""
+
+#: ../../src/Styles.cpp:110
 msgid "User-defined labels"
 msgstr ""
 
-#: ../../src/MaximaManual.cpp:483
+#: ../../src/dialogs/ConfigDialogue.cpp:770
+msgid "User-defined labels if available"
+msgstr ""
+
+#: ../../src/MaximaManual.cpp:500
 msgid "Using Maxima help file from wxMaxima configuration file (helpFile=...))"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:4825
+#: ../../src/wxMaxima.cpp:1566
 msgid "Using Maxima path from command line."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:4822
+#: ../../src/wxMaxima.cpp:1563
 #, fuzzy
 msgid "Using configured Maxima path."
 msgstr "Configurar o wxMaxima"
 
-#: ../../src/wxMaxima.cpp:2961
+#: ../../src/MaximaProcessManager.cpp:976
 msgid "Using gnuplot's antialiassing-less png driver for embedded plots as pngcairo could not be found"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2956
+#: ../../src/MaximaProcessManager.cpp:971
 msgid "Using gnuplot's pngcairo driver for embedded plots"
 msgstr ""
 
@@ -7891,478 +11743,963 @@ msgstr ""
 msgid "Using the built-in list of manual anchors."
 msgstr ""
 
-#: ../../src/WXMXformat.cpp:266
+#: ../../src/dialogs/AboutDialog.cpp:46
+#, c-format
+msgid ""
+"Using: %s\n"
+"\n"
+msgstr ""
+
+#: ../../src/WXMXformat.cpp:268
 msgid "Validated that the XML representation of the document actually is valid XML"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8755
+#: ../../src/dialogs/ConfigDialogue.cpp:542
+#: ../../src/wizards/ActualValuesStorageWiz.cpp:49
+#, fuzzy
+msgid "Value"
+msgstr "Valor:"
+
+#: ../../src/MaximaCommandMenus.cpp:756
 #, fuzzy
 msgid "Value at a given point"
 msgstr "Avaliar formas substa&ntivas"
 
-#: ../../src/Worksheet.cpp:1987
+#: ../../src/worksheet/WorksheetContextMenu.cpp:759
 msgid "Value at a specific point"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7801
+#: ../../src/MaximaCommandMenus.cpp:982
 #, fuzzy
 msgid "Value at that point:"
 msgstr "Avaliar formas substa&ntivas"
 
-#: ../../src/wxMaxima.cpp:7812 ../../src/wxMaxima.cpp:7825
-#: ../../src/wxMaxima.cpp:7827
+#: ../../src/MaximaCommandMenus.cpp:993 ../../src/MaximaCommandMenus.cpp:1006
+#: ../../src/MaximaCommandMenus.cpp:1008
 #, fuzzy
 msgid "Value y at that point:"
 msgstr "Avaliar formas substa&ntivas"
 
-#: ../../src/wxMaxima.cpp:7910
+#: ../../src/MaximaCommandMenus.cpp:1091 ../../src/wizards/BC2Wiz.cpp:36
+#: ../../src/wizards/BC2Wiz.cpp:42
 msgid "Value:"
 msgstr "Valor:"
 
-#: ../../src/wxMaxima.cpp:8201
+#: ../../src/MaximaCommandMenus.cpp:1391
 msgid "Var #1"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8202
+#: ../../src/MaximaCommandMenus.cpp:1392
 msgid "Var #2"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:6852 ../../src/wxMaxima.cpp:8183
+#: ../../src/MaximaCommandMenus.cpp:1371 ../../src/MaximaCommandMenus.cpp:1755
+#: ../../src/dialogs/ConfigDialogue.cpp:541
+#: ../../src/sidebars/VariablesPane.cpp:54
 msgid "Variable"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:6530 ../../src/wxMaxima.cpp:6536
-#: ../../src/wxMaxima.cpp:8568
+#: ../../src/wizards/DrawWiz.cpp:61 ../../src/wizards/DrawWiz.cpp:166
+msgid "Variable for the x value"
+msgstr ""
+
+#: ../../src/wizards/DrawWiz.cpp:78 ../../src/wizards/DrawWiz.cpp:181
+msgid "Variable for the y value"
+msgstr ""
+
+#: ../../src/wizards/DrawWiz.cpp:198
+msgid "Variable for the z value"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:1586 ../../src/MaximaCommandMenus.cpp:3050
+#: ../../src/MaximaCommandMenus.cpp:3056
+#: ../../src/wizards/ActualValuesStorageWiz.cpp:48
 #, fuzzy
 msgid "Variable name"
 msgstr "Variável antiga:"
 
-#: ../../src/wxMaximaFrame.cpp:1085
+#: ../../src/wxMaximaFrame.cpp:1119
 #, fuzzy
 msgid "Variable name, not contents..."
 msgstr "Variável antiga:"
 
-#: ../../src/wxMaxima.cpp:7157 ../../src/wxMaxima.cpp:7675
+#: ../../src/MaximaCommandMenus.cpp:4029 ../../src/MaximaCommandMenus.cpp:4547
 #, fuzzy
 msgid "Variable name:"
 msgstr "Variável antiga:"
 
-#: ../../src/wxMaxima.cpp:7752 ../../src/wxMaxima.cpp:7766
+#: ../../src/MaximaCommandMenus.cpp:933 ../../src/MaximaCommandMenus.cpp:947
 #, fuzzy
 msgid "Variable(s)"
 msgstr "Variável(is):"
 
-#: ../../src/wxMaxima.cpp:7849 ../../src/wxMaxima.cpp:7901
-#: ../../src/wxMaxima.cpp:9012 ../../src/wxMaxima.cpp:10057
+#: ../../src/MaximaCommandMenus.cpp:266 ../../src/MaximaCommandMenus.cpp:1030
+#: ../../src/MaximaCommandMenus.cpp:1082 ../../src/MaximaCommandMenus.cpp:3546
 msgid "Variable(s):"
 msgstr "Variável(is):"
 
-#: ../../src/wxMaxima.cpp:7714 ../../src/wxMaxima.cpp:7725
-#: ../../src/wxMaxima.cpp:7777 ../../src/wxMaxima.cpp:8934
-#: ../../src/wxMaxima.cpp:8941 ../../src/wxMaxima.cpp:8952
-#: ../../src/wxMaxima.cpp:8977 ../../src/wxMaxima.cpp:8982
-#: ../../src/wxMaxima.cpp:9063 ../../src/wxMaxima.cpp:10039
+#: ../../src/MaximaCommandMenus.cpp:185 ../../src/MaximaCommandMenus.cpp:195
+#: ../../src/MaximaCommandMenus.cpp:206 ../../src/MaximaCommandMenus.cpp:231
+#: ../../src/MaximaCommandMenus.cpp:236 ../../src/MaximaCommandMenus.cpp:317
+#: ../../src/MaximaCommandMenus.cpp:958 ../../src/MaximaCommandMenus.cpp:3528
+#: ../../src/wizards/IntegrateWiz.cpp:36 ../../src/wizards/LimitWiz.cpp:32
+#: ../../src/wizards/Plot2dWiz.cpp:45 ../../src/wizards/Plot2dWiz.cpp:55
+#: ../../src/wizards/Plot2dWiz.cpp:496 ../../src/wizards/Plot3dWiz.cpp:34
+#: ../../src/wizards/Plot3dWiz.cpp:43 ../../src/wizards/SeriesWiz.cpp:33
+#: ../../src/wizards/SumWiz.cpp:34
 msgid "Variable:"
 msgstr "Variável:"
 
-#: ../../src/wxMaximaFrame.cpp:277 ../../src/wxMaximaFrame.cpp:720
+#: ../../src/wxMaximaFrame.cpp:298 ../../src/wxMaximaFrame.cpp:755
 msgid "Variables"
 msgstr "Variáveis"
 
-#: ../../src/wxMaxima.cpp:9043 ../../src/wxMaxima.cpp:9593
+#: ../../src/MaximaCommandMenus.cpp:297 ../../src/MaximaCommandMenus.cpp:1833
+#: ../../src/wizards/SystemWiz.cpp:72
 msgid "Variables:"
 msgstr "Variáveis:"
 
-#: ../../src/WXMXformat.cpp:337
+#: ../../src/sidebars/StatSidebar.cpp:58
+msgid "Variance..."
+msgstr "Variância..."
+
+#: ../../src/WXMXformat.cpp:339
 msgid "Verified that we are able to read the whole .zip archive we produced."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:836
+#: ../../src/dialogs/ConfigDialogue.cpp:232
+msgid "Vietnamese"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:870
 msgid "View"
 msgstr ""
 
-#: ../../src/Autocomplete.cpp:235
+#: ../../src/Autocomplete.cpp:305
 msgid "Waiting for m_addFiles_backgroundThread to finish"
 msgstr ""
 
-#: ../../src/Autocomplete.cpp:122 ../../src/Autocomplete.cpp:240
+#: ../../src/Autocomplete.cpp:154 ../../src/Autocomplete.cpp:310
 msgid "Waiting for m_addSymbols_backgroundThread to finish"
 msgstr ""
 
-#: ../../src/MaximaManual.cpp:533
-msgid "Waiting for the Manual anchors background task."
-msgstr ""
-
-#: ../../src/MaximaManual.cpp:562
+#: ../../src/MaximaManual.cpp:586
 msgid "Waiting for the thread that parses the maxima manual to finish"
 msgstr ""
 
-#: ../../src/MathParser.cpp:1229 ../../src/wxMaxima.cpp:3296
-#: ../../src/wxMaxima.cpp:3308 ../../src/wxMaxima.cpp:4613
-#: ../../src/wxMaxima.cpp:4703 ../../src/wxMaxima.cpp:4840
+#: ../../src/dialogs/ConfigDialogue.cpp:1410
+msgid "Warn if an inactive window is idle"
+msgstr ""
+
+#: ../../src/MathParser.cpp:1343 ../../src/MaximaFileIO.cpp:536
+#: ../../src/MaximaProcessManager.cpp:1100
+#: ../../src/MaximaResponseReader.cpp:361 ../../src/wxMaxima.cpp:1585
 msgid "Warning"
 msgstr "Aviso"
 
-#: ../../src/wxMaximaFrame.cpp:1556
+#: ../../src/wxMaximaFrame.cpp:1593
 #, fuzzy
 msgid "Warning:"
 msgstr "Aviso"
 
-#: ../../src/Dirstructure.cpp:72
+#: ../../src/Dirstructure.cpp:73
 #, c-format
 msgid ""
 "Warning: Cannot create %s, the directory maxima keeps configuration, user packages and caches in.\n"
 "Make sure that your system's home directory is set up correctly"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1546
+#: ../../src/cells/GroupCell.cpp:400 ../../src/cells/GroupCell.cpp:406
+msgid "Warning: Lookalike chars: "
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1583
 msgid "Warning: No test if the argument of the log is complex, positive or negative"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:5063
+#: ../../src/dialogs/BinaryNameCtrl.cpp:76
+msgid ""
+"We weren't searching for the location of wxMaxima!\n"
+"\n"
+"Please enter the path to the program again."
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:3603 ../../src/MaximaCommandMenus.cpp:3613
+msgid "WebP (*.webp)|*.webp|"
+msgstr ""
+
+#: ../../src/wxMaxima.cpp:1871
 msgid "Welcome to wxMaxima"
 msgstr "Bem-vindo ao wxMaxima"
 
-#: ../../src/wxMaxima.cpp:8583
+#: ../../src/MaximaCommandMenus.cpp:1601
 msgid "What to do:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1058
+#: ../../src/dialogs/TipOfTheDay.cpp:134
+msgid "When applying functions with one argument from menus, the default argument is '%'. To apply the function to some other value, select it in the document before executing a menu command."
+msgstr "Ao aplicar funções com um argumento a partir dos menus, o argumento padrão é '%'. Para aplicar a função a um outro valor, selecione-o do documento antes de executar o comando do menu."
+
+#: ../../src/wxMaximaFrame.cpp:1092
 msgid "When to invoke the lisp compiler's debugger"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7046
+#: ../../src/MaximaCommandMenus.cpp:3918
 msgid "While loop"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1063
+#: ../../src/wxMaximaFrame.cpp:1097
 msgid "While loop..."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:5673
+#: ../../src/dialogs/TipOfTheDay.cpp:243
+msgid "While wxMaxima is programmed mostly in C++, it also uses some Lisp code. You can help to improve wxMaxima, if you have knowledge of Common Lisp."
+msgstr ""
+
+#: ../../src/MaximaFileIO.cpp:780
 msgid "Whole document (*.wxmx)|*.wxmx|The input, readable by load() (maxima > 5.38) (*.wxm)|*.wxm|All Files (*.*)|*"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:210
+#: ../../src/wxMaxima.cpp:309
 msgid "Will try to generate a stack backtrace, if the program ever crashes"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:6920
+#: ../../src/dialogs/ConfigDialogue.cpp:280
+msgid "Worksheet"
+msgstr ""
+
+#: ../../src/MaximaResponseReader.cpp:117
+#, c-format
+msgid "Worksheet export of type \"%s\" is not supported yet."
+msgstr ""
+
+#: ../../src/worksheet/Worksheet.cpp:4911
 msgid "Worksheet got activated"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:6840
+#: ../../src/worksheet/Worksheet.cpp:4843
 msgid "Worksheet got the mouse focus"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:7191 ../../src/Worksheet.cpp:7279
+#: ../../src/sidebars/PerformanceSidebar.cpp:47
+msgid "Worksheet repaints:"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:428
+msgid "Wrap equations exported by the \"copy as LaTeX\" feature between \\[ and \\] as equation markers"
+msgstr ""
+
+#: ../../src/worksheet/Worksheet.cpp:5200
 msgid "Wrapped search"
 msgstr ""
 
-#: ../../src/WXMXformat.cpp:282
+#: ../../src/WXMXformat.cpp:284
 msgid "Wrote all image and gnuplot files to the zip archive"
 msgstr ""
 
-#: ../../src/WXMXformat.cpp:272
+#: ../../src/WXMXformat.cpp:274
 msgid "Wrote the XML representation of the document to the zip archive"
 msgstr ""
 
-#: ../../src/WXMXformat.cpp:116
+#: ../../src/WXMXformat.cpp:117
 msgid "Wrote the mimetype info"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:11147
-#, fuzzy, c-format
+#: ../../src/wizards/DrawWiz.cpp:942 ../../src/wizards/DrawWiz.cpp:949
+#: ../../src/wizards/DrawWiz.cpp:961 ../../src/wizards/DrawWiz.cpp:974
+#: ../../src/wizards/DrawWiz.cpp:977
+msgid "X"
+msgstr ""
+
+#: ../../src/MathParser.cpp:1279
+msgid "XML nesting limit exceeded"
+msgstr ""
+
+#: ../../src/sidebars/GreekSidebar.cpp:191
+msgid "Xi"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:728
+#, fuzzy
+msgid "Yes"
+msgstr "sim"
+
+#: ../../src/dialogs/TipOfTheDay.cpp:64
+msgid "You can access the last output using the variable '%'. You can access the output of previous commands using variables '%on' where n is the number of output."
+msgstr "Você pode acessar a última saída com a variável '%'. Você pode acessar a saída de comandos anteriores usando a variável '%on' onde n é o número da saída."
+
+#: ../../src/dialogs/TipOfTheDay.cpp:118
+msgid "You can evaluate your whole document by using 'Cell->Evaluate All Cells' menu command or the appropriate key shortcut. The cells will be evaluated in the order they appear in the document."
+msgstr "Você pode avaliar todo o documento usando o menu 'Célula->Avaliar todas as células' ou a tecla de atalho correspondente. As células serão avalidas na ordem em que aparecem no documento."
+
+#: ../../src/dialogs/TipOfTheDay.cpp:98
+#, fuzzy
+msgid "You can get help on a Maxima function by selecting or clicking on the function name and pressing F1. wxMaxima will search the help index for the selection or the word under the cursor."
+msgstr "Você pode obter ajuda sobre uma função do Maxima selecionando-a ou clicando no nome da função e apertando F1. O wxMaxima vai pesquisar no índice da ajuda pela palavra selecionada ou pela palavra onde está o cursor."
+
+#: ../../src/dialogs/TipOfTheDay.cpp:92
+msgid "You can hide output part of cells by clicking in the triangle on the left side of cells. This works on text cells also."
+msgstr "Você pode esconder a saída das células clicando no triângulo no lado esquerdo das células. Isso funciona também em células de texto."
+
+#: ../../src/dialogs/TipOfTheDay.cpp:81
+#, fuzzy
+msgid "You can insert different types of 'cells' in wxMaxima documents using the 'Cell' menu. Note that only 'input cells' can be evaluated, while others are used for commenting and structuring your calculations."
+msgstr "Você pode inserir diferentes tipos de 'células' num documento do wxMaxima usando o menu 'Célula'. Note que apenas 'células de entrada' são avaliadas, as outras são usadas para comentar ou estruturar seus cálculos."
+
+#: ../../src/dialogs/TipOfTheDay.cpp:112
+msgid "You can select multiple cells either with a mouse - click'n'drag from between cells or from a cell bracket on the left - or with a keyboard - hold down Shift while moving the horizontal cursor - and then operate on selection. This comes in handy when you want to delete or evaluate multiple cells."
+msgstr "Você pode selecionar vários células com o mouse - clique e arraste desde algum ponto entre células ou dos marcadores à esquerda - ou com o teclado - segure Shift enquanto move o cursor horizontal - e então operar na seleção. Isso é útil quando você quer apagar ou calcular múltiplas células."
+
+#: ../../src/dialogs/TipOfTheDay.cpp:232
 msgid ""
-"You have version %s. The newest version source code is available for is %s.\n"
+"You found a bug in wxMaxima? Please report it at https://github.com/wxMaxima-developers/wxmaxima/issues\n"
+"A mathematical bug is maybe a bug in Maxima (the backend), which can be reported at https://sourceforge.net/p/maxima/bugs/\n"
+"Please check, before, if the bug was not already reported."
+msgstr ""
+
+#: ../../src/dialogs/TipOfTheDay.cpp:238
+msgid "You got an idea for an improvement of wxMaxima? Great! Please submit your idea at https://github.com/wxMaxima-developers/wxmaxima/issues. "
+msgstr ""
+
+#: ../../src/wxMaxima.cpp:3404 ../../src/wxMaxima.cpp:3458
+#, c-format
+msgid ""
+"You have version %s. The newest wxMaxima release is %s.\n"
 "\n"
 "Select OK to visit the wxMaxima webpage."
 msgstr ""
-"Você tem a versão %s. A versão atual é %s.\n"
-"\n"
-"Selecione OK para visitar a página do wxMaxima."
 
-#: ../../src/wxMaxima.cpp:11202
+#: ../../src/wxMaxima.cpp:3508
 msgid "Your changes will be lost if you don't save them."
 msgstr "Suas mudanças serão perdidas se você não as salvar."
 
-#: ../../src/wxMaxima.cpp:11156
+#: ../../src/wxMaxima.cpp:3412 ../../src/wxMaxima.cpp:3466
 msgid "Your version of wxMaxima is up to date."
 msgstr "Sua versão do wxMaxima está atualizada."
 
-#: ../../src/wxMaximaFrame.cpp:805
+#: ../../src/sidebars/GreekSidebar.cpp:183
+msgid "Zeta"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:842
 #, fuzzy
 msgid "Zoom &In\tCtrl++"
 msgstr "Aprox&imar\tAlt+I"
 
-#: ../../src/wxMaximaFrame.cpp:806
+#: ../../src/wxMaximaFrame.cpp:843
 #, fuzzy
 msgid "Zoom Ou&t\tCtrl+-"
 msgstr "Afas&tar\tAlt+O"
 
-#: ../../src/wxMaximaFrame.cpp:805
+#: ../../src/wxMaximaFrame.cpp:842
 msgid "Zoom in 10%"
 msgstr "Aproximar em 10%"
 
-#: ../../src/wxMaximaFrame.cpp:806
+#: ../../src/wxMaximaFrame.cpp:843
 msgid "Zoom out 10%"
 msgstr "Afastar em 10%"
 
-#: ../../src/wxMaxima.cpp:10915 ../../src/wxMaximaFrame.cpp:187
+#: ../../src/wxMaxima.cpp:3204 ../../src/wxMaximaFrame.cpp:201
 msgid "[ unsaved ]"
 msgstr "[ não salvo ]"
 
-#: ../../src/wxMaxima.cpp:10920
+#: ../../src/wxMaxima.cpp:3206
 msgid "[ unsaved* ]"
 msgstr "[ não salvo* ]"
 
-#: ../../src/Worksheet.cpp:5278
-#, c-format
-msgid "_%d.gif\"  alt=\"Animated Diagram\" loading=\"lazy\" style=\"max-width:90%%;\">\n"
+#: ../../src/wizards/DrawWiz.cpp:819 ../../src/wizards/DrawWiz.cpp:825
+msgid "[[x_1,x_2,...],[y_1,y_2,...]]"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:5484
-#, c-format
-msgid "_%d.gif\" alt=\"Animated Diagram\" style=\"max-width:90%%;\" loading=\"lazy\">"
+#: ../../src/wizards/DrawWiz.cpp:814
+msgid "[x_1, x_2,...] or [x_1, x_2,...],[y_1, y_2,...] or matrix([x_1,y_1],[x_2,y_2],...)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1690
+#: ../../src/wizards/ListSortWiz.cpp:46
+msgid "a<b (Maxima default)"
+msgstr ""
+
+#: ../../src/sidebars/GreekSidebar.cpp:151
+msgid "alpha"
+msgstr ""
+
+#: ../../src/sidebars/SymbolsSidebar.cpp:95
+#, fuzzy
+msgid "and"
+msgstr "Expandir"
+
+#: ../../src/wizards/MatWiz.cpp:160
+msgid "antisymmetric"
+msgstr "antisimétrica"
+
+#: ../../src/wxMaximaFrame.cpp:1727
 #, fuzzy
 msgid "apply function to each element"
 msgstr "Aplicar função a uma lista"
 
-#: ../../src/wxMaximaFrame.cpp:739
+#: ../../src/wxMaximaFrame.cpp:776
 msgid "as 1D ASCII"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:742
+#: ../../src/wxMaximaFrame.cpp:779
 msgid "as ASCII Art"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:745
+#: ../../src/wxMaximaFrame.cpp:782
 msgid "as ASCII+Unicode Art"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1680
+#: ../../src/wxMaximaFrame.cpp:1717
 msgid "as storage for actual values for variables"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1139
+#: ../../src/sidebars/GreekSidebar.cpp:152
+msgid "beta"
+msgstr ""
+
+#: ../../src/wizards/LimitWiz.cpp:42
+msgid "both sides"
+msgstr "bilateral"
+
+#: ../../src/wxMaximaFrame.cpp:1173
 msgid "char to Ascii code..."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7836
+#: ../../src/sidebars/GreekSidebar.cpp:172
+msgid "chi"
+msgstr ""
+
+#: ../../src/MaximaFileIO.cpp:318
+#, c-format
+msgid "content.xml exceeds the sanity limit of %zu bytes; the file may be corrupt or a decompression bomb."
+msgstr ""
+
+#: ../../src/wizards/Plot2dWiz.cpp:70 ../../src/wizards/Plot2dWiz.cpp:372
+#: ../../src/wizards/Plot3dWiz.cpp:61 ../../src/wizards/Plot3dWiz.cpp:358
+msgid "default"
+msgstr "padrão"
+
+#: ../../src/sidebars/GreekSidebar.cpp:154
+msgid "delta"
+msgstr ""
+
+#: ../../src/wizards/MatWiz.cpp:159
+msgid "diagonal"
+msgstr "diagonal"
+
+#: ../../src/cells/FracCell.cpp:73
+msgid "diff(): Cannot find the multiplication sign I should hide"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:1017
 msgid "diff(x,t)="
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1064 ../../src/wxMaximaFrame.cpp:1702
+#: ../../src/wxMaximaFrame.cpp:1098 ../../src/wxMaximaFrame.cpp:1739
 msgid "do for each element"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:2027
+#: ../../src/sidebars/SymbolsSidebar.cpp:92
+msgid "empty"
+msgstr ""
+
+#: ../../src/sidebars/GreekSidebar.cpp:155
+#, fuzzy
+msgid "epsilon"
+msgstr "Epsilon:"
+
+#: ../../src/sidebars/SymbolsSidebar.cpp:100
+msgid "equivalent"
+msgstr ""
+
+#: ../../src/sidebars/GreekSidebar.cpp:157
+msgid "eta"
+msgstr ""
+
+#: ../../src/worksheet/WorksheetContextMenu.cpp:799
 msgid "ev() shall evaluate this automatically"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7130
+#: ../../src/sidebars/SymbolsSidebar.cpp:88
+msgid "exists"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:4002
 #, fuzzy
 msgid "expression:"
 msgstr "Expressão:"
 
-#: ../../src/Worksheet.cpp:2025
+#: ../../src/worksheet/WorksheetContextMenu.cpp:797
 msgid "f(x) stays f(x) even if the value of f(x) is computable"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7204 ../../src/wxMaxima.cpp:7209
+#: ../../src/dialogs/ConfigDialogue.cpp:467
+msgid ""
+"false=Don't generate subscripts\n"
+"true=Automatically convert underscores to subscript markers if the would-be subscript is a number or a single letter\n"
+"all=_ marks subscripts."
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:4076 ../../src/MaximaCommandMenus.cpp:4081
 #, fuzzy
 msgid "filename:"
 msgstr "Variável antiga:"
 
-#: ../../src/wxMaximaFrame.cpp:1674
+#: ../../src/wxMaximaFrame.cpp:1711
 #, fuzzy
 msgid "from a list"
 msgstr "Criar lista"
 
-#: ../../src/wxMaximaFrame.cpp:1671
+#: ../../src/wxMaximaFrame.cpp:1708
 msgid "from a rule"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1685
+#: ../../src/wxMaximaFrame.cpp:1722
 #, fuzzy
 msgid "from function arguments"
 msgstr "Nomes de funções"
 
-#: ../../src/wxMaximaFrame.cpp:1669
+#: ../../src/wxMaximaFrame.cpp:1706
 msgid "from individual elements"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8210 ../../src/wxMaxima.cpp:8553
+#: ../../src/MaximaCommandMenus.cpp:1400 ../../src/MaximaCommandMenus.cpp:1566
 #, fuzzy
 msgid "function"
 msgstr "Função"
 
-#: ../../src/wxMaximaFrame.cpp:747
+#: ../../src/sidebars/GreekSidebar.cpp:153
+msgid "gamma"
+msgstr ""
+
+#: ../../src/wizards/MatWiz.cpp:159
+msgid "general"
+msgstr "geral"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1630
+msgid "gnuplot: Without command console"
+msgstr ""
+
+#: ../../src/sidebars/SymbolsSidebar.cpp:118
+#, fuzzy
+msgid "greater than or equal"
+msgstr "Célula de subseção"
+
+#: ../../src/sidebars/SymbolsSidebar.cpp:87
+#, fuzzy
+msgid "in"
+msgstr "Localizar"
+
+#: ../../src/wxMaximaFrame.cpp:784
 msgid "in 2D"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8554
+#: ../../src/wizards/Plot2dWiz.cpp:70 ../../src/wizards/Plot2dWiz.cpp:198
+#: ../../src/wizards/Plot2dWiz.cpp:372 ../../src/wizards/Plot2dWiz.cpp:402
+#: ../../src/wizards/Plot3dWiz.cpp:61 ../../src/wizards/Plot3dWiz.cpp:194
+#: ../../src/wizards/Plot3dWiz.cpp:358 ../../src/wizards/Plot3dWiz.cpp:386
+msgid "inline"
+msgstr "embutido"
+
+#: ../../src/sidebars/SymbolsSidebar.cpp:104
+#, fuzzy
+msgid "intersection"
+msgstr "Direção:"
+
+#: ../../src/sidebars/GreekSidebar.cpp:159
+msgid "iota"
+msgstr ""
+
+#: ../../src/sidebars/GreekSidebar.cpp:160
+msgid "kappa"
+msgstr ""
+
+#: ../../src/sidebars/GreekSidebar.cpp:161
+msgid "lambda"
+msgstr ""
+
+#: ../../src/wizards/LimitWiz.cpp:42
+msgid "left"
+msgstr "esquerda"
+
+#: ../../src/sidebars/SymbolsSidebar.cpp:117
+#, fuzzy
+msgid "less or equal"
+msgstr "Célula de subseção"
+
+#: ../../src/MaximaCommandMenus.cpp:1567
 #, fuzzy
 msgid "list"
 msgstr "Criar lista"
 
-#: ../../src/wxMaximaFrame.cpp:1405
+#: ../../src/wizards/Plot2dWiz.cpp:54 ../../src/wizards/Plot2dWiz.cpp:64
+msgid "logscale"
+msgstr "escala logarítmica"
+
+#: ../../src/wizards/DrawWiz.cpp:822
+msgid "matrix([x_1,x_2,...],[y_1,y_2,...])"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1439
 msgid "max(abs(A(i,j))) (complex)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1404
+#: ../../src/wxMaximaFrame.cpp:1438
 msgid "max(abs(A(i,j))) (real)"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8046
+#: ../../src/sidebars/GreekSidebar.cpp:162
+msgid "mu"
+msgstr ""
+
+#: ../../src/sidebars/SymbolsSidebar.cpp:120
+#, fuzzy
+msgid "much greater than"
+msgstr "Célula de subseção"
+
+#: ../../src/sidebars/SymbolsSidebar.cpp:119
+msgid "much less than"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:1232
 #, fuzzy
 msgid "m×n Matrix A:"
 msgstr "Matriz:"
 
-#: ../../src/wxMaxima.cpp:7378 ../../src/wxMaxima.cpp:8527
-#: ../../src/wxMaxima.cpp:8533
+#: ../../src/MaximaCommandMenus.cpp:1538 ../../src/MaximaCommandMenus.cpp:1544
+#: ../../src/MaximaCommandMenus.cpp:4250
 #, fuzzy
 msgid "n:"
 msgstr "Localizar"
 
-#: ../../src/Worksheet.cpp:2000
+#: ../../src/sidebars/SymbolsSidebar.cpp:112
+msgid "nabla sign"
+msgstr ""
+
+#: ../../src/sidebars/SymbolsSidebar.cpp:98
+msgid "nand"
+msgstr ""
+
+#: ../../src/worksheet/WorksheetContextMenu.cpp:772
 msgid "nary: f(x, f(y,z)) = foo(x,y,z)"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:2024
+#: ../../src/sidebars/SymbolsSidebar.cpp:99
+#, fuzzy
+msgid "nor"
+msgstr "não"
+
+#: ../../src/sidebars/SymbolsSidebar.cpp:102
+#, fuzzy
+msgid "not"
+msgstr "não"
+
+#: ../../src/sidebars/SymbolsSidebar.cpp:116
+msgid "not bytewise identical"
+msgstr ""
+
+#: ../../src/sidebars/SymbolsSidebar.cpp:108
+msgid "not subset"
+msgstr ""
+
+#: ../../src/sidebars/SymbolsSidebar.cpp:107
+msgid "not subset or equal"
+msgstr ""
+
+#: ../../src/worksheet/WorksheetContextMenu.cpp:796
 msgid "noun: Not evaluated by default"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1710
+#: ../../src/wxMaximaFrame.cpp:1747
 #, fuzzy
 msgid "nth"
 msgstr "não"
 
-#: ../../src/Worksheet.cpp:2021
+#: ../../src/sidebars/GreekSidebar.cpp:163
+msgid "nu"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:1233
+msgid "n×1 Matrix b:"
+msgstr ""
+
+#: ../../src/sidebars/GreekSidebar.cpp:174
+msgid "omega"
+msgstr ""
+
+#: ../../src/sidebars/GreekSidebar.cpp:165
+msgid "omicron"
+msgstr ""
+
+#: ../../src/sidebars/SymbolsSidebar.cpp:96
+msgid "or"
+msgstr ""
+
+#: ../../src/worksheet/WorksheetContextMenu.cpp:793
 msgid "outative: f(2*x) = 2*f(x)"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7440 ../../src/wxMaxima.cpp:7445
-#: ../../src/wxMaxima.cpp:7455
+#: ../../src/cells/TextCell.cpp:260
+msgid "part() or the [] operator was used in order to extract the nth element of something that was less than n elements long."
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:4312 ../../src/MaximaCommandMenus.cpp:4317
+#: ../../src/MaximaCommandMenus.cpp:4327
 msgid "part:"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8942
+#: ../../src/sidebars/SymbolsSidebar.cpp:111
+#, fuzzy
+msgid "partial sign"
+msgstr "Frações parciais"
+
+#: ../../src/sidebars/GreekSidebar.cpp:171
+msgid "phi"
+msgstr ""
+
+#: ../../src/sidebars/GreekSidebar.cpp:166
+msgid "pi"
+msgstr ""
+
+#: ../../src/sidebars/SymbolsSidebar.cpp:101
+msgid "plus or minus"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:196
 #, fuzzy
 msgid "point:"
 msgstr "Ponto:"
 
-#: ../../src/wxMaxima.cpp:7740
+#: ../../src/MaximaCommandMenus.cpp:921
 #, fuzzy
 msgid "precision:"
 msgstr "Precisão"
 
-#: ../../src/wxMaxima.cpp:7255
+#: ../../src/graphical_io/Printout.cpp:95
+#, c-format
+msgid "printOut: Setting the page size to (%li,%li)"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:4127
 #, fuzzy
 msgid "printf"
 msgstr "Imprimir"
 
-#: ../../src/wxMaximaFrame.cpp:1108
+#: ../../src/wxMaximaFrame.cpp:1142
 #, fuzzy
 msgid "printf..."
 msgstr "Derivar..."
 
-#: ../../src/wxMaxima.cpp:8650
+#: ../../src/sidebars/SymbolsSidebar.cpp:115
+msgid "proportional to"
+msgstr ""
+
+#: ../../src/sidebars/GreekSidebar.cpp:173
+msgid "psi"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:642
 msgid "radcan() is a powerful tools for simplification trigonometric functions but needs to be taken with care: If a function has more than one branch radcan uses the one that looks like it would fit best, not necessarily the one that makes sense for the problem that resulted in the Expression that is to be simplified."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8731
+#: ../../src/MaximaCommandMenus.cpp:726
 msgid "ratsubst works like subst, but it knows some basic maths, if needed."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1111
+#: ../../src/wxMaximaFrame.cpp:1145
 #, fuzzy
 msgid "readbyte..."
 msgstr "Integrar..."
 
-#: ../../src/wxMaximaFrame.cpp:1110
+#: ../../src/wxMaximaFrame.cpp:1144
 #, fuzzy
 msgid "readchar..."
 msgstr "Gráfico de torta..."
 
-#: ../../src/wxMaximaFrame.cpp:1109
+#: ../../src/wxMaximaFrame.cpp:1143
 #, fuzzy
 msgid "readline..."
 msgstr "Variância..."
 
-#: ../../src/wxMaxima.cpp:10018
+#: ../../src/cells/TextCell.cpp:264
+msgid "rest() tried to drop more entries from a list than the list was long."
+msgstr ""
+
+#: ../../src/sidebars/GreekSidebar.cpp:167
+msgid "rho"
+msgstr ""
+
+#: ../../src/wizards/LimitWiz.cpp:42
+msgid "right"
+msgstr "direita"
+
+#: ../../src/wizards/DrawWiz.cpp:310
+msgid "secondary x axis label"
+msgstr ""
+
+#: ../../src/wizards/DrawWiz.cpp:315
+msgid "secondary x range (automatic if incomplete)"
+msgstr ""
+
+#: ../../src/wizards/DrawWiz.cpp:325
+msgid "secondary y axis label"
+msgstr ""
+
+#: ../../src/wizards/DrawWiz.cpp:330
+msgid "secondary y range (automatic if incomplete)"
+msgstr ""
+
+#: ../../src/sidebars/GreekSidebar.cpp:168
+msgid "sigma"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:3507
 msgid ""
 "solve() will solve a list of equations only if for n independent equations there are n variables to solve to.\n"
 "If only one result variable is of interest the other result variables can be used to to tell solve() which variables to eliminate from the solution\n"
 "solve() searches for a global solution. If a problem has different solutions depending on the range its variables are in one way to successfully use solve() is to use solve() to eliminate variables one by one and to manually choose which of the solutions solve() found matches the current problem."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7745
+#: ../../src/MaximaCommandMenus.cpp:926
 msgid ""
 "solve() will solve a list of equations only if for n independent equations there are n variables to solve to.\n"
 "If only one result variable is of interest the other result variables solve needs to do its work can be used to tell solve() which variables to eliminate in the solution for the interesting variable."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7784
+#: ../../src/MaximaCommandMenus.cpp:965
 msgid ""
 "solves an equation of the form\n"
 "    'diff(y,t) = -y;"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7789
+#: ../../src/sidebars/SymbolsSidebar.cpp:81
+msgid "sqrt (needs parenthesis for its argument to work as a Maxima command)"
+msgstr ""
+
+#: ../../src/sidebars/SymbolsSidebar.cpp:106
+#, fuzzy
+msgid "subset"
+msgstr "Subseção"
+
+#: ../../src/sidebars/SymbolsSidebar.cpp:105
+#, fuzzy
+msgid "subset or equal"
+msgstr "Célula de subseção"
+
+#: ../../src/wizards/MatWiz.cpp:160
+msgid "symmetric"
+msgstr "simétrica"
+
+#: ../../src/MaximaCommandMenus.cpp:970
 msgid "t:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1075
+#: ../../src/sidebars/GreekSidebar.cpp:169
+msgid "tau"
+msgstr ""
+
+#: ../../src/cells/TextCell.cpp:340
+msgid ""
+"the [] operator tried to extract an element of a list, a matrix, an equation or an array. But instead of an integer number something was used whose numerical value is unknown or not an integer.\n"
+"Floating-point numbers are bound to contain small rounding errors and therefore in most cases don't work as an array index thatneeds to be an exact integer number."
+msgstr ""
+
+#: ../../src/wizards/DrawWiz.cpp:725
+#, fuzzy
+msgid "the x and the y coordinate."
+msgstr "Coordenadas y separadas por vírgulas."
+
+#: ../../src/wizards/DrawWiz.cpp:729
+msgid "the x, the y and the z coordinate."
+msgstr ""
+
+#: ../../src/sidebars/SymbolsSidebar.cpp:89
+msgid "there is no"
+msgstr ""
+
+#: ../../src/sidebars/GreekSidebar.cpp:158
+msgid "theta"
+msgstr ""
+
+#: ../../src/sidebars/SymbolsSidebar.cpp:78
+msgid "to the power of 2"
+msgstr ""
+
+#: ../../src/sidebars/SymbolsSidebar.cpp:79
+msgid "to the power of 3"
+msgstr ""
+
+#: ../../src/sidebars/SymbolsSidebar.cpp:103
+msgid "union"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1109
 msgid "unnamed function (lambda)..."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:11190
+#: ../../src/wxMaxima.cpp:3496
 msgid "unsaved"
 msgstr "não salvo"
 
-#: ../../src/wxMaxima.cpp:5667 ../../src/wxMaxima.cpp:6114
-#: ../../src/wxMaximaFrame.cpp:189
+#: ../../src/MaximaCommandMenus.cpp:2270 ../../src/MaximaFileIO.cpp:774
+#: ../../src/wxMaximaFrame.cpp:203
 msgid "untitled"
 msgstr "sem título"
 
-#: ../../src/wxMaximaFrame.cpp:1700
+#: ../../src/sidebars/GreekSidebar.cpp:170
+#, fuzzy
+msgid "upsilon"
+msgstr "Epsilon:"
+
+#: ../../src/wxMaximaFrame.cpp:1737
 #, fuzzy
 msgid "use as function arguments"
 msgstr "Nomes de funções"
 
-#: ../../src/wxMaximaFrame.cpp:1696
+#: ../../src/wxMaximaFrame.cpp:1733
 msgid "use the actual values stored"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1112
+#: ../../src/dialogs/ConfigDialogue.cpp:1633
+msgid "wgnuplot: Steals the mouse focus during plotting"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1146
 msgid "writebyte..."
 msgstr ""
 
-#: ../../src/main.cpp:509
+#: ../../src/dialogs/AboutDialog.cpp:64 ../../src/main.cpp:796
 msgid "wxMaxima"
 msgstr ""
 
-#: ../../src/main.cpp:516
+#: ../../src/main.cpp:805
 #, fuzzy, c-format
 msgid "wxMaxima %ld"
 msgstr "wxMaxima %s "
 
-#: ../../src/wxMaxima.cpp:10913 ../../src/wxMaxima.cpp:10918
-#: ../../src/wxMaxima.cpp:10929 ../../src/wxMaxima.cpp:10934
-#: ../../src/wxMaximaFrame.cpp:185
+#: ../../src/wxMaxima.cpp:3193 ../../src/wxMaximaFrame.cpp:199
 #, fuzzy, c-format
 msgid "wxMaxima %s (%s) "
 msgstr "wxMaxima %s "
 
-#: ../../src/wxMaxima.cpp:4490
+#: ../../src/dialogs/DiffFrame.cpp:352
+msgid "wxMaxima Diff Viewer"
+msgstr ""
+
+#: ../../src/dialogs/TipOfTheDay.cpp:159
+msgid "wxMaxima can be made to execute commands at every start-up by placing them in a text file with the name wxmaxima.rc in the user directory. This directory can be found by typing maxima_userdir;"
+msgstr ""
+
+#: ../../src/MaximaFileIO.cpp:398
 msgid "wxMaxima cannot read the xml contents of "
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2546
+#: ../../src/dialogs/ConfigDialogue.cpp:142
+#: ../../src/dialogs/ConfigDialogue.cpp:311
+msgid "wxMaxima configuration"
+msgstr "Configuração do wxMaxima"
+
+#: ../../src/MaximaProcessManager.cpp:211
 msgid ""
 "wxMaxima could not start a server.\n"
 "\n"
@@ -8370,82 +12707,202 @@ msgid ""
 "enabled, that no internet safety appliance is configured to intercept creation of servers even if said server only accepts connections from local application (maxima insists on the graphical frontend acting as a server it can connect on over a local socket) and try again!"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:5285
+#: ../../src/dialogs/TipOfTheDay.cpp:127
+msgid "wxMaxima dialogs set default values for inputs entries, one of which is '%'. If you have made a selection in your document, the selection will be used instead of '%'."
+msgstr "As janelas do wxMaxima têm valores padrão para as entradas, um dos quais é '%'. Se você selecionou algo no documento, a seleção será usada no lugar de '%'."
+
+#: ../../src/MaximaCommandMenus.cpp:4604
 msgid "wxMaxima document"
 msgstr "Documento do wxMaxima"
 
-#: ../../src/wxMaxima.cpp:4162 ../../src/wxMaxima.cpp:4221
-#: ../../src/wxMaxima.cpp:4230
+#: ../../src/MaximaCommandMenus.cpp:2241
+msgid "wxMaxima document (*.wxm, *.wxmx)|*.wxm;*.wxmx"
+msgstr "Documento do wxMaxima (*.wxm, *.wxmx)|*.wxm;*.wxmx"
+
+#: ../../src/MaximaFileIO.cpp:63 ../../src/MaximaFileIO.cpp:120
+#: ../../src/MaximaFileIO.cpp:129
 msgid "wxMaxima encountered an error loading "
 msgstr "o wxMaxima encontrou um erro carregando "
 
-#: ../../src/wxMaximaFrame.cpp:1881
+#: ../../src/wxMaximaFrame.cpp:1918
 msgid "wxMaxima help"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1465 ../../src/Worksheet.cpp:1839
+#: ../../src/dialogs/AboutDialog.cpp:41
+#, fuzzy
+msgid "wxMaxima is a cross-platform graphical user interface for the computer algebra system Maxima based on wxWidgets.\n"
+msgstr "O wxMaxima é uma interface baseada no wxWidgets para o sistema de álgebra computacional MAXIMA."
+
+#: ../../src/wxMaxima.cpp:2854
+#, c-format
+msgid ""
+"wxMaxima is now the .wxmx diff tool for:%s\n"
+"\n"
+"Open a .wxmx file's \"Diff\" in TortoiseSVN/TortoiseGit to compare it side by side."
+msgstr ""
+
+#: ../../src/dialogs/TipOfTheDay.cpp:240
+msgid "wxMaxima is programmed in C++ using the wxWidgets toolkit and uses CMake as build system. You can contribute to wxMaxima, if you have some knowledge with this environment."
+msgstr ""
+
+#: ../../src/dialogs/TipOfTheDay.cpp:228
+msgid "wxMaxima needs more developers. It is an open source project where you can contribute. Join the wxMaxima development at: https://github.com/wxMaxima-developers/wxmaxima"
+msgstr ""
+
+#: ../../src/dialogs/TipOfTheDay.cpp:224
+msgid "wxMaxima needs more translators. We do not speak every language. Help us to translate wxMaxima and the manual to your language. Join the wxMaxima development at: https://github.com/wxMaxima-developers/wxmaxima"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:407
+msgid "wxMaxima normally stores the gnuplot sources for every plot made using draw() in order to be able to open plots interactively in gnuplot later. This setting defines the limit [in Megabytes per plot] for this feature."
+msgstr ""
+
+#: ../../src/dialogs/TipOfTheDay.cpp:172
+msgid ""
+"wxMaxima provides the \"table_form\" command that shows lists in an alternative form. One example would be:\n"
+"\n"
+"table_form([1,2,3,4,5]);"
+msgstr ""
+
+#: ../../src/worksheet/WorksheetContextMenu.cpp:236
+#: ../../src/worksheet/WorksheetContextMenu.cpp:611
 msgid "wxMaxima remembers answers from the last run and is able to automatically send them to maxima, if requested"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1470 ../../src/Worksheet.cpp:1844
+#: ../../src/worksheet/WorksheetContextMenu.cpp:241
+#: ../../src/worksheet/WorksheetContextMenu.cpp:616
 msgid "wxMaxima remembers answers from the last run and is able to offer them as the default answer"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1896
+#: ../../src/dialogs/ConfigDialogue.cpp:481
+msgid "wxMaxima remembers the answers to maxima's questions. If this checkbox is set it automatically offers to enter the last answer to this question the user has input."
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1933
 #, fuzzy
 msgid "wxMaxima shows help in a browser"
 msgstr "Arquivo não encontrado"
 
-#: ../../src/wxMaximaFrame.cpp:1894
+#: ../../src/wxMaximaFrame.cpp:1931
 #, fuzzy
 msgid "wxMaxima shows help in the sidebar"
 msgstr "Arquivo não encontrado"
 
-#: ../../src/wxMaximaFrame.cpp:111
+#: ../../src/dialogs/ConfigDialogue.cpp:1095
+#, fuzzy
+msgid "wxMaxima startup file location: "
+msgstr "Iniciar animação"
+
+#: ../../src/wxMaximaFrame.cpp:119
 #, c-format
 msgid "wxMaxima version %s"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1954
+#: ../../src/worksheet/Worksheet.cpp:6164
+msgid "wxMaxima worksheet"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1997
 #, fuzzy
 msgid "wxMaxima's ChangeLog"
 msgstr "Ícone do wxMaxima"
 
-#: ../../src/wxMaximaFrame.cpp:1952
+#: ../../src/wxMaximaFrame.cpp:1995
 msgid "wxMaxima's license"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:144
+#: ../../src/wxMaximaFrame.cpp:152
 msgid "wxWidgets is using GTK 2"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:142
+#: ../../src/wxMaximaFrame.cpp:150
 msgid "wxWidgets is using GTK 3"
 msgstr ""
 
-#: ../../src/WXMXformat.cpp:367
+#: ../../src/WXMXformat.cpp:369
 msgid "wxmx file saved"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8375
+#: ../../src/MaximaResponseReader.cpp:104
+msgid "wxworksheettohtml/totex: no target file name was given."
+msgstr ""
+
+#: ../../src/wxMaxima.cpp:2204
+#, c-format
+msgid "wxworksheettohtml: could not write \"%s\"."
+msgstr ""
+
+#: ../../src/wxMaxima.cpp:2178
+#, c-format
+msgid "wxworksheettohtml: unknown flavor \"%s\"; using native MathML. Known flavors: mathml, mathjax, svg, bitmap."
+msgstr ""
+
+#: ../../src/wxMaxima.cpp:2246
+#, c-format
+msgid "wxworksheettotex: could not write \"%s\"."
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:709
+msgid "x"
+msgstr ""
+
+#: ../../src/wizards/DrawWiz.cpp:266
+msgid "x axis label"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:2021
 msgid "x direction [in multiples of the tick frequency]"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:4500 ../../src/wxMaxima.cpp:4643
+#: ../../src/wizards/DrawWiz.cpp:269
+msgid "x range (automatic if incomplete)"
+msgstr ""
+
+#: ../../src/sidebars/GreekSidebar.cpp:164
+msgid "xi"
+msgstr ""
+
+#: ../../src/MaximaFileIO.cpp:408 ../../src/MaximaFileIO.cpp:566
 msgid "xml contained in the file claims not to be a wxMaxima worksheet. "
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8376
+#: ../../src/sidebars/SymbolsSidebar.cpp:97
+#, fuzzy
+msgid "xor"
+msgstr "Exportar"
+
+#: ../../src/wizards/DrawWiz.cpp:279
+msgid "y axis label"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:2022
 msgid "y direction [in multiples of the tick frequency]"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7789
+#: ../../src/wizards/DrawWiz.cpp:282
+msgid "y range (automatic if incomplete)"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:970
 msgid "y:"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:2
-msgid "# The wxMaxima user manual"
+#: ../../src/wizards/DrawWiz.cpp:294
+msgid "z axis label"
+msgstr ""
+
+#: ../../src/wizards/DrawWiz.cpp:298
+msgid "z range (automatic if incomplete)"
+msgstr ""
+
+#: ../../src/sidebars/GreekSidebar.cpp:156
+msgid "zeta"
+msgstr ""
+
+#. type: Title #
+#: ../../info/wxmaxima.md:1
+#, no-wrap
+msgid "The wxMaxima user manual"
 msgstr ""
 
 #. type: Plain text
@@ -8458,24 +12915,16 @@ msgstr ""
 msgid "![wxMaxima logo](./wxMaximaLogo.png){ id=img_wxMaximaLogo }"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:7 ../../info/wxmaxima.md:425
-#: ../../info/wxmaxima.md:880 ../../info/wxmaxima.md:1090
-#: ../../info/wxmaxima.md:1137 ../../info/wxmaxima.md:1161
+#. type: Title #
+#: ../../info/wxmaxima.md:9
 #, no-wrap
-msgid "______________________________________________________________________\n"
+msgid "Introduction to wxMaxima"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:10
-#, fuzzy
-#| msgid "Welcome to wxMaxima"
-msgid "# Introduction to wxMaxima"
-msgstr "Bem-vindo ao wxMaxima"
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:12
-msgid "## _Maxima_ and wxMaxima"
+#. type: Title ##
+#: ../../info/wxmaxima.md:11
+#, no-wrap
+msgid "_Maxima_ and wxMaxima"
 msgstr ""
 
 #. type: Plain text
@@ -8488,12 +12937,11 @@ msgstr ""
 msgid "A computer algebra system (CAS) like _Maxima_ fits into this framework. A CAS can provide the logic behind an arbitrary precision calculator application or it can do automatic transforms of formulas in the background of a bigger system (e.g., [Sage](https://www.sagemath.org/)). Alternatively, it can be used directly as a free-standing system. _Maxima_ can be accessed via a command line. Often, however, an interface like _wxMaxima_ proves a more efficient way to access the software, especially for newcomers."
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:18
-#, fuzzy
-#| msgid "&Maxima"
-msgid "### _Maxima_"
-msgstr "&Maxima"
+#. type: Title ###
+#: ../../info/wxmaxima.md:17
+#, no-wrap
+msgid "_Maxima_"
+msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:20
@@ -8507,15 +12955,15 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:24
-msgid "Extensive documentation for _Maxima_ is [available in the internet](https://maxima.sourceforge.io/documentation.html). Part of this documentation is also available in wxMaxima’s help menu. Pressing the Help key (on most systems the <kbd>F1</kbd> key) causes _wxMaxima_’s context-sensitive help feature to automatically jump to _Maxima_’s manual page for the command at the cursor."
+#, no-wrap
+msgid "Extensive documentation for _Maxima_ is  [available in the internet](https://maxima.sourceforge.io/documentation.html). Part of this documentation is also available in wxMaxima’s help menu. Pressing the Help key (on most systems the <kbd>F1</kbd> key) causes _wxMaxima_’s context-sensitive help feature to automatically jump to _Maxima_’s manual page for the command at the cursor.\n"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:26
-#, fuzzy
-#| msgid "&Maxima"
-msgid "### WxMaxima"
-msgstr "&Maxima"
+#. type: Title ###
+#: ../../info/wxmaxima.md:25
+#, no-wrap
+msgid "WxMaxima"
+msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:28
@@ -8532,9 +12980,10 @@ msgstr ""
 msgid "The calculations that are entered in _wxMaxima_ are performed by the _Maxima_ command-line tool in the background."
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:34
-msgid "## Workbook basics"
+#. type: Title ##
+#: ../../info/wxmaxima.md:33
+#, no-wrap
+msgid "Workbook basics"
 msgstr ""
 
 #. type: Plain text
@@ -8542,9 +12991,10 @@ msgstr ""
 msgid "Much of _wxMaxima_ is self-explaining, but some details require attention. [This site](https://wxMaxima-developers.github.io/wxmaxima/help.html) contains a number of workbooks that address various aspects of _wxMaxima_. Working through some of these (particularly the \"10 minute _(wx)Maxima_ tutorial\") will increase one’s familiarity with both the content of _Maxima_ and the use of _wxMaxima_ to interact with _Maxima_. This manual concentrates on describing aspects of _wxMaxima_ that are not likely to be self-evident and that might not be covered in the online material."
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:38
-msgid "### The workbook approach"
+#. type: Title ###
+#: ../../info/wxmaxima.md:37
+#, no-wrap
+msgid "The workbook approach"
 msgstr ""
 
 #. type: Plain text
@@ -8582,12 +13032,11 @@ msgstr ""
 msgid "![Example of different wxMaxima cells](./cell-example.png){ id=img_cell-example }"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:54
-#, fuzzy
-#| msgid "Merge Cells"
-msgid "### Cells"
-msgstr "Mesclar células"
+#. type: Title ###
+#: ../../info/wxmaxima.md:53
+#, no-wrap
+msgid "Cells"
+msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:56
@@ -8643,9 +13092,10 @@ msgstr ""
 msgid "\"`/*`\" marks the start of the comment, \"`*/`\" the end."
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:71
-msgid "### Horizontal and vertical cursors"
+#. type: Title ###
+#: ../../info/wxmaxima.md:70
+#, no-wrap
+msgid "Horizontal and vertical cursors"
 msgstr ""
 
 #. type: Plain text
@@ -8670,7 +13120,8 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:80
-msgid "When you start wxMaxima, you will only see the blinking horizontal cursor. If you start typing, a math cell will be automatically created and the cursor will change to a regular vertical one (you will see a right arrow as \"prompt\", after the Math cell is evaluated (<kbd>CTRL</kbd>+<kbd>ENTER</kbd>), you will see the labels, e.g. `(%i1)`, `(%o1)`)."
+#, no-wrap
+msgid "When you start wxMaxima, you will only see the blinking horizontal cursor. If you start typing, a math cell will be automatically created and the cursor will change to a regular vertical one (you will see a right arrow as \"prompt\", after the Math cell is evaluated (<kbd>CTRL</kbd>+<kbd>ENTER</kbd>), you will see the labels, e.g. `(%i1)`, `(%o1)`).\n"
 msgstr ""
 
 #. type: Plain text
@@ -8693,24 +13144,28 @@ msgstr ""
 msgid "![(blinking) horizontal cursor between cells](./horizontal-cursor-between-cells.png){ id=img_horizontal_cursor_between_cells }"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:90
-msgid "### Sending cells to Maxima"
+#. type: Title ###
+#: ../../info/wxmaxima.md:89
+#, no-wrap
+msgid "Sending cells to Maxima"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:92
-msgid "The command in a code cell is executed once by pressing <kbd>CTRL</kbd>+<kbd>ENTER</kbd>, <kbd>SHIFT</kbd>+<kbd>ENTER</kbd> or the <kbd>ENTER</kbd> key on the keypad. The _wxMaxima_ default is to enter commands when either <kbd>CTRL</kbd>+<kbd>ENTER</kbd> or <kbd>SHIFT</kbd>+<kbd>ENTER</kbd> is entered, but _wxMaxima_ can be configured to execute commands in response to <kbd>ENTER</kbd>."
+#, no-wrap
+msgid "The command in a code cell is executed once by pressing <kbd>CTRL</kbd>+<kbd>ENTER</kbd>, <kbd>SHIFT</kbd>+<kbd>ENTER</kbd> or the <kbd>ENTER</kbd> key on the keypad. The _wxMaxima_ default is to enter commands when either <kbd>CTRL</kbd>+<kbd>ENTER</kbd> or <kbd>SHIFT</kbd>+<kbd>ENTER</kbd> is entered, but _wxMaxima_ can be configured to execute commands in response to <kbd>ENTER</kbd>.\n"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:94
-msgid "### Command autocompletion"
+#. type: Title ###
+#: ../../info/wxmaxima.md:93
+#, no-wrap
+msgid "Command autocompletion"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:96
-msgid "_WxMaxima_ contains an autocompletion feature that is triggered via the menu (Cell/Complete Word) or alternatively by pressing the key combination <kbd>CTRL</kbd>+<kbd>SPACE</kbd>. The autocompletion is context-sensitive. For example, if activated within a unit specification for ezUnits it will offer a list of applicable units."
+#, no-wrap
+msgid "_WxMaxima_ contains an autocompletion feature that is triggered via the menu (Cell/Complete Word) or alternatively by pressing the key combination <kbd>CTRL</kbd>+<kbd>SPACE</kbd>. The autocompletion is context-sensitive. For example, if activated within a unit specification for ezUnits it will offer a list of applicable units.\n"
 msgstr ""
 
 #. type: Plain text
@@ -8720,14 +13175,15 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:100
-msgid "Besides completing a file name, a unit name, or the current command or variable name, the autocompletion is able to show a template for most of the commands indicating the type (and meaning) of the parameters this program expects. To activate this feature press <kbd>SHIFT</kbd>+<kbd>CTRL</kbd>+<kbd>SPACE</kbd> or select the respective menu item (Cell/Show Template)."
+#, no-wrap
+msgid "Besides completing a file name, a unit name, or the current command or variable name, the autocompletion is able to show a template for most of the commands indicating the type (and meaning) of the parameters this program expects. To activate this feature press <kbd>SHIFT</kbd>+<kbd>CTRL</kbd>+<kbd>SPACE</kbd> or select the respective menu item (Cell/Show Template).\n"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:102
-#, fuzzy
-msgid "#### Greek characters"
-msgstr "Constantes gregas"
+#. type: Title ####
+#: ../../info/wxmaxima.md:101
+#, no-wrap
+msgid "Greek characters"
+msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:104
@@ -8783,9 +13239,10 @@ msgstr ""
 msgid "You can also use the \"Greek letters\"-sidebar to enter the Greek letters."
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:134
-msgid "##### Attention: Lookalike characters"
+#. type: Title #####
+#: ../../info/wxmaxima.md:133
+#, no-wrap
+msgid "Attention: Lookalike characters"
 msgstr ""
 
 #. type: Plain text
@@ -8871,12 +13328,14 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:203
-msgid "If a special symbol isn’t in the list, it is possible to input arbitrary Unicode characters by pressing <kbd>ESC</kbd> \\[number of the character (hexadecimal)\\] <kbd>ESC</kbd>. Additionally the \"symbols\" sidebar has a right-click menu that allow to display a list of all available Unicode symbols one can add to this toolbar or to the worksheet."
+#, no-wrap
+msgid "If a special symbol isn’t in the list, it is possible to input arbitrary Unicode characters by pressing <kbd>ESC</kbd> \\[number of the character (hexadecimal)\\] <kbd>ESC</kbd>. Additionally the \"symbols\" sidebar has a right-click menu that allow to display a list of all available Unicode symbols one can add to this toolbar or to the worksheet.\n"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:205
-msgid "<kbd>ESC</kbd><kbd>6</kbd><kbd>1</kbd><kbd>ESC</kbd> therefore results in an `a`."
+#, no-wrap
+msgid "<kbd>ESC</kbd><kbd>6</kbd><kbd>1</kbd><kbd>ESC</kbd> therefore results in an `a`.\n"
 msgstr ""
 
 #. type: Plain text
@@ -8886,12 +13345,16 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:210
-msgid "It may be the case that e.g. Greek characters or mathematical symbols are not included in the selected font, then they can not be displayed.  To solve that problem, select other fonts (using: Edit -> Configure -> Style)."
+#, no-wrap
+msgid ""
+"It may be the case that e.g. Greek characters or mathematical symbols are not included in the selected font, then they can not be displayed.\n"
+"To solve that problem, select other fonts (using: Edit -> Configure -> Style).\n"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:212
-msgid "### Unicode replacement"
+#. type: Title ###
+#: ../../info/wxmaxima.md:211
+#, no-wrap
+msgid "Unicode replacement"
 msgstr ""
 
 #. type: Plain text
@@ -8914,9 +13377,10 @@ msgstr ""
 msgid "It is recommended to use **Maxima code** (not these Unicode code points) in input cells (Rationale: (a) it might be possible, that the used font for math input does not contain them; (b) if you save the document as `wxm`-file, it is usually readable by (command line) Maxima, but these changes will of course not work in command line Maxima); but they may occur, if you cut&paste a formula from another document."
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:223
-msgid "### Side Panes"
+#. type: Title ###
+#: ../../info/wxmaxima.md:222
+#, no-wrap
+msgid "Side Panes"
 msgstr ""
 
 #. type: Plain text
@@ -8939,9 +13403,10 @@ msgstr ""
 msgid "![Increase or decrease headings in the TOC side pane](./Sidepane-TOC-convert-headings.png){ id=Sidepane-TOC-convert-headings }"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:234
-msgid "### MathML output"
+#. type: Title ###
+#: ../../info/wxmaxima.md:233
+#, no-wrap
+msgid "MathML output"
 msgstr ""
 
 #. type: Plain text
@@ -8949,9 +13414,10 @@ msgstr ""
 msgid "Several word processors and similar programs either recognize [MathML](https://www.w3.org/Math/) input and automatically insert it as an editable 2D equation - or (like LibreOffice) have an equation editor that offers an “import MathML from clipboard” feature. Others support RTF maths. _WxMaxima_, therefore, offers several entries in the right-click menu."
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:238
-msgid "### Markdown support"
+#. type: Title ###
+#: ../../info/wxmaxima.md:237
+#, no-wrap
+msgid "Markdown support"
 msgstr ""
 
 #. type: Plain text
@@ -8959,11 +13425,10 @@ msgstr ""
 msgid "_WxMaxima_ offers a set of standard [Markdown](https://en.wikipedia.org/wiki/Markdown) conventions that don’t collide with mathematical notation. One of these elements is bullet lists."
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:250
+#. type: Fenced code block (text)
+#: ../../info/wxmaxima.md:241
 #, no-wrap
 msgid ""
-"```text\n"
 "Ordinary text\n"
 " * One item, indentation level 1\n"
 " * Another item at indentation level 1\n"
@@ -8971,37 +13436,47 @@ msgid ""
 "   * A second item at the second indentation level\n"
 " * A third item at the first indentation level\n"
 "Ordinary text\n"
-"```\n"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:252
-msgid "_WxMaxima_ will recognize text starting with `>` chars as block quotes:"
+#, no-wrap
+msgid "_WxMaxima_ will recognize text starting with `>` chars as block quotes:\n"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:260
-msgid "```text Ordinary text > quote quote quote quote > quote quote quote quote > quote quote quote quote Ordinary text ```"
+#. type: Fenced code block (text)
+#: ../../info/wxmaxima.md:253
+#, no-wrap
+msgid ""
+"Ordinary text\n"
+"> quote quote quote quote\n"
+"> quote quote quote quote\n"
+"> quote quote quote quote\n"
+"Ordinary text\n"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:262
-msgid "_WxMaxima_’s TeX and HTML output will also recognize `=>` and replace it by the corresponding Unicode sign:"
+#, no-wrap
+msgid "_WxMaxima_’s TeX and HTML output will also recognize `=>` and replace it by the corresponding Unicode sign:\n"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:266
-msgid "```text cogito => sum.  ```"
+#. type: Fenced code block (text)
+#: ../../info/wxmaxima.md:263
+#, no-wrap
+msgid "cogito => sum.\n"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:268
-msgid "Other symbols the HTML and TeX export will recognize are `<=` and `>=` for comparisons, a double-pointed double arrow (`<=>`), single-headed arrows (`<->`, `->` and `<-`) and `+/-` as the respective sign. For TeX output also `<<` and `>>` are recognized."
+#, no-wrap
+msgid "Other symbols the HTML and TeX export will recognize are `<=` and `>=` for comparisons, a double-pointed double arrow (`<=>`), single-headed arrows (`<->`, `->` and `<-`) and `+/-` as the respective sign. For TeX output also `<<` and `>>` are recognized.\n"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:270
-msgid "### Hotkeys"
+#. type: Title ###
+#: ../../info/wxmaxima.md:269
+#, no-wrap
+msgid "Hotkeys"
 msgstr ""
 
 #. type: Plain text
@@ -9024,9 +13499,10 @@ msgstr ""
 msgid "<kbd>SHIFT</kbd>+<kbd>SPACE</kbd> inserts a non-breaking space."
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:278
-msgid "### Raw TeX in the TeX export"
+#. type: Title ###
+#: ../../info/wxmaxima.md:277
+#, no-wrap
+msgid "Raw TeX in the TeX export"
 msgstr ""
 
 #. type: Plain text
@@ -9034,20 +13510,21 @@ msgstr ""
 msgid "If a text cell begins with `TeX:` the TeX export contains the literal text that follows the `TeX:` marker. Using this feature allows the entry of TeX markup within the _wxMaxima_ workbook."
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:282
-#, fuzzy
-msgid "## File Formats"
-msgstr "Arquivo não encontrado"
+#. type: Title ##
+#: ../../info/wxmaxima.md:281
+#, no-wrap
+msgid "File Formats"
+msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:284
 msgid "The material that is developed in a _wxMaxima_ session can be stored for later use in any of three ways:"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:286
-msgid "### .mac"
+#. type: Title ###
+#: ../../info/wxmaxima.md:285
+#, no-wrap
+msgid ".mac"
 msgstr ""
 
 #. type: Plain text
@@ -9075,14 +13552,18 @@ msgstr ""
 msgid "You can be use `.mac` files for writing your own library of macros. But since they don’t contain enough structural information they cannot be read back as a _wxMaxima_ session."
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:299
-msgid "### .wxm"
+#. type: Title ###
+#: ../../info/wxmaxima.md:298
+#, no-wrap
+msgid ".wxm"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:302
-msgid "`.wxm` files contain the worksheet except for _Maxima_’s output. On Maxima versions >5.38 they can be read using _Maxima_’s `load()` function just as .mac files. Well - mostly. Questions (like `asksign(x)`) are problematic, as the answer is written in the `.wxm` file (so that it can be suggested after loading), but that can Maxima not evaluate.  You can prevent Maxima from asking questions by using `assume()` to declare some properties, Maxima wants to know."
+#, no-wrap
+msgid ""
+"`.wxm` files contain the worksheet except for _Maxima_’s output. On Maxima versions >5.38 they can be read using _Maxima_’s `load()` function just as .mac files. Well - mostly. Questions (like `asksign(x)`) are problematic, as the answer is written in the `.wxm` file (so that it can be suggested after loading), but that can Maxima not evaluate.\n"
+"You can prevent Maxima from asking questions by using `assume()` to declare some properties, Maxima wants to know.\n"
 msgstr ""
 
 #. type: Plain text
@@ -9090,9 +13571,10 @@ msgstr ""
 msgid "With this plain-text format, it sometimes is unavoidable that worksheets that use new features are not downwards-compatible with older versions of _wxMaxima_."
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:306
-msgid "#### File format of wxm files"
+#. type: Title ####
+#: ../../info/wxmaxima.md:305
+#, no-wrap
+msgid "File format of wxm files"
 msgstr ""
 
 #. type: Plain text
@@ -9105,9 +13587,12 @@ msgstr ""
 msgid "It starts with the following comment:"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:315
-msgid "```maxima /* [wxMaxima batch file version 1] [ DO NOT EDIT BY HAND! ]*/ /* [ Created with wxMaxima version 24.02.2_DevelopmentSnapshot ] */ ```"
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:311
+#, no-wrap
+msgid ""
+"/* [wxMaxima batch file version 1] [ DO NOT EDIT BY HAND! ]*/\n"
+"/* [ Created with wxMaxima version 24.02.2_DevelopmentSnapshot ] */\n"
 msgstr ""
 
 #. type: Plain text
@@ -9115,15 +13600,13 @@ msgstr ""
 msgid "And then the cells follow, encoded as Maxima comments, e.g. a section cell:"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:323
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:318
 #, no-wrap
 msgid ""
-"```maxima\n"
 "/* [wxMaxima: section start ]\n"
 "Title of the section\n"
 "   [wxMaxima: section end   ] */\n"
-"```\n"
 msgstr ""
 
 #. type: Plain text
@@ -9131,16 +13614,14 @@ msgstr ""
 msgid "or (in a Math cell the input is of course *not* commented out (the output is not saved in a `wxm` file)):"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:332
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:326
 #, no-wrap
 msgid ""
-"```maxima\n"
 "/* [wxMaxima: input   start ] */\n"
 "f(x):=x^2+1$\n"
 "f(2);\n"
 "/* [wxMaxima: input   end   ] */\n"
-"```\n"
 msgstr ""
 
 #. type: Plain text
@@ -9148,16 +13629,14 @@ msgstr ""
 msgid "Images are [Base64 encoded](https://en.wikipedia.org/wiki/Base64) with the image type as first line):"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:341
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:335
 #, no-wrap
 msgid ""
-"```maxima\n"
 "/* [wxMaxima: image   start ]\n"
 "jpg\n"
 "[very chaotic looking character sequence]\n"
 "   [wxMaxima: image   end   ] */\n"
-"```\n"
 msgstr ""
 
 #. type: Plain text
@@ -9165,13 +13644,10 @@ msgstr ""
 msgid "A page break is just one line containing:"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:347
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:344
 #, no-wrap
-msgid ""
-"```maxima\n"
-"/* [wxMaxima: page break    ] */\n"
-"```\n"
+msgid "/* [wxMaxima: page break    ] */\n"
 msgstr ""
 
 #. type: Plain text
@@ -9179,20 +13655,19 @@ msgstr ""
 msgid "And folded cells marked by:"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:355
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:350
 #, no-wrap
 msgid ""
-"```maxima\n"
 "/* [wxMaxima: fold    start ] */\n"
 "...\n"
 "/* [wxMaxima: fold    end   ] */\n"
-"```\n"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:357
-msgid "### .wxmx"
+#. type: Title ###
+#: ../../info/wxmaxima.md:356
+#, no-wrap
+msgid ".wxmx"
 msgstr ""
 
 #. type: Plain text
@@ -9200,9 +13675,10 @@ msgstr ""
 msgid "This XML-based file format saves the complete worksheet including things like the zoom factor and the watchlist. It is the preferred file format."
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:361
-msgid "#### File format of wxmx files"
+#. type: Title ####
+#: ../../info/wxmaxima.md:360
+#, no-wrap
+msgid "File format of wxmx files"
 msgstr ""
 
 #. type: Plain text
@@ -9240,9 +13716,10 @@ msgstr ""
 msgid "So, if something goes wrong, you can unzip a wxMaxima document (maybe rename it before to a `zip`-file), maybe make changes in the `content.xml` file with a text editor, or replace an broken image, zip the files again, probably rename the `zip` to a `wxmx`-file - and you get another modified `wxmx`-file."
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:375
-msgid "## Configuration options"
+#. type: Title ##
+#: ../../info/wxmaxima.md:374
+#, no-wrap
+msgid "Configuration options"
 msgstr ""
 
 #. type: Plain text
@@ -9265,9 +13742,10 @@ msgstr ""
 msgid "![wxMaxima configuration 1](./wxMaxima_configuration_001.png){ id=img_wxMaxima_configuration_001 }"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:384
-msgid "### Default animation framerate"
+#. type: Title ###
+#: ../../info/wxmaxima.md:383
+#, no-wrap
+msgid "Default animation framerate"
 msgstr ""
 
 #. type: Plain text
@@ -9275,9 +13753,10 @@ msgstr ""
 msgid "The animation framerate that is used for new animations is kept in the variable `wxanimate_framerate`. The initial value this variable will contain in a new worksheet can be changed using the configuration dialogue."
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:388
-msgid "### Default plot size for new _maxima_ sessions"
+#. type: Title ###
+#: ../../info/wxmaxima.md:387
+#, no-wrap
+msgid "Default plot size for new _maxima_ sessions"
 msgstr ""
 
 #. type: Plain text
@@ -9290,26 +13769,23 @@ msgstr ""
 msgid "In order to set the plot size of a single graph only use the following notation can be used that sets a variable’s value for one command only:"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:401
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:393
 #, no-wrap
 msgid ""
-"```maxima\n"
 "wxdraw2d(\n"
 "   explicit(\n"
 "       x^2,\n"
 "       x,-5,5\n"
 "   )\n"
 "), wxplot_size=[480,480]$\n"
-"```\n"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:403
-#, fuzzy
-#| msgid "Set fixed font in text controls."
-msgid "### Match parenthesis in text controls"
-msgstr "Usa fonte monoespaçada nos controles de texto."
+#. type: Title ###
+#: ../../info/wxmaxima.md:402
+#, no-wrap
+msgid "Match parenthesis in text controls"
+msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:405
@@ -9326,9 +13802,10 @@ msgstr ""
 msgid "If text is selected if any of these keys is pressed the selected text will be put between the matched signs."
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:410
-msgid "### Don’t save the worksheet automatically"
+#. type: Title ###
+#: ../../info/wxmaxima.md:409
+#, no-wrap
+msgid "Don’t save the worksheet automatically"
 msgstr ""
 
 #. type: Plain text
@@ -9351,14 +13828,18 @@ msgstr ""
 msgid "And the file will automatically be saved every 3 minutes."
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:419
-msgid "### Where is the configuration saved?"
+#. type: Title ###
+#: ../../info/wxmaxima.md:418
+#, no-wrap
+msgid "Where is the configuration saved?"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:422
-msgid "If you are using Unix/Linux, the configuration information will be saved in a file `.wxMaxima` in your home directory (if you are using wxWidgets \\< 3.1.1), or `.config/wxMaxima.conf` ((XDG-Standard) if wxWidgets >= 3.1.1 is used). You can retrieve the wxWidgets version from the command `wxbuild_info();` or by using the menu option Help->About. [wxWidgets](https://www.wxwidgets.org/) is the cross-platform GUI library, which is the base for _wxMaxima_ (therefore the `wx` in the name).  (Since the filename starts with a dot, `.wxMaxima` or `.config` will be hidden)."
+#, no-wrap
+msgid ""
+"If you are using Unix/Linux, the configuration information will be saved in a file `.wxMaxima` in your home directory (if you are using wxWidgets \\< 3.1.1), or `.config/wxMaxima.conf` ((XDG-Standard) if wxWidgets >= 3.1.1 is used). You can retrieve the wxWidgets version from the command `wxbuild_info();` or by using the menu option Help->About. [wxWidgets](https://www.wxwidgets.org/) is the cross-platform GUI library, which is the base for _wxMaxima_ (therefore the `wx` in the name).\n"
+"(Since the filename starts with a dot, `.wxMaxima` or `.config` will be hidden).\n"
 msgstr ""
 
 #. type: Plain text
@@ -9366,9 +13847,10 @@ msgstr ""
 msgid "If you are using Windows, the configuration will be stored in the registry. You will find the entries for _wxMaxima_ at the following position in the registry: `HKEY_CURRENT_USER\\Software\\wxMaxima`"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:428
-msgid "# Extensions to _Maxima_"
+#. type: Title #
+#: ../../info/wxmaxima.md:427
+#, no-wrap
+msgid "Extensions to _Maxima_"
 msgstr ""
 
 #. type: Plain text
@@ -9376,12 +13858,11 @@ msgstr ""
 msgid "_WxMaxima_ is primarily a graphical user interface for _Maxima_. As such, its main purpose is to pass along commands to _Maxima_ and to report the results of executing those commands. In some cases, however, _wxMaxima_ adds functionality to _Maxima_. _WxMaxima_’s ability to generate reports by exporting a workbook’s contents to HTML and LaTeX files has been mentioned. This section considers some ways that _wxMaxima_ enhances the inclusion of graphics in a session."
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:432
-#, fuzzy
-#| msgid "Show defined variables"
-msgid "## Subscripted variables"
-msgstr "Mostrar variáveis definidas"
+#. type: Title ##
+#: ../../info/wxmaxima.md:431
+#, no-wrap
+msgid "Subscripted variables"
+msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:434
@@ -9425,12 +13906,14 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:449
-msgid "You can use the menu \"View->Autosubscript\" to set these values."
+#, no-wrap
+msgid "You can use the menu \"View->Autosubscript\" to set these values.\n"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:451
-msgid "## User feedback in the status bar"
+#. type: Title ##
+#: ../../info/wxmaxima.md:450
+#, no-wrap
+msgid "User feedback in the status bar"
 msgstr ""
 
 #. type: Plain text
@@ -9438,11 +13921,10 @@ msgstr ""
 msgid "Long-running commands can provide user feedback in the status bar. This user feedback is replaced by any new feedback that is placed there (allowing to use it as a progress indicator) and is deleted as soon as the current command sent to _Maxima_ is finished. It is safe to use `wxstatusbar()` even in libraries that might be used with plain _Maxima_ (as opposed to _wxMaxima_): If _wxMaxima_ isn’t present the `wxstatusbar()` command will just be left unevaluated."
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:464
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:454
 #, no-wrap
 msgid ""
-"```maxima\n"
 "for i:1 thru 10 do (\n"
 "    /* Tell the user how far we got */\n"
 "    wxstatusbar(concat(\"Pass \",i)),\n"
@@ -9451,12 +13933,12 @@ msgid ""
 "    /* program execution (here: for 3 seconds) */\n"
 "    ?sleep(3)\n"
 ")$\n"
-"```\n"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:466
-msgid "## Exporting the worksheet from within Maxima"
+#. type: Title ##
+#: ../../info/wxmaxima.md:465
+#, no-wrap
+msgid "Exporting the worksheet from within Maxima"
 msgstr ""
 
 #. type: Plain text
@@ -9464,9 +13946,12 @@ msgstr ""
 msgid "The command `wxworksheettohtml()` exports the current worksheet to an HTML file from within a running _Maxima_ session, which is convenient for scripted or batch export. Like `wxstatusbar()` it is safe to use in code that might also run in plain (console) _Maxima_: if _wxMaxima_ isn’t present the command is simply left unevaluated."
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:473
-msgid "```maxima wxworksheettohtml(\"report.html\")$ wxworksheettohtml(\"report.html\", flavor=\"svg\", wxmx=true)$ ```"
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:469
+#, no-wrap
+msgid ""
+"wxworksheettohtml(\"report.html\")$\n"
+"wxworksheettohtml(\"report.html\", flavor=\"svg\", wxmx=true)$\n"
 msgstr ""
 
 #. type: Plain text
@@ -9494,9 +13979,12 @@ msgstr ""
 msgid "The companion command `wxworksheettotex()` exports to a LaTeX (`.tex`) file the same way:"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:489
-msgid "```maxima wxworksheettotex(\"report.tex\")$ wxworksheettotex(\"report.tex\", documentclass=\"report\", documentclassoptions=\"12pt,a4paper\")$ ```"
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:485
+#, no-wrap
+msgid ""
+"wxworksheettotex(\"report.tex\")$\n"
+"wxworksheettotex(\"report.tex\", documentclass=\"report\", documentclassoptions=\"12pt,a4paper\")$\n"
 msgstr ""
 
 #. type: Plain text
@@ -9514,9 +14002,10 @@ msgstr ""
 msgid "Support for `wxworksheettopdf()` is planned."
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:498
-msgid "## Plotting"
+#. type: Title ##
+#: ../../info/wxmaxima.md:497
+#, no-wrap
+msgid "Plotting"
 msgstr ""
 
 #. type: Plain text
@@ -9524,9 +14013,10 @@ msgstr ""
 msgid "Plotting (having fundamentally to do with graphics) is a place where a graphical user interface will have to provide some extensions to the original program."
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:502
-msgid "### Embedding a plot into the worksheet"
+#. type: Title ###
+#: ../../info/wxmaxima.md:501
+#, no-wrap
+msgid "Embedding a plot into the worksheet"
 msgstr ""
 
 #. type: Plain text
@@ -9568,9 +14058,10 @@ msgstr ""
 msgid "If you got problems with one of these functions, please check, if the problem exists in the the Maxima function too (e.g. you got an error with `wxplot2d()`, check the same plot in the Maxima command `plot2d()` (which opens the plot in a separate Window)). If the problem does not disappear, it is most likely a Maxima issue and should be reported in the [Maxima bugtracker](https://sourceforge.net/p/maxima/bugs/). Or maybe a Gnuplot issue."
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:526
-msgid "### Making embedded plots bigger or smaller"
+#. type: Title ###
+#: ../../info/wxmaxima.md:525
+#, no-wrap
+msgid "Making embedded plots bigger or smaller"
 msgstr ""
 
 #. type: Plain text
@@ -9578,11 +14069,10 @@ msgstr ""
 msgid "As noted above, the configure dialog provides a way to change the default size plots created which sets the starting value of `wxplot_size`. The plotting routines of _wxMaxima_ respect this variable that specifies the size of a plot in pixels. It can always be queried or used to set the size of the following plots:"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:538
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:529
 #, no-wrap
 msgid ""
-"```maxima\n"
 "wxplot_size:[1200,800]$\n"
 "wxdraw2d(\n"
 "    explicit(\n"
@@ -9590,7 +14080,6 @@ msgid ""
 "        x,1,10\n"
 "    )\n"
 ")$\n"
-"```\n"
 msgstr ""
 
 #. type: Plain text
@@ -9598,18 +14087,16 @@ msgstr ""
 msgid "If the size of only one plot is to be changed _Maxima_ provides a canonical way to change an attribute only for the current cell. In this usage the specification `wxplot_size = [value1, value2]` is appended to the `wxdraw2d( )` command, and is not part of the `wxdraw2d` command."
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:549
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:541
 #, no-wrap
 msgid ""
-"```maxima\n"
 "wxdraw2d(\n"
 "    explicit(\n"
 "        sin(x),\n"
 "        x,1,10\n"
 "    )\n"
 "),wxplot_size=[1600,800]$\n"
-"```\n"
 msgstr ""
 
 #. type: Plain text
@@ -9617,9 +14104,10 @@ msgstr ""
 msgid "Setting the size of embedded plot with `wxplot_size` works for embedded plots using e.g. `wxplot`, `wxdraw`, `wxcontour_plot` and `wximplicit_plot` commands and for embedded animations with `with_slider_draw` and `wxanimate` commands."
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:553
-msgid "### Better quality plots"
+#. type: Title ###
+#: ../../info/wxmaxima.md:552
+#, no-wrap
+msgid "Better quality plots"
 msgstr ""
 
 #. type: Plain text
@@ -9627,9 +14115,10 @@ msgstr ""
 msgid "_Gnuplot_ doesn’t seem to provide a portable way of determining whether it supports the high-quality bitmap output that the Cairo library provides. On systems where _Gnuplot_ is compiled to use this library the pngCairo option from the configuration menu (that can be overridden by the variable `wxplot_pngcairo`) enables support for antialiasing and additional line styles. If `wxplot_pngCairo` is set without _Gnuplot_ supporting this the result will be error messages instead of graphics."
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:557
-msgid "### Opening embedded plots in interactive _Gnuplot_ windows"
+#. type: Title ###
+#: ../../info/wxmaxima.md:556
+#, no-wrap
+msgid "Opening embedded plots in interactive _Gnuplot_ windows"
 msgstr ""
 
 #. type: Plain text
@@ -9637,9 +14126,10 @@ msgstr ""
 msgid "If a plot was generated using the `wxdraw`-type commands (`wxplot2d` and `wxplot3d` isn’t supported by this feature) and the file size of the underlying _Gnuplot_ project isn’t way too high _wxMaxima_ offers a right-click menu that allows to open the plot in an interactive _Gnuplot_ window."
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:561
-msgid "### Opening Gnuplot’s command console in `plot` windows"
+#. type: Title ###
+#: ../../info/wxmaxima.md:560
+#, no-wrap
+msgid "Opening Gnuplot’s command console in `plot` windows"
 msgstr ""
 
 #. type: Plain text
@@ -9647,9 +14137,10 @@ msgstr ""
 msgid "On MS Windows, there are two Gnuplot programs, `gnuplot.exe` and `wgnuplot.exe`.  You can configure, which command should be used using the configuration menu. `wgnuplot.exe` offers the possibility to open a console window, where _gnuplot_ commands can be entered into, `gnuplot.exe` does not offer this possibility. Unfortunately, `wgnuplot.exe` causes _Gnuplot_ to \"steal\" the keyboard focus for a short time every time a plot is prepared."
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:566
-msgid "### Embedding animations into the spreadsheet"
+#. type: Title ###
+#: ../../info/wxmaxima.md:565
+#, no-wrap
+msgid "Embedding animations into the spreadsheet"
 msgstr ""
 
 #. type: Plain text
@@ -9662,11 +14153,10 @@ msgstr ""
 msgid "The first two arguments for `with_slider_draw` are the name of the variable that is stepped between the plots and a list of the values of these variable. The arguments that follow are the ordinary arguments for `wxdraw2d`:"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:581
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:571
 #, no-wrap
 msgid ""
-"```maxima\n"
 "with_slider_draw(\n"
 "    f,[1,2,3,4,5,6,7,10],\n"
 "    title=concat(\"f=\",f,\"Hz\"),\n"
@@ -9675,7 +14165,6 @@ msgid ""
 "        x,0,1\n"
 "    ),grid=true\n"
 ");\n"
-"```\n"
 msgstr ""
 
 #. type: Plain text
@@ -9683,11 +14172,10 @@ msgstr ""
 msgid "The same functionality for 3D plots is accessible as `with_slider_draw3d`, which allows for rotating 3d plots:"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:600
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:584
 #, no-wrap
 msgid ""
-"```maxima\n"
 "wxanimate_autoplay:true;\n"
 "wxanimate_framerate:20;\n"
 "with_slider_draw3d(\n"
@@ -9702,7 +14190,6 @@ msgid ""
 "        y,-π,π\n"
 "    )\n"
 ")$\n"
-"```\n"
 msgstr ""
 
 #. type: Plain text
@@ -9710,11 +14197,10 @@ msgstr ""
 msgid "If the general shape of the plot is what matters it might suffice to move the plot just a little bit in order to make its 3D nature available to the intuition:"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:619
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:603
 #, no-wrap
 msgid ""
-"```maxima\n"
 "wxanimate_autoplay:true;\n"
 "wxanimate_framerate:20;\n"
 "with_slider_draw3d(\n"
@@ -9729,7 +14215,6 @@ msgid ""
 "        y,-2*π,2*π\n"
 "    )\n"
 ")$\n"
-"```\n"
 msgstr ""
 
 #. type: Plain text
@@ -9752,14 +14237,12 @@ msgstr ""
 msgid "Normally the animations are played back or exported with the frame rate chosen in the configuration of _wxMaxima_. To set the speed at an individual animation is played back the variable `wxanimate_framerate` can be used:"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:631
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:627
 #, no-wrap
 msgid ""
-"```maxima\n"
 "wxanimate(a, 10,\n"
 "    sin(a*x), [x,-5,5]), wxanimate_framerate=6$\n"
-"```\n"
 msgstr ""
 
 #. type: Plain text
@@ -9767,11 +14250,10 @@ msgstr ""
 msgid "The animation functions use _Maxima_’s `makelist` command and therefore share the pitfall that the slider variable’s value is substituted into the expression only if the variable is directly visible in the expression. Therefore the following example will fail:"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:643
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:634
 #, no-wrap
 msgid ""
-"```maxima\n"
 "f:sin(a*x);\n"
 "with_slider_draw(\n"
 "    a,makelist(i/2,i,1,10),\n"
@@ -9779,7 +14261,6 @@ msgid ""
 "    grid=true,\n"
 "    explicit(f,x,0,10)\n"
 ")$\n"
-"```\n"
 msgstr ""
 
 #. type: Plain text
@@ -9787,11 +14268,10 @@ msgstr ""
 msgid "If _Maxima_ is explicitly asked to substitute the slider’s value plotting works fine instead:"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:658
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:646
 #, no-wrap
 msgid ""
-"```maxima\n"
 "f:sin(a*x);\n"
 "with_slider_draw(\n"
 "    b,makelist(i/2,i,1,10),\n"
@@ -9802,12 +14282,12 @@ msgid ""
 "        x,0,10\n"
 "    )\n"
 ")$\n"
-"```\n"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:660
-msgid "### Opening multiple plots in contemporaneous windows"
+#. type: Title ###
+#: ../../info/wxmaxima.md:659
+#, no-wrap
+msgid "Opening multiple plots in contemporaneous windows"
 msgstr ""
 
 #. type: Plain text
@@ -9815,24 +14295,20 @@ msgstr ""
 msgid "While not being provided by _wxMaxima_ this feature of _Maxima_ (on setups that support it) sometimes comes in handily. The following example comes from a post from Mario Rodriguez to the _Maxima_ mailing list:"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:665
-msgid "```maxima load(draw);"
-msgstr ""
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:668
-msgid "/* Parabola in window #1 */ draw2d(terminal=[wxt,1],explicit(x^2,x,-1,1));"
-msgstr ""
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:671
-msgid "/* Parabola in window #2 */ draw2d(terminal=[wxt,2],explicit(x^2,x,-1,1));"
-msgstr ""
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:675
-msgid "/* Paraboloid in window #3 */ draw3d(terminal=[wxt,3],explicit(x^2+y^2,x,-1,1,y,-1,1)); ```"
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:663
+#, no-wrap
+msgid ""
+"load(draw);\n"
+"\n"
+"/* Parabola in window #1 */\n"
+"draw2d(terminal=[wxt,1],explicit(x^2,x,-1,1));\n"
+"\n"
+"/* Parabola in window #2 */\n"
+"draw2d(terminal=[wxt,2],explicit(x^2,x,-1,1));\n"
+"\n"
+"/* Paraboloid in window #3 */\n"
+"draw3d(terminal=[wxt,3],explicit(x^2+y^2,x,-1,1,y,-1,1));\n"
 msgstr ""
 
 #. type: Plain text
@@ -9840,11 +14316,10 @@ msgstr ""
 msgid "Plotting multiple plots in the same window is possible, too (the same is possible in command line Maxima with the standard `draw()` command):"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:688
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:678
 #, no-wrap
 msgid ""
-"```maxima\n"
 "wxdraw(\n"
 "  gr2d(\n"
 "    key=\"sin (x)\",grid=[2,2],\n"
@@ -9853,22 +14328,17 @@ msgid ""
 "    key=\"cos (x)\",grid=[2,2],\n"
 "    explicit(cos(x),x,0,2*%pi))\n"
 ");\n"
-"```\n"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:690
-msgid "### The \"Plot using draw\" side pane"
+#. type: Title ###
+#: ../../info/wxmaxima.md:689
+#, no-wrap
+msgid "The \"Plot using draw\" side pane"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:692
 msgid "The \"Plot using draw\" sidebar hides a simple code generator that allows generating scenes that make use of some of the flexibility of the _draw_ package _maxima_ comes with."
-msgstr ""
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:694
-msgid "#### 2D"
 msgstr ""
 
 #. type: Plain text
@@ -9882,30 +14352,19 @@ msgid "One helpful feature of the 2D button is that it allows to set up the scen
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:700
-msgid "#### 3D"
-msgstr ""
-
-#. type: Plain text
 #: ../../info/wxmaxima.md:702
 msgid "Generates the skeleton of a `draw()` command that draws a 3D scene. If neither a 2D nor a 3D scene is set up, all of the other buttons set up a 2D scene that contains the command the button generates."
 msgstr ""
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:704
-#, fuzzy
-#| msgid "Expression"
-msgid "#### Expression"
-msgstr "Expressão"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:706
 msgid "Appends a standard plot of an expression like `sin(x)`, `x*sin(x)` or `x^2+2*x-4` to the `draw()` command the cursor currently is in. If there is no draw command a 2D scene with the plot is generated. Each scene can be filled with any number of plots."
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:708
-msgid "#### Implicit plot"
+#. type: Title ####
+#: ../../info/wxmaxima.md:707
+#, no-wrap
+msgid "Implicit plot"
 msgstr ""
 
 #. type: Plain text
@@ -9914,31 +14373,13 @@ msgid "Tries to find all points an expression like `y=sin(x)`, `y*sin(x)=3` or `
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:712
-#, fuzzy
-#| msgid "Parametric plot"
-msgid "#### Parametric plot"
-msgstr "Gráfico paramétrico"
-
-#. type: Plain text
 #: ../../info/wxmaxima.md:714
 msgid "Steps a variable from a lower limit to an upper limit and uses two expressions like `t*sin(t)` and `t*cos(t)` for generating the x, y (and in 3D plots also z) coordinates of a curve that is put into the current draw command."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:716
-#, fuzzy
-msgid "#### Points"
-msgstr "Ponto:"
-
-#. type: Plain text
 #: ../../info/wxmaxima.md:718
 msgid "Draws many points that can optionally be joined. The coordinates of the points are taken from a list of lists, a 2D array or one list or array for each axis."
-msgstr ""
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:720
-msgid "#### Diagram title"
 msgstr ""
 
 #. type: Plain text
@@ -9947,18 +14388,8 @@ msgid "Draws a title on the upper end of the diagram,"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:724
-msgid "#### Axis"
-msgstr ""
-
-#. type: Plain text
 #: ../../info/wxmaxima.md:726
 msgid "Sets up the axis."
-msgstr ""
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:728
-msgid "#### Contour"
 msgstr ""
 
 #. type: Plain text
@@ -9967,19 +14398,14 @@ msgid "(Only for 3D plots): Adds contour lines similar to the ones one can find 
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:732
-#, fuzzy
-msgid "#### Plot name"
-msgstr "Lista:"
-
-#. type: Plain text
 #: ../../info/wxmaxima.md:734
 msgid "Adds a legend entry showing the next plot’s name to the legend of the diagram. An empty name disables generating legend entries for the following plots."
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:736
-msgid "#### Line colour"
+#. type: Title ####
+#: ../../info/wxmaxima.md:735
+#, no-wrap
+msgid "Line colour"
 msgstr ""
 
 #. type: Plain text
@@ -9987,9 +14413,10 @@ msgstr ""
 msgid "Sets the line colour for the following plots the current draw command contains."
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:740
-msgid "#### Fill colour"
+#. type: Title ####
+#: ../../info/wxmaxima.md:739
+#, no-wrap
+msgid "Fill colour"
 msgstr ""
 
 #. type: Plain text
@@ -9998,19 +14425,8 @@ msgid "Sets the fill colour for the following plots the current draw command con
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:744
-#, fuzzy
-msgid "#### Grid"
-msgstr "Grade:"
-
-#. type: Plain text
 #: ../../info/wxmaxima.md:746
 msgid "Pops up a wizard that allows to set up grid lines."
-msgstr ""
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:748
-msgid "#### Accuracy"
 msgstr ""
 
 #. type: Plain text
@@ -10018,9 +14434,10 @@ msgstr ""
 msgid "Allows to select an adequate point in the speed vs. accuracy tradeoff that is part of any plot program."
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:752
-msgid "### Modify font and font size for plots"
+#. type: Title ###
+#: ../../info/wxmaxima.md:751
+#, no-wrap
+msgid "Modify font and font size for plots"
 msgstr ""
 
 #. type: Plain text
@@ -10028,16 +14445,14 @@ msgstr ""
 msgid "Especially when you use a high resolution display, the default font size might be very small. For the `draw`-based commands, you can set the font / font size using options like `font=...`, `font_size=...`, e.g.:"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:761
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:755
 #, no-wrap
 msgid ""
-"~~~maxima\n"
 "wxdraw2d(\n"
 "     font=\"Helvetica\",\n"
 "     font_size=30,\n"
 "     explicit(sin(x),x,1,10));\n"
-"~~~\n"
 msgstr ""
 
 #. type: Plain text
@@ -10045,14 +14460,12 @@ msgstr ""
 msgid "For the `plot`-commands (e.g. `wxplot2d`, `wxplot3d`) font sizes and fonts can be set using the `gnuplot_preamble` command, e.g.:"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:768
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:764
 #, no-wrap
 msgid ""
-"~~~maxima\n"
 "wxplot2d(sin(x),[x,1,10],\n"
 "         [gnuplot_preamble, \"set tics font \\\"Arial, 30\\\"; set xlabel font \\\",20\\\"; set ylabel font \\\",20\\\";\"]);\n"
-"~~~\n"
 msgstr ""
 
 #. type: Plain text
@@ -10065,9 +14478,10 @@ msgstr ""
 msgid "Read the Maxima and Gnuplot documentation for further information.  Note: Gnuplot seems to have issues with larger font sizes, see [wxMaxima issue 1966](https://github.com/wxMaxima-developers/wxmaxima/issues/1966)."
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:775
-msgid "## Embedding graphics"
+#. type: Title ##
+#: ../../info/wxmaxima.md:774
+#, no-wrap
+msgid "Embedding graphics"
 msgstr ""
 
 #. type: Plain text
@@ -10075,14 +14489,16 @@ msgstr ""
 msgid "If the `.wxmx` file format is being used embedding files in a _wxMaxima_ project can be done as easily as per drag-and-drop. But sometimes (for example if an image’s contents might change later on in a session) it is better to tell the file to load the image on evaluation:"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:781
-msgid "```maxima show_image(\"man.png\"); ```"
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:778
+#, no-wrap
+msgid "show_image(\"man.png\");\n"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:783
-msgid "## Startup files"
+#. type: Title ##
+#: ../../info/wxmaxima.md:782
+#, no-wrap
+msgid "Startup files"
 msgstr ""
 
 #. type: Plain text
@@ -10110,303 +14526,340 @@ msgstr ""
 msgid "These files are in the Maxima user directory (usually `%USERPROFILE%/maxima` in Windows, `$HOME/.maxima` otherwise). The location can be found out with the command: `maxima_userdir;`"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:794
-#, fuzzy
-msgid "## Special variables wx..."
-msgstr "Apagar uma variável"
+#. type: Title ##
+#: ../../info/wxmaxima.md:793
+#, no-wrap
+msgid "Special variables wx..."
+msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:805
+#: ../../info/wxmaxima.md:811
 msgid "`wxsubscripts` tells _Maxima_ if it should convert variable names that contain an underscore (`R_150` or the like) into subscripted variables. See `wxdeclare_subscript` for details which variable names are automatically converted."
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:805
+#: ../../info/wxmaxima.md:811
 msgid "`wxfilename`: This variable contains the name of the file currently opened in _wxMaxima_."
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:805
+#: ../../info/wxmaxima.md:811
 msgid "`wxdirname`: This variable contains the name the directory, in which the file currently opened in _wxMaxima_ is."
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:805
+#: ../../info/wxmaxima.md:811
 msgid "`wxplot_pngcairo` tells whether _wxMaxima_ tries to use _Gnuplot_’s pngcairo terminal that provides more line styles and a better overall graphics quality."
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:805
+#: ../../info/wxmaxima.md:811
 msgid "`wxplot_size` defines the resolution of embedded plots."
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:805
+#: ../../info/wxmaxima.md:811
 msgid "`wxchangedir`: On most operating systems _wxMaxima_ automatically sets _Maxima_’s working directory to the directory of the current file. This allows file I/O (e.g. by `read_matrix`) to work without specifying the whole path to the file that has to be read or written. On Windows this feature sometimes causes error messages and therefore can be set to `false` from the config dialogue."
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:805
+#: ../../info/wxmaxima.md:811
 msgid "`wxanimate_framerate`: The number of frames per second the following animations have to be played back with."
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:805
+#: ../../info/wxmaxima.md:811
 msgid "`wxanimate_autoplay`: Automatically play animations by default?"
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:805
+#: ../../info/wxmaxima.md:811
 msgid "`wxmaximaversion`: Returns the version number of _wxMaxima_."
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:805
+#: ../../info/wxmaxima.md:811
 msgid "`wxwidgetsversion`: Returns the wxWidgets version _wxMaxima_ is using."
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:807
-msgid "## Pretty-printing 2D output"
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:811
+msgid "`wxdirs`: A struct holding the paths _wxMaxima_ itself uses, since these differ by maintainer, distribution and operating system:"
+msgstr ""
+
+#. type: Bullet: '  - '
+#: ../../info/wxmaxima.md:811
+msgid "`wxdirs@userconfdir`: The directory the user's configuration is stored in. Same directory as `maxima_userdir` (see above) - both point at the same place, `wxdirs@userconfdir` is only useful if that is more convenient to reach from a `.mac` file than the Maxima-side variable."
+msgstr ""
+
+#. type: Bullet: '  - '
+#: ../../info/wxmaxima.md:811
+msgid "`wxdirs@datadir`: The directory _wxMaxima_'s own data (icons, the built-in autocompletion list, ...) is installed in."
+msgstr ""
+
+#. type: Bullet: '  - '
+#: ../../info/wxmaxima.md:811
+msgid "`wxdirs@helpdir`: The directory the offline copy of this manual is installed in."
+msgstr ""
+
+#. type: Bullet: '  - '
+#: ../../info/wxmaxima.md:811
+msgid "`wxdirs@localedir`: The directory _wxMaxima_'s translation files are installed in."
+msgstr ""
+
+#. type: Bullet: '  - '
+#: ../../info/wxmaxima.md:811
+msgid "`wxdirs@maximalocation`: The path to the _Maxima_ executable _wxMaxima_ is configured to start."
+msgstr ""
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:812
+#, no-wrap
+msgid "Pretty-printing 2D output"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:809
+#: ../../info/wxmaxima.md:815
 msgid "The function `table_form()` displays a 2D list in a form that is more readable than the output from _Maxima_’s default output routine. The input is a list of one or more lists. Like the \"print\" command, this command displays output even when ended with a dollar sign. Ending the command with a semicolon results in the same table along with a \"done\" statement."
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:818
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:816
 #, no-wrap
 msgid ""
-"```maxima\n"
 "table_form(\n"
 "    [\n"
 "        [1,2],\n"
 "        [3,4]\n"
 "    ]\n"
 ")$\n"
-"```\n"
-msgstr ""
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:820
-msgid "As the next example shows, the lists that are assembled by the `table_form` command can be created before the command is executed."
-msgstr ""
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:822
-msgid "![A third table example](./MatrixTableExample.png){ id=img_MatrixTableExample }"
-msgstr ""
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:824
-msgid "Also, because a matrix is a list of lists, matrices can be converted to tables in a similar fashion."
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:826
-msgid "![Another table_form example](./SecondTableExample.png){ id=img_SecondTableExample }"
+msgid "As the next example shows, the lists that are assembled by the `table_form` command can be created before the command is executed."
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:828
-msgid "The function `wx_matrix()` is a wrapper for Maxima's `matrix()` command that allows for more flexible formatting of matrices in wxMaxima:"
+msgid "![A third table example](./MatrixTableExample.png){ id=img_MatrixTableExample }"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:830
+msgid "Also, because a matrix is a list of lists, matrices can be converted to tables in a similar fashion."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:832
+msgid "![Another table_form example](./SecondTableExample.png){ id=img_SecondTableExample }"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:834
+msgid "The function `wx_matrix()` is a wrapper for Maxima's `matrix()` command that allows for more flexible formatting of matrices in wxMaxima:"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:836
 #, no-wrap
 msgid "**`wx_matrix( <matrix>, [options] )`**\n"
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:835
+#: ../../info/wxmaxima.md:841
 msgid "**`lines=true`**: Draws internal separator lines between the cells. This is required to visually separate headings from data."
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:835
+#: ../../info/wxmaxima.md:841
 msgid "**`rownames=true`**: Tells wxMaxima that the first column of the matrix contains labels."
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:835
+#: ../../info/wxmaxima.md:841
 msgid "**`colnames=true`**: Tells wxMaxima that the first row of the matrix contains labels."
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:835
+#: ../../info/wxmaxima.md:841
 msgid "**`parenstyle=<style>`**: Sets the type of parenthesis or brackets to draw around the matrix. Supported styles are: `round` `()`, `square` `[]`, `angled` `<>`, `straight` `||`, or `none`."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:837
+#: ../../info/wxmaxima.md:843
 #, fuzzy
 #| msgid "Example"
 msgid "Example:"
 msgstr "Exemplo"
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:842
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:844
 #, no-wrap
 msgid ""
-"```maxima\n"
 "wx_matrix(matrix([\"Name\", \"Value\"], [\"X\", 10], [\"Y\", 20]),\n"
 "          lines=true, rownames=true, colnames=true, parenstyle=square);\n"
-"```\n"
+msgstr ""
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:849
+#, no-wrap
+msgid "Bug reporting"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:844
-msgid "## Bug reporting"
-msgstr ""
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:846
+#: ../../info/wxmaxima.md:852
 msgid "_WxMaxima_ provides a few functions that gather bug reporting information about the current system:"
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:849
+#: ../../info/wxmaxima.md:855
 msgid "`wxbuild_info()` gathers information about the currently running version of _wxMaxima_"
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:849
+#: ../../info/wxmaxima.md:855
 msgid "`wxbug_report()` tells how and where to file bugs"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:851
-msgid "## Marking output being drawn in red"
-msgstr ""
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:854
-msgid "_Maxima_’s `box()` command causes _wxMaxima_ to print its argument with a red foreground, if the second argument to the command is the text `highlight`."
-msgstr ""
-
-#. type: Plain text
+#. type: Title ##
 #: ../../info/wxmaxima.md:856
-#, fuzzy
-msgid "## Output rendering."
-msgstr "Cadeias de caracteres"
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:858
-msgid "With `set_display()` one can set, how wxMaxima will render the output."
+#, no-wrap
+msgid "Marking output being drawn in red"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:860
+msgid "_Maxima_’s `box()` command causes _wxMaxima_ to print its argument with a red foreground, if the second argument to the command is the text `highlight`."
+msgstr ""
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:861
+#, no-wrap
+msgid "Output rendering."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:864
+msgid "With `set_display()` one can set, how wxMaxima will render the output."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:866
 msgid "`set_display('xml)` is the default value. Here Maxima speaks to wxMaxima using an (machine readable) XML-dialect (can be seen in the \"Raw XML sidebar\") and outputs the resulting formulas nicely rendered, e.g. pretty Matrices, Square root signs, fractions, etc."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:863
-msgid "<!--- Currently that does not work as it should, the line with the output label is shifted right (issue: #2006) --> `set_display('ascii)` causes wxMaxima to output formulas as in command line Maxima - as ASCII-Art."
-msgstr ""
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:865
-msgid "`set_display('none)` causes 'one-line' ASCII results - the same as the command line Maxima command `display2d:false;` does."
-msgstr ""
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:867
-msgid "# Help menu"
-msgstr ""
-
-#. type: Plain text
 #: ../../info/wxmaxima.md:869
-msgid "WxMaxima’s help menu provides access to the Maxima and wxMaxima manual, tips, some example worksheets and in command line Maxima included demos (the `demo()` command)."
+#, no-wrap
+msgid ""
+"<!--- Currently that does not work as it should, the line with the output label is shifted right (issue: #2006) -->\n"
+"`set_display('ascii)` causes wxMaxima to output formulas as in command line Maxima - as ASCII-Art.\n"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:871
-msgid "Please notice, that the demos write:"
+msgid "`set_display('none)` causes 'one-line' ASCII results - the same as the command line Maxima command `display2d:false;` does."
+msgstr ""
+
+#. type: Title #
+#: ../../info/wxmaxima.md:872
+#, no-wrap
+msgid "Help menu"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:875
-msgid "~~~text At the ’_’ prompt, type ’;’ and <enter> to proceed with the demonstration.  ~~~"
+msgid "WxMaxima’s help menu provides access to the Maxima and wxMaxima manual, tips, some example worksheets and in command line Maxima included demos (the `demo()` command)."
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:877
-msgid "That is valid for command-line Maxima, however in wxMaxima by default it is necessary to continue the demonstration with: <kbd>CTRL</kbd>+<kbd>ENTER</kbd>"
+msgid "Please notice, that the demos write:"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:879
-msgid "(That can be configured in the Configure->Worksheet->\"Hotkeys for sending commands to Maxima\" menu.)"
+#. type: Fenced code block (text)
+#: ../../info/wxmaxima.md:878
+#, no-wrap
+msgid "At the ’_’ prompt, type ’;’ and <enter> to proceed with the demonstration.\n"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:883
-msgid "# Troubleshooting"
+#, no-wrap
+msgid "That is valid for command-line Maxima, however in wxMaxima by default it is necessary to continue the demonstration with: <kbd>CTRL</kbd>+<kbd>ENTER</kbd>\n"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:885
-#, fuzzy
-msgid "## Cannot connect to _Maxima_"
-msgstr ""
-"\n"
-"Não conectado."
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:887
-msgid "Since _Maxima_ (the program that does the actual mathematics) and _wxMaxima_ (providing the easy-to-use user interface) are separate programs that communicate by the means of a local network connection. Therefore the most probable cause is that this connection is somehow not working. For example, a firewall could be set up in a way that it doesn’t just prevent unauthorized connections from the internet (and perhaps intercept some connections to the internet, too), but also blocks inter-process-communication inside the same computer. Note that since _Maxima_ is being run by a Lisp processor the process communication that is blocked does not necessarily have to be named \"maxima\". Common names of the program that opens the network connection would be sbcl, gcl, ccl, lisp.exe, or similar names."
+#, no-wrap
+msgid "(That can be configured in the Configure->Worksheet->\"Hotkeys for sending commands to Maxima\" menu.)\n"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:889
-msgid "On Unix computers another possible reason would be that the loopback network that provides network connections between two programs in the same computer isn’t properly configured."
+#. type: Title #
+#: ../../info/wxmaxima.md:888
+#, no-wrap
+msgid "Troubleshooting"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:891
-msgid "## How to save data from a broken .wxmx file"
+#. type: Title ##
+#: ../../info/wxmaxima.md:890
+#, no-wrap
+msgid "Cannot connect to _Maxima_"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:893
-msgid "Internally most modern XML-based formats are ordinary zip files. _WxMaxima_ doesn’t turn on compression, so the contents of `.wxmx` files can be viewed in any text editor."
+msgid "Since _Maxima_ (the program that does the actual mathematics) and _wxMaxima_ (providing the easy-to-use user interface) are separate programs that communicate by the means of a local network connection. Therefore the most probable cause is that this connection is somehow not working. For example, a firewall could be set up in a way that it doesn’t just prevent unauthorized connections from the internet (and perhaps intercept some connections to the internet, too), but also blocks inter-process-communication inside the same computer. Note that since _Maxima_ is being run by a Lisp processor the process communication that is blocked does not necessarily have to be named \"maxima\". Common names of the program that opens the network connection would be sbcl, gcl, ccl, lisp.exe, or similar names."
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:895
-msgid "If the zip signature at the end of the file is still intact after renaming a broken `.wxmx` file to `.zip` most operating systems will provide a way to extract any portion of the information that is stored inside it. This can be done when there is a need of recovering the original image files from a text processor document. If the zip signature isn’t intact that does not need to be the end of the world: If _wxMaxima_ during saving detected that something went wrong there will be a `.wxmx~` file whose contents might help."
+msgid "On Unix computers another possible reason would be that the loopback network that provides network connections between two programs in the same computer isn’t properly configured."
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:897
-msgid "And even if there isn’t such a file: The `.wxmx` file is a container format and the XML portion is stored uncompressed. It it is possible to rename the `.wxmx` file to a `.txt` file and to use a text editor to recover the XML portion of the file’s contents (it starts with `<?xml version=\"1.0\" encoding=\"UTF-8\"?>` and ends with `</wxMaximaDocument>`. Before and after that text you will see some unreadable binary contents in the text editor)."
+#. type: Title ##
+#: ../../info/wxmaxima.md:896
+#, no-wrap
+msgid "How to save data from a broken .wxmx file"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:899
-msgid "If a text file containing only these contents (e.g. copy and paste this text into a new file) is saved as a file ending in `.xml`, _wxMaxima_ will know how to recover the text from the document."
+msgid "Internally most modern XML-based formats are ordinary zip files. _WxMaxima_ doesn’t turn on compression, so the contents of `.wxmx` files can be viewed in any text editor."
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:901
-msgid "## I want some debug info to be displayed on the screen before my command has finished"
+msgid "If the zip signature at the end of the file is still intact after renaming a broken `.wxmx` file to `.zip` most operating systems will provide a way to extract any portion of the information that is stored inside it. This can be done when there is a need of recovering the original image files from a text processor document. If the zip signature isn’t intact that does not need to be the end of the world: If _wxMaxima_ during saving detected that something went wrong there will be a `.wxmx~` file whose contents might help."
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:903
-msgid "Normally _wxMaxima_ waits for the whole 2D formula to be transferred before it begins to typeset. This saves time for making many attempts to typeset a only partially completed equation. There is a `disp` command, though, that will provide debug output immediately and without waiting for the current _Maxima_ command to finish:"
+#, no-wrap
+msgid "And even if there isn’t such a file: The `.wxmx` file is a container format and the XML portion is stored uncompressed. It it is possible to rename the `.wxmx` file to a `.txt` file and to use a text editor to recover the XML portion of the file’s contents (it starts with `<?xml version=\"1.0\" encoding=\"UTF-8\"?>` and ends with `</wxMaximaDocument>`. Before and after that text you will see some unreadable binary contents in the text editor).\n"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:913
+#: ../../info/wxmaxima.md:905
+msgid "If a text file containing only these contents (e.g. copy and paste this text into a new file) is saved as a file ending in `.xml`, _wxMaxima_ will know how to recover the text from the document."
+msgstr ""
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:906
+#, no-wrap
+msgid "I want some debug info to be displayed on the screen before my command has finished"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:909
+msgid "Normally _wxMaxima_ waits for the whole 2D formula to be transferred before it begins to typeset. This saves time for making many attempts to typeset a only partially completed equation. There is a `disp` command, though, that will provide debug output immediately and without waiting for the current _Maxima_ command to finish:"
+msgstr ""
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:910
 #, no-wrap
 msgid ""
-"```maxima\n"
 "for i:1 thru 10 do (\n"
 "   disp(i),\n"
 "   /* (sleep n) is a Lisp function, which can be used */\n"
@@ -10414,273 +14867,285 @@ msgid ""
 "   /* program execution (here: for 3 seconds) */\n"
 "   ?sleep(3)\n"
 ")$\n"
-"```\n"
-msgstr ""
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:915
-msgid "Alternatively one can look for the `wxstatusbar()` command above."
-msgstr ""
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:917
-msgid "## Plotting only shows a closed empty envelope with an error message"
-msgstr ""
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:919
-msgid "This means that _wxMaxima_ could not read the file _Maxima_ that was supposed to instruct _Gnuplot_ to create."
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:921
+msgid "Alternatively one can look for the `wxstatusbar()` command above."
+msgstr ""
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:922
+#, no-wrap
+msgid "Plotting only shows a closed empty envelope with an error message"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:925
+msgid "This means that _wxMaxima_ could not read the file _Maxima_ that was supposed to instruct _Gnuplot_ to create."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:927
 msgid "Possible reasons for this error are:"
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:926
+#: ../../info/wxmaxima.md:932
 msgid "The plotting command is part of a third-party package like `implicit_plot` but this package was not loaded by _Maxima_’s `load()` command before trying to plot."
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:926
+#: ../../info/wxmaxima.md:932
 msgid "_Maxima_ tried to do something the currently installed version of _Gnuplot_ isn’t able to understand. In this case, a file ending in `.gnuplot` located in the directory, which _Maxima_’s variable `maxima_userdir` is pointing, contains the instructions from _Maxima_ to _Gnuplot_. Most of the time, this file’s contents therefore are helpful when debugging the problem."
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:926
+#: ../../info/wxmaxima.md:932
 msgid "Gnuplot was instructed to use the pngCairo library that provides antialiasing and additional line styles, but it was not compiled to support this possibility. Solution: Uncheck the \"Use the Cairo terminal for the plot\" checkbox in the configuration dialog and don’t set `wxplot_pngcairo` to true from _Maxima_."
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:926
+#: ../../info/wxmaxima.md:932
 msgid "Gnuplot didn’t output a valid `.png` file."
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:928
-msgid "## Plotting an animation results in “error: undefined variable”"
+#. type: Title ##
+#: ../../info/wxmaxima.md:933
+#, no-wrap
+msgid "Plotting an animation results in “error: undefined variable”"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:930
+#: ../../info/wxmaxima.md:936
 msgid "The value of the slider variable by default is only substituted into the expression that is to be plotted if it is visible there. Using a `subst` command that substitutes the slider variable into the equation to plot resolves this problem. At the end of section [Embedding animations into the spreadsheet](#embedding-animations-into-the-spreadsheet), you can see an example."
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:932
-msgid "## I lost cell content and undo doesn’t remember"
+#. type: Title ##
+#: ../../info/wxmaxima.md:937
+#, no-wrap
+msgid "I lost cell content and undo doesn’t remember"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:934
+#: ../../info/wxmaxima.md:940
 msgid "There are separate undo functions for cell operations and for changes inside of cells so chances are low that this ever happens. If it does there are several methods to recover data:"
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:939
+#: ../../info/wxmaxima.md:945
 msgid "_WxMaxima_ actually has two undo features: The global undo buffer that is active if no cell is selected and a per-cell undo buffer that is active if the cursor is inside a cell. It is worth trying to use both undo options in order to see if an old value can still be accessed."
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:939
+#: ../../info/wxmaxima.md:945
 msgid "If you still have a way to find out what label _Maxima_ has assigned to the cell just type in the cell’s label and its contents will reappear."
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:939
+#: ../../info/wxmaxima.md:945
 msgid "If you don’t: Don’t panic. In the “View” menu there is a way to show a history pane that shows all _Maxima_ commands that have been issued recently."
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:939
+#: ../../info/wxmaxima.md:945
 msgid "If nothing else helps _Maxima_ contains a replay feature:"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:943
-msgid "```maxima playback(); ```"
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:946
+#, no-wrap
+msgid "playback();\n"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:945
-msgid "## _WxMaxima_ starts up with the message “Maxima process terminated.”"
-msgstr ""
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:947
-msgid "One possible reason is that _Maxima_ cannot be found in the location that is set in the “Maxima” tab of _wxMaxima_’s configuration dialog and therefore won’t run at all. Setting the path to a working _Maxima_ binary should fix this problem."
-msgstr ""
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:949
-msgid "## Maxima is forever calculating and not responding to input"
-msgstr ""
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:951
-msgid "It is theoretically possible that _wxMaxima_ doesn’t realize that _Maxima_ has finished calculating and therefore never gets informed it can send new data to _Maxima_. If this is the case “Trigger evaluation” might resynchronize the two programs."
+#. type: Title ##
+#: ../../info/wxmaxima.md:950
+#, no-wrap
+msgid "_WxMaxima_ starts up with the message “Maxima process terminated.”"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:953
-msgid "## My SBCL-based _Maxima_ runs out of memory"
+msgid "One possible reason is that _Maxima_ cannot be found in the location that is set in the “Maxima” tab of _wxMaxima_’s configuration dialog and therefore won’t run at all. Setting the path to a working _Maxima_ binary should fix this problem."
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:955
-msgid "The Lisp compiler SBCL by default comes with a memory limit that allows it to run even on low-end computers. When compiling a big software package like Lapack or dealing with extremely big lists of equations this limit might be too low. In order to extend the limits, SBCL can be provided with the command line parameter `--dynamic-space-size` that tells SBCL how many megabytes it should reserve. A 32bit Windows-SBCL can reserve up to 999 Megabytes. A 64-bit SBCL version running on Windows can be instructed to use more than the about 1280 Megabytes compiling Lapack needs."
+#. type: Title ##
+#: ../../info/wxmaxima.md:954
+#, no-wrap
+msgid "Maxima is forever calculating and not responding to input"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:957
-msgid "One way to provide _Maxima_ (and thus SBCL) with command line parameters is the \"Additional parameters for Maxima\" field of _wxMaxima_’s configuration dialogue."
+msgid "It is theoretically possible that _wxMaxima_ doesn’t realize that _Maxima_ has finished calculating and therefore never gets informed it can send new data to _Maxima_. If this is the case “Trigger evaluation” might resynchronize the two programs."
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:959
-msgid "![sbcl memory](./sbclMemory.png){ id=img_sbclMemory }"
+#. type: Title ##
+#: ../../info/wxmaxima.md:958
+#, no-wrap
+msgid "My SBCL-based _Maxima_ runs out of memory"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:961
-msgid "## Input sometimes is sluggish/ignoring keys on Ubuntu"
+msgid "The Lisp compiler SBCL by default comes with a memory limit that allows it to run even on low-end computers. When compiling a big software package like Lapack or dealing with extremely big lists of equations this limit might be too low. In order to extend the limits, SBCL can be provided with the command line parameter `--dynamic-space-size` that tells SBCL how many megabytes it should reserve. A 32bit Windows-SBCL can reserve up to 999 Megabytes. A 64-bit SBCL version running on Windows can be instructed to use more than the about 1280 Megabytes compiling Lapack needs."
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:963
-msgid "Installing the package `ibus-gtk` should resolve this issue. See ([https://bugs.launchpad.net/ubuntu/+source/wxwidgets3.0/+bug/1421558](https://bugs.launchpad.net/ubuntu/+source/wxwidgets3.0/+bug/1421558)) for details."
+msgid "One way to provide _Maxima_ (and thus SBCL) with command line parameters is the \"Additional parameters for Maxima\" field of _wxMaxima_’s configuration dialogue."
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:965
-msgid "## _WxMaxima_ halts when _Maxima_ processes Greek characters or Umlauts"
+msgid "![sbcl memory](./sbclMemory.png){ id=img_sbclMemory }"
+msgstr ""
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:966
+#, no-wrap
+msgid "Input sometimes is sluggish/ignoring keys on Ubuntu"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:967
-msgid "If your _Maxima_ is based on SBCL the following lines have to be added to your `.sbclrc`:"
+#: ../../info/wxmaxima.md:969
+msgid "Installing the package `ibus-gtk` should resolve this issue. See ([https://bugs.launchpad.net/ubuntu/+source/wxwidgets3.0/+bug/1421558](https://bugs.launchpad.net/ubuntu/+source/wxwidgets3.0/+bug/1421558)) for details."
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:971
-msgid "```commonlisp (setf sb-impl::*default-external-format* :utf-8)  ```"
+#. type: Title ##
+#: ../../info/wxmaxima.md:970
+#, no-wrap
+msgid "_WxMaxima_ halts when _Maxima_ processes Greek characters or Umlauts"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:973
-msgid "The folder where this file has to be placed is system- and installation-specific. But any SBCL-based _Maxima_ that already has evaluated a cell in the current session will happily tell where it can be found after getting the following command:"
+msgid "If your _Maxima_ is based on SBCL the following lines have to be added to your `.sbclrc`:"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:977
-msgid "```maxima :lisp (sb-impl::userinit-pathname)  ```"
+#. type: Fenced code block (commonlisp)
+#: ../../info/wxmaxima.md:974
+#, no-wrap
+msgid "(setf sb-impl::*default-external-format* :utf-8)\n"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:979
-msgid "## Note concerning Wayland (recent Linux/BSD distributions)"
+msgid "The folder where this file has to be placed is system- and installation-specific. But any SBCL-based _Maxima_ that already has evaluated a cell in the current session will happily tell where it can be found after getting the following command:"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:982
-msgid "There seem to be issues with the Wayland Display Server and wxWidgets.  WxMaxima may be affected, e.g. that sidebars are not moveable."
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:980
+#, no-wrap
+msgid ":lisp (sb-impl::userinit-pathname)\n"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:986
-msgid "You can either disable Wayland and use X11 instead (globally)  or just tell, that wxMaxima should use the X Window System by setting: `GDK_BACKEND=x11`"
+#. type: Title ##
+#: ../../info/wxmaxima.md:984
+#, no-wrap
+msgid "Note concerning Wayland (recent Linux/BSD distributions)"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:988
+msgid "There seem to be issues with the Wayland Display Server and wxWidgets.  WxMaxima may be affected, e.g. that sidebars are not moveable."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:992
+msgid "You can either disable Wayland and use X11 instead (globally)  or just tell, that wxMaxima should use the X Window System by setting: `GDK_BACKEND=x11`"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:994
 #, fuzzy
 #| msgid "Restart Maxima"
 msgid "E.g. start wxMaxima with:"
 msgstr "Reiniciar Maxima"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:990
+#: ../../info/wxmaxima.md:996
 msgid "`GDK_BACKEND=x11 wxmaxima`"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:992
-msgid "## The menu bar disappears on KDE Plasma"
-msgstr ""
-
-#. type: Plain text
+#. type: Title ##
 #: ../../info/wxmaxima.md:997
-msgid "On some KDE Plasma installations the global menu bar disappears when clicked.  As this is a bug in the global menu proxy, the only way to avoid it is to tell that wxMaxima should use its own menu bar instead of the global one.  This is done by setting: `UBUNTU_MENUPROXY=0`"
-msgstr ""
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:1001
-msgid "Starting with version 26.05.0, wxMaxima attempts to set this variable automatically if it detects an affected system (KDE, Unity, or Ubuntu with older wxWidgets versions)."
+#, no-wrap
+msgid "The menu bar disappears on KDE Plasma"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:1003
-msgid "If the automatic fix fails, you can manually start wxMaxima with:"
-msgstr ""
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:1005
-msgid "`UBUNTU_MENUPROXY=0 wxmaxima`"
+msgid "On some KDE Plasma installations the global menu bar disappears when clicked.  As this is a bug in the global menu proxy, the only way to avoid it is to tell that wxMaxima should use its own menu bar instead of the global one.  This is done by setting: `UBUNTU_MENUPROXY=0`"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:1007
-msgid "## Why is the integrated manual browser not offered on my Windows PC?"
+msgid "Starting with version 26.05.0, wxMaxima attempts to set this variable automatically if it detects an affected system (KDE, Unity, or Ubuntu with older wxWidgets versions)."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1010
+#: ../../info/wxmaxima.md:1009
+msgid "If the automatic fix fails, you can manually start wxMaxima with:"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1011
+msgid "`UBUNTU_MENUPROXY=0 wxmaxima`"
+msgstr ""
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:1012
+#, no-wrap
+msgid "Why is the integrated manual browser not offered on my Windows PC?"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1016
 msgid "Either wxWidgets wasn’t compiled with support for Microsoft’s webview2 or Microsoft’s webview2 isn’t installed."
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:1012
-msgid "## Why is the external manual browser not working on my Linux box?"
+#. type: Title ##
+#: ../../info/wxmaxima.md:1017
+#, no-wrap
+msgid "Why is the external manual browser not working on my Linux box?"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1018
+#: ../../info/wxmaxima.md:1024
 msgid "The HTML browser might be a snap, flatpack or appimage version. All of these typically cannot access files that are installed on your local system. Another reason might be that maxima or wxMaxima is installed as a snap, flatpack or something else that doesn’t give the host system access to its contents. A third reason might be that the maxima HTML manual isn’t installed and the online one cannot be accessed."
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:1020
-msgid "## Can I make _wxMaxima_ output both image files and embedded plots at once?"
+#. type: Title ##
+#: ../../info/wxmaxima.md:1025
+#, no-wrap
+msgid "Can I make _wxMaxima_ output both image files and embedded plots at once?"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1022
+#: ../../info/wxmaxima.md:1028
 msgid "The worksheet embeds `.png files. _WxMaxima_ allows the user to specify where they should be generated:"
 msgstr ""
 
-#. type: Plain text
+#. type: Fenced code block (maxima)
 #: ../../info/wxmaxima.md:1029
 #, no-wrap
 msgid ""
-"```maxima\n"
 "wxdraw2d(\n"
 "    file_name=\"test\",  /* extension .png automatically added */\n"
 "    explicit(sin(x),x,1,10)\n"
 ");\n"
-"```\n"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1031
+#: ../../info/wxmaxima.md:1037
 msgid "If a different format is to be used, it is easier to generate the images and then import them into the worksheet again:"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:1050
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:1038
 #, no-wrap
 msgid ""
-"```maxima\n"
 "load(\"draw\");\n"
 "pngdraw(name,[contents]):=\n"
 "(\n"
@@ -10698,217 +15163,234 @@ msgid ""
 ");\n"
 "pngdraw2d(name,[contents]):=\n"
 "    pngdraw(name,gr2d(contents));\n"
-msgstr ""
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:1055
-#, no-wrap
-msgid ""
+"\n"
 "pngdraw2d(\"Test\",\n"
 "        explicit(sin(x),x,1,10)\n"
 ");\n"
-"```\n"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:1057
-msgid "## Can I set the aspect ratio of an embedded plot?"
-msgstr ""
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:1059
-msgid "Use the variable `wxplot_size`:"
+#. type: Title ##
+#: ../../info/wxmaxima.md:1062
+#, no-wrap
+msgid "Can I set the aspect ratio of an embedded plot?"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:1065
+msgid "Use the variable `wxplot_size`:"
+msgstr ""
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:1066
 #, no-wrap
 msgid ""
-"```maxima\n"
 "wxdraw2d(\n"
 "    explicit(sin(x),x,1,10)\n"
 "),wxplot_size=[1000,1000];\n"
-"```\n"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:1067
-msgid "## After upgrading to MacOS 13.1 plot and/or draw commands output error messages like"
+#. type: Title ##
+#: ../../info/wxmaxima.md:1072
+#, no-wrap
+msgid "After upgrading to MacOS 13.1 plot and/or draw commands output error messages like"
 msgstr ""
 
-#. type: Plain text
+#. type: Fenced code block (text)
 #: ../../info/wxmaxima.md:1074
-msgid "```text 1 HIToolbox 0x00007ff80cd91726 _ZN15MenuBarInstance22EnsureAutoShowObserverEv + 102 2 HIToolbox 0x00007ff80cd912b8 _ZN15MenuBarInstance14EnableAutoShowEv + 52 3 HIToolbox 0x00007ff80cd35908 SetMenuBarObscured + 408 ...  ```"
-msgstr ""
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:1076
-msgid "This might be an issue with the operating system. Disable the hiding of the menu bar (SystemSettings => Desktop & Dock => Menu Bar) might solve the issue. See [wxMaxima issue #1746](https://github.com/wxMaxima-developers/wxmaxima/issues/1746) for more information."
-msgstr ""
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:1078
-msgid "## Logging"
+#, no-wrap
+msgid ""
+"1 HIToolbox 0x00007ff80cd91726 _ZN15MenuBarInstance22EnsureAutoShowObserverEv + 102\n"
+"2 HIToolbox 0x00007ff80cd912b8 _ZN15MenuBarInstance14EnableAutoShowEv + 52\n"
+"3 HIToolbox 0x00007ff80cd35908 SetMenuBarObscured + 408\n"
+"...\n"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:1082
-msgid "Log messages might be helpful to debug problems. WxMaxima can log many events. Most log entries will be helpful for developers, especially in case of problems or bugs. If you run a \"Release\"-Build, the log windows is not shown by default, if you run a development version, it is shown by default as a second window. You can enable and disable this window using the \"View->Toggle log window\" menu entry."
+#, no-wrap
+msgid "This might be an issue with the operating system. Disable the hiding of the menu bar (SystemSettings => Desktop & Dock => Menu Bar) might solve the issue. See [wxMaxima issue #1746](https://github.com/wxMaxima-developers/wxmaxima/issues/1746) for more information.\n"
+msgstr ""
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:1083
+#, no-wrap
+msgid "Logging"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1084
+#: ../../info/wxmaxima.md:1088
+#, no-wrap
+msgid ""
+"Log messages might be helpful to debug problems. WxMaxima can log many events. Most log entries will be helpful for developers, especially in case of problems or bugs. If you run a \"Release\"-Build,\n"
+"the log windows is not shown by default, if you run a development version, it is shown by default as a second window. You can enable and disable\n"
+"this window using the \"View->Toggle log window\" menu entry.\n"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1090
 msgid "Messages are not 'lost', if the log window is not shown, if you select to show the log window later, you will see past log messages (if you did not clear the messages)."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1086
+#: ../../info/wxmaxima.md:1092
 msgid "Such messages may be helpful, when you create bug reports (or trying to find a bug by yourself)."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1089
+#: ../../info/wxmaxima.md:1095
 msgid "Log messages can (additionally) be printed to STDERR, when using the command line option \"--logtostderr\". On Windows a separate text console will be opened, as a Windows GUI application does not have the standard IO connected."
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:1093
-msgid "# FAQ"
+#. type: Title #
+#: ../../info/wxmaxima.md:1098
+#, no-wrap
+msgid "FAQ"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:1095
-msgid "## Is there a way to make more text fit on a LaTeX page?"
-msgstr ""
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:1097
-msgid "Yes. Use the [LaTeX package \"geometry\"](https://ctan.org/pkg/geometry) to specify the size of the borders."
-msgstr ""
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:1099
-msgid "You can add the following line to the LaTeX preamble (for example by using the respective field in the config dialogue (\"Export\"->\"Additional lines for the TeX preamble\"), to set borders of 1cm):"
+#. type: Title ##
+#: ../../info/wxmaxima.md:1100
+#, no-wrap
+msgid "Is there a way to make more text fit on a LaTeX page?"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:1103
-msgid "```latex \\usepackage[left=1cm,right=1cm,top=1cm,bottom=1cm]{geometry} ```"
+msgid "Yes. Use the [LaTeX package \"geometry\"](https://ctan.org/pkg/geometry) to specify the size of the borders."
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:1105
-msgid "## Is there a dark mode?"
+#, no-wrap
+msgid "You can add the following line to the LaTeX preamble (for example by using the respective field in the config dialogue (\"Export\"->\"Additional lines for the TeX preamble\"), to set borders of 1cm):\n"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:1107
-msgid "If wxWidgets is new enough, _wxMaxima_ will automatically be in dark mode if the rest of the operating system is. The worksheet itself is by default equipped with a bright background. But it can be configured otherwise. Alternatively, there is a `View/Invert worksheet brightness` menu entry that allows to quickly convert the worksheet from dark to bright and vice versa."
+#. type: Fenced code block (latex)
+#: ../../info/wxmaxima.md:1106
+#, no-wrap
+msgid "\\usepackage[left=1cm,right=1cm,top=1cm,bottom=1cm]{geometry}\n"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:1109
-msgid "## _WxMaxima_ sometimes hangs for several seconds once in the first minute"
-msgstr ""
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:1111
-msgid "_WxMaxima_ delegates some big tasks like parsing _Maxima_’s >1000-page-manual to background tasks, which normally goes totally unnoticed. At the moment the result of such a task is needed, though, it is possible that _wxMaxima_ needs to wait a couple of seconds before it can continue its work."
+#. type: Title ##
+#: ../../info/wxmaxima.md:1110
+#, no-wrap
+msgid "Is there a dark mode?"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:1113
-msgid "## Especially when testing new locale settings, a message box \"locale ’xx_YY’ can not be set\" occurs"
+msgid "If wxWidgets is new enough, _wxMaxima_ will automatically be in dark mode if the rest of the operating system is. The worksheet itself is by default equipped with a bright background. But it can be configured otherwise. Alternatively, there is a `View/Invert worksheet brightness` menu entry that allows to quickly convert the worksheet from dark to bright and vice versa."
+msgstr ""
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:1114
+#, no-wrap
+msgid "_WxMaxima_ sometimes hangs for several seconds once in the first minute"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1115
+#: ../../info/wxmaxima.md:1117
+#, no-wrap
+msgid "_WxMaxima_ delegates some big tasks like parsing _Maxima_’s >1000-page-manual to background tasks, which normally goes totally unnoticed. At the moment the result of such a task is needed, though, it is possible that _wxMaxima_ needs to wait a couple of seconds before it can continue its work.\n"
+msgstr ""
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:1118
+#, no-wrap
+msgid "Especially when testing new locale settings, a message box \"locale ’xx_YY’ can not be set\" occurs"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1121
 msgid "![Locale warning](./locale-warning.png){ id=img_locale_warning}"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1119
+#: ../../info/wxmaxima.md:1125
 msgid "(The same problem can occur with other applications too). The translations seem okay after you click on ’OK’. WxMaxima does not only use its own translations but the translations of the wxWidgets framework too."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1122
+#: ../../info/wxmaxima.md:1128
 msgid "These locales maybe not present in the system. On Ubuntu/Debian systems they can be generated using: `dpkg-reconfigure locales`"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:1124
-msgid "## How can I use symbols for real numbers, natural numbers (ℝ, ℕ), etc.?"
-msgstr ""
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:1126
-msgid "You can find these symbols in the Unicode sidebar (search for ’double-struck capital’). But the selected font must also support these symbols. If they do not display properly, select another font."
-msgstr ""
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:1128
-msgid "## How can a Maxima script determine, if it is running under wxMaxima or command line Maxima?"
-msgstr ""
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:1130
-msgid "If wxMaxima is used, the Maxima variable `maxima_frontend` is set to `wxmaxima`. The Maxima variable `maxima_frontend_version` contains the wxMaxima version in this case."
+#. type: Title ##
+#: ../../info/wxmaxima.md:1129
+#, no-wrap
+msgid "How can I use symbols for real numbers, natural numbers (ℝ, ℕ), etc.?"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:1132
-msgid "If no frontend is used (you are using command line Maxima), these variables are `false`."
+msgid "You can find these symbols in the Unicode sidebar (search for ’double-struck capital’). But the selected font must also support these symbols. If they do not display properly, select another font."
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:1134
-msgid "## Help! I can not save my document!"
+#. type: Title ##
+#: ../../info/wxmaxima.md:1133
+#, no-wrap
+msgid "How can a Maxima script determine, if it is running under wxMaxima or command line Maxima?"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:1136
-msgid "If saving as wxmx file does not work, try saving the document as wxm file (and vice versa). And you can also try to remove all output (Menu Cell->Remove all output) and save that file, maybe some unexpected output causes issues during the save process."
+msgid "If wxMaxima is used, the Maxima variable `maxima_frontend` is set to `wxmaxima`. The Maxima variable `maxima_frontend_version` contains the wxMaxima version in this case."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1140
-#, fuzzy
-msgid "# Command-line arguments"
-msgstr "Coordenadas x separadas por vírgulas."
+#: ../../info/wxmaxima.md:1138
+msgid "If no frontend is used (you are using command line Maxima), these variables are `false`."
+msgstr ""
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:1139
+#, no-wrap
+msgid "Help! I can not save my document!"
+msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:1142
+#, no-wrap
+msgid "If saving as wxmx file does not work, try saving the document as wxm file (and vice versa). And you can also try to remove all output (Menu Cell->Remove all output) and save that file, maybe some unexpected output causes issues during the save process.\n"
+msgstr ""
+
+#. type: Title #
+#: ../../info/wxmaxima.md:1145
+#, no-wrap
+msgid "Command-line arguments"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1148
 msgid "Usually you can start programs with a graphical user interface just by clicking on a desktop icon or desktop menu entry. WxMaxima - if started from the command line - still provides some command-line switches, though."
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:1158
+#: ../../info/wxmaxima.md:1164
 msgid "`-v` or `--version`: Output the version information"
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:1158
+#: ../../info/wxmaxima.md:1164
 msgid "`-h` or `--help`: Output a short help text"
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:1158
+#: ../../info/wxmaxima.md:1164
 msgid "`-o` or `--open=<str>`: Open the filename given as an argument to this command-line switch"
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:1158
+#: ../../info/wxmaxima.md:1164
 msgid "`-e` or `--eval`: Evaluate the file after opening it."
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:1158
+#: ../../info/wxmaxima.md:1164
 msgid "`-b` or `--batch`: If the command-line opens a file all cells in this file are evaluated and the file is saved afterward. This is for example useful if the session described in the file makes _Maxima_ generate output files. Batch-processing will be stopped if _wxMaxima_ detects that _Maxima_ has output an error and will pause if _Maxima_ has a question: Mathematics is somewhat interactive by nature so a completely interaction-free batch processing cannot always be guaranteed."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1158
+#: ../../info/wxmaxima.md:1164
 #, no-wrap
 msgid ""
 "- `--logtostderr`:                 Log all \"debug messages\" sidebar messages to stderr, too.\n"
@@ -10924,44 +15406,169 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1160
+#: ../../info/wxmaxima.md:1166
 msgid "Instead of a minus, some operating systems might use a dash in front of the command-line switches."
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:1164
-msgid "# About the program, contributing to wxMaxima"
-msgstr ""
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:1166
-msgid "wxMaxima is mainly developed using the programming language C++ using the [wxWidgets framework](https://www.wxwidgets.org), as build system we use [CMake](https://www.cmake.org), a small part is written in Lisp. You can contribute to wxMaxima, join the wxMaxima project at <https://github.com/wxMaxima-developers/wxmaxima>, if you have knowledge of these programming languages and want to help and contribute to the open source project wxMaxima."
-msgstr ""
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:1168
-msgid "But not only programmers are necessary! You can also contribute to wxMaxima, if you help to improve the documentation, find and report bugs (and maybe bugfixes), suggest new features, help to translate wxMaxima or the manual to your language (read the README.md in the [locale subdirectory](https://github.com/wxMaxima-developers/wxmaxima/tree/main/locales) how wxMaxima and the manual can be translated)."
-msgstr ""
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:1170
-msgid "Or answer questions of other users in the discussion forum."
+#. type: Title #
+#: ../../info/wxmaxima.md:1169
+#, no-wrap
+msgid "About the program, contributing to wxMaxima"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:1172
-msgid "The source code of wxMaxima is documented using Doxygen [here](https://wxmaxima-developers.github.io/wxmaxima/Doxygen-documentation/)."
+msgid "wxMaxima is mainly developed using the programming language C++ using the [wxWidgets framework](https://www.wxwidgets.org), as build system we use [CMake](https://www.cmake.org), a small part is written in Lisp. You can contribute to wxMaxima, join the wxMaxima project at <https://github.com/wxMaxima-developers/wxmaxima>, if you have knowledge of these programming languages and want to help and contribute to the open source project wxMaxima."
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:1174
+msgid "But not only programmers are necessary! You can also contribute to wxMaxima, if you help to improve the documentation, find and report bugs (and maybe bugfixes), suggest new features, help to translate wxMaxima or the manual to your language (read the README.md in the [locale subdirectory](https://github.com/wxMaxima-developers/wxmaxima/tree/main/locales) how wxMaxima and the manual can be translated)."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1176
+msgid "Or answer questions of other users in the discussion forum."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1178
+msgid "The source code of wxMaxima is documented using Doxygen [here](https://wxmaxima-developers.github.io/wxmaxima/Doxygen-documentation/)."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1180
 msgid "The program is nearly self-contained, so except for system libraries (and the wxWidgets library), no external dependencies (like graphic files or the Lisp part (the `wxmathML.lisp`-file) is needed, these files are included in the executable."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1175
-msgid "If you are a developer, you might want to try out a modified `wxmathML.lisp`-file without recompiling everything, one can use the command line option `--wxmathml-lisp=<str>` to use another Lisp file, not the included one."
+#: ../../info/wxmaxima.md:1181
+#, no-wrap
+msgid "If you are a developer, you might want to try out a modified `wxmathML.lisp`-file without recompiling everything, one can use the command line option `--wxmathml-lisp=<str>` to use another Lisp file, not the included one.\n"
 msgstr ""
+
+#, fuzzy
+#~ msgid "1×n Matrix b:"
+#~ msgstr "Matriz:"
+
+#, fuzzy
+#~ msgid "Calculate variation"
+#~ msgstr "Calcular produtos"
+
+#, fuzzy
+#~ msgid "Hide All Toolbars\tAlt+Shift+-"
+#~ msgstr "Esconder todos\tAlt+Shift+-"
+
+#, fuzzy
+#~ msgid "Integrate numerically"
+#~ msgstr "Integrar (risch)"
+
+#, fuzzy
+#~ msgid "Load a list from a csv file"
+#~ msgstr "Carregar um arquivo de pacote Maxima"
+
+#, fuzzy
+#~ msgid "Main Toolbar\tAlt+Shift+B"
+#~ msgstr "Barra de ferramentas\tAlt+Shift+T"
+
+#, fuzzy
+#~ msgid "Multivariate linear regression"
+#~ msgstr "Regressão linear..."
+
+#~ msgid "Parts of the document will not be loaded correctly!"
+#~ msgstr "Partes do documento não serão carregadas corretamente!"
+
+#, fuzzy
+#~ msgid "Read List from csv file..."
+#~ msgstr "Ler estilo de um arquivo"
+
+#, fuzzy, c-format
+#~ msgid ""
+#~ "You have version %s. The newest version source code is available for is %s.\n"
+#~ "\n"
+#~ "Select OK to visit the wxMaxima webpage."
+#~ msgstr ""
+#~ "Você tem a versão %s. A versão atual é %s.\n"
+#~ "\n"
+#~ "Selecione OK para visitar a página do wxMaxima."
+
+#, fuzzy
+#~| msgid "Welcome to wxMaxima"
+#~ msgid "# Introduction to wxMaxima"
+#~ msgstr "Bem-vindo ao wxMaxima"
+
+#, fuzzy
+#~| msgid "&Maxima"
+#~ msgid "### _Maxima_"
+#~ msgstr "&Maxima"
+
+#, fuzzy
+#~| msgid "&Maxima"
+#~ msgid "### WxMaxima"
+#~ msgstr "&Maxima"
+
+#, fuzzy
+#~| msgid "Merge Cells"
+#~ msgid "### Cells"
+#~ msgstr "Mesclar células"
+
+#, fuzzy
+#~ msgid "#### Greek characters"
+#~ msgstr "Constantes gregas"
+
+#, fuzzy
+#~ msgid "## File Formats"
+#~ msgstr "Arquivo não encontrado"
+
+#, fuzzy
+#~| msgid "Set fixed font in text controls."
+#~ msgid "### Match parenthesis in text controls"
+#~ msgstr "Usa fonte monoespaçada nos controles de texto."
+
+#, fuzzy
+#~| msgid "Show defined variables"
+#~ msgid "## Subscripted variables"
+#~ msgstr "Mostrar variáveis definidas"
+
+#, fuzzy
+#~| msgid "Expression"
+#~ msgid "#### Expression"
+#~ msgstr "Expressão"
+
+#, fuzzy
+#~| msgid "Parametric plot"
+#~ msgid "#### Parametric plot"
+#~ msgstr "Gráfico paramétrico"
+
+#, fuzzy
+#~ msgid "#### Points"
+#~ msgstr "Ponto:"
+
+#, fuzzy
+#~ msgid "#### Plot name"
+#~ msgstr "Lista:"
+
+#, fuzzy
+#~ msgid "#### Grid"
+#~ msgstr "Grade:"
+
+#, fuzzy
+#~ msgid "## Special variables wx..."
+#~ msgstr "Apagar uma variável"
+
+#, fuzzy
+#~ msgid "## Output rendering."
+#~ msgstr "Cadeias de caracteres"
+
+#, fuzzy
+#~ msgid "## Cannot connect to _Maxima_"
+#~ msgstr ""
+#~ "\n"
+#~ "Não conectado."
+
+#, fuzzy
+#~ msgid "# Command-line arguments"
+#~ msgstr "Coordenadas x separadas por vírgulas."
 
 #, fuzzy
 #~ msgid "Killing Maxima."
@@ -10999,22 +15606,6 @@ msgstr ""
 #~ "Verifique se você tem suporte a rede\n"
 #~ "habilitado e tente novamente!"
 
-#, fuzzy
-#~ msgid "Maxima version: "
-#~ msgstr ""
-#~ "\n"
-#~ "Versão do Maxima: "
-
-#, fuzzy
-#~ msgid "Maxima was compiled using: "
-#~ msgstr ""
-#~ "\n"
-#~ "Versão do Maxima: "
-
-#, fuzzy
-#~ msgid "wxMaxima is a cross-platform graphical user interface for the computer algebra system Maxima based on wxWidgets.\n"
-#~ msgstr "O wxMaxima é uma interface baseada no wxWidgets para o sistema de álgebra computacional MAXIMA."
-
 #~ msgid ""
 #~ "\n"
 #~ "\n"
@@ -11030,42 +15621,8 @@ msgstr ""
 #~ msgstr "sim"
 
 #, fuzzy
-#~ msgid "\"Numpad Enter\" always evaluates cells"
-#~ msgstr "Enter calcula células"
-
-#~ msgid "(Use default language)"
-#~ msgstr "(Usar idioma padrão)"
-
-#~ msgid "A 'horizontal cursor' was introduced in wxMaxima 0.8.0. It looks like a horizontal line between cells. It indicates where a new cell will appear if you type or paste text or execute a menu command."
-#~ msgstr "Um 'cursor horizontal' foi introduzido no wxMaxima 0.8.0. Ele é mostrado como uma linha horizontal entre células. Ele mostra onde uma nova célula vai aparecer se você digitar ou colar texto, ou se executar um comando do menu."
-
-#, fuzzy
-#~ msgid "A new document format has been introduced in wxMaxima 0.8.2 that saves not only your input and text commentaries, but also the outputs of your calculations. When saving your document, select 'Whole document (*.wxmx)' format."
-#~ msgstr "Um novo formato de documento foi introduzido no wxMaxima 0.8.2 que salva não só a entrada e os comentários textuais, mas também as saídas dos cálculos. Quando salvar o documento, selecione o formato 'Documento XML do wxMaxima'."
-
-#~ msgid "Additional parameters for Maxima (e.g. -l clisp)."
-#~ msgstr "Parâmetros adicionais para o Maxima (p.ex. -l clisp)."
-
-#, fuzzy
 #~ msgid "Additional parameters for maxima"
 #~ msgstr "Parâmetros adicionais:"
-
-#, fuzzy
-#~ msgid "All variable names"
-#~ msgstr "Variável antiga:"
-
-#~ msgid "All|*"
-#~ msgstr "Todos|*"
-
-#~ msgid "Ask to save untitled documents"
-#~ msgstr "Pedir salvamento de documentos sem título"
-
-#, fuzzy
-#~ msgid "Auto-insert closing parenthesis"
-#~ msgstr "Parêntesis aos pares nos controles de texto"
-
-#~ msgid "Barsplot..."
-#~ msgstr "Gráfico de barras..."
 
 #~ msgid "Bat files (*.bat)|*.bat|All|*"
 #~ msgstr "Arquivos de lote (*.bat)|*.bat|Todos|*"
@@ -11073,221 +15630,6 @@ msgstr ""
 #, fuzzy
 #~ msgid "Bat files (*.bat)|*.bat|Exe files (*.exe)||All|*"
 #~ msgstr "Arquivos de lote (*.bat)|*.bat|Todos|*"
-
-#~ msgid "Bold"
-#~ msgstr "Negrito"
-
-#~ msgid "Boxplot..."
-#~ msgstr "Gráfico de caixa..."
-
-#, fuzzy
-#~ msgid "By default, Shift-Enter is used to evaluate commands, while Enter is used for multiline input. This behaviour can be changed in 'Edit->Configure' dialog by checking 'Enter evaluates cells'. This switches the roles of these two key commands."
-#~ msgstr "Por padrão Shift+Enter é usado para avaliar comandos, e Enter é usado para entrada de múltiplas linhas. Ese comportamento pode ser alterado na janela 'Editar->Configurações' marcando 'Enter calcula células'. Essa opção inverte as ações das duas teclas."
-
-#~ msgid "Canonical (tr)"
-#~ msgstr "Forma canônica (tr)"
-
-#~ msgid "Catalan"
-#~ msgstr "Catalão"
-
-#, fuzzy
-#~ msgid "ChangeLog"
-#~ msgstr "Mudar variável"
-
-#~ msgid "Choose font"
-#~ msgstr "Escolher fonte"
-
-#, fuzzy
-#~ msgid "Choose the %s Font"
-#~ msgstr "Escolher fonte"
-
-#, fuzzy
-#~ msgid "Clear the selection"
-#~ msgstr "Cortar seleção"
-
-#~ msgid "Config file (*.ini)|*.ini"
-#~ msgstr "Arquivo de configuração (*.ini)|*.ini"
-
-#, fuzzy
-#~ msgid "Convert to Heading 5"
-#~ msgstr "Converter para &gama"
-
-#, fuzzy
-#~ msgid "Convert to Heading 6"
-#~ msgstr "Converter para &gama"
-
-#, fuzzy
-#~ msgid "Convert to Section"
-#~ msgstr "Converter para forma &retangular"
-
-#, fuzzy
-#~ msgid "Convert to Sub-Subsection"
-#~ msgstr "Inserir célula de subseção"
-
-#, fuzzy
-#~ msgid "Convert to Subsection"
-#~ msgstr "Converter para forma &retangular"
-
-#, fuzzy
-#~ msgid "Convert to Title"
-#~ msgstr "Converter para &fatoriais"
-
-#~ msgid "Czech"
-#~ msgstr "Tcheco"
-
-#~ msgid "Danish"
-#~ msgstr "Dinamarquês"
-
-#, fuzzy
-#~ msgid "Default port for communication with wxMaxima:"
-#~ msgstr "A porta padrão usada para comunicação entre o Maxima e o wxMaxima."
-
-#~ msgid "Deviation..."
-#~ msgstr "Desvio..."
-
-#~ msgid "Diff..."
-#~ msgstr "Derivar..."
-
-#, fuzzy
-#~ msgid "Display"
-#~ msgstr "Alternar exibição do &tempo"
-
-#, fuzzy
-#~ msgid "Display all digits"
-#~ msgstr "Algoritmo de exibição"
-
-#~ msgid "English"
-#~ msgstr "Inglês"
-
-#~ msgid "Enter Matrix..."
-#~ msgstr "&Introduzir matriz..."
-
-#, fuzzy
-#~ msgid "Enter adds newlines, Ctrl+Enter evaluates cells"
-#~ msgstr "Enter calcula células"
-
-#, fuzzy
-#~ msgid "Enter evaluates cells, Ctrl+Enter adds newlines"
-#~ msgstr "Enter calcula células"
-
-#~ msgid "Enter the path to the Maxima executable."
-#~ msgstr "Informe o caminho para o executável Maxima."
-
-#, fuzzy
-#~ msgid "Environment variables for maxima"
-#~ msgstr "Parâmetros adicionais:"
-
-#, fuzzy
-#~ msgid "Epsilon"
-#~ msgstr "Epsilon:"
-
-#, fuzzy
-#~ msgid "Evaluate"
-#~ msgstr "Avaliar célula(s)"
-
-#~ msgid "Example text"
-#~ msgstr "Texto de exemplo"
-
-#~ msgid "Expand"
-#~ msgstr "Expandir"
-
-#~ msgid "Expand (tr)"
-#~ msgstr "Expandir (tr)"
-
-#, fuzzy
-#~ msgid "Export As"
-#~ msgstr "Exportar"
-
-#, fuzzy
-#~ msgid "Export all settings"
-#~ msgstr "Exportação para TeX falhou!"
-
-#, fuzzy
-#~ msgid "Export equations to HTML as:"
-#~ msgstr "Exportação para HTML falhou!"
-
-#, fuzzy
-#~ msgid "Export the style settings"
-#~ msgstr "Exportação para TeX falhou!"
-
-#, fuzzy
-#~ msgid "Exporting to .mac file failed!"
-#~ msgstr "Exportação para TeX falhou!"
-
-#~ msgid "Factor"
-#~ msgstr "Fatorar"
-
-#, fuzzy
-#~ msgid "Find:"
-#~ msgstr "Localizar"
-
-#, fuzzy
-#~ msgid "Finnish"
-#~ msgstr "Dinamarquês"
-
-#~ msgid "Fixed font in text controls"
-#~ msgstr "Fonte monoespaçada nos controles de texto"
-
-#~ msgid "Fonts"
-#~ msgstr "Fontes"
-
-#~ msgid "French"
-#~ msgstr "Francês"
-
-#~ msgid "Galician"
-#~ msgstr "Galego"
-
-#~ msgid "German"
-#~ msgstr "Alemão"
-
-#~ msgid "Greek"
-#~ msgstr "Grego"
-
-#, fuzzy
-#~ msgid "Hide"
-#~ msgstr "Dividir célula"
-
-#, fuzzy
-#~ msgid "Highlight the matching parenthesis"
-#~ msgstr "Parêntesis aos pares nos controles de texto"
-
-#~ msgid "Histogram..."
-#~ msgstr "Histograma..."
-
-#~ msgid "Horizontal cursor works like a normal cursor, but it operates on cells: press up or down arrow to move it, holding down Shift while moving will select cells, pressing backspace or delete twice will delete a cell next to it."
-#~ msgstr "O cursor horizontal funciona como um cursor normal, mas ele opera em células: pressione as setas para cima ou para baixo para movê-lo; segure Shift enquanto move para selecionar células; pressione Backspace ou Delete duas vezes apaga a célula próxima ao cursor."
-
-#~ msgid "Hungarian"
-#~ msgstr "Húngaro"
-
-#~ msgid "If your calculation is taking too long to evaluate, you can try 'Maxima->Interrupt' or 'Maxima->Restart Maxima' menu commands."
-#~ msgstr "Se seu cálculo está demorando de mais para executar, você pode tentar os menus 'Maxima->Interromper' ou 'Maxima->Reiniciar o Maxima'."
-
-#~ msgid "Image"
-#~ msgstr "Imagem"
-
-#, fuzzy
-#~ msgid "Import+Export"
-#~ msgstr "Exportar"
-
-#~ msgid "Infinity"
-#~ msgstr "Infinito"
-
-#, fuzzy
-#~ msgid "Integral sign"
-#~ msgstr "Integrar expressão"
-
-#, fuzzy
-#~ msgid "Intelligently hide cell brackets"
-#~ msgstr "Marcador da célula ativa"
-
-#, fuzzy
-#~ msgid "Interaction"
-#~ msgstr "Direção:"
-
-#, fuzzy
-#~ msgid "Internal"
-#~ msgstr "Integrar"
 
 #~ msgid ""
 #~ "Invalid entry for Maxima program.\n"
@@ -11298,377 +15640,12 @@ msgstr ""
 #~ "\n"
 #~ "Por favor informe o caminho do programa Maxima novamente."
 
-#~ msgid "Italian"
-#~ msgstr "Italiano"
-
-#~ msgid "Italic"
-#~ msgstr "Itálico"
-
-#~ msgid "Japanese"
-#~ msgstr "Japonês"
-
-#~ msgid "Keep percent sign with special symbols: %e, %i, etc."
-#~ msgstr "Manter símbolo de percentual com símbolos especiais: %e, %i, etc."
-
-#~ msgid "Language used for wxMaxima GUI."
-#~ msgstr "Idioma usada para a interface do wxMaxima."
-
-#~ msgid "Language:"
-#~ msgstr "Idioma:"
-
-#~ msgid "Least Squares Fit..."
-#~ msgstr "Mínimos quadrados..."
-
-#~ msgid "Limit..."
-#~ msgstr "Limite..."
-
-#~ msgid "Linear Regression..."
-#~ msgstr "Regressão linear..."
-
-#, fuzzy
-#~ msgid "List of labels"
-#~ msgstr "Rótulos de entrada"
-
-#~ msgid "Load"
-#~ msgstr "Carregar"
-
-#~ msgid "Load style from file"
-#~ msgstr "Ler estilo de um arquivo"
-
-#, fuzzy
-#~ msgid "Match Case"
-#~ msgstr "Arquivo batch (de lote)"
-
-#, fuzzy
-#~ msgid "Maxima Location"
-#~ msgstr "Questões do Maxima"
-
-#, fuzzy
-#~ msgid "Maxima configuration"
-#~ msgstr "Configuração do wxMaxima"
-
-#~ msgid "Maxima program:"
-#~ msgstr "Programa Maxima:"
-
-#, fuzzy
-#~ msgid "Maxima session (*.mac)|*.mac"
-#~ msgstr "Pacote Maxima (*.mac)|*.mac"
-
-#, fuzzy
-#~ msgid "Maxima usage"
-#~ msgstr "Ícone do wxMaxima"
-
-#, fuzzy
-#~ msgid ""
-#~ "Maxima uses ':=' to define functions, e.g.:\n"
-#~ "f(x) := x^2;"
-#~ msgstr "O Maxima usa ':' para atribuir valores ('a : 3;') e ':=' para definir funções ('f(x) := x^2;')."
-
-#~ msgid "Mean Difference Test..."
-#~ msgstr "Teste de diferença entre médias..."
-
-#~ msgid "Mean Test..."
-#~ msgstr "Teste de média..."
-
-#~ msgid "Mean..."
-#~ msgstr "Média..."
-
-#~ msgid "Median..."
-#~ msgstr "Mediana..."
-
-#, fuzzy
-#~ msgid "Misc settings"
-#~ msgstr "Exportação para TeX falhou!"
-
-#~ msgid "Normality Test..."
-#~ msgstr "Teste de normalidade..."
-
-#~ msgid "Open a cell when Maxima expects input"
-#~ msgstr "Abrir uma célula quando o Maxima espera entrada"
-
-#, fuzzy
-#~ msgid "Parametric Plot"
-#~ msgstr "Gráfico paramétrico"
-
-#~ msgid "Piechart..."
-#~ msgstr "Gráfico de torta..."
-
-#~ msgid "Please restart wxMaxima for changes to take effect!"
-#~ msgstr "Queira reiniciar o wxMaxima para as mudanças terem efeito!"
-
-#~ msgid "Polish"
-#~ msgstr "Polonês"
-
-#~ msgid "Portuguese (Brazilian)"
-#~ msgstr "Português (Brasileiro)"
-
-#, fuzzy
-#~ msgid "Print Margins"
-#~ msgstr "Imprimir"
-
-#, fuzzy
-#~ msgid "Print scale:"
-#~ msgstr "Imprimir documento"
-
-#, fuzzy
-#~ msgid "Printout settings"
-#~ msgstr "Exportação para TeX falhou!"
-
-#, fuzzy
-#~ msgid "Privacy settings"
-#~ msgstr "Exportação para TeX falhou!"
-
-#, fuzzy
-#~ msgid "Product sign"
-#~ msgstr "Produto"
-
-#~ msgid "Read Matrix..."
-#~ msgstr "Ler matriz..."
-
-#, fuzzy
-#~ msgid "Read config to file"
-#~ msgstr "Salvar seleção para arquivo"
-
-#~ msgid "Rectform"
-#~ msgstr "Forma ret"
-
-#~ msgid "Reduce (tr)"
-#~ msgstr "Reduzir (tr)"
-
-#, fuzzy
-#~ msgid "Reloading the styles from disc"
-#~ msgstr "Ler estilo de um arquivo"
-
-#, fuzzy
-#~ msgid "Replace All"
-#~ msgstr "Selecionar tudo"
-
-#, fuzzy
-#~ msgid "Revert changes"
-#~ msgstr "Desfazer última alteração"
-
-#, fuzzy
-#~ msgid "Right"
-#~ msgstr "direita"
-
-#~ msgid "Russian"
-#~ msgstr "Russo"
-
-#, fuzzy
-#~ msgid "Save config to file"
-#~ msgstr "Salvar seleção para arquivo"
-
-#~ msgid "Save style to file"
-#~ msgstr "Salvar estilo para um arquivo"
-
-#~ msgid "Scatterplot..."
-#~ msgstr "Gráfico de dispersão..."
-
-#, fuzzy
-#~ msgid "Select"
-#~ msgstr "Seleção"
-
 #~ msgid "Select Maxima program"
 #~ msgstr "Selecione o programa Maxima"
 
 #, fuzzy
-#~ msgid "Selecting a part of an output and right-clicking on the selection will bring up a menu with convenient functions that will operate on the selection."
-#~ msgstr "Selecionar uma parte da saída e clicar com o botão direito na seleção traz um menu com funções convenientes que operam na seleção."
-
-#, fuzzy
-#~ msgid "Show labels:"
-#~ msgstr "Mostrar &variáveis"
-
-#~ msgid "Show long expressions in wxMaxima document."
-#~ msgstr "Mostrar expressões grandes no documento do wxMaxima."
-
-#, fuzzy
-#~ msgid "Show long expressions:"
-#~ msgstr "Mostrar expressões longas"
-
-#, fuzzy
 #~ msgid "Show section numbers"
 #~ msgstr "Mostrar &funções"
-
-#, fuzzy
-#~ msgid "Simple"
-#~ msgstr "Amostra:"
-
-#~ msgid "Simplify"
-#~ msgstr "Simplificar"
-
-#~ msgid "Simplify (r)"
-#~ msgstr "Simplificar (r)"
-
-#~ msgid "Simplify (tr)"
-#~ msgstr "Simplificar (tr)"
-
-#, fuzzy
-#~ msgid "Since wxMaxima 0.8.2 you can also insert images into your documents. Use 'Cell->Insert Image...' menu command."
-#~ msgstr "Desde o wxMaxima 0.8.2 você pode inserir imagens nos documentos. Use o menu 'Célula->Inserir imagem...'. Note que você precisa salvar o documento no formato 'Documento XML do wxMaxima' para que a imagem seja salva junto com o documento."
-
-#~ msgid "Solve ODE..."
-#~ msgstr "Resolver EDO..."
-
-#~ msgid "Spanish"
-#~ msgstr "Espanhol"
-
-#, fuzzy
-#~ msgid "Standard Options"
-#~ msgstr "Opções"
-
-#~ msgid "Style"
-#~ msgstr "Estilo"
-
-#~ msgid "Styles"
-#~ msgstr "Estilos"
-
-#~ msgid "Subsample..."
-#~ msgstr "Subamostra..."
-
-#~ msgid "Subst..."
-#~ msgstr "Substituir..."
-
-#, fuzzy
-#~ msgid "Text Only"
-#~ msgstr "Célula de texto"
-
-#~ msgid "The default port used for communication between Maxima and wxMaxima."
-#~ msgstr "A porta padrão usada para comunicação entre o Maxima e o wxMaxima."
-
-#~ msgid "Title, section and subsection cells can be folded to hide their contents. To fold or unfold, click in the square next to the cell. If you shift-click, all sublevels of that cell will also fold/unfold."
-#~ msgstr "Células de título, seção e subseção podem ser recolhidas para ocultar seu conteúdo. Para recolher ou expandir, clique no quadrado próximo à celula. Se você segurar Shift enquanto clica, todos os subníveis daquela célula também serão recolhidos/expandidos."
-
-#~ msgid "To plot in polar coordinates, select 'set polar' in the Options entry for Plot2d dialog. You can also plot in spherical and cylindrical coordinates in 3D."
-#~ msgstr "Para fazer gráficos em coordenadas polares, selecione 'Polar' em Opções na janela de gráficos bidimensionais. Você também pode fazer gráficos em coordenadas esféricas e cilíndricas em 3D."
-
-#, fuzzy
-#~ msgid "To put parentheses around an expression, select it, and press '(' or ')' depending on where you want the cursor to appear afterwards."
-#~ msgstr "Para inserir parêntesis ao redor de uma expressão, selecione-a e pressione '(' ou ')', dependende de onde você quer que o cursor apareça depois."
-
-#~ msgid "To save the size and position of wxMaxima windows between session, use 'Edit->Configure' dialog."
-#~ msgstr "Para salvar o tamanho e posição da janela do wxMaxima entre sessões, use a janela 'Maxima->Configurações'."
-
-#, fuzzy
-#~ msgid "To start using wxMaxima right away, start typing your command. An input cell should appear. Then press Shift-Enter to evaluate your command."
-#~ msgstr "Para iniciar a usar o wxMaxima, digite o seu comando. Uma célula de entrada deve aparecer. Aperte Shift+Enter para executar seu comando."
-
-#, fuzzy
-#~ msgid "Top"
-#~ msgstr "Até:"
-
-#~ msgid "Ukrainian"
-#~ msgstr "Ucraniano"
-
-#, fuzzy
-#~ msgid "Upsilon"
-#~ msgstr "Epsilon:"
-
-#~ msgid "Use centered dot character for multiplication"
-#~ msgstr "Usar um ponto centralizado para indicar multiplicação"
-
-#, fuzzy
-#~ msgid "Value"
-#~ msgstr "Valor:"
-
-#~ msgid "Variance..."
-#~ msgstr "Variância..."
-
-#~ msgid "When applying functions with one argument from menus, the default argument is '%'. To apply the function to some other value, select it in the document before executing a menu command."
-#~ msgstr "Ao aplicar funções com um argumento a partir dos menus, o argumento padrão é '%'. Para aplicar a função a um outro valor, selecione-o do documento antes de executar o comando do menu."
-
-#, fuzzy
-#~ msgid "Yes"
-#~ msgstr "sim"
-
-#~ msgid "You can access the last output using the variable '%'. You can access the output of previous commands using variables '%on' where n is the number of output."
-#~ msgstr "Você pode acessar a última saída com a variável '%'. Você pode acessar a saída de comandos anteriores usando a variável '%on' onde n é o número da saída."
-
-#~ msgid "You can evaluate your whole document by using 'Cell->Evaluate All Cells' menu command or the appropriate key shortcut. The cells will be evaluated in the order they appear in the document."
-#~ msgstr "Você pode avaliar todo o documento usando o menu 'Célula->Avaliar todas as células' ou a tecla de atalho correspondente. As células serão avalidas na ordem em que aparecem no documento."
-
-#, fuzzy
-#~ msgid "You can get help on a Maxima function by selecting or clicking on the function name and pressing F1. wxMaxima will search the help index for the selection or the word under the cursor."
-#~ msgstr "Você pode obter ajuda sobre uma função do Maxima selecionando-a ou clicando no nome da função e apertando F1. O wxMaxima vai pesquisar no índice da ajuda pela palavra selecionada ou pela palavra onde está o cursor."
-
-#~ msgid "You can hide output part of cells by clicking in the triangle on the left side of cells. This works on text cells also."
-#~ msgstr "Você pode esconder a saída das células clicando no triângulo no lado esquerdo das células. Isso funciona também em células de texto."
-
-#, fuzzy
-#~ msgid "You can insert different types of 'cells' in wxMaxima documents using the 'Cell' menu. Note that only 'input cells' can be evaluated, while others are used for commenting and structuring your calculations."
-#~ msgstr "Você pode inserir diferentes tipos de 'células' num documento do wxMaxima usando o menu 'Célula'. Note que apenas 'células de entrada' são avaliadas, as outras são usadas para comentar ou estruturar seus cálculos."
-
-#~ msgid "You can select multiple cells either with a mouse - click'n'drag from between cells or from a cell bracket on the left - or with a keyboard - hold down Shift while moving the horizontal cursor - and then operate on selection. This comes in handy when you want to delete or evaluate multiple cells."
-#~ msgstr "Você pode selecionar vários células com o mouse - clique e arraste desde algum ponto entre células ou dos marcadores à esquerda - ou com o teclado - segure Shift enquanto move o cursor horizontal - e então operar na seleção. Isso é útil quando você quer apagar ou calcular múltiplas células."
-
-#, fuzzy
-#~ msgid "and"
-#~ msgstr "Expandir"
-
-#, fuzzy
-#~ msgid "epsilon"
-#~ msgstr "Epsilon:"
-
-#, fuzzy
-#~ msgid "greater than or equal"
-#~ msgstr "Célula de subseção"
-
-#, fuzzy
-#~ msgid "in"
-#~ msgstr "Localizar"
-
-#, fuzzy
-#~ msgid "intersection"
-#~ msgstr "Direção:"
-
-#, fuzzy
-#~ msgid "less or equal"
-#~ msgstr "Célula de subseção"
-
-#, fuzzy
-#~ msgid "much greater than"
-#~ msgstr "Célula de subseção"
-
-#, fuzzy
-#~ msgid "nor"
-#~ msgstr "não"
-
-#, fuzzy
-#~ msgid "not"
-#~ msgstr "não"
-
-#, fuzzy
-#~ msgid "partial sign"
-#~ msgstr "Frações parciais"
-
-#, fuzzy
-#~ msgid "subset"
-#~ msgstr "Subseção"
-
-#, fuzzy
-#~ msgid "subset or equal"
-#~ msgstr "Célula de subseção"
-
-#, fuzzy
-#~ msgid "upsilon"
-#~ msgstr "Epsilon:"
-
-#~ msgid "wxMaxima configuration"
-#~ msgstr "Configuração do wxMaxima"
-
-#~ msgid "wxMaxima dialogs set default values for inputs entries, one of which is '%'. If you have made a selection in your document, the selection will be used instead of '%'."
-#~ msgstr "As janelas do wxMaxima têm valores padrão para as entradas, um dos quais é '%'. Se você selecionou algo no documento, a seleção será usada no lugar de '%'."
-
-#, fuzzy
-#~ msgid "wxMaxima startup file location: "
-#~ msgstr "Iniciar animação"
-
-#, fuzzy
-#~ msgid "xor"
-#~ msgstr "Exportar"
-
-#~ msgid "Direction:"
-#~ msgstr "Direção:"
 
 #, fuzzy
 #~ msgid "Lisp files (*.lisp)|*.lisp|All|*"
@@ -11763,9 +15740,6 @@ msgstr ""
 
 #~ msgid "At value"
 #~ msgstr "Valor no ponto"
-
-#~ msgid "BC2"
-#~ msgstr "CC2"
 
 #~ msgid "Char poly"
 #~ msgstr "Polinômio característico"
@@ -11873,184 +15847,11 @@ msgstr ""
 #~ msgid "Save panes layout between sessions."
 #~ msgstr "Salvar layout dos painéis entre sessões."
 
-#, fuzzy
-#~ msgid " samples"
-#~ msgstr "Exemplo"
-
-#, fuzzy
-#~ msgid " times"
-#~ msgstr "Vezes:"
-
-#~ msgid "&Definite integration"
-#~ msgstr "Integração &definida"
-
-#~ msgid "&Nusum"
-#~ msgstr "&Nusum"
-
-#~ msgid "&Rational"
-#~ msgstr "&Racional"
-
-#~ msgid "&Special"
-#~ msgstr "E&special"
-
-#~ msgid "&Taylor series"
-#~ msgstr "Série de &Taylor"
-
-#~ msgid "&pm3d"
-#~ msgstr "&pm3d"
-
-#~ msgid "- Infinity"
-#~ msgstr "- Infinito"
-
-#, fuzzy
-#~ msgid "A function f(a,b), named"
-#~ msgstr "Nomes de funções"
-
-#, fuzzy
-#~ msgid "A page break"
-#~ msgstr "Quebra de página"
-
-#, fuzzy
-#~ msgid "A static plot"
-#~ msgstr "Gráfico paramétrico"
-
-#, fuzzy
-#~ msgid "A sub-subsection heading"
-#~ msgstr "Célula de subseção"
-
-#, fuzzy
-#~ msgid "A subsection heading"
-#~ msgstr "Célula de subseção"
-
-#~ msgid "Browse"
-#~ msgstr "Procurar"
-
-#~ msgid "Choose new plot format:"
-#~ msgstr "Informe novo formato para gráficos:"
-
-#~ msgid "Comma separated x coordinates"
-#~ msgstr "Coordenadas x separadas por vírgulas."
-
-#~ msgid "Comma separated y coordinates"
-#~ msgstr "Coordenadas y separadas por vírgulas."
-
-#~ msgid "Constant"
-#~ msgstr "Constante"
-
-#, fuzzy
-#~ msgid "Data format"
-#~ msgstr "Formato do gráfico"
-
-#~ msgid "Depth:"
-#~ msgstr "Grau máximo:"
-
-#~ msgid "Discrete plot"
-#~ msgstr "Gráfico discreto"
-
 #~ msgid "Equation %d:"
 #~ msgstr "Equação %d:"
 
-#~ msgid "Figure %d:"
-#~ msgstr "Figura %d:"
-
 #~ msgid "File:"
 #~ msgstr "Arquivo:"
-
-#~ msgid "Format:"
-#~ msgstr "Formato:"
-
-#, fuzzy
-#~ msgid "Frame counter end"
-#~ msgstr "Arquivo não encontrado"
-
-#~ msgid "Grid:"
-#~ msgstr "Grade:"
-
-#~ msgid "Method:"
-#~ msgstr "Método:"
-
-#~ msgid "New value:"
-#~ msgstr "Valor novo:"
-
-#~ msgid "Old value:"
-#~ msgstr "Valor antigo:"
-
-#~ msgid "Options:"
-#~ msgstr "Opções:"
-
-#, fuzzy
-#~ msgid "Plot an explicit expression"
-#~ msgstr "Encontrar o limite de uma expressão"
-
-#~ msgid "Plot to file:"
-#~ msgstr "Gráfico para arquivo:"
-
-#, fuzzy
-#~ msgid "Point type:"
-#~ msgstr "Ponto:"
-
-#, fuzzy
-#~ msgid "Reuse last"
-#~ msgstr "Criar lista"
-
-#~ msgid "Save plot to file"
-#~ msgstr "Salvar gráfico para um arquivo"
-
-#~ msgid "Special"
-#~ msgstr "Especial"
-
-#, fuzzy
-#~ msgid "Start value of the parameter"
-#~ msgstr "Valor float do último resultado"
-
-#~ msgid "Ticks:"
-#~ msgstr "Marcações:"
-
-#, fuzzy
-#~ msgid "Type in text"
-#~ msgstr "Copiar como imagem"
-
-#~ msgid "Use Gosper algorithm"
-#~ msgstr "User algoritmo Gosper"
-
-#~ msgid "antisymmetric"
-#~ msgstr "antisimétrica"
-
-#~ msgid "both sides"
-#~ msgstr "bilateral"
-
-#~ msgid "default"
-#~ msgstr "padrão"
-
-#~ msgid "diagonal"
-#~ msgstr "diagonal"
-
-#~ msgid "general"
-#~ msgstr "geral"
-
-#~ msgid "inline"
-#~ msgstr "embutido"
-
-#~ msgid "left"
-#~ msgstr "esquerda"
-
-#~ msgid "logscale"
-#~ msgstr "escala logarítmica"
-
-#~ msgid "symmetric"
-#~ msgstr "simétrica"
-
-#, fuzzy
-#~ msgid "the x and the y coordinate."
-#~ msgstr "Coordenadas y separadas por vírgulas."
-
-#, fuzzy
-#~ msgid "Complex infinity."
-#~ msgstr "Simplificação &complexa"
-
-#, fuzzy
-#~ msgid "The inverse laplace transform."
-#~ msgstr "T&ransformada inversa de Laplace..."
 
 #~ msgid "Greek constants"
 #~ msgstr "Constantes gregas"
@@ -12098,9 +15899,6 @@ msgstr ""
 #~ msgstr ""
 #~ "\n"
 #~ "Lisp: "
-
-#~ msgid "wxMaxima document (*.wxm, *.wxmx)|*.wxm;*.wxmx"
-#~ msgstr "Documento do wxMaxima (*.wxm, *.wxmx)|*.wxm;*.wxmx"
 
 #~ msgid "&Interrupt\tCtrl+."
 #~ msgstr "&Interromper\tCtrl+."

--- a/locales/wxMaxima/ru.po
+++ b/locales/wxMaxima/ru.po
@@ -54,23 +54,23 @@ msgstr "\n"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1569
 msgid "      -X \"--control-stack-size <int>\""
-msgstr ""
+msgstr "      -X \"--control-stack-size <int>\""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1568
 msgid "      -X \"--dynamic-space-size <int>\""
-msgstr ""
+msgstr "      -X \"--dynamic-space-size <int>\""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1572
 msgid "      -X '--control-stack-size <int>'"
-msgstr ""
+msgstr "      -X '--control-stack-size <int>'"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1571
 msgid "      -X '--dynamic-space-size <int>'"
-msgstr ""
+msgstr "      -X '--dynamic-space-size <int>'"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1551
 msgid "      -l <name>"
-msgstr ""
+msgstr "      -l <name>"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1557
 msgid "      -u <versionnumber>"
@@ -168,7 +168,7 @@ msgstr " (Формат файла (WXM версии 1, первая строка
 #: ../../src/cells/ImgCell.cpp:212 ../../src/cells/ImgCell.cpp:214
 #: ../../src/cells/ImgCell.cpp:216
 msgid " (Graphics) "
-msgstr ""
+msgstr " (графика) "
 
 #: ../../src/cells/EditorCell.cpp:3551 ../../src/cells/EditorCell.cpp:3820
 #: ../../src/cells/EditorCell.cpp:3945
@@ -178,7 +178,7 @@ msgstr ""
 
 #: ../../src/cells/EditorCell.cpp:3553
 msgid " ... + 1 hidden line"
-msgstr ""
+msgstr " ... + 1 скрытая строка"
 
 #: ../../src/dialogs/TipOfTheDay.cpp:273
 msgid " Did you know? "
@@ -194,15 +194,15 @@ msgstr " Неверно, если a является комплексным"
 
 #: ../../src/wizards/DrawWiz.cpp:964 ../../src/wizards/DrawWiz.cpp:980
 msgid " samples"
-msgstr ""
+msgstr " выборок"
 
 #: ../../src/wizards/DrawWiz.cpp:929 ../../src/wizards/DrawWiz.cpp:945
 msgid " samples, on demand split "
-msgstr ""
+msgstr " выборок, разделение по запросу "
 
 #: ../../src/wizards/DrawWiz.cpp:933 ../../src/wizards/DrawWiz.cpp:952
 msgid " times"
-msgstr ""
+msgstr " кратно"
 
 #: ../../src/MaximaCommandMenus.cpp:4413
 msgid "\".\" = \"The current directory\"\n"
@@ -217,7 +217,7 @@ msgstr "«..» означает «на один каталог выше»."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1208
 msgid "\"Copy LaTeX\" adds equation markers"
-msgstr ""
+msgstr "«Копировать как LaTeX» добавляет обозначения уравнений"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:446
 msgid "\"MathML (rendered by the browser)\" is the recommended choice: every current browser renders MathML natively and instantly, and the exported page needs no JavaScript and makes no requests to any external server.\n"
@@ -227,11 +227,11 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:930
 msgid "\"Numpad Enter\" always evaluates cells"
-msgstr ""
+msgstr "Всегда выполнять команды в полях по клавише Enter цифрового блока"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:90
 msgid "\"implies\" symbol"
-msgstr ""
+msgstr "символ «из этого следует»"
 
 #: ../../src/dialogs/DiffFrame.cpp:306
 #, c-format
@@ -246,7 +246,7 @@ msgstr "%i полей в очереди на вычисление"
 #: ../../src/sidebars/TableOfContents.cpp:570
 #, c-format
 msgid "%li Levels"
-msgstr ""
+msgstr "%li уровней"
 
 #: ../../src/worksheet/Worksheet.cpp:423
 #, c-format
@@ -318,7 +318,7 @@ msgstr "&Копировать\tCtrl+C"
 
 #: ../../src/wizards/IntegrateWiz.cpp:39
 msgid "&Definite integration"
-msgstr ""
+msgstr "&Определённое интегрирование"
 
 #: ../../src/wxMaximaFrame.cpp:1658
 msgid "&Demoivre"
@@ -434,11 +434,11 @@ msgstr "&Цифровой вывод"
 
 #: ../../src/wizards/IntegrateWiz.cpp:52
 msgid "&Numerical integration"
-msgstr ""
+msgstr "&Численное интегрирование"
 
 #: ../../src/wizards/SumWiz.cpp:44
 msgid "&Nusum"
-msgstr ""
+msgstr "&Суммирование (nusum)"
 
 #: ../../src/main.cpp:675
 msgid "&Open\tCtrl+O"
@@ -454,7 +454,7 @@ msgstr "&Графики"
 
 #: ../../src/wizards/SeriesWiz.cpp:45
 msgid "&Power series"
-msgstr ""
+msgstr "&Степенной ряд"
 
 #: ../../src/wxMaximaFrame.cpp:655
 msgid "&Print...\tCtrl+P"
@@ -462,7 +462,7 @@ msgstr "&Печать...\tCtrl+P"
 
 #: ../../src/wizards/SubstituteWiz.cpp:38
 msgid "&Rational"
-msgstr ""
+msgstr "&Рациональное выражение"
 
 #: ../../src/wxMaximaFrame.cpp:1631
 msgid "&Reduce Trigonometric"
@@ -494,11 +494,11 @@ msgstr "&Решить..."
 
 #: ../../src/wizards/Plot2dWiz.cpp:42
 msgid "&Special"
-msgstr ""
+msgstr "&Дополнительно"
 
 #: ../../src/wizards/LimitWiz.cpp:45
 msgid "&Taylor series"
-msgstr ""
+msgstr "&Ряд Тейлора"
 
 #: ../../src/wxMaximaFrame.cpp:1069
 msgid "&Time Display"
@@ -518,7 +518,7 @@ msgstr "&Переменные"
 
 #: ../../src/wizards/Plot3dWiz.cpp:79
 msgid "&pm3d"
-msgstr ""
+msgstr "&pm3d"
 
 #: ../../src/cells/AnimationCell.cpp:475
 msgid "(Animation)"
@@ -546,15 +546,15 @@ msgstr "(Вероятно, проблема с правами?)"
 
 #: ../../src/sidebars/CharButton.cpp:211
 msgid "(Might not be displayed correctly in at least one of the worksheet fonts)"
-msgstr ""
+msgstr "(Может отображаться некорректно по крайней мере в одном из шрифтов листа)"
 
 #: ../../src/sidebars/VariablesPane.cpp:254
 msgid "(Not a valid variable name)"
-msgstr ""
+msgstr "(Некорректное имя переменной)"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:183
 msgid "(Use default language)"
-msgstr ""
+msgstr "(Использовать язык по умолчанию)"
 
 #: ../../src/MaximaCommandMenus.cpp:440
 msgid "(f(x),x,a,b)), Epsilon algorithm"
@@ -588,7 +588,7 @@ msgstr "(f(x),x,y) с сингулярностями и разрывами"
 #: ../../src/wizards/DrawWiz.cpp:303 ../../src/wizards/DrawWiz.cpp:320
 #: ../../src/wizards/DrawWiz.cpp:335
 msgid "-"
-msgstr ""
+msgstr "-"
 
 #: ../../src/wizards/IntegrateWiz.cpp:192
 #: ../../src/wizards/IntegrateWiz.cpp:202
@@ -596,7 +596,7 @@ msgstr ""
 #: ../../src/wizards/IntegrateWiz.cpp:217 ../../src/wizards/LimitWiz.cpp:132
 #: ../../src/wizards/LimitWiz.cpp:142
 msgid "- Infinity"
-msgstr ""
+msgstr "- Бесконечность"
 
 #: ../../src/MaximaOutputAppender.cpp:116
 msgid "... [suppressed additional lines as the output is longer than allowed in the wxMaxima configuration] "
@@ -608,15 +608,15 @@ msgstr "Данные .wxm в буфере обмена с необычным з�
 
 #: ../../src/sidebars/TableOfContents.cpp:567
 msgid "1 Level"
-msgstr ""
+msgstr "1 уровень"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:77
 msgid "1/2"
-msgstr ""
+msgstr "1/2"
 
 #: ../../src/sidebars/DrawSidebar.cpp:45
 msgid "2D"
-msgstr ""
+msgstr "2D"
 
 #: ../../src/wxMaximaFrame.cpp:1346
 msgid "2D Array to Matrix..."
@@ -640,7 +640,7 @@ msgstr ""
 
 #: ../../src/sidebars/DrawSidebar.cpp:49
 msgid "3D"
-msgstr ""
+msgstr "3D"
 
 #: ../../src/wxMaxima.cpp:1833
 #, c-format
@@ -653,7 +653,7 @@ msgstr "При использовании «:lisp» в качестве перв
 
 #: ../../src/dialogs/TipOfTheDay.cpp:102
 msgid "A 'horizontal cursor' was introduced in wxMaxima 0.8.0. It looks like a horizontal line between cells. It indicates where a new cell will appear if you type or paste text or execute a menu command."
-msgstr ""
+msgstr "Горизонтальный курсор был введён в wxMaxima версии 0.8.0. Он выглядит как горизонтальная линия между полями. Он показывает, где начинается новое поле, когда пользователь вводит или вставляет текст или запускает команду меню."
 
 #: ../../src/MaximaCommandMenus.cpp:3039
 msgid "A Ctrl-F event"
@@ -679,7 +679,7 @@ msgstr "Событие поиска, %s"
 
 #: ../../src/wizards/ListSortWiz.cpp:63
 msgid "A function f(a,b), named"
-msgstr ""
+msgstr "Функция f(a,b), с именем"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:784
 msgid "A function returning integers"
@@ -691,7 +691,7 @@ msgstr "Функция, возвращающая положительные чи
 
 #: ../../src/wizards/DrawWiz.cpp:164
 msgid "A good example equation would be x^2+y^2=1"
-msgstr ""
+msgstr "Пример уравнения: x^2+y^2=1"
 
 #: ../../src/cells/GroupCell.cpp:2193 ../../src/cells/GroupCell.cpp:2196
 msgid "A heading"
@@ -715,15 +715,15 @@ msgstr "Матрица, каждая строка которой являетс�
 
 #: ../../src/dialogs/TipOfTheDay.cpp:84
 msgid "A new document format has been introduced in wxMaxima 0.8.2 that saves not only your input and text commentaries, but also the outputs of your calculations. When saving your document, select 'Whole document (*.wxmx)' format."
-msgstr ""
+msgstr "Новый формат документа был введён в wxMaxima версии 0.8.2. Он позволяет сохранять не только текст и комментарии, но и выводы ваших вычислений. При сохранении документа выбирайте формат «Весь документ (*.wxmx)»."
 
 #: ../../src/cells/GroupCell.cpp:2175
 msgid "A page break"
-msgstr ""
+msgstr "Разрыв страницы"
 
 #: ../../src/dialogs/TipOfTheDay.cpp:168
 msgid "A plot to be embedded into the work sheet by preceding its name with a \"wx\". \"draw\" can be replaced by \"wxdraw\", plot by \"wxplot\" etc."
-msgstr ""
+msgstr "Для добавления графика на лист перед его именем можно использовать префикс «wx». «draw» можно заменить на «wxdraw», «plot» на «wxplot» и так далее."
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:735
 msgid "A rational variable"
@@ -735,7 +735,7 @@ msgstr "Правоассоциативная функция"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:436
 msgid "A scale factor for the printout. Helpful for printing big equations on small pdf pages."
-msgstr ""
+msgstr "Коэффициент масштабирования для распечатки. Полезно при печати больших уравнений на маленьких страницах PDF."
 
 #: ../../src/wxMaximaFrame.cpp:1671
 msgid "A search-and-replace for equations"
@@ -743,27 +743,27 @@ msgstr "Поиск и замена для уравнений"
 
 #: ../../src/cells/EditorCell.cpp:4522 ../../src/cells/GroupCell.cpp:2184
 msgid "A section heading"
-msgstr ""
+msgstr "Заголовок раздела"
 
 #: ../../src/wizards/DrawWiz.cpp:479
 msgid "A static plot"
-msgstr ""
+msgstr "Статический график"
 
 #: ../../src/cells/EditorCell.cpp:4534
 msgid "A sub-sub-sub-subsection heading"
-msgstr ""
+msgstr "Заголовок под-под-под-подраздела"
 
 #: ../../src/cells/EditorCell.cpp:4531
 msgid "A sub-sub-subsection heading"
-msgstr ""
+msgstr "Заголовок под-под-подраздела"
 
 #: ../../src/cells/EditorCell.cpp:4528 ../../src/cells/GroupCell.cpp:2190
 msgid "A sub-subsection heading"
-msgstr ""
+msgstr "Заголовок под-подраздела"
 
 #: ../../src/cells/EditorCell.cpp:4525 ../../src/cells/GroupCell.cpp:2187
 msgid "A subsection heading"
-msgstr ""
+msgstr "Заголовок подраздела"
 
 #: ../../src/wxMaximaFrame.cpp:1673
 msgid "A subst with basic maths knowledge"
@@ -771,7 +771,7 @@ msgstr "subst со знанием базовой математики"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:239
 msgid "A symbol from the configuration dialogue"
-msgstr ""
+msgstr "Символ из диалога настройки"
 
 #: ../../src/cells/GroupCell.cpp:2181
 msgid "A text cell"
@@ -808,7 +808,7 @@ msgstr "Расчёты ASCII"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1618
 msgid "Abort evaluation on error"
-msgstr ""
+msgstr "Прекращать вычисление при ошибке"
 
 #: ../../src/MaximaEvaluator.cpp:214
 #, c-format
@@ -841,7 +841,7 @@ msgstr ""
 
 #: ../../src/sidebars/DrawSidebar.cpp:103
 msgid "Accuracy"
-msgstr ""
+msgstr "Точность"
 
 #: ../../src/wxMaximaFrame.cpp:1405
 msgid "Ad&joint Matrix"
@@ -861,7 +861,7 @@ msgstr "Добавить новый элемент в начало списка.
 
 #: ../../src/sidebars/VariablesPane.cpp:228
 msgid "Add all"
-msgstr ""
+msgstr "Добавить все"
 
 #: ../../src/MaximaCommandMenus.cpp:1621
 msgid "Add an element to the end of a list"
@@ -881,11 +881,11 @@ msgstr "Добавить равенство в упроститель рацио
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:204
 msgid "Add more symbols"
-msgstr ""
+msgstr "Добавить больше символов"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1262
 msgid "Add the .wxmx file to the HTML export"
-msgstr ""
+msgstr "Добавлять файл .wxmx при экспорте в HTML"
 
 #: ../../src/wxMaximaFrame.cpp:1049
 msgid "Add to &Path..."
@@ -893,7 +893,7 @@ msgstr "Добавить к &пути..."
 
 #: ../../src/sidebars/UnicodeSidebar.cpp:105
 msgid "Add to symbols Sidebar"
-msgstr ""
+msgstr "Добавить на боковую панель символов"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:304
 #: ../../src/worksheet/WorksheetContextMenu.cpp:337
@@ -904,23 +904,23 @@ msgstr "Добавить в список отслеживания"
 #: ../../src/sidebars/XmlInspector.cpp:147
 #, c-format
 msgid "Added much text (%li chars) to the XML inspector."
-msgstr ""
+msgstr "В анализатор XML добавлено много текста (%li символов)."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1896
 msgid "Additional clipboard formats to put on the clipboard on ordinary copy"
-msgstr ""
+msgstr "Дополнительные форматы буфера обмена для вставки данных при обычном копировании"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:393
 msgid "Additional commands to be added to the preamble of LaTeX output for pdftex."
-msgstr ""
+msgstr "Дополнительные команды для добавления к преамбуле вывода LaTeX для pdftex."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1187
 msgid "Additional lines for the TeX preamble:"
-msgstr ""
+msgstr "Дополнительные строки для преамбулы TeX:"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:389
 msgid "Additional parameters for Maxima (e.g. -l clisp)."
-msgstr ""
+msgstr "Дополнительные параметры команды Maxima (например, -l clisp)."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1543
 msgid "Additional parameters for Maxima (restart Maxima after changes)"
@@ -928,7 +928,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1318
 msgid "Additional symbols for the \"symbols\" sidebar:"
-msgstr ""
+msgstr "Дополнительные символы для боковой панели символов:"
 
 #: ../../src/wxMaximaFrame.cpp:1599
 msgid "Additionally: log(a*b)=log(a)+log(b)"
@@ -972,7 +972,7 @@ msgstr "Псевдонимы"
 
 #: ../../src/sidebars/TableOfContents.cpp:572
 msgid "All Levels"
-msgstr ""
+msgstr "Все уровни"
 
 #: ../../src/wxMaximaFrame.cpp:1751
 msgid "All but the 1st n elements"
@@ -988,7 +988,7 @@ msgstr "Все типы, которые можно открыть (*.wxm, *.wxmx
 
 #: ../../src/dialogs/ConfigDialogue.cpp:750
 msgid "All variable names"
-msgstr ""
+msgstr "Все имена переменных"
 
 #: ../../src/wxMaximaFrame.cpp:770
 msgid "All visible sidebars"
@@ -1016,7 +1016,7 @@ msgstr ""
 
 #: ../../src/dialogs/BinaryNameCtrl.cpp:69
 msgid "All|*"
-msgstr ""
+msgstr "Все|*"
 
 #: ../../src/wxMaximaFrame.cpp:800
 msgid "Always after underscores"
@@ -1036,7 +1036,7 @@ msgstr "Всегда показывать все цифры"
 
 #: ../../src/wizards/DrawWiz.cpp:484
 msgid "An animation with multiple frames"
-msgstr ""
+msgstr "Анимация из нескольких кадров"
 
 #: ../../src/cells/GroupCell.cpp:2202
 msgid "An image cell"
@@ -1194,7 +1194,7 @@ msgstr "Код ASCII в символ..."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1397
 msgid "Ask to save untitled documents"
-msgstr ""
+msgstr "Выводить запрос на сохранение документов без названия"
 
 #: ../../src/dialogs/MaximaNotStartingDialog.cpp:36
 msgid "Asking the user for the location of a working maxima binary"
@@ -1218,21 +1218,21 @@ msgstr "Внимание! Для длинных списков извлечен�
 
 #: ../../src/dialogs/ConfigDialogue.cpp:897
 msgid "Auto-indent new lines"
-msgstr ""
+msgstr "Автоотступ в новых строках"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:893
 msgid "Auto-insert closing parenthesis"
-msgstr ""
+msgstr "Автоматически вставлять закрывающую скобку"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1441
 #: ../../src/dialogs/ConfigDialogue.cpp:1472
 #: ../../src/dialogs/MaximaNotStartingDialog.cpp:43
 msgid "Autodetect"
-msgstr ""
+msgstr "Определять автоматически"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1236
 msgid "Automatic"
-msgstr ""
+msgstr "Автоматически"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:391
 msgid "Automatic labels"
@@ -1241,7 +1241,7 @@ msgstr "Автоматические метки"
 #: ../../src/dialogs/ConfigDialogue.cpp:769
 #, c-format
 msgid "Automatic labels (%i1, %o1,...)"
-msgstr ""
+msgstr "Автоматические метки (%i1, %o1,...)"
 
 #: ../../src/wxMaximaFrame.cpp:986
 msgid "Automatically answer questions"
@@ -1253,7 +1253,7 @@ msgstr "Автоматически заполнять ответы, извест
 
 #: ../../src/dialogs/ConfigDialogue.cpp:460
 msgid "Automatically insert a closing parenthesis the moment the user enters an opening one."
-msgstr ""
+msgstr "Автоматически вставлять закрывающую скобку при вводе открывающей скобки пользователем."
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:235
 #: ../../src/worksheet/WorksheetContextMenu.cpp:610
@@ -1288,15 +1288,15 @@ msgstr "Автоперевод этой переменной в нижний и�
 
 #: ../../src/dialogs/ConfigDialogue.cpp:734
 msgid "Autowrap long lines:"
-msgstr ""
+msgstr "Автоматический перенос длинных строк:"
 
 #: ../../src/sidebars/DrawSidebar.cpp:75
 msgid "Axis"
-msgstr ""
+msgstr "Ось"
 
 #: ../../src/wizards/BC2Wiz.cpp:59
 msgid "BC2"
-msgstr ""
+msgstr "BC2"
 
 #: ../../src/MaximaManual.cpp:559
 msgid "Background task that compiles the Manual anchors scheduled."
@@ -1304,7 +1304,7 @@ msgstr "Запланирована фоновая задача, которая �
 
 #: ../../src/sidebars/StatSidebar.cpp:91
 msgid "Barsplot..."
-msgstr ""
+msgstr "Столбиковая диаграмма..."
 
 #: ../../src/wxMaximaFrame.cpp:1384
 msgid "Basic matrix operations"
@@ -1343,27 +1343,27 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:141
 msgid "Besides the global undo functionality that is active when the cursor is between cells, wxMaxima has a per-cell undo function that is active if the cursor is inside a cell. Pressing Ctrl+Z inside a cell can therefore been used for a fine-pitch undo that doesn't affect latter changes made in other cells."
-msgstr ""
+msgstr "Помимо функциональности глобальной отмены (работает, когда курсор находится между полями), wxMaxima предоставляет возможность выполнения отмены в отдельных полях (работает, когда курсор находится внутри поля). Если нажать комбинацию клавиш Ctrl+Z, когда курсор находится внутри поля, можно выполнить «малую» операцию отмены, которая не затронет изменения, сделанные в других полях."
 
 #: ../../src/sidebars/GreekSidebar.cpp:179
 msgid "Beta"
-msgstr ""
+msgstr "Β"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1898
 msgid "Bitmap"
-msgstr ""
+msgstr "Растр"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1273
 msgid "Bitmap scale for export:"
-msgstr ""
+msgstr "Масштаб растрового рисунка для экспорта:"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1223
 msgid "Bitmaps"
-msgstr ""
+msgstr "Растровые изображения"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2109
 msgid "Bold"
-msgstr ""
+msgstr "Жирный"
 
 #: ../../src/wxMaxima.cpp:2259
 msgid "Both horizontal and vertical cursor active at the same time"
@@ -1371,7 +1371,7 @@ msgstr "Одновременно активны и горизонтальный,
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1999
 msgid "Bottom"
-msgstr ""
+msgstr "Снизу"
 
 #: ../../src/MaximaCommandMenus.cpp:1381
 msgid "Bottom end"
@@ -1387,13 +1387,13 @@ msgstr ""
 
 #: ../../src/sidebars/StatSidebar.cpp:97
 msgid "Boxplot..."
-msgstr ""
+msgstr "Коробчатая диаграмма..."
 
 #: ../../src/dialogs/BinaryNameCtrl.cpp:42 ../../src/wizards/CsvWiz.cpp:57
 #: ../../src/wizards/CsvWiz.cpp:131 ../../src/wizards/Plot2dWiz.cpp:114
 #: ../../src/wizards/Plot3dWiz.cpp:109
 msgid "Browse"
-msgstr ""
+msgstr "Просмотр"
 
 #: ../../src/wxMathml.cpp:101
 msgid "Bug: After removing the whitespace wxMathml.lisp is shorter than expected!"
@@ -1442,7 +1442,7 @@ msgstr "Ошибка: вывод HTML не является корректным
 
 #: ../../src/cells/Cell.cpp:289
 msgid "Bug: Math Cell that claims to have no group Cell it belongs to"
-msgstr ""
+msgstr "Ошибка: математическое поле сообщает об отсутствии группового поля, к которому оно принадлежит."
 
 #: ../../src/Configuration.h:741
 msgid "Bug: Maximum number of digits that is to be displayed is too low!"
@@ -1454,7 +1454,7 @@ msgstr "Ошибка: отсутствует содержимое."
 
 #: ../../src/cells/GroupCell.cpp:1498
 msgid "Bug: No image counter to write to!"
-msgstr ""
+msgstr "Ошибка: нет счётчика изображений для записи данных!"
 
 #: ../../src/cells/AnimationCell.cpp:543 ../../src/cells/EditorCell.cpp:2968
 #: ../../src/cells/ImgCell.cpp:353 ../../src/graphical_io/BitmapOut.cpp:161
@@ -1473,7 +1473,7 @@ msgstr "Ошибка: буфер обмена уже открыт."
 
 #: ../../src/cells/EditorCell.cpp:3051
 msgid "Bug: The clipboard isn't open on pasting into an editor cell"
-msgstr ""
+msgstr "Ошибка: буфер обмена не был открыт при выполнении вставки в поле редактора."
 
 #: ../../src/cells/GroupCell.cpp:2288
 msgid "Bug: The predecessor to a GroupCell is not a GroupCell."
@@ -1485,7 +1485,7 @@ msgstr ""
 
 #: ../../src/cells/GroupCell.cpp:340
 msgid "Bug: Trying to append NULL to a group cell."
-msgstr ""
+msgstr "Ошибка: попытка добавить NULL к групповому полю."
 
 #: ../../src/worksheet/Worksheet.cpp:5939
 msgid "Bug: Trying to move a title out by one sectioning unit"
@@ -1509,7 +1509,7 @@ msgstr "Ошибка: действие отмены с одновременны�
 
 #: ../../src/cells/EditorCell.cpp:4541
 msgid "Bug: Unknown type of text"
-msgstr ""
+msgstr "Ошибка: неизвестный тип текста."
 
 #: ../../src/cells/EditorCell.cpp:3981 ../../src/cells/TextCell.cpp:479
 msgid "Bug: dc == NULL"
@@ -1517,11 +1517,11 @@ msgstr ""
 
 #: ../../src/cells/EditorCell.cpp:2637
 msgid "Bug: x position of cell is unknown!"
-msgstr ""
+msgstr "Ошибка: неизвестное положение поля по x!"
 
 #: ../../src/cells/EditorCell.cpp:2638
 msgid "Bug: y position of cell is unknown!"
-msgstr ""
+msgstr "Ошибка: неизвестное положение поля по y!"
 
 #: ../../src/wxMaximaFrame.cpp:1985
 msgid "Build &Info"
@@ -1534,7 +1534,7 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:54
 msgid "By default, Shift-Enter is used to evaluate commands, while Enter is used for multiline input. This behaviour can be changed in 'Edit->Configure' dialog by checking 'Enter evaluates cells'. This switches the roles of these two key commands."
-msgstr ""
+msgstr "По умолчанию комбинация клавиш Shift-Enter используется для запуска команд, а Enter — для многострокового ввода текста. Это поведение можно изменить в меню «Правка->Настройка» установкой флажка «Выполнять команды в полях по клавише Enter»."
 
 #: ../../src/MaximaCommandMenus.cpp:4087
 msgid "Byte:"
@@ -1559,7 +1559,7 @@ msgstr ""
 #: ../../src/cells/FontVariantCache.cpp:96
 #, c-format
 msgid "Caching font variant: %s"
-msgstr ""
+msgstr "Кэширование варианта шрифта: %s"
 
 #: ../../src/wxMaximaFrame.cpp:1519
 msgid "Calculate &Product..."
@@ -1704,7 +1704,7 @@ msgstr ""
 #: ../../src/cells/FontVariantCache.cpp:85
 #, c-format
 msgid "Cannot create a font based on %s. Falling back to a default font."
-msgstr ""
+msgstr "Не удалось создать шрифт на основе %s. Будет использован шрифт по умолчанию."
 
 #: ../../src/MaximaProcessManager.cpp:368
 msgid "Cannot find a maxima binary and no binary chosen in the config dialogue."
@@ -1728,20 +1728,20 @@ msgstr "Не удалось интерпретировать компонент 
 
 #: ../../src/cells/EditorCell.cpp:2991
 msgid "Cannot put the copied text on the clipboard"
-msgstr ""
+msgstr "Не удалось поместить скопированный текст в буфер обмена"
 
 #: ../../src/cells/EditorCell.cpp:2984
 msgid "Cannot put the copied text on the clipboard (1st try)"
-msgstr ""
+msgstr "Не удалось поместить скопированный текст в буфер обмена (первая попытка)"
 
 #: ../../src/cells/EditorCell.cpp:2988
 msgid "Cannot put the copied text on the clipboard (2nd try)"
-msgstr ""
+msgstr "Не удалось поместить скопированный текст в буфер обмена (вторая попытка)"
 
 #: ../../src/graphical_io/OutCommon.cpp:98
 #, c-format
 msgid "Cannot remove the file %s"
-msgstr ""
+msgstr "Не удалось удалить файл %s"
 
 #: ../../src/sidebars/History.cpp:258
 #, c-format
@@ -1772,11 +1772,11 @@ msgstr "Не удалось запустить исполняемый файл M
 
 #: ../../src/sidebars/MathSidebar.cpp:62
 msgid "Canonical (tr)"
-msgstr ""
+msgstr "Каноническая форма (триг.)"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:188
 msgid "Catalan"
-msgstr ""
+msgstr "Каталанский"
 
 #: ../../src/MaximaCommandMenus.cpp:466
 msgid "Cauchy principal value of f(x)/(x-c), finite interval"
@@ -1833,7 +1833,7 @@ msgstr "Сменить каталог..."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:859
 msgid "Change names of greek letters to greek letters"
-msgstr ""
+msgstr "Заменить названия греческих букв на греческие буквы"
 
 #: ../../src/wxMaximaFrame.cpp:1073
 msgid "Change the 2d display algorithm used to display math output"
@@ -1841,7 +1841,7 @@ msgstr "Изменить способ, применяемый для отобр�
 
 #: ../../src/dialogs/ConfigDialogue.cpp:489
 msgid "Change the text \"alpha\" and \"beta\" to the corresponding greek letter?"
-msgstr ""
+msgstr "Заменить текстовые «альфа» и «бета» на соответствующие греческие буквы?"
 
 #: ../../src/MaximaCommandMenus.cpp:136
 msgid "Change variable"
@@ -1861,7 +1861,7 @@ msgstr "Заменить переменную в интеграле или су�
 
 #: ../../src/dialogs/ChangeLogDialog.cpp:37
 msgid "ChangeLog"
-msgstr ""
+msgstr "Журнал изменений"
 
 #: ../../src/wxMaximaFrame.cpp:1060
 msgid "Changed option variables"
@@ -1922,15 +1922,15 @@ msgstr "Проверка доступности новой версии wxMaxima
 
 #: ../../src/sidebars/GreekSidebar.cpp:199
 msgid "Chi"
-msgstr ""
+msgstr "Χ"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:189
 msgid "Chinese (Simplified)"
-msgstr ""
+msgstr "Китайский (упрощённый)"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:190
 msgid "Chinese (traditional)"
-msgstr ""
+msgstr "Китайский (традиционный)"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1554
 msgid "Choose a Lisp Maxima was compiled with"
@@ -1942,11 +1942,11 @@ msgstr ""
 
 #: ../../src/sidebars/HelpBrowser.cpp:204
 msgid "Choose between the following help topics:"
-msgstr ""
+msgstr "Доступные темы справки:"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2100
 msgid "Choose font"
-msgstr ""
+msgstr "Выбор шрифта"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:793
 msgid "Choose how mathematical output is formatted:\n"
@@ -1957,12 +1957,12 @@ msgstr ""
 
 #: ../../src/wizards/PlotFormatWiz.cpp:31
 msgid "Choose new plot format:"
-msgstr ""
+msgstr "Выберите новый формат графиков:"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2432
 #, c-format
 msgid "Choose the %s Font"
-msgstr ""
+msgstr "Выберите шрифт %s"
 
 #: ../../src/wxMaximaFrame.cpp:837
 msgid "Choose the parenthesis type for Matrices"
@@ -1998,7 +1998,7 @@ msgstr "Очистить все gradefs"
 
 #: ../../src/sidebars/History.cpp:116
 msgid "Clear all history"
-msgstr ""
+msgstr "Очистить весь журнал"
 
 #: ../../src/wxMaximaFrame.cpp:1034
 msgid "Clear all labels"
@@ -2030,16 +2030,16 @@ msgstr "Очистить все переменные"
 
 #: ../../src/sidebars/History.cpp:115
 msgid "Clear the selection"
-msgstr ""
+msgstr "Очистить выделение"
 
 #: ../../src/cells/FontVariantCache.cpp:44
 #, c-format
 msgid "Cleared font cache for font %s"
-msgstr ""
+msgstr "Очищен кэш шрифта для шрифта %s"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1926
 msgid "Clipboard format parameters"
-msgstr ""
+msgstr "Параметры формата буфера обмена"
 
 #: ../../src/wxMaximaFrame.cpp:637
 msgid "Close\tCtrl+W"
@@ -2131,7 +2131,7 @@ msgstr "Столбцы"
 
 #: ../../src/wizards/MatWiz.cpp:155
 msgid "Columns:"
-msgstr ""
+msgstr "Столбцы:"
 
 #: ../../src/wxMaximaFrame.cpp:1621
 msgid "Combine factorials in an expression"
@@ -2147,11 +2147,11 @@ msgstr "Закрывающая скобка сразу после запятой
 
 #: ../../src/wizards/Plot2dWiz.cpp:626
 msgid "Comma separated x coordinates"
-msgstr ""
+msgstr "Введите список x-координат, разделённых запятыми"
 
 #: ../../src/wizards/Plot2dWiz.cpp:627
 msgid "Comma separated y coordinates"
-msgstr ""
+msgstr "Введите список y-координат, разделённых запятыми"
 
 #: ../../src/MaximaCommandMenus.cpp:4071
 msgid "Comma-separated arguments"
@@ -2237,11 +2237,11 @@ msgstr "Команда:"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1145
 msgid "Commands that are executed at every start of maxima."
-msgstr ""
+msgstr "Команды, которые выполняются при каждом запуске Maxima."
 
 #: ../../src/cells/EditorCell.cpp:4538
 msgid "Comment (ordinary worksheet text that isn't fed to maxima)"
-msgstr ""
+msgstr "Комментарий (обычный текст на листе, который не передаётся в Maxima)"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:465
 msgid "Comment Selection"
@@ -2377,16 +2377,16 @@ msgstr "Условие:"
 #: ../../src/dialogs/ConfigDialogue.cpp:2641
 #: ../../src/dialogs/ConfigDialogue.cpp:2647
 msgid "Config file (*.ini)|*.ini"
-msgstr ""
+msgstr "Файл конфигурации (*.ini)|*.ini"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2539
 #, c-format
 msgid "Config item \"%s\" was of an unknown type"
-msgstr ""
+msgstr "Неизвестный тип элемента конфигурации «%s»"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2607
 msgid "Configuration warning"
-msgstr ""
+msgstr "Предупреждение настройки"
 
 #: ../../src/ToolBar.cpp:367 ../../src/ToolBar.cpp:369
 #: ../../src/wxMaximaFrame.cpp:722 ../../src/wxMaximaFrame.cpp:724
@@ -2395,7 +2395,7 @@ msgstr "Настроить wxMaxima"
 
 #: ../../src/wizards/DrawWiz.cpp:829
 msgid "Connect the dots"
-msgstr ""
+msgstr "Соединить точки"
 
 #: ../../src/MaximaProcessManager.cpp:163
 msgid "Connection attempt, but connection failed."
@@ -2409,7 +2409,7 @@ msgstr "Соединение с Maxima потеряно."
 #: ../../src/wizards/IntegrateWiz.cpp:208 ../../src/wizards/LimitWiz.cpp:133
 #: ../../src/wizards/SeriesWiz.cpp:105
 msgid "Constant"
-msgstr ""
+msgstr "Константа"
 
 #: ../../src/MaximaCommandMenus.cpp:1102
 msgid "Construct a fraction"
@@ -2421,7 +2421,7 @@ msgstr "Построить дробь..."
 
 #: ../../src/sidebars/VariablesPane.cpp:58
 msgid "Contents"
-msgstr ""
+msgstr "Содержимое"
 
 #: ../../src/MaximaCommandMenus.cpp:3970
 msgid "Contents:"
@@ -2437,27 +2437,27 @@ msgstr "Контекстная &справка\tF1"
 
 #: ../../src/sidebars/DrawSidebar.cpp:80
 msgid "Contour"
-msgstr ""
+msgstr "Контур"
 
 #: ../../src/sidebars/DrawSidebar.cpp:101
 msgid "Contour lines for 3d plots"
-msgstr ""
+msgstr "Контурные линии для 3D-графиков"
 
 #: ../../src/wizards/DrawWiz.cpp:648
 msgid "Contour lines on surface and Bottom"
-msgstr ""
+msgstr "Контурные линии на поверхности и внизу"
 
 #: ../../src/wizards/DrawWiz.cpp:644
 msgid "Contour lines on the Bottom"
-msgstr ""
+msgstr "Контурные линии внизу"
 
 #: ../../src/wizards/DrawWiz.cpp:641
 msgid "Contour lines on the Surface"
-msgstr ""
+msgstr "Контурные линии на поверхности"
 
 #: ../../src/wizards/DrawWiz.cpp:629
 msgid "Contour lines settings for the following 3d plots"
-msgstr ""
+msgstr "Параметры контурных линий для следующих 3D-графиков"
 
 #: ../../src/wxMaximaFrame.cpp:1579
 msgid "Contract Logarithms"
@@ -2542,30 +2542,30 @@ msgstr "Преобразовать в &стандартную форму"
 #: ../../src/sidebars/TableOfContents.cpp:522
 #: ../../src/sidebars/TableOfContents.cpp:543
 msgid "Convert to Heading 5"
-msgstr ""
+msgstr "Преобразовать в Заголовок 5"
 
 #: ../../src/sidebars/TableOfContents.cpp:519
 msgid "Convert to Heading 6"
-msgstr ""
+msgstr "Преобразовать в Заголовок 6"
 
 #: ../../src/sidebars/TableOfContents.cpp:531
 #: ../../src/sidebars/TableOfContents.cpp:552
 msgid "Convert to Section"
-msgstr ""
+msgstr "Преобразовать в раздел"
 
 #: ../../src/sidebars/TableOfContents.cpp:525
 #: ../../src/sidebars/TableOfContents.cpp:546
 msgid "Convert to Sub-Subsection"
-msgstr ""
+msgstr "Преобразовать в под-подраздел"
 
 #: ../../src/sidebars/TableOfContents.cpp:528
 #: ../../src/sidebars/TableOfContents.cpp:549
 msgid "Convert to Subsection"
-msgstr ""
+msgstr "Преобразовать в подраздел"
 
 #: ../../src/sidebars/TableOfContents.cpp:555
 msgid "Convert to Title"
-msgstr ""
+msgstr "Преобразовать в заголовок"
 
 #: ../../src/wxMaximaFrame.cpp:1200
 msgid "Convert to downcase..."
@@ -2751,22 +2751,22 @@ msgstr "Кнопки «Копировать», «Вырезать» и «Вст�
 #: ../../src/dialogs/ConfigDialogue.cpp:2523
 #, c-format
 msgid "Copying config bool \"%s\""
-msgstr ""
+msgstr "Копирование булева значения конфигурации «%s»"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2533
 #, c-format
 msgid "Copying config float \"%s\""
-msgstr ""
+msgstr "Копирование значения с плавающей точкой конфигурации «%s»"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2528
 #, c-format
 msgid "Copying config int \"%s\""
-msgstr ""
+msgstr "Копирование целого значения конфигурации «%s»"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2518
 #, c-format
 msgid "Copying config string \"%s\""
-msgstr ""
+msgstr "Копирование строки конфигурации «%s»"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:191
 msgid "Corsican"
@@ -2859,7 +2859,7 @@ msgstr "Создать список на основе элементов, раз
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1389
 msgid "Create scalable plots."
-msgstr ""
+msgstr "Создать масштабируемые графики."
 
 #: ../../src/wxMaximaFrame.cpp:1116
 msgid "Create struct..."
@@ -2883,7 +2883,7 @@ msgstr ""
 
 #: ../../src/worksheet/Worksheet.cpp:6115
 msgid "Cursor"
-msgstr ""
+msgstr "Курсор"
 
 #: ../../src/Styles.cpp:126
 msgid "Cursor color"
@@ -2905,11 +2905,11 @@ msgstr "Вырезать выделение"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:193
 msgid "Czech"
-msgstr ""
+msgstr "Чешский"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:194
 msgid "Danish"
-msgstr ""
+msgstr "Датский"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2069
 msgid "Dark"
@@ -2925,7 +2925,7 @@ msgstr "Файл данных (*.csv, *.tab, *.txt)|*.csv;*.tab;*.txt"
 
 #: ../../src/wizards/DrawWiz.cpp:810
 msgid "Data format"
-msgstr ""
+msgstr "Формат данных"
 
 #: ../../src/MaximaCommandMenus.cpp:1767 ../../src/MaximaCommandMenus.cpp:1772
 #: ../../src/MaximaCommandMenus.cpp:1777 ../../src/MaximaCommandMenus.cpp:1781
@@ -2979,15 +2979,15 @@ msgstr "Убывающая функция f(x)<x"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1336
 msgid "Default animation framerate:"
-msgstr ""
+msgstr "Частота кадров анимации по умолчанию:"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:717
 msgid "Default plot size for new maxima sessions:"
-msgstr ""
+msgstr "Размер графика по умолчанию для новых сеансов Maxima:"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1534
 msgid "Default port for communication with wxMaxima:"
-msgstr ""
+msgstr "Порт, используемый по умолчанию для связи с wxMaxima:"
 
 #: ../../src/MaximaCommandMenus.cpp:3946
 msgid "Define a function"
@@ -3027,7 +3027,7 @@ msgstr "Определить структуру..."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:404
 msgid "Define the default speed (in frames per second) animations are played back with."
-msgstr ""
+msgstr "Определить скорость по умолчанию (в кадрах в секунду), с которой воспроизводится анимация."
 
 #: ../../src/wxMaximaFrame.cpp:1114
 msgid "Define variable..."
@@ -3100,7 +3100,7 @@ msgstr "Разделитель:"
 
 #: ../../src/sidebars/GreekSidebar.cpp:181
 msgid "Delta"
-msgstr ""
+msgstr "Δ"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:110
 #: ../../src/worksheet/WorksheetContextMenu.cpp:558
@@ -3126,7 +3126,7 @@ msgstr "Зависимости"
 
 #: ../../src/wizards/SeriesWiz.cpp:42
 msgid "Depth:"
-msgstr ""
+msgstr "Глубина:"
 
 #: ../../src/MaximaCommandMenus.cpp:994
 msgid "Derivate of y at that point:"
@@ -3161,7 +3161,7 @@ msgstr ""
 
 #: ../../src/sidebars/StatSidebar.cpp:61
 msgid "Deviation..."
-msgstr ""
+msgstr "Отклонение..."
 
 #: ../../src/wxMaximaFrame.cpp:1534
 msgid "Di&vide Polynomials..."
@@ -3173,11 +3173,11 @@ msgstr ""
 
 #: ../../src/sidebars/DrawSidebar.cpp:71
 msgid "Diagram title"
-msgstr ""
+msgstr "Заголовок диаграммы"
 
 #: ../../src/sidebars/HelpBrowser.cpp:51
 msgid "Didn't find an installed offline manual."
-msgstr ""
+msgstr "Не удалось найти установленное автономное руководство пользователя."
 
 #: ../../src/MaximaManual.cpp:534
 msgid "Didn't find the maxima HTML manual."
@@ -3193,7 +3193,7 @@ msgstr ""
 
 #: ../../src/sidebars/MathSidebar.cpp:80
 msgid "Diff..."
-msgstr ""
+msgstr "Дифференцировать..."
 
 #: ../../src/dialogs/DiffFrame.cpp:308
 #, c-format
@@ -3222,7 +3222,7 @@ msgstr "Дифференцирует выражение n раз"
 
 #: ../../src/wizards/LimitWiz.cpp:41
 msgid "Direction:"
-msgstr ""
+msgstr "Направление:"
 
 #: ../../src/wxMaximaFrame.cpp:1246
 msgid "Directory operations"
@@ -3234,11 +3234,11 @@ msgstr ""
 
 #: ../../src/wizards/Plot2dWiz.cpp:418 ../../src/wizards/Plot2dWiz.cpp:619
 msgid "Discrete plot"
-msgstr ""
+msgstr "Дискретный график"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:699
 msgid "Display"
-msgstr ""
+msgstr "Отображение"
 
 #: ../../src/wxMaximaFrame.cpp:1075
 msgid "Display Te&X Form"
@@ -3250,11 +3250,11 @@ msgstr "Способ вывода"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:827
 msgid "Display all and allow linebreaks in long numbers"
-msgstr ""
+msgstr "Отобразить все и включить перенос строки для длинных чисел"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:820
 msgid "Display all digits"
-msgstr ""
+msgstr "Отобразить все цифры"
 
 #: ../../src/wxMaximaFrame.cpp:788
 msgid "Display an expression as maxima's internal lisp representation"
@@ -3282,7 +3282,7 @@ msgstr "Показать последний результат в формате
 
 #: ../../src/dialogs/ConfigDialogue.cpp:804
 msgid "Display of long numbers"
-msgstr ""
+msgstr "Отображение длинных чисел"
 
 #: ../../src/ToolBar.cpp:580
 #, c-format
@@ -3361,11 +3361,11 @@ msgstr "Документ был сохранён в более новой вер
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1170
 msgid "Documentclass for TeX export:"
-msgstr ""
+msgstr "Класс документа для экспорта в TeX:"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1178
 msgid "Documentclass options:"
-msgstr ""
+msgstr "Параметры класса документа:"
 
 #: ../../src/wxMaximaFrame.cpp:807
 msgid "Don't autosubscript after an underscore"
@@ -3411,19 +3411,19 @@ msgstr "Не использовать скобки для матриц"
 
 #: ../../src/dialogs/DiffFrame.cpp:428 ../../src/dialogs/FindReplacePane.cpp:83
 msgid "Down"
-msgstr ""
+msgstr "Вниз"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:185
 msgid "Drag-and-drop unicode symbols here"
-msgstr ""
+msgstr "Перетащите сюда символы Юникода"
 
 #: ../../src/wizards/DrawWiz.cpp:155
 msgid "Draw all points where an equation is true."
-msgstr ""
+msgstr "Рисовать все точки, в которых уравнение справедливо."
 
 #: ../../src/wizards/DrawWiz.cpp:802
 msgid "Draw points"
-msgstr ""
+msgstr "Рисовать точки"
 
 #: ../../src/MaximaCommandMenus.cpp:1536
 msgid "Drop the first n list elements"
@@ -3543,7 +3543,7 @@ msgstr "Неизвестное событие сокета."
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:129
 msgid "End of proof"
-msgstr ""
+msgstr "Конец доказательства"
 
 #: ../../src/MaximaCommandMenus.cpp:1024
 msgid "End of t:"
@@ -3551,19 +3551,19 @@ msgstr "Конец t:"
 
 #: ../../src/wizards/DrawWiz.cpp:71 ../../src/wizards/DrawWiz.cpp:176
 msgid "End of the x value"
-msgstr ""
+msgstr "Конец значения x"
 
 #: ../../src/wizards/DrawWiz.cpp:88 ../../src/wizards/DrawWiz.cpp:191
 msgid "End of the y value"
-msgstr ""
+msgstr "Конец значения y"
 
 #: ../../src/wizards/DrawWiz.cpp:208
 msgid "End of the z value"
-msgstr ""
+msgstr "Конец значения z"
 
 #: ../../src/wizards/DrawWiz.cpp:760
 msgid "End value of the parameter"
-msgstr ""
+msgstr "Конечное значение параметра"
 
 #: ../../src/MaximaResponseReader.cpp:432
 #: ../../src/MaximaResponseReader.cpp:586
@@ -3576,19 +3576,19 @@ msgstr "Инженерный формат (12.1e6 и так далее)"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:196
 msgid "English"
-msgstr ""
+msgstr "Английский"
 
 #: ../../src/wizards/DrawWiz.cpp:552
 msgid "Enhanced 3D settings:"
-msgstr ""
+msgstr "Расширенные параметры 3D:"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1919
 msgid "Enhanced meta file (emf)"
-msgstr ""
+msgstr "Расширенный метафайл (emf)"
 
 #: ../../src/sidebars/StatSidebar.cpp:106
 msgid "Enter Matrix..."
-msgstr ""
+msgstr "&Ввести матрицу..."
 
 #: ../../src/MaximaCommandMenus.cpp:2255
 msgid "Enter UUID to jump to:"
@@ -3600,7 +3600,7 @@ msgstr "Введите матрицу"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:925
 msgid "Enter adds newlines, Ctrl+Enter evaluates cells"
-msgstr ""
+msgstr "Добавлять новые строки по клавише Enter, выполнять команды в полях по комбинации клавиш Ctrl+Enter"
 
 #: ../../src/MaximaCommandMenus.cpp:873
 msgid "Enter an equation for rational simplification:"
@@ -3608,11 +3608,11 @@ msgstr "Введите уравнение для рационального уп
 
 #: ../../src/wizards/SystemWiz.cpp:50
 msgid "Enter comma separated list of variables."
-msgstr ""
+msgstr "Введите список переменных, разделённых запятыми."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:921
 msgid "Enter evaluates cells, Ctrl+Enter adds newlines"
-msgstr ""
+msgstr "Выполнять команды в полях по клавише Enter, добавлять новые строки по комбинации клавиш Ctrl+Enter"
 
 #: ../../src/MaximaCommandMenus.cpp:1357
 msgid "Enter matrix"
@@ -3628,7 +3628,7 @@ msgstr "Введите новую точность для чисел с плав
 
 #: ../../src/dialogs/ConfigDialogue.cpp:388
 msgid "Enter the path to the Maxima executable."
-msgstr ""
+msgstr "Введите путь к исполняемому файлу Maxima."
 
 #: ../../src/MaximaCommandMenus.cpp:1103
 msgid "Enumerator:"
@@ -3640,11 +3640,11 @@ msgstr "Переменные среды"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1605
 msgid "Environment variables for maxima"
-msgstr ""
+msgstr "Переменные среды для Maxima"
 
 #: ../../src/sidebars/GreekSidebar.cpp:182
 msgid "Epsilon"
-msgstr ""
+msgstr "Ε"
 
 #: ../../src/MaximaCommandMenus.cpp:299
 msgid "Epsilon:"
@@ -3683,7 +3683,7 @@ msgstr "Уравнение:"
 
 #: ../../src/dialogs/TipOfTheDay.cpp:196
 msgid "Equations have several advantages over functions. For example they can be manipulated with factor(), expand() and similar functions. They can easily be introduced one into another. Also they are always printed out as 2D maths."
-msgstr ""
+msgstr "Уравнения имеют несколько преимуществ перед функциями. Например, их можно преобразовывать с помощью factor(), expand() и других подобных функций. Их можно легко вставлять друг в друга. Кроме того, они всегда выводятся в удобочитаемой 2d-форме."
 
 #: ../../src/MaximaFileIO.cpp:64 ../../src/MaximaFileIO.cpp:121
 #: ../../src/MaximaFileIO.cpp:130 ../../src/MaximaFileIO.cpp:399
@@ -3739,11 +3739,11 @@ msgstr "Экранирует все специальные символы в с�
 
 #: ../../src/sidebars/GreekSidebar.cpp:184
 msgid "Eta"
-msgstr ""
+msgstr "Η"
 
 #: ../../src/sidebars/TableOfContents.cpp:513
 msgid "Evaluate"
-msgstr ""
+msgstr "Вычислить"
 
 #: ../../src/wxMaximaFrame.cpp:1689
 msgid "Evaluate &Noun Forms..."
@@ -3877,11 +3877,11 @@ msgstr "Чётное число"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2659
 msgid "Example text"
-msgstr ""
+msgstr "Текст примера"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1547
 msgid "Examples:"
-msgstr ""
+msgstr "Примеры:"
 
 #: ../../src/wxMaximaFrame.cpp:1740
 msgid "Execute a command for each element of the list"
@@ -3893,11 +3893,11 @@ msgstr "Выход"
 
 #: ../../src/sidebars/MathSidebar.cpp:53
 msgid "Expand"
-msgstr ""
+msgstr "Раскрыть"
 
 #: ../../src/sidebars/MathSidebar.cpp:68
 msgid "Expand (tr)"
-msgstr ""
+msgstr "Раскрыть (триг.)"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:356
 msgid "Expand Expression"
@@ -3942,7 +3942,7 @@ msgstr "Экспорт"
 
 #: ../../src/sidebars/History.cpp:152
 msgid "Export As"
-msgstr ""
+msgstr "Экспортировать как"
 
 #: ../../src/wxMaximaFrame.cpp:1742
 msgid "Export List to csv file..."
@@ -3958,15 +3958,15 @@ msgstr "Экспортировать матрицу в файл CSV"
 
 #: ../../src/sidebars/History.cpp:102
 msgid "Export all history to a .mac file"
-msgstr ""
+msgstr "Экспортировать весь журнал в файл .mac"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1016
 msgid "Export all settings"
-msgstr ""
+msgstr "Экспортировать все параметры"
 
 #: ../../src/sidebars/History.cpp:105
 msgid "Export commands from the current maxima session to a .mac file"
-msgstr ""
+msgstr "Экспортировать команды из текущего сеанса Maxima в файл .mac"
 
 #: ../../src/wxMaximaFrame.cpp:652
 msgid "Export document to a HTML or LaTeX file"
@@ -3974,7 +3974,7 @@ msgstr "Экспортировать документ в файл HTML или La
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1218
 msgid "Export equations to HTML as:"
-msgstr ""
+msgstr "Экспортировать уравнения в HTML как:"
 
 #: ../../src/wxMaximaFrame.cpp:600
 msgid "Export failed."
@@ -3990,7 +3990,7 @@ msgstr ""
 
 #: ../../src/sidebars/History.cpp:108
 msgid "Export selected commands to a .mac file"
-msgstr ""
+msgstr "Экспортировать выбранные команды в файл .mac"
 
 #: ../../src/wxMaximaFrame.cpp:588
 msgid "Export successful."
@@ -4002,11 +4002,11 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1022
 msgid "Export the style settings"
-msgstr ""
+msgstr "Экспортировать параметры стиля"
 
 #: ../../src/sidebars/History.cpp:111
 msgid "Export visible commands to a .mac file"
-msgstr ""
+msgstr "Экспортировать отображаемые команды в файл .mac"
 
 #: ../../src/MaximaCommandMenus.cpp:3417
 #, c-format
@@ -4020,7 +4020,7 @@ msgstr ""
 
 #: ../../src/sidebars/History.cpp:228
 msgid "Exporting to .mac file failed!"
-msgstr ""
+msgstr "Не удалось выполнить экспорт в файл .mac!"
 
 #: ../../src/MaximaCommandMenus.cpp:2343
 msgid "Exporting to HTML failed!"
@@ -4056,19 +4056,19 @@ msgstr "Выражение или список выражений, раздел�
 
 #: ../../src/wizards/DrawWiz.cpp:733
 msgid "Expression that calculates the x value"
-msgstr ""
+msgstr "Выражение, которое вычисляет значение x"
 
 #: ../../src/wizards/DrawWiz.cpp:738
 msgid "Expression that calculates the y value"
-msgstr ""
+msgstr "Выражение, которое вычисляет значение y"
 
 #: ../../src/wizards/DrawWiz.cpp:744
 msgid "Expression that calculates the z value"
-msgstr ""
+msgstr "Выражение, которое вычисляет значение z"
 
 #: ../../src/wizards/DrawWiz.cpp:56
 msgid "Expression to plot"
-msgstr ""
+msgstr "Выражение для построения графика"
 
 #: ../../src/wxMaximaFrame.cpp:1122
 msgid "Expression to string..."
@@ -4223,7 +4223,7 @@ msgstr "Извлекает прямоугольник из двухмерног�
 
 #: ../../src/sidebars/MathSidebar.cpp:50
 msgid "Factor"
-msgstr ""
+msgstr "Факторизовать"
 
 #: ../../src/wxMaximaFrame.cpp:1558
 msgid "Factor Complex"
@@ -4298,7 +4298,7 @@ msgstr "Поля:"
 #: ../../src/cells/GroupCell.cpp:2115
 #, c-format
 msgid "Figure %d:"
-msgstr ""
+msgstr "Фигура %d:"
 
 #: ../../src/main.cpp:678
 msgid "File"
@@ -4350,7 +4350,7 @@ msgstr "Имя файла или список имён файлов, разде�
 
 #: ../../src/sidebars/DrawSidebar.cpp:93
 msgid "Fill color"
-msgstr ""
+msgstr "Цвет заливки"
 
 #: ../../src/ToolBar.cpp:401 ../../src/ToolBar.cpp:403
 msgid "Find"
@@ -4471,7 +4471,7 @@ msgstr "Найти максимальную сумму значений по м�
 
 #: ../../src/dialogs/FindReplacePane.cpp:46
 msgid "Find:"
-msgstr ""
+msgstr "Найти:"
 
 #: ../../src/wxMaximaFrame.cpp:1869
 msgid "Fine-tune the display of engineering-format numbers"
@@ -4479,7 +4479,7 @@ msgstr "Настроить отображение чисел в инженерн
 
 #: ../../src/dialogs/ConfigDialogue.cpp:197
 msgid "Finnish"
-msgstr ""
+msgstr "Финский"
 
 #: ../../src/wxMaximaFrame.cpp:1749
 msgid "First"
@@ -4492,11 +4492,11 @@ msgstr "Аппроксимация кривых по данным измерен
 #: ../../src/dialogs/ConfigDialogue.cpp:1404
 #, c-format
 msgid "Fix reordered reference indices (of %i, %o) before saving"
-msgstr ""
+msgstr "Исправлять переупорядоченные индексы ссылок (%i, %o) перед сохранением"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:873
 msgid "Fixed font in text controls"
-msgstr ""
+msgstr "Фиксированный шрифт в текстовом вводе"
 
 #: ../../src/MaximaCommandMenus.cpp:4039
 msgid "Flush stream"
@@ -4524,11 +4524,11 @@ msgstr ""
 
 #: ../../src/wizards/DrawWiz.cpp:341
 msgid "Following plots use secondary x axis"
-msgstr ""
+msgstr "Следующие графики используют вторичную ось x"
 
 #: ../../src/wizards/DrawWiz.cpp:347
 msgid "Following plots use secondary y axis"
-msgstr ""
+msgstr "Следующие графики используют вторичную ось y"
 
 #: ../../src/sidebars/PerformanceSidebar.cpp:37
 msgid "Font cache hits:"
@@ -4540,11 +4540,11 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2047
 msgid "Fonts"
-msgstr ""
+msgstr "Шрифты"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:442
 msgid "For each Text-, Sectioning or code cell wxMaxima can display a bracket showing the extend of the cell and allowing to fold it. This setting now tells if this bracket is to be printed, as well."
-msgstr ""
+msgstr "Программа wxMaxima может отображать для каждого текстового поля, поля раздела или поля кода квадратную скобку, которая показывает размер поля и позволяет свернуть его. Этот параметр позволяет настроить, следует ли также выводить эту скобку на печать."
 
 #: ../../src/ToolBar.cpp:495
 msgid "For faster creation of cells the following shortcuts exist:\n\n"
@@ -4576,7 +4576,7 @@ msgstr "Цикл for..."
 
 #: ../../src/wizards/Plot2dWiz.cpp:69 ../../src/wizards/Plot3dWiz.cpp:60
 msgid "Format:"
-msgstr ""
+msgstr "Формат:"
 
 #: ../../src/worksheet/Worksheet.cpp:301 ../../src/wxMaxima.cpp:3521
 msgid "Forwarding the keyboard focus to a text control"
@@ -4621,15 +4621,15 @@ msgstr "Кадр %li из %li"
 
 #: ../../src/wizards/DrawWiz.cpp:488
 msgid "Frame counter"
-msgstr ""
+msgstr "Счётчик кадров"
 
 #: ../../src/wizards/DrawWiz.cpp:499
 msgid "Frame counter end"
-msgstr ""
+msgstr "Конец счётчика кадров"
 
 #: ../../src/wizards/DrawWiz.cpp:494
 msgid "Frame counter start"
-msgstr ""
+msgstr "Начало счётчика кадров"
 
 #: ../../src/MaximaCommandMenus.cpp:102
 msgid "Frame rate"
@@ -4641,7 +4641,7 @@ msgstr "Освободить все неиспользуемые объекты"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:198
 msgid "French"
-msgstr ""
+msgstr "Французский"
 
 #: ../../src/wxMaximaFrame.cpp:1447
 msgid "Frobenius Norm sqrt(sum((A(i,j))^2)) (complex)"
@@ -4724,11 +4724,11 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:199
 msgid "Galician"
-msgstr ""
+msgstr "Галисийский"
 
 #: ../../src/sidebars/GreekSidebar.cpp:180
 msgid "Gamma"
-msgstr ""
+msgstr "Γ"
 
 #: ../../src/wxMaximaFrame.cpp:316
 msgid "General Math"
@@ -4780,7 +4780,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:201
 msgid "German"
-msgstr ""
+msgstr "Немецкий"
 
 #: ../../src/wxMaximaFrame.cpp:1656
 msgid "Get &Imaginary Part"
@@ -4868,7 +4868,7 @@ msgstr "Больше, если игнорировать регистр?..."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:202
 msgid "Greek"
-msgstr ""
+msgstr "Греческий"
 
 #: ../../src/wxMaximaFrame.cpp:281
 msgid "Greek Letters"
@@ -4880,11 +4880,11 @@ msgstr "Греческие буквы\tAlt+Shift+G"
 
 #: ../../src/sidebars/DrawSidebar.cpp:97
 msgid "Grid"
-msgstr ""
+msgstr "Сетка"
 
 #: ../../src/wizards/Plot3dWiz.cpp:52
 msgid "Grid:"
-msgstr ""
+msgstr "Сетка:"
 
 #: ../../src/wxMaximaFrame.cpp:1852
 msgid "Guess an exact number that could be meant by this float"
@@ -4892,7 +4892,7 @@ msgstr "Подсчёт точного числа, которое может об
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1215
 msgid "HTML"
-msgstr ""
+msgstr "HTML"
 
 #: ../../src/MaximaCommandMenus.cpp:2279
 msgid "HTML file (*.html)|*.html|maxima batch file (*.mac)|*.mac|LaTeX file (*.tex)|*.tex"
@@ -4940,7 +4940,7 @@ msgstr "Справка"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1461
 msgid "Help browser:"
-msgstr ""
+msgstr "Браузер справки:"
 
 #: ../../src/ToolBar.cpp:835
 msgid "Help button"
@@ -4959,7 +4959,7 @@ msgstr ""
 
 #: ../../src/sidebars/TableOfContents.cpp:510
 msgid "Hide"
-msgstr ""
+msgstr "Скрыть"
 
 #: ../../src/ToolBar.cpp:471 ../../src/ToolBar.cpp:473
 msgid "Hide Code"
@@ -4999,7 +4999,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:487
 msgid "Hide all multiplication signs that aren't really necessary for understanding the equation"
-msgstr ""
+msgstr "Скрывать все знаки умножения, которые не являются необходимыми для понимания уравнения"
 
 #: ../../src/wxMaximaFrame.cpp:767
 msgid "Hide all panes"
@@ -5019,15 +5019,15 @@ msgstr "Скрывать знаки умножения"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:854
 msgid "Hide multiplication signs, if possible"
-msgstr ""
+msgstr "Скрывать знаки умножения, если возможно"
 
 #: ../../src/wizards/DrawWiz.cpp:555
 msgid "Hide objects behind the surface"
-msgstr ""
+msgstr "Скрывать объекты за поверхностью"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:502
 msgid "Hide the brackets that mark the extend of the worksheet cells at the worksheet's right side and that contain the \"hide\" button of the cell if the cells aren't active."
-msgstr ""
+msgstr "Если поля неактивны, скрывать находящиеся с левой стороны листа квадратные скобки, которые обозначают размеры полей листа и содержат кнопки скрытия полей."
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:702
 #: ../../src/worksheet/WorksheetContextMenu.cpp:835
@@ -5045,11 +5045,11 @@ msgstr "Выделение (рамка)"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:869
 msgid "Highlight the matching parenthesis"
-msgstr ""
+msgstr "Выделять парные скобки"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:463
 msgid "Highlight the opening or closing parenthesis for the parenthesis the cursor is at."
-msgstr ""
+msgstr "Выделять открывающую или закрывающую скобку, которая является парной для той скобки, на которую указывает курсор."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:204
 msgid "Hindi"
@@ -5061,7 +5061,7 @@ msgstr "Гистограмма"
 
 #: ../../src/sidebars/StatSidebar.cpp:85
 msgid "Histogram..."
-msgstr ""
+msgstr "Гистограмма..."
 
 #: ../../src/wxMaximaFrame.cpp:246
 msgid "History"
@@ -5073,7 +5073,7 @@ msgstr "Журнал\tAlt+Shift+I"
 
 #: ../../src/dialogs/TipOfTheDay.cpp:105
 msgid "Horizontal cursor works like a normal cursor, but it operates on cells: press up or down arrow to move it, holding down Shift while moving will select cells, pressing backspace or delete twice will delete a cell next to it."
-msgstr ""
+msgstr "Горизонтальный курсор работает как обычный, только в полях: чтобы перемещать его, используйте клавиши со стрелками вниз и вверх. Для выделения полей удерживайте при перемещении клавишу Shift. Нажатие клавиши Backspace или двойное нажатие клавиши Delete удалит содержимое поля рядом с курсором."
 
 #: ../../src/wxMaximaFrame.cpp:1563
 msgid "Horner's rule"
@@ -5081,7 +5081,7 @@ msgstr "Правило Горнера"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:918
 msgid "Hotkeys for sending commands to maxima"
-msgstr ""
+msgstr "Комбинации клавиш для отправки команд в Maxima"
 
 #: ../../src/MaximaCommandMenus.cpp:398
 msgid "How many digits to show:"
@@ -5093,7 +5093,7 @@ msgstr "Способ отображения новых уравнений"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:205
 msgid "Hungarian"
-msgstr ""
+msgstr "Венгерский"
 
 #: ../../src/wxMaximaFrame.cpp:1147
 msgid "I/O"
@@ -5101,7 +5101,7 @@ msgstr "Ввод/вывод"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:121
 msgid "Identical to"
-msgstr ""
+msgstr "Идентично"
 
 #: ../../src/MaximaCommandMenus.cpp:3874
 msgid "If a program doesn't need local variables, Maxima allows putting the commands between parentheses. The result of the last operation is the return value of the program."
@@ -5109,51 +5109,51 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:145
 msgid "If maxima versions compiled with different lisps are installed: The name of the lisp to use by default"
-msgstr ""
+msgstr "Если установлены версии Maxima, которые были скомпилированы с помощью разных вариантов Lisp: имя Lisp, которое используется по умолчанию"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:174
 msgid "If maxima was compiled by GCL: Garbage Collect at minimum allocation past this heapsize"
-msgstr ""
+msgstr "Если Maxima скомпилирована с помощью GCL: очистить кучу не ниже этого размера кучи"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:171
 msgid "If maxima was compiled by GCL: Minimum allocation fraction between Garbage Collects"
-msgstr ""
+msgstr "Если Maxima скомпилирована с помощью GCL: доля минимального выделения между циклами сбора мусора"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:168
 msgid "If maxima was compiled by GCL: Only garbage collect past this heapsize fraction of working mem"
-msgstr ""
+msgstr "Если Maxima скомпилирована с помощью GCL: минимальная доля кучи в размере рабочей памяти перед очисткой кучи"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:180
 msgid "If maxima was compiled by GCL: Share the allocated memory between gcl processes. Allows more than one gcl-compiled maxima to run at the same time, but might provoke crashes."
-msgstr ""
+msgstr "Если Maxima скомпилирована с помощью GCL: разделять выделенную память между процессами gcl. Это позволяет одновременно запускать несколько процессов Maxima на одном компьютере, но иногда приводит к сбоям."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:177
 msgid "If maxima was compiled by GCL: The fraction of the total installed RAM to reserve for maxima"
-msgstr ""
+msgstr "Если Maxima скомпилирована с помощью GCL: доля общей установленной ОЗУ, которая резервируется для Maxima"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:375
 msgid "If multiple cells are evaluated in one go: Abort evaluation if wxMaxima detects that maxima has encountered any error."
-msgstr ""
+msgstr "Когда выполняются команды сразу для нескольких полей: прекращать вычисление, если wxMaxima определит, что в Maxima произошла ошибка."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:727
 msgid "If not extremely long"
-msgstr ""
+msgstr "Если не крайне длинные"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:726
 msgid "If not very long"
-msgstr ""
+msgstr "Если не очень длинные"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:418
 msgid "If numbers are getting longer than this number of digits they will be displayed abbreviated by an ellipsis."
-msgstr ""
+msgstr "Если число состоит из большего количества цифр, чем указано здесь, его оставшаяся часть будет отображаться в виде троеточия."
 
 #: ../../src/dialogs/TipOfTheDay.cpp:181
 msgid "If the \"Autosave\" functionality is enabled in the configuration dialogue wxMaxima acts like mobile apps that backup the file every few minutes and save it on closing."
-msgstr ""
+msgstr "Если в диалоге настройки включена опция автосохранения, wxMaxima будет работать похожим на мобильные приложения образом: выполнять резервное копирование файла каждые несколько минут и сохранять его при закрытии программы."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:396
 msgid "If the font provides big parenthesis symbols: Use them when big parenthesis are needed for maths display."
-msgstr ""
+msgstr "Если в шрифте имеются символы больших скобок: использовать их, когда для отображения расчётов требуются большие скобки."
 
 #: ../../src/cells/TextCell.cpp:327
 msgid "If the thing maxima complains about actually looks like a polynomial you can try running it through ratdisrep() in order to fix that problem."
@@ -5169,15 +5169,15 @@ msgstr "Если тип функционального параметра изв
 
 #: ../../src/dialogs/ConfigDialogue.cpp:399
 msgid "If this checkbox is checked wxMaxima automatically saves the file closing and every few minutes giving wxMaxima a more cellphone-app-like feel as the file is virtually always saved. If this checkbox is unchecked from time to time a backup is made in the temp folder instead."
-msgstr ""
+msgstr "Если этот флажок установлен, wxMaxima выполняет автоматическое сохранение файла каждые несколько минут и при закрытии. Это придаёт работе программы сходство с мобильными приложениями — файл практически всегда сохранён. Если этот флажок снят, вместо этого программа будет периодически сохранять резервную копию во временной папке."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:378
 msgid "If this checkbox is set a new code cell is opened as soon as maxima requests data. If it isn't set a new code cell is opened in this case as soon as the user starts typing in code."
-msgstr ""
+msgstr "Если этот флажок установлен, новое поле кода будет открыто сразу после запроса данных Maxima. Если этот флажок снят, новое поле кода в таком случае будет открыто сразу после начала ввода кода пользователем."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:372
 msgid "If this checkbox isn't checked the current command is sent to maxima only on pressing Ctrl+Enter"
-msgstr ""
+msgstr "Если этот флажок не установлен, текущая команда будет отправлена в Maxima только при нажатии Ctrl+Enter"
 
 #: ../../src/MathParser.cpp:945
 msgid "If this isn't a function returning a lambda() expression a multiplication sign (*) between closing and opening parenthesis is missing here."
@@ -5190,7 +5190,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:439
 msgid "If this option is set the .wxmx source of the current file is copied to a place a link to is put into the result of an export."
-msgstr ""
+msgstr "Если этот параметр включён, wxmx-код текущего файла копируется в расположение, на которое указывает ссылка из результата экспорта."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1873
 msgid "If unset, Maxima's output is announced to the screen reader as maths in a linear text form. Set this option if your screen reader can speak MathML properly."
@@ -5198,15 +5198,15 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:247
 msgid "If you have ideas, how to improve the design or functionality of wxMaxima, please share your ideas at the issue list or discussion forum at https://github.com/wxMaxima-developers/wxmaxima/."
-msgstr ""
+msgstr "Предложения по улучшению интерфейса или возможностей wxMaxima можно предоставить по следующему адресу: https://github.com/wxMaxima-developers/wxmaxima/ (воспользуйтесь списком вопросов или форумом для обсуждений)."
 
 #: ../../src/dialogs/TipOfTheDay.cpp:76
 msgid "If you type an operator (one of +*/^=,) as the first symbol in an input cell, % will be automatically inserted before the operator, as on a graphing calculator. You can disable this feature from the 'Edit->Configure' dialog."
-msgstr ""
+msgstr "Если использовать оператор (может быть одним из следующих: +*/^=,) в качестве первого символа в поле ввода, то перед ним будет автоматически вставлен символ %, как на графическом калькуляторе. Это поведение можно отключить с помощью диалогового окна «Правка->Настройка»."
 
 #: ../../src/dialogs/TipOfTheDay.cpp:122
 msgid "If your calculation is taking too long to evaluate, you can try 'Maxima->Interrupt' or 'Maxima->Restart Maxima' menu commands."
-msgstr ""
+msgstr "Если вычисление занимает долгое время, можно выполнить команды меню «Maxima->Прервать» или «Maxima->Перезапустить»."
 
 #: ../../src/MaximaManual.cpp:420
 msgid "Ignoring the cache version for the manual anchors."
@@ -5214,7 +5214,7 @@ msgstr "Игнорируется версия кэша для ключевых �
 
 #: ../../src/sidebars/FormatSidebar.cpp:66
 msgid "Image"
-msgstr ""
+msgstr "Изображение"
 
 #: ../../src/Image.cpp:110
 msgid "Image data had zero length!"
@@ -5236,15 +5236,15 @@ msgstr "ImageCell без изображения."
 
 #: ../../src/sidebars/DrawSidebar.cpp:60
 msgid "Implicit Plot"
-msgstr ""
+msgstr "График неявной функции"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1028
 msgid "Import settings"
-msgstr ""
+msgstr "Параметры импорта"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1013
 msgid "Import+Export"
-msgstr ""
+msgstr "Импорт и экспорт"
 
 #: ../../src/MathParser.cpp:395
 msgid "Importing compressed gnuplot sources for an animation"
@@ -5279,11 +5279,11 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:214
 msgid "In text cells bullet lists can be created by beginning a line with \" * \". The number of spaces in front of the \"*\" determines the indentation level; Indentation can be continued in the next line by indenting the line using spaces."
-msgstr ""
+msgstr "В текстовых полях можно создавать маркированные списки, начиная строку символом «*». Количество пробелов перед «*» определяет уровень отступа. Отступ можно продолжить на следующей строке, добавив в её начало необходимое количество пробелов."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:421
 msgid "In the LaTeX output: Put exponents after an eventual subscript instead of above it. Might increase readability for some fonts and short subscripts."
-msgstr ""
+msgstr "В выводе LaTeX: помещать показатели степени после последних нижних индексов, а не над ними. Это может повысить удобочитаемость для некоторых шрифтов и коротких нижних индексов."
 
 #: ../../src/MaximaCommandMenus.cpp:1869
 msgid "Include columns:"
@@ -5295,15 +5295,15 @@ msgstr "Возрастающая функция f(x)>x"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:884
 msgid "Incremental Search"
-msgstr ""
+msgstr "Последовательный поиск"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:844
 msgid "Indent equations by the label width"
-msgstr ""
+msgstr "Отступ в уравнениях на ширину метки"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:512
 msgid "Indent maths so all lines are in par with the first line that starts after the label."
-msgstr ""
+msgstr "Установить отступ в расчётах так, чтобы все строки были выровнены по первой строке, которая начинается после метки."
 
 #: ../../src/sidebars/TableOfContents.cpp:583
 msgid "Indentation"
@@ -5344,7 +5344,7 @@ msgstr ""
 #: ../../src/wizards/IntegrateWiz.cpp:215 ../../src/wizards/LimitWiz.cpp:132
 #: ../../src/wizards/LimitWiz.cpp:140
 msgid "Infinity"
-msgstr ""
+msgstr "Бесконечность"
 
 #: ../../src/wxMaximaFrame.cpp:1986
 msgid "Info about Maxima build"
@@ -5402,7 +5402,7 @@ msgstr "Вставить"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:889
 msgid "Insert % before an operator at the beginning of a cell"
-msgstr ""
+msgstr "Вставлять символ % перед оператором в начале поля"
 
 #: ../../src/wxMaximaFrame.cpp:939
 msgid "Insert &Section Cell\tCtrl+3"
@@ -5538,7 +5538,7 @@ msgstr ""
 
 #: ../../src/sidebars/HelpBrowser.cpp:111
 msgid "Instantiating the HTML manual browser"
-msgstr ""
+msgstr "Создание экземпляра браузера руководства пользователя в формате HTML"
 
 #: ../../src/MaximaProcessManager.cpp:1066
 msgid "Instructed to prefer gnuplot over wgnuplot"
@@ -5550,11 +5550,11 @@ msgstr "Указано отдавать wgnuplot приоритет над gnupl
 
 #: ../../src/dialogs/ConfigDialogue.cpp:749
 msgid "Integers and single letters"
-msgstr ""
+msgstr "Целые числа и отдельные буквы"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:113
 msgid "Integral sign"
-msgstr ""
+msgstr "Знак интеграла"
 
 #: ../../src/MaximaCommandMenus.cpp:149 ../../src/MaximaCommandMenus.cpp:170
 msgid "Integral/Sum:"
@@ -5588,15 +5588,15 @@ msgstr "Интегрировать..."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:834
 msgid "Intelligently hide cell brackets"
-msgstr ""
+msgstr "Умное скрытие квадратных скобок полей"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:881
 msgid "Interaction"
-msgstr ""
+msgstr "Взаимодействие"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1349
 msgid "Interactive popup memory limit [MB/plot]:"
-msgstr ""
+msgstr "Ограничение памяти для интерактивного открытия [МБ/график]:"
 
 #: ../../src/wxMaximaFrame.cpp:1774
 msgid "Interleave"
@@ -5612,7 +5612,7 @@ msgstr "Чередовать два списка"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1465
 msgid "Internal"
-msgstr ""
+msgstr "Встроенный"
 
 #: ../../src/wxMaximaFrame.cpp:1121
 msgid "Interpret like input..."
@@ -5661,7 +5661,7 @@ msgstr "Вводит одну или несколько установок зн�
 
 #: ../../src/sidebars/RegexCtrl.cpp:40
 msgid "Invalid RegEx!"
-msgstr ""
+msgstr "Недопустимое регулярное выражение!"
 
 #: ../../src/MathParser.cpp:1338
 #, c-format
@@ -5678,7 +5678,7 @@ msgstr "Обратное п&реобразование Лапласа..."
 
 #: ../../src/sidebars/GreekSidebar.cpp:186
 msgid "Iota"
-msgstr ""
+msgstr "Ι"
 
 #: ../../src/MaximaCommandMenus.cpp:4150
 msgid "Is Char 1 greater than Char2, if case is ignored?"
@@ -5794,7 +5794,7 @@ msgstr "В верхнем регистре?..."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:498
 msgid "Issue a notification if maxima finishes calculating while the wxMaxima window isn't in focus."
-msgstr ""
+msgstr "Показывать уведомление, если Maxima завершает расчёты, когда окно wxMaxima не находится в фокусе."
 
 #: ../../src/worksheet/Worksheet.cpp:4237
 msgid "Issuing the active cell's undo function"
@@ -5806,27 +5806,27 @@ msgstr "Срабатывание функции отмены на листе"
 
 #: ../../src/dialogs/TipOfTheDay.cpp:185
 msgid "It is possible to add custom symbols to the \"symbols\" sidebar by copying them into the respective field in the configuration dialogue."
-msgstr ""
+msgstr "Можно добавить пользовательские символы в боковую панель символов, скопировав их в соответствующее поле диалога настройки."
 
 #: ../../src/dialogs/TipOfTheDay.cpp:152
 msgid "It is possible to define reusable Maxima libraries with wxMaxima that can be later loaded by using the load() function. All that has to be done is to export a file in the .mac or to save it in the .wxm format. Note, though, that a few special characters like the \"not equal\" symbol for \"#\" are handled by wxMaxima, not by Maxima and therefore cannot be recognized on load()."
-msgstr ""
+msgstr "Можно задать библиотеки Maxima, которые можно будет использовать в wxMaxima с помощью функции load(). Для этого нужно экспортировать необходимые команды в виде файла в формате .mac или сохранить их в формате .wxm. Следует учитывать, что некоторые специальные символы, в частности, символ «не равно» для обозначения «#», обрабатываются wxMaxima, а не Maxima, и, следовательно, не могут быть распознаны при использовании функции load()."
 
 #: ../../src/wizards/DrawWiz.cpp:476
 msgid "It needs to be filled with objects to draw afterwards."
-msgstr ""
+msgstr "Необходимо добавить объекты для последующей отрисовки."
 
 #: ../../src/wizards/ActualValuesStorageWiz.cpp:38
 msgid "It therefore makes sense to apply the known values for variables as late as possible."
-msgstr ""
+msgstr "Поэтому имеет смысл применять известные значения переменных как можно позже."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:207
 msgid "Italian"
-msgstr ""
+msgstr "Итальянский"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2111
 msgid "Italic"
-msgstr ""
+msgstr "Курсив"
 
 #: ../../src/MaximaCommandMenus.cpp:1617 ../../src/MaximaCommandMenus.cpp:1623
 msgid "Item"
@@ -5838,7 +5838,7 @@ msgstr "Название итератора:"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:208
 msgid "Japanese"
-msgstr ""
+msgstr "Японский"
 
 #: ../../src/MaximaCommandMenus.cpp:2255
 msgid "Jump to UUID"
@@ -5866,16 +5866,16 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:210
 msgid "Kabyle"
-msgstr ""
+msgstr "Кабильский"
 
 #: ../../src/sidebars/GreekSidebar.cpp:187
 msgid "Kappa"
-msgstr ""
+msgstr "Κ"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:864
 #, c-format
 msgid "Keep percent sign with special symbols: %e, %i, etc."
-msgstr ""
+msgstr "Показывать знак процента для специальных символов: %e, %i и так далее"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:212
 msgid "Korean"
@@ -5903,19 +5903,19 @@ msgstr "Норма L[inf] (вещественная)"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1166
 msgid "LaTeX"
-msgstr ""
+msgstr "LaTeX"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1199
 msgid "LaTeX: Place exponents after, instead above subscripts"
-msgstr ""
+msgstr "LaTeX: помещать показатели степени после нижних индексов, а не над ними"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1204
 msgid "LaTeX: Use the \"partial derivative\" symbol to represent diff()"
-msgstr ""
+msgstr "LaTeX: использовать символ «частная производная» для представления diff()"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:758
 msgid "Label width:"
-msgstr ""
+msgstr "Ширина метки:"
 
 #: ../../src/wxMaximaFrame.cpp:1059
 msgid "Labels"
@@ -5936,11 +5936,11 @@ msgstr "Лямбда генерирует функцию, но не даёт е�
 
 #: ../../src/dialogs/ConfigDialogue.cpp:470
 msgid "Language used for wxMaxima GUI."
-msgstr ""
+msgstr "Язык, используемый в интерфейсе wxMaxima."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1311
 msgid "Language:"
-msgstr ""
+msgstr "Язык:"
 
 #: ../../src/MaximaCommandMenus.cpp:251
 msgid "Laplace"
@@ -5987,7 +5987,7 @@ msgstr "Не удалось запустить системный браузер
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:126
 msgid "Leads to"
-msgstr ""
+msgstr "Ведёт к"
 
 #: ../../src/wxMaximaFrame.cpp:1530
 msgid "Least Common Multiple..."
@@ -5999,11 +5999,11 @@ msgstr "Прив. методом наименьших квадратов"
 
 #: ../../src/sidebars/StatSidebar.cpp:79
 msgid "Least Squares Fit..."
-msgstr ""
+msgstr "Прив. методом наименьших квадратов..."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2007
 msgid "Left"
-msgstr ""
+msgstr "Слева"
 
 #: ../../src/MaximaCommandMenus.cpp:1166 ../../src/MaximaCommandMenus.cpp:1171
 #: ../../src/MaximaCommandMenus.cpp:1191 ../../src/MaximaCommandMenus.cpp:1197
@@ -6036,12 +6036,12 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:163
 msgid "Libraries can be accessed by any wxMaxima process regardless of which directory it runs in, if they are placed in the user directory. This directory can be found by typing maxima_userdir;"
-msgstr ""
+msgstr "Любой процесс wxMaxima, в каком бы каталоге он не выполнялся, может получить доступ к библиотекам, если они размещены в каталоге пользователя. Чтобы найти этот каталог, введите maxima_userdir;"
 
 #: ../../src/dialogs/LicenseDialog.cpp:63
 #: ../../src/dialogs/LicenseDialog.cpp:77
 msgid "License"
-msgstr ""
+msgstr "Лицензия"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2068
 msgid "Light"
@@ -6057,15 +6057,15 @@ msgstr "Предел"
 
 #: ../../src/sidebars/MathSidebar.cpp:86
 msgid "Limit..."
-msgstr ""
+msgstr "Предел..."
 
 #: ../../src/sidebars/DrawSidebar.cpp:88
 msgid "Line color"
-msgstr ""
+msgstr "Цвет линии"
 
 #: ../../src/sidebars/StatSidebar.cpp:76
 msgid "Linear Regression..."
-msgstr ""
+msgstr "Линейная регрессия..."
 
 #: ../../src/MaximaCommandMenus.cpp:4068
 msgid "Lisp format string:"
@@ -6113,15 +6113,15 @@ msgstr "Вывести содержимое каталога..."
 
 #: ../../src/wizards/ListSortWiz.cpp:34
 msgid "List name:"
-msgstr ""
+msgstr "Название списка:"
 
 #: ../../src/sidebars/VariablesPane.cpp:188
 msgid "List of arrays"
-msgstr ""
+msgstr "Список массивов"
 
 #: ../../src/sidebars/VariablesPane.cpp:191
 msgid "List of changed options"
-msgstr ""
+msgstr "Список изменённых опций"
 
 #: ../../src/MaximaCommandMenus.cpp:4197
 msgid "List of char to String"
@@ -6137,47 +6137,47 @@ msgstr "Список символов:"
 
 #: ../../src/sidebars/VariablesPane.cpp:179
 msgid "List of functional dependencies"
-msgstr ""
+msgstr "Список функциональных зависимостей"
 
 #: ../../src/sidebars/VariablesPane.cpp:203
 msgid "List of labels"
-msgstr ""
+msgstr "Список меток"
 
 #: ../../src/sidebars/VariablesPane.cpp:200
 msgid "List of structs"
-msgstr ""
+msgstr "Список структур"
 
 #: ../../src/sidebars/VariablesPane.cpp:197
 msgid "List of user aliases"
-msgstr ""
+msgstr "Список пользовательских псевдонимов"
 
 #: ../../src/sidebars/VariablesPane.cpp:185
 msgid "List of user functions"
-msgstr ""
+msgstr "Список пользовательских функций"
 
 #: ../../src/sidebars/VariablesPane.cpp:194
 msgid "List of user rules"
-msgstr ""
+msgstr "Список пользовательских правил"
 
 #: ../../src/sidebars/VariablesPane.cpp:182
 msgid "List of user variables"
-msgstr ""
+msgstr "Список пользовательских переменных"
 
 #: ../../src/sidebars/VariablesPane.cpp:206
 msgid "List of user-defined derivatives"
-msgstr ""
+msgstr "Список заданных пользователем производных"
 
 #: ../../src/sidebars/VariablesPane.cpp:216
 msgid "List of user-defined let rule packages"
-msgstr ""
+msgstr "Список заданных пользователем пакетов правил"
 
 #: ../../src/sidebars/VariablesPane.cpp:212
 msgid "List of user-defined macros"
-msgstr ""
+msgstr "Список заданных пользователем макросов"
 
 #: ../../src/sidebars/VariablesPane.cpp:209
 msgid "List of user-defined properties"
-msgstr ""
+msgstr "Список заданных пользователем свойств"
 
 #: ../../src/MaximaCommandMenus.cpp:1575
 msgid "List with values"
@@ -6198,7 +6198,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2162
 msgid "Load"
-msgstr ""
+msgstr "Загрузить"
 
 #: ../../src/MaximaCommandMenus.cpp:2356
 msgid "Load Package"
@@ -6238,7 +6238,7 @@ msgstr "Загрузить Lisp..."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2645
 msgid "Load style from file"
-msgstr ""
+msgstr "Загрузить стиль из файла"
 
 #: ../../src/wxMaximaFrame.cpp:1232
 msgid "Load the file/dir operations (operatingsystem)"
@@ -6254,7 +6254,7 @@ msgstr "Загрузить генератор трансляций (gentran)"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:128
 msgid "Long Right arrow"
-msgstr ""
+msgstr "Длинная стрелка вправо"
 
 #: ../../src/MaximaCommandMenus.cpp:1409
 msgid "Loop variable"
@@ -6274,7 +6274,7 @@ msgstr "М&атрица"
 
 #: ../../src/sidebars/XmlInspector.cpp:104
 msgid "MAXIMA RESPONSE:"
-msgstr ""
+msgstr "ОТВЕТ MAXIMA:"
 
 #: ../../src/MaximaCommandMenus.cpp:3965
 msgid "Macro contents:"
@@ -6338,7 +6338,7 @@ msgstr "Применить функцию к элементам матрицы, 
 
 #: ../../src/dialogs/FindReplacePane.cpp:71
 msgid "Match Case"
-msgstr ""
+msgstr "Учитывать регистр"
 
 #: ../../src/Styles.cpp:139
 msgid "Math Default"
@@ -6350,7 +6350,7 @@ msgstr ""
 
 #: ../../src/cells/Cell.cpp:1490
 msgid "Math output"
-msgstr ""
+msgstr "Вывод формул"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1221
 msgid "MathML (rendered by the browser)"
@@ -6362,11 +6362,11 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1906
 msgid "MathML as HTML"
-msgstr ""
+msgstr "MathML как HTML"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1902
 msgid "MathML description"
-msgstr ""
+msgstr "Описание MathML"
 
 #: ../../src/wxMaximaFrame.cpp:307
 msgid "Mathematical Symbols"
@@ -6446,11 +6446,11 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:281
 msgid "Maxima"
-msgstr ""
+msgstr "Maxima"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1433
 msgid "Maxima Location"
-msgstr ""
+msgstr "Расположение Maxima"
 
 #: ../../src/MaximaCommandMenus.cpp:619
 msgid "Maxima allows making functions \"nouns\", which means that they aren't automatically evaluated as soon as Maxima encounters them.\n"
@@ -6484,19 +6484,19 @@ msgstr "Maxima автоматически упрощает выражения, �
 
 #: ../../src/cells/EditorCell.cpp:4516
 msgid "Maxima code"
-msgstr ""
+msgstr "Код Maxima"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1110
 msgid "Maxima commands to be executed at every start of Maxima"
-msgstr ""
+msgstr "Команды Maxima для выполнения при каждом запуске Maxima"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1063
 msgid "Maxima commands to be executed every time wxMaxima starts Maxima"
-msgstr ""
+msgstr "Команды Maxima для выполнения при каждом запуске Maxima программой wxMaxima"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1507
 msgid "Maxima configuration"
-msgstr ""
+msgstr "Конфигурация Maxima"
 
 #: ../../src/MaximaResponseReader.cpp:346
 msgid "Maxima didn't attempt to authenticate!"
@@ -6572,11 +6572,11 @@ msgstr "Процесс Maxima неожиданно завершился."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1437
 msgid "Maxima program:"
-msgstr ""
+msgstr "Программа Maxima:"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:382
 msgid "Maxima provides no \"forget all\" command that flushes all settings a maxima session could make. wxMaxima therefore normally defaults to starting a fresh maxima process every time the worksheet is to be re-evaluated. As this needs a little bit of time this switch allows to disable this behavior."
-msgstr ""
+msgstr "В программе Maxima не предусмотрена команда «забыть всё», которая сбрасывает все изменения параметров, сделанные в ходе сеанса Maxima. Поэтому программа wxMaxima обычно запускает новый процесс Maxima при каждом повторном вычислении листа. Так на это требуется определённое время, данное поведение можно изменить с помощью этого переключателя (он позволяет отключить перезапуск сеансов и сэкономить время)."
 
 #: ../../src/Styles.cpp:108
 msgid "Maxima question labels"
@@ -6596,7 +6596,7 @@ msgstr "Maxima отправляет новый набор переменных �
 
 #: ../../src/sidebars/History.cpp:153
 msgid "Maxima session (*.mac)|*.mac"
-msgstr ""
+msgstr "Сеанс Maxima (*.mac)|*.mac"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1518 ../../src/wxMaximaFrame.cpp:1981
 msgid "Maxima shows help in a browser"
@@ -6628,11 +6628,11 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1143
 msgid "Maxima startup file location: "
-msgstr ""
+msgstr "Расположение файла запуска Maxima: "
 
 #: ../../src/dialogs/TipOfTheDay.cpp:68
 msgid "Maxima supports three types of numbers: exact fractions (which can be generated for example by typing 1/10), IEEE floating-point numbers (0.2) and arbitrary precision big floats (1b-1). Note that, owing to their nature as binary (not decimal) numbers, there is for example no way to generate an IEEE floating-point number that exactly equals 0.1. If floating-point numbers are used instead of fractions, Maxima will therefore sometimes have to introduce a (very small) error and use things like 3602879701896397/36028797018963968 for 0.1."
-msgstr ""
+msgstr "Maxima поддерживает три типа чисел:  правильные дроби (которые можно получить, например, введя 1/10), числа IEEE с плавающей точкой (0.2) и числа с плавающей точкой повышенной точности (1b-1). Поскольку числа по своей природе являются двоичными (а не десятичными), нельзя, например, записать число IEEE с плавающей точкой, которое точно равно 0.1. Если в Maxima вместо дробей используются числа с плавающей точкой, возникает ошибка (очень маленькая), то есть использование 3602879701896397/36028797018963968 вместо 0.1 добавляет (очень малую) погрешность."
 
 #: ../../src/wxMaximaFrame.cpp:1265
 msgid "Maxima to other language"
@@ -6648,7 +6648,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1615
 msgid "Maxima usage"
-msgstr ""
+msgstr "Использование Maxima"
 
 #: ../../src/MaximaResponseReader.cpp:776
 #, c-format
@@ -6744,7 +6744,7 @@ msgstr "Руководство пользователя Maxima находитс�
 
 #: ../../src/wizards/ActualValuesStorageWiz.cpp:34
 msgid "Maxima's power lies in symbolic operations."
-msgstr ""
+msgstr "Maxima позволяет выполнять символьные вычисления."
 
 #: ../../src/StatusBar.cpp:365
 msgid "Maxima's reader is in Lisp mode (after to_lisp()).\n"
@@ -6791,7 +6791,7 @@ msgstr "Максимальное абсолютное значение, кото
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1931
 msgid "Maximum bitmap size on clipboard [Mb]:"
-msgstr ""
+msgstr "Максимальный размер растрового изображения в буфере обмена [МБ]:"
 
 #: ../../src/MaximaCommandMenus.cpp:488 ../../src/MaximaCommandMenus.cpp:501
 #: ../../src/MaximaCommandMenus.cpp:516 ../../src/MaximaCommandMenus.cpp:530
@@ -6804,19 +6804,19 @@ msgstr "Максимальное количество цифр для отобр
 
 #: ../../src/dialogs/ConfigDialogue.cpp:811
 msgid "Maximum number of displayed digits:"
-msgstr ""
+msgstr "Максимальное количество отображаемых цифр:"
 
 #: ../../src/sidebars/StatSidebar.cpp:70
 msgid "Mean Difference Test..."
-msgstr ""
+msgstr "Проверка разности средних..."
 
 #: ../../src/sidebars/StatSidebar.cpp:67
 msgid "Mean Test..."
-msgstr ""
+msgstr "Проверка среднего..."
 
 #: ../../src/sidebars/StatSidebar.cpp:52
 msgid "Mean..."
-msgstr ""
+msgstr "Cреднее..."
 
 #: ../../src/MaximaCommandMenus.cpp:1806
 msgid "Mean:"
@@ -6824,7 +6824,7 @@ msgstr "Среднее:"
 
 #: ../../src/sidebars/StatSidebar.cpp:55
 msgid "Median..."
-msgstr ""
+msgstr "Медиана..."
 
 #: ../../src/wxMaximaFrame.cpp:1961
 msgid "Memoizing"
@@ -6845,7 +6845,7 @@ msgstr "Сообщение потока stdout Maxima: "
 
 #: ../../src/wizards/IntegrateWiz.cpp:55
 msgid "Method:"
-msgstr ""
+msgstr "Метод:"
 
 #: ../../src/wxMaximaFrame.cpp:1360
 msgid "Methods of generating a matrix"
@@ -6871,11 +6871,11 @@ msgstr "Минимальное абсолютное значение, котор
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1270
 msgid "Misc"
-msgstr ""
+msgstr "Прочее"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1963
 msgid "Misc settings"
-msgstr ""
+msgstr "Различные параметры"
 
 #: ../../src/wxMaxima.cpp:3134 ../../src/wxMaxima.cpp:3136
 msgid "Mismatched parenthesis"
@@ -6912,7 +6912,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:189
 msgid "Mu"
-msgstr ""
+msgstr "Μ"
 
 #: ../../src/wxMaximaFrame.cpp:1386
 msgid "Multiplication, exponent and similar"
@@ -6936,7 +6936,7 @@ msgstr "Имя t:"
 
 #: ../../src/wizards/DrawWiz.cpp:750
 msgid "Name of the parameter"
-msgstr ""
+msgstr "Имя параметра"
 
 #: ../../src/MaximaCommandMenus.cpp:1019
 msgid "Name of x:"
@@ -6944,7 +6944,7 @@ msgstr "Имя x:"
 
 #: ../../src/wizards/MatWiz.cpp:163
 msgid "Name:"
-msgstr ""
+msgstr "Имя:"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:216
 msgid "Nepali"
@@ -7007,7 +7007,7 @@ msgstr "Создать документ"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:901
 msgid "New lines: Jump to text"
-msgstr ""
+msgstr "Новые строки: переходить к тексту"
 
 #: ../../src/MaximaResponseReader.cpp:1015
 #, c-format
@@ -7020,7 +7020,7 @@ msgstr "Новая часть:"
 
 #: ../../src/wizards/SubstituteWiz.cpp:35
 msgid "New value:"
-msgstr ""
+msgstr "Новое значение:"
 
 #: ../../src/MaximaCommandMenus.cpp:151 ../../src/MaximaCommandMenus.cpp:171
 #: ../../src/MaximaCommandMenus.cpp:254 ../../src/MaximaCommandMenus.cpp:259
@@ -7058,7 +7058,7 @@ msgstr ""
 
 #: ../../src/wizards/DrawWiz.cpp:636
 msgid "No contour lines"
-msgstr ""
+msgstr "Без контурных линий"
 
 #: ../../src/dialogs/DiffFrame.cpp:304
 msgid "No differences"
@@ -7095,11 +7095,11 @@ msgstr "Совпадений не найдено"
 
 #: ../../src/wizards/DrawWiz.cpp:651
 msgid "No plot, only contour lines"
-msgstr ""
+msgstr "Без графика, только контурные линии"
 
 #: ../../src/wizards/DrawWiz.cpp:837
 msgid "No points"
-msgstr ""
+msgstr "Без точек"
 
 #: ../../src/MaximaResponseReader.cpp:145
 msgid "No topics found in topic flag"
@@ -7115,7 +7115,7 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:179
 msgid "Non-builtin symbols"
-msgstr ""
+msgstr "Невстроенные символы"
 
 #: ../../src/wxMaximaFrame.cpp:834
 msgid "None"
@@ -7123,7 +7123,7 @@ msgstr "Нет"
 
 #: ../../src/sidebars/StatSidebar.cpp:73
 msgid "Normality Test..."
-msgstr ""
+msgstr "Проверка нормальности распределения..."
 
 #: ../../src/cells/TextCell.cpp:271
 msgid "Normally computers use floating-point numbers that can be handled incredibly fast while being accurate to dozens of digits. They will, though, introduce a small error into some common numbers. For example 0.1 is represented as 3602879701896397/36028797018963968.\n"
@@ -7134,11 +7134,11 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:431
 msgid "Normally html expects images to be rather low-res but space saving. These images tend to look rather blurry when viewed on modern screens. Therefore this setting was introduces that selects the factor by which the HTML export increases the resolution in respect to the default value."
-msgstr ""
+msgstr "Обычно в HTML используются изображения с небольшим разрешением, что позволяет экономить пространство на носителе информации. На современных экранах они выглядят расплывчатыми. Поэтому был добавлен этот параметр — с его помощью можно настроить коэффициент увеличения разрешения при экспорте в HTML относительно значения по умолчанию."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:217
 msgid "Norwegian"
-msgstr ""
+msgstr "Норвежский"
 
 #: ../../src/MaximaCommandMenus.cpp:1351
 msgid "Not a valid matrix dimension!"
@@ -7174,7 +7174,7 @@ msgstr "Вычисление не активировано, так как нет
 
 #: ../../src/sidebars/GreekSidebar.cpp:190
 msgid "Nu"
-msgstr ""
+msgstr "Ν"
 
 #: ../../src/MaximaCommandMenus.cpp:177
 msgid "Num. deg:"
@@ -7317,7 +7317,7 @@ msgstr "Нечётное число"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:910
 msgid "Offer answers for questions known from previous runs"
-msgstr ""
+msgstr "Предлагать ответы на вопросы, известные с прошлых выполнений"
 
 #: ../../src/cells/TextCell.cpp:332
 msgid "Often caused by recursive function calls. Some lisps allow increasing the control stack size using command-line arguments."
@@ -7325,7 +7325,7 @@ msgstr ""
 
 #: ../../src/wizards/SubstituteWiz.cpp:32
 msgid "Old value:"
-msgstr ""
+msgstr "Прежнее значение:"
 
 #: ../../src/MaximaCommandMenus.cpp:151 ../../src/MaximaCommandMenus.cpp:172
 #: ../../src/MaximaCommandMenus.cpp:253 ../../src/MaximaCommandMenus.cpp:259
@@ -7334,11 +7334,11 @@ msgstr "Старая переменная:"
 
 #: ../../src/sidebars/GreekSidebar.cpp:201
 msgid "Omega"
-msgstr ""
+msgstr "Ω"
 
 #: ../../src/sidebars/GreekSidebar.cpp:192
 msgid "Omicron"
-msgstr ""
+msgstr "Ο"
 
 #: ../../src/wxMaximaFrame.cpp:1089
 msgid "On all errors"
@@ -7362,7 +7362,7 @@ msgstr "Только целые числа и отдельные буквы"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:771
 msgid "Only user-defined labels"
-msgstr ""
+msgstr "Только пользовательские метки"
 
 #: ../../src/MaximaCommandMenus.cpp:2197 ../../src/ToolBar.cpp:330
 #: ../../src/ToolBar.cpp:333 ../../src/main.cpp:882
@@ -7371,7 +7371,7 @@ msgstr "Открыть"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:905
 msgid "Open a cell when Maxima expects input"
-msgstr ""
+msgstr "Открывать поле, когда Maxima ожидает ввод"
 
 #: ../../src/wxMaximaFrame.cpp:629
 msgid "Open a document"
@@ -7445,7 +7445,7 @@ msgstr "Оптимизировать для экономии памяти"
 
 #: ../../src/wizards/DrawWiz.cpp:97
 msgid "Optional: A 2nd expression that defines a region to fill"
-msgstr ""
+msgstr "Необязательно: второе выражение, которое определяет область для заполнения"
 
 #: ../../src/ToolBar.cpp:367 ../../src/ToolBar.cpp:369
 #: ../../src/dialogs/ConfigDialogue.cpp:284
@@ -7454,7 +7454,7 @@ msgstr "Опции"
 
 #: ../../src/wizards/Plot2dWiz.cpp:75 ../../src/wizards/Plot3dWiz.cpp:66
 msgid "Options:"
-msgstr ""
+msgstr "Опции:"
 
 #: ../../src/dialogs/FindReplacePane.cpp:109
 msgid "Output"
@@ -7515,7 +7515,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:458
 msgid "PNG images can be read by old wxMaxima versions - but aren't really scalable."
-msgstr ""
+msgstr "Изображения PNG могут быть прочитаны предыдущими версиями wxMaxima, но они не подходят для масштабирования."
 
 #: ../../src/MaximaCommandMenus.cpp:175
 msgid "Pade approximation"
@@ -7527,7 +7527,7 @@ msgstr "Паде-аппроксимация ряда Тейлора"
 
 #: ../../src/sidebars/FormatSidebar.cpp:69
 msgid "Pagebreak"
-msgstr ""
+msgstr "Разрыв страницы"
 
 #: ../../src/wxMaximaFrame.cpp:1674
 msgid "Parallel Substitute..."
@@ -7539,7 +7539,7 @@ msgstr "Параллельная подстановка"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:124
 msgid "Parallel to"
-msgstr ""
+msgstr "Параллельно"
 
 #: ../../src/MaximaCommandMenus.cpp:3991
 msgid "Parameter name:"
@@ -7551,11 +7551,11 @@ msgstr "Параметр(ы):"
 
 #: ../../src/sidebars/DrawSidebar.cpp:64
 msgid "Parametric Plot"
-msgstr ""
+msgstr "Параметрический график"
 
 #: ../../src/wizards/Plot2dWiz.cpp:417 ../../src/wizards/Plot2dWiz.cpp:523
 msgid "Parametric plot"
-msgstr ""
+msgstr "Параметрический график"
 
 #: ../../src/MaximaCommandMenus.cpp:4211
 msgid "Parse string"
@@ -7609,7 +7609,7 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:125
 msgid "Perpendicular to"
-msgstr ""
+msgstr "Перпендикулярно"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:218
 msgid "Persian"
@@ -7617,15 +7617,15 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:198
 msgid "Phi"
-msgstr ""
+msgstr "Φ"
 
 #: ../../src/sidebars/GreekSidebar.cpp:193
 msgid "Pi"
-msgstr ""
+msgstr "Π"
 
 #: ../../src/sidebars/StatSidebar.cpp:94
 msgid "Piechart..."
-msgstr ""
+msgstr "Круговая диаграмма..."
 
 #: ../../src/wxMaxima.cpp:1585
 msgid "Please configure wxMaxima with 'Edit->Configure'."
@@ -7633,7 +7633,7 @@ msgstr "Настройте wxMaxima с помощью меню «Правка ->
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2606
 msgid "Please restart wxMaxima for changes to take effect!"
-msgstr ""
+msgstr "Перезапустите wxMaxima, чтобы изменения вступили в силу!"
 
 #: ../../src/MaximaCommandMenus.cpp:2250
 msgid "Please select exactly 2 or 3 files."
@@ -7674,16 +7674,16 @@ msgstr "Трёхмерный график..."
 
 #: ../../src/wizards/DrawWiz.cpp:713
 msgid "Plot a parametric curve"
-msgstr ""
+msgstr "График параметрической кривой"
 
 #: ../../src/wizards/DrawWiz.cpp:45 ../../src/wizards/DrawWiz.cpp:148
 #: ../../src/wizards/DrawWiz.cpp:255
 msgid "Plot an explicit expression"
-msgstr ""
+msgstr "График явного выражения"
 
 #: ../../src/wizards/DrawWiz.cpp:53
 msgid "Plot an expression, for example sin(x) or (x+1)^2."
-msgstr ""
+msgstr "График выражения, например, sin(x) или (x+1)^2."
 
 #: ../../src/MaximaCommandMenus.cpp:1776
 msgid "Plot as bars"
@@ -7707,11 +7707,11 @@ msgstr "Трёхмерный график"
 
 #: ../../src/sidebars/DrawSidebar.cpp:83
 msgid "Plot name"
-msgstr ""
+msgstr "Название графика"
 
 #: ../../src/wizards/Plot2dWiz.cpp:84 ../../src/wizards/Plot3dWiz.cpp:80
 msgid "Plot to file:"
-msgstr ""
+msgstr "Вывести график в файл:"
 
 #: ../../src/wxMaximaFrame.cpp:341 ../../src/wxMaximaFrame.cpp:749
 msgid "Plot using Draw"
@@ -7731,7 +7731,7 @@ msgstr "Точка, в которой известно значение:"
 
 #: ../../src/wizards/DrawWiz.cpp:842
 msgid "Point type:"
-msgstr ""
+msgstr "Тип точки:"
 
 #: ../../src/MaximaCommandMenus.cpp:186 ../../src/MaximaCommandMenus.cpp:1090
 #: ../../src/wizards/BC2Wiz.cpp:33 ../../src/wizards/BC2Wiz.cpp:39
@@ -7741,11 +7741,11 @@ msgstr "Точка:"
 
 #: ../../src/sidebars/DrawSidebar.cpp:67
 msgid "Points"
-msgstr ""
+msgstr "Точки"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:219
 msgid "Polish"
-msgstr ""
+msgstr "Польский"
 
 #: ../../src/MaximaCommandMenus.cpp:215 ../../src/MaximaCommandMenus.cpp:220
 #: ../../src/MaximaCommandMenus.cpp:225
@@ -7781,7 +7781,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:221
 msgid "Portuguese (Brazilian)"
-msgstr ""
+msgstr "Португальский (Бразилия)"
 
 #: ../../src/wxMaximaFrame.cpp:1223
 msgid "Position of a match"
@@ -7797,7 +7797,7 @@ msgstr ""
 
 #: ../../src/wizards/Plot2dWiz.cpp:474 ../../src/wizards/Plot3dWiz.cpp:422
 msgid "Postscript file (*.eps)|*.eps|All|*"
-msgstr ""
+msgstr "Postscript (*.eps)|*.eps|Все|*"
 
 #: ../../src/MaximaCommandMenus.cpp:190
 msgid "Power series"
@@ -7817,7 +7817,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1492
 msgid "Prefer the all-in-one-file >1000 page manual"
-msgstr ""
+msgstr "Предпочитать файл «всё в одном» > 1000-страничное руководство"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:389
 msgid "Prefer user labels"
@@ -7845,7 +7845,7 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:146
 msgid "Pressing Ctrl+Space or Ctrl+Tab starts an autocomplete function that can not only complete all functions that are integrated into the Maxima core and their parameters: It also knows about parameters from currently loaded packages and from functions that are defined in the current file."
-msgstr ""
+msgstr "Нажатие комбинации клавиш Ctrl+Пробел или Ctrl+Tab запускает функцию автодополнения, которая позволяет дополнить не только все встроенные в ядро Maxima функции и их параметры, но и параметры из текущих загруженных пакетов и определённых в текущем файле функций."
 
 #: ../../src/wxMaximaFrame.cpp:961
 msgid "Previous Command\tAlt+Up"
@@ -7861,7 +7861,7 @@ msgstr "Печать"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1988
 msgid "Print Margins"
-msgstr ""
+msgstr "Границы печатного поля"
 
 #: ../../src/ToolBar.cpp:820
 msgid "Print button"
@@ -7882,15 +7882,15 @@ msgstr "Отображать числа с плавающей точкой с э
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1968
 msgid "Print scale:"
-msgstr ""
+msgstr "Масштаб печати:"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1981
 msgid "Print the cell brackets [drawn to their left]"
-msgstr ""
+msgstr "Печать квадратных скобок полей [слева от них]"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:287
 msgid "Printout settings"
-msgstr ""
+msgstr "Параметры распечатки"
 
 #: ../../src/graphical_io/Printout.cpp:208
 msgid "Printout: Cannot find a suitable point for a page break!"
@@ -7936,7 +7936,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:936
 msgid "Privacy settings"
-msgstr ""
+msgstr "Параметры конфиденциальности"
 
 #: ../../src/WXMXformat.cpp:256
 msgid "Produced invalid XML. The erroneous XML data has therefore not been saved but has been put on the clipboard in order to allow debugging it.\n"
@@ -7949,7 +7949,7 @@ msgstr "Произведение"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:123
 msgid "Product sign"
-msgstr ""
+msgstr "Знак произведения"
 
 #: ../../src/wxMaximaFrame.cpp:1129
 msgid "Program"
@@ -7973,7 +7973,7 @@ msgstr "Программный блок без локальных перемен
 
 #: ../../src/sidebars/GreekSidebar.cpp:200
 msgid "Psi"
-msgstr ""
+msgstr "Ψ"
 
 #: ../../src/wxMaximaFrame.cpp:1788
 msgid "Push"
@@ -7997,7 +7997,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1910
 msgid "RTF with OMML maths"
-msgstr ""
+msgstr "RTF с расчётами OMML"
 
 #: ../../src/MaximaCommandMenus.cpp:207
 msgid "Range radius:"
@@ -8059,7 +8059,7 @@ msgstr "Прочитать каталог"
 
 #: ../../src/sidebars/StatSidebar.cpp:103
 msgid "Read Matrix..."
-msgstr ""
+msgstr "Прочитать матрицу..."
 
 #: ../../src/MaximaCommandMenus.cpp:4008
 msgid "Read a structure field"
@@ -8075,7 +8075,7 @@ msgstr "Прочитать символ"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2488
 msgid "Read config to file"
-msgstr ""
+msgstr "Прочитать конфигурацию из файла"
 
 #: ../../src/MaximaCommandMenus.cpp:4405
 msgid "Read environment variable"
@@ -8188,7 +8188,7 @@ msgstr "Получен первый запрос Maxima: %s"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1327
 msgid "Recent files list length:"
-msgstr ""
+msgstr "Длина списка последних файлов:"
 
 #: ../../src/wxMaximaFrame.cpp:634
 msgid "Recover unsaved"
@@ -8196,7 +8196,7 @@ msgstr "Восстановить несохранённые"
 
 #: ../../src/sidebars/MathSidebar.cpp:56
 msgid "Rectform"
-msgstr ""
+msgstr "Ст. форма"
 
 #: ../../src/wxMaximaFrame.cpp:1677
 msgid "Recursive Substitute..."
@@ -8220,7 +8220,7 @@ msgstr "Повторить последнее действие"
 
 #: ../../src/sidebars/MathSidebar.cpp:71
 msgid "Reduce (tr)"
-msgstr ""
+msgstr "Привести (триг.)"
 
 #: ../../src/wxMaximaFrame.cpp:1632
 msgid "Reduce trigonometric expression"
@@ -8237,7 +8237,7 @@ msgstr "Отказ в отправке поля в Maxima: "
 
 #: ../../src/dialogs/FindReplacePane.cpp:85
 msgid "Regex"
-msgstr ""
+msgstr "Регулярное выражение"
 
 #: ../../src/MaximaCommandMenus.cpp:4335
 msgid "Regex match"
@@ -8270,11 +8270,11 @@ msgstr "Перезагрузить изображение «%s»"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:997
 msgid "Reload all GUI settings from disc"
-msgstr ""
+msgstr "Перезагрузить все параметры графического интерфейса с диска"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1004
 msgid "Reload the style settings from disc"
-msgstr ""
+msgstr "Перезагрузить все параметры стиля с диска"
 
 #: ../../src/MaximaCommandMenus.cpp:3212
 #, c-format
@@ -8283,15 +8283,15 @@ msgstr "Перезагрузка файла изображения %s."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2573
 msgid "Reloading the configuration from disc"
-msgstr ""
+msgstr "Перезагрузка конфигурации с диска"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2581
 msgid "Reloading the styles from disc"
-msgstr ""
+msgstr "Перезагрузка стилей с диска"
 
 #: ../../src/sidebars/VariablesPane.cpp:220
 msgid "Remove"
-msgstr ""
+msgstr "Удалить"
 
 #: ../../src/wxMaximaFrame.cpp:917
 msgid "Remove All Output"
@@ -8307,7 +8307,7 @@ msgstr ""
 
 #: ../../src/sidebars/VariablesPane.cpp:225
 msgid "Remove all"
-msgstr ""
+msgstr "Удалить все"
 
 #: ../../src/wxMaximaFrame.cpp:1785
 msgid "Remove all list elements that appear twice in a row. Normally used in conjunction with sort."
@@ -8387,7 +8387,7 @@ msgstr "Циклическое покомпонентное умножение"
 
 #: ../../src/dialogs/FindReplacePane.cpp:117
 msgid "Replace All"
-msgstr ""
+msgstr "Заменить все"
 
 #: ../../src/MaximaCommandMenus.cpp:4350
 msgid "Replace all regex matches"
@@ -8416,7 +8416,7 @@ msgstr "Заменено вхождений: %li."
 
 #: ../../src/dialogs/FindReplacePane.cpp:62
 msgid "Replacement:"
-msgstr ""
+msgstr "Замена:"
 
 #: ../../src/MaximaCommandMenus.cpp:768
 msgid "Replaces the subexpression that part(expr, n_1, n_2, ...) would select by a new value. The part numbers form a path: n_1 selects a part of the expression, n_2 a part of that, and so on."
@@ -8428,7 +8428,7 @@ msgstr "Сообщить об ошибке"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:983
 msgid "Reset all GUI settings"
-msgstr ""
+msgstr "Сбросить все параметры графического интерфейса"
 
 #: ../../src/wxMaximaFrame.cpp:1030
 msgid "Reset option variables"
@@ -8436,12 +8436,12 @@ msgstr "Сбросить переменные"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:990
 msgid "Reset the Style settings"
-msgstr ""
+msgstr "Сбросить все параметры стиля"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2557
 #: ../../src/dialogs/ConfigDialogue.cpp:2565
 msgid "Resetting all configuration settings"
-msgstr ""
+msgstr "Сброс всех параметров конфигурации"
 
 #: ../../src/ToolBar.cpp:411 ../../src/ToolBar.cpp:417
 #: ../../src/wxMaximaFrame.cpp:1008
@@ -8531,7 +8531,7 @@ msgstr ""
 
 #: ../../src/wizards/DrawWiz.cpp:836
 msgid "Reuse last"
-msgstr ""
+msgstr "Повторно использовать последний"
 
 #: ../../src/wxMaximaFrame.cpp:1780
 msgid "Reverse"
@@ -8547,19 +8547,19 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:295
 msgid "Revert all to defaults"
-msgstr ""
+msgstr "Вернуть все значения по умолчанию"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:980
 msgid "Revert changes"
-msgstr ""
+msgstr "Отменить изменения"
 
 #: ../../src/sidebars/GreekSidebar.cpp:194
 msgid "Rho"
-msgstr ""
+msgstr "Ρ"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2015
 msgid "Right"
-msgstr ""
+msgstr "Справа"
 
 #: ../../src/MaximaCommandMenus.cpp:1167 ../../src/MaximaCommandMenus.cpp:1172
 #: ../../src/MaximaCommandMenus.cpp:1192 ../../src/MaximaCommandMenus.cpp:1198
@@ -8568,7 +8568,7 @@ msgstr "Правая матрица:"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:127
 msgid "Right arrow"
-msgstr ""
+msgstr "Стрелка вправо"
 
 #: ../../src/MaximaCommandMenus.cpp:1380
 msgid "Right end"
@@ -8608,7 +8608,7 @@ msgstr "Строки"
 
 #: ../../src/wizards/MatWiz.cpp:152
 msgid "Rows:"
-msgstr ""
+msgstr "Строки:"
 
 #: ../../src/MaximaCommandMenus.cpp:1391
 msgid "Rule"
@@ -8678,7 +8678,7 @@ msgstr "Применяет выражение к каждому элементу
 
 #: ../../src/dialogs/ConfigDialogue.cpp:223
 msgid "Russian"
-msgstr ""
+msgstr "Русский"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1578
 msgid "SBCL: use <int>Mbytes of heap"
@@ -8690,11 +8690,11 @@ msgstr ""
 
 #: ../../src/sidebars/XmlInspector.cpp:78
 msgid "SENT TO MAXIMA:"
-msgstr ""
+msgstr "ОТПРАВЛЕНО В MAXIMA:"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1224
 msgid "SVG graphics"
-msgstr ""
+msgstr "SVG-графика"
 
 #: ../../src/MaximaCommandMenus.cpp:1810
 msgid "Sample 1:"
@@ -8710,19 +8710,19 @@ msgstr "Выборка:"
 
 #: ../../src/wizards/DrawWiz.cpp:956
 msgid "Samples for explicit and parametric plots:"
-msgstr ""
+msgstr "Выборки для графиков явных функций и параметрических графиков:"
 
 #: ../../src/wizards/DrawWiz.cpp:969
 msgid "Samples for implicit plots and regions:"
-msgstr ""
+msgstr "Выборки для графиков неявных функций и областей:"
 
 #: ../../src/wizards/DrawWiz.cpp:937
 msgid "Samples for implicit plots:"
-msgstr ""
+msgstr "Выборки для графиков неявных функций:"
 
 #: ../../src/wizards/DrawWiz.cpp:924
 msgid "Samples on a line:"
-msgstr ""
+msgstr "Выборок на линию:"
 
 #: ../../src/ToolBar.cpp:331 ../../src/ToolBar.cpp:334
 #: ../../src/dialogs/ConfigDialogue.cpp:2163 ../../src/wxMaxima.cpp:3507
@@ -8767,7 +8767,7 @@ msgstr "Сохранить как Lisp..."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2478
 msgid "Save config to file"
-msgstr ""
+msgstr "Сохранить конфигурацию в файл"
 
 #: ../../src/ToolBar.cpp:331 ../../src/ToolBar.cpp:334
 #: ../../src/wxMaximaFrame.cpp:639
@@ -8780,7 +8780,7 @@ msgstr "Сохранить документ как"
 
 #: ../../src/wizards/Plot2dWiz.cpp:473 ../../src/wizards/Plot3dWiz.cpp:421
 msgid "Save plot to file"
-msgstr ""
+msgstr "Сохранить график в файл"
 
 #: ../../src/wxMaximaFrame.cpp:713
 msgid "Save selection from document to an image file"
@@ -8792,11 +8792,11 @@ msgstr "Сохранить выделение в файл"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2640
 msgid "Save style to file"
-msgstr ""
+msgstr "Сохранить стиль в файл"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1384
 msgid "Save the worksheet automatically"
-msgstr ""
+msgstr "Сохранять лист автоматически"
 
 #: ../../src/MaximaFileIO.cpp:873
 msgid "Saving failed!"
@@ -8812,7 +8812,7 @@ msgstr "Сохранение выполнено успешно, но пропа�
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1914
 msgid "Scalable Vector Graphics (svg)"
-msgstr ""
+msgstr "Scalable Vector Graphics (svg)"
 
 #: ../../src/MaximaCommandMenus.cpp:3536
 msgid "Scalable Vector image (*.svg)|*.svg|Compressed Scalable Vector Image (*.svgz)|*.svgz|PNG image (*.png)|*.png|JPEG image (*.jpg)|*.jpg|GIF image (*.gif)|*.gif|Windows bitmap (*.bmp)|*.bmp|"
@@ -8824,7 +8824,7 @@ msgstr "График рассеяния"
 
 #: ../../src/sidebars/StatSidebar.cpp:88
 msgid "Scatterplot..."
-msgstr ""
+msgstr "График рассеяния..."
 
 #: ../../src/Autocomplete.cpp:157
 msgid "Scheduling a background task that compiles a new list of autocompletable maxima commands."
@@ -8872,7 +8872,7 @@ msgstr ""
 
 #: ../../src/wizards/DrawWiz.cpp:158
 msgid "See also the speed <-> accuracy button."
-msgstr ""
+msgstr "См. также кнопку «скорость <-> точность."
 
 #: ../../src/MaximaCommandMenus.cpp:4030
 msgid "Seek to position"
@@ -8888,7 +8888,7 @@ msgstr "Вероятно, пакет с общими файлами Maxima не 
 
 #: ../../src/sidebars/TableOfContents.cpp:511
 msgid "Select"
-msgstr ""
+msgstr "Выбрать"
 
 #: ../../src/MaximaCommandMenus.cpp:2239
 msgid "Select 2 or 3 files to compare"
@@ -8915,7 +8915,7 @@ msgstr "Выделить подвыборку"
 #: ../../src/wizards/IntegrateWiz.cpp:208 ../../src/wizards/LimitWiz.cpp:133
 #: ../../src/wizards/SeriesWiz.cpp:105
 msgid "Select a constant"
-msgstr ""
+msgstr "Выбрать константу"
 
 #: ../../src/ToolBar.cpp:390 ../../src/ToolBar.cpp:392
 #: ../../src/wxMaximaFrame.cpp:710
@@ -8936,7 +8936,7 @@ msgstr "Выбрать способ отображения"
 
 #: ../../src/dialogs/TipOfTheDay.cpp:109
 msgid "Selecting a part of an output and right-clicking on the selection will bring up a menu with convenient functions that will operate on the selection."
-msgstr ""
+msgstr "Выбор части вывода и щелчок правой кнопкой мыши по выделению вызовет меню с функциями, которые позволяют управлять выделенным."
 
 #: ../../src/Styles.cpp:127
 msgid "Selection color"
@@ -9024,7 +9024,7 @@ msgstr "Установить точность для &чисел с плаваю
 
 #: ../../src/dialogs/ConfigDialogue.cpp:479
 msgid "Set fixed font in text controls."
-msgstr ""
+msgstr "Установить фиксированный шрифт в текстовом вводе."
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:68
 #: ../../src/worksheet/WorksheetContextMenu.cpp:250
@@ -9033,7 +9033,7 @@ msgstr "Установить разрешение изображения"
 
 #: ../../src/dialogs/ResolutionChooser.cpp:29
 msgid "Set image resolution [in ppi]"
-msgstr ""
+msgstr "Установить разрешение изображения [в пикселах на дюйм]"
 
 #: ../../src/wxMaximaFrame.cpp:1547
 msgid "Set main variable..."
@@ -9041,7 +9041,7 @@ msgstr "Установить основную переменную..."
 
 #: ../../src/dialogs/MaxSizeChooser.cpp:29
 msgid "Set maximum image size [in mm]"
-msgstr ""
+msgstr "Установить максимальный размер изображения [в мм]"
 
 #: ../../src/wxMaximaFrame.cpp:1810
 msgid "Set plot format"
@@ -9101,7 +9101,7 @@ msgstr "Установить увеличение в 80%"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:163
 msgid "Sets the language, line ending type and charset encoding programs will use"
-msgstr ""
+msgstr "Устанавливает язык, тип конца строки и кодировку, которые будут использовать программы"
 
 #: ../../src/MaximaEvaluator.cpp:574
 #, c-format
@@ -9114,24 +9114,24 @@ msgstr "Установка формата запросов и справки"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:165
 msgid "Setting this to \"cat\" causes gnuplot not to halt if there is much output"
-msgstr ""
+msgstr "При установке этого параметра в значение «cat» Gnuplot не будет прекращать работу, когда выводится слишком много текста"
 
 #: ../../src/wizards/DrawWiz.cpp:546
 msgid "Settings for the following 3d plots"
-msgstr ""
+msgstr "Параметры для следующих 3D-графиков"
 
 #: ../../src/wizards/DrawWiz.cpp:462
 #, c-format
 msgid "Setup a %iD scene"
-msgstr ""
+msgstr "Настройка %iD-сцены"
 
 #: ../../src/sidebars/DrawSidebar.cpp:48
 msgid "Setup a 2D plot"
-msgstr ""
+msgstr "Настроить двумерный график"
 
 #: ../../src/sidebars/DrawSidebar.cpp:52
 msgid "Setup a 3D plot"
-msgstr ""
+msgstr "Настроить трёхмерный график"
 
 #: ../../src/wxMaximaFrame.cpp:1326
 msgid "Setup atvalues for solving ODE with Laplace transformation"
@@ -9143,11 +9143,11 @@ msgstr "Установить вычисления по модулю"
 
 #: ../../src/sidebars/DrawSidebar.cpp:78
 msgid "Setup the axis"
-msgstr ""
+msgstr "Настроить ось"
 
 #: ../../src/wizards/DrawWiz.cpp:263
 msgid "Setup the axis for the current plot."
-msgstr ""
+msgstr "Настроить ось для текущего графика."
 
 #: ../../src/MaximaCommandMenus.cpp:411
 msgid "Setup the engineering format"
@@ -9195,7 +9195,7 @@ msgstr "Показать все команды, похожие на:"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:206
 msgid "Show all unicode symbols"
-msgstr ""
+msgstr "Показать все символы Юникода"
 
 #: ../../src/MaximaCommandMenus.cpp:2111
 msgid "Show an example for the command:"
@@ -9207,7 +9207,7 @@ msgstr "Показать пример использования"
 
 #: ../../src/sidebars/History.cpp:121
 msgid "Show commands from current session only"
-msgstr ""
+msgstr "Показывать только команды из текущего сеанса"
 
 #: ../../src/wxMaximaFrame.cpp:1921
 msgid "Show commands similar to"
@@ -9243,7 +9243,7 @@ msgstr "Показывать метки ввода"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:766
 msgid "Show labels:"
-msgstr ""
+msgstr "Показывать метки:"
 
 #: ../../src/wxMaximaFrame.cpp:787
 msgid "Show lisp representation"
@@ -9251,11 +9251,11 @@ msgstr "Показать Lisp-представление"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:465
 msgid "Show long expressions in wxMaxima document."
-msgstr ""
+msgstr "Показывать длинные выражения в документе wxMaxima."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:722
 msgid "Show long expressions:"
-msgstr ""
+msgstr "Показывать длинные выражения:"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:377
 msgid "Show max. 100 digits"
@@ -9319,7 +9319,7 @@ msgstr "Показывать кнопку отмены и повторения �
 
 #: ../../src/dialogs/TipOfTheDay.cpp:288
 msgid "Show tips at Startup"
-msgstr ""
+msgstr "Показывать подсказки при запуске"
 
 #: ../../src/wxMaximaFrame.cpp:1040 ../../src/wxMaximaFrame.cpp:1045
 msgid "Show used + to-be-freed memory"
@@ -9344,11 +9344,11 @@ msgstr "Боковые панели"
 
 #: ../../src/sidebars/GreekSidebar.cpp:195
 msgid "Sigma"
-msgstr ""
+msgstr "Σ"
 
 #: ../../src/dialogs/FindReplacePane.cpp:88
 msgid "Simple"
-msgstr ""
+msgstr "Простой"
 
 #: ../../src/MaximaCommandMenus.cpp:1819
 msgid "Simple linear regression"
@@ -9356,7 +9356,7 @@ msgstr ""
 
 #: ../../src/sidebars/MathSidebar.cpp:44
 msgid "Simplify"
-msgstr ""
+msgstr "Упростить"
 
 #: ../../src/wxMaximaFrame.cpp:1550
 msgid "Simplify &Radicals..."
@@ -9364,11 +9364,11 @@ msgstr "Упростить &радикалы..."
 
 #: ../../src/sidebars/MathSidebar.cpp:47
 msgid "Simplify (r)"
-msgstr ""
+msgstr "Упростить (рац.)"
 
 #: ../../src/sidebars/MathSidebar.cpp:65
 msgid "Simplify (tr)"
-msgstr ""
+msgstr "Упростить (триг.)"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:352
 msgid "Simplify Expression"
@@ -9408,7 +9408,7 @@ msgstr "Упростить суммы"
 
 #: ../../src/wizards/SumWiz.cpp:68
 msgid "Simplify the sum"
-msgstr ""
+msgstr "Упростить сумму"
 
 #: ../../src/wxMaximaFrame.cpp:1629
 msgid "Simplify trigonometric expression"
@@ -9416,7 +9416,7 @@ msgstr "Упростить тригонометрическое выражени
 
 #: ../../src/dialogs/TipOfTheDay.cpp:139
 msgid "Since wxMaxima 0.8.2 you can also insert images into your documents. Use 'Cell->Insert Image...' menu command."
-msgstr ""
+msgstr "Начиная с версии 0.8.2 программы Maxima, поддерживается возможность вставки изображений в документы. Используйте команду меню «Поле->Вставить изображение...»."
 
 #: ../../src/wxMaximaFrame.cpp:1433
 msgid "Singular Values"
@@ -9448,7 +9448,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2113
 msgid "Slanted"
-msgstr ""
+msgstr "Наклонный"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:225
 msgid "Slovak"
@@ -9473,7 +9473,7 @@ msgstr "Решение ОДУ:"
 
 #: ../../src/wizards/BC2Wiz.cpp:30
 msgid "Solution:"
-msgstr ""
+msgstr "Решение:"
 
 #: ../../src/MaximaCommandMenus.cpp:3446
 msgid "Solve"
@@ -9513,7 +9513,7 @@ msgstr "Решить ОДУ с помощью &преобразования Ла
 
 #: ../../src/sidebars/MathSidebar.cpp:77
 msgid "Solve ODE..."
-msgstr ""
+msgstr "Решить ОДУ..."
 
 #: ../../src/wxMaximaFrame.cpp:1432
 msgid "Solve a linear equation system using dgesv"
@@ -9621,7 +9621,7 @@ msgstr "Сортировать"
 
 #: ../../src/wizards/ListSortWiz.cpp:41
 msgid "Sort Criterion:"
-msgstr ""
+msgstr "Критерий сортировки:"
 
 #: ../../src/MaximaCommandMenus.cpp:1500
 msgid "Sort a list"
@@ -9641,16 +9641,16 @@ msgstr "Исходный список:"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:227
 msgid "Spanish"
-msgstr ""
+msgstr "Испанский"
 
 #: ../../src/wizards/IntegrateWiz.cpp:44 ../../src/wizards/IntegrateWiz.cpp:50
 #: ../../src/wizards/LimitWiz.cpp:38 ../../src/wizards/SeriesWiz.cpp:39
 msgid "Special"
-msgstr ""
+msgstr "Дополнительно"
 
 #: ../../src/wizards/DrawWiz.cpp:918
 msgid "Speed versus accuracy"
-msgstr ""
+msgstr "Скорость <-> Точность"
 
 #: ../../src/MaximaCommandMenus.cpp:4241
 msgid "Split"
@@ -9678,7 +9678,7 @@ msgstr "Квадратные"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1300
 msgid "Standard Options"
-msgstr ""
+msgstr "Стандартные параметры"
 
 #: ../../src/Styles.cpp:115
 msgid "Standard Text"
@@ -9690,7 +9690,7 @@ msgstr "Запустить анимацию"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1622
 msgid "Start a new maxima for each re-evaluation"
-msgstr ""
+msgstr "Запускать новый экземпляр Maxima для каждого повторного вычисления"
 
 #: ../../src/MaximaCommandMenus.cpp:1023
 msgid "Start of t:"
@@ -9698,15 +9698,15 @@ msgstr "Начало t:"
 
 #: ../../src/wizards/DrawWiz.cpp:66 ../../src/wizards/DrawWiz.cpp:171
 msgid "Start of the x value"
-msgstr ""
+msgstr "Начало значения x"
 
 #: ../../src/wizards/DrawWiz.cpp:83 ../../src/wizards/DrawWiz.cpp:186
 msgid "Start of the y value"
-msgstr ""
+msgstr "Начало значения y"
 
 #: ../../src/wizards/DrawWiz.cpp:203
 msgid "Start of the z value"
-msgstr ""
+msgstr "Начало значения z"
 
 #: ../../src/ToolBar.cpp:507 ../../src/ToolBar.cpp:519
 msgid "Start or Stop animation"
@@ -9718,11 +9718,11 @@ msgstr "Запустить или остановить текущую выбра
 
 #: ../../src/dialogs/ConfigDialogue.cpp:496
 msgid "Start searching while the phrase to search for is still being typed."
-msgstr ""
+msgstr "Начинать поиск ещё до окончания ввода поискового запроса"
 
 #: ../../src/wizards/DrawWiz.cpp:755
 msgid "Start value of the parameter"
-msgstr ""
+msgstr "Начальное значение параметра"
 
 #: ../../src/wxMaxima.cpp:403
 msgid "Starting Maxima process failed"
@@ -9747,7 +9747,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:286
 msgid "Startup commands"
-msgstr ""
+msgstr "Команды запуска"
 
 #: ../../src/wxMaximaFrame.cpp:266
 msgid "Statistics"
@@ -9763,7 +9763,7 @@ msgstr "Ширина шага:"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:939
 msgid "Store filenames in image cells to enable image reloading after re-opening the worksheet"
-msgstr ""
+msgstr "Сохранять имена файлов в полях изображений, чтобы изображения можно было перезагружать после повторного открытия листа"
 
 #: ../../src/wxMaximaFrame.cpp:831
 msgid "Straight lines"
@@ -9789,7 +9789,7 @@ msgstr "Поток:"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2117
 msgid "Strike Through"
-msgstr ""
+msgstr "Зачёркнутый"
 
 #: ../../src/wxMaximaFrame.cpp:1219
 msgid "String"
@@ -9857,15 +9857,15 @@ msgstr "Структуры"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:282
 msgid "Style"
-msgstr ""
+msgstr "Стиль"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2082
 msgid "Styles"
-msgstr ""
+msgstr "Стили"
 
 #: ../../src/sidebars/StatSidebar.cpp:112
 msgid "Subsample..."
-msgstr ""
+msgstr "Подвыборка..."
 
 #: ../../src/ToolBar.cpp:484 ../../src/sidebars/FormatSidebar.cpp:54
 msgid "Subsection"
@@ -9885,7 +9885,7 @@ msgstr "Subst — это улучшенные поиск и замена стр�
 
 #: ../../src/sidebars/MathSidebar.cpp:59
 msgid "Subst..."
-msgstr ""
+msgstr "Подставить..."
 
 #: ../../src/MaximaCommandMenus.cpp:715 ../../src/MaximaCommandMenus.cpp:3490
 #: ../../src/MaximaCommandMenus.cpp:4500 ../../src/wizards/SubstituteWiz.cpp:53
@@ -9961,7 +9961,7 @@ msgstr "Сумма"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:122
 msgid "Sum sign"
-msgstr ""
+msgstr "Знак суммы"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:228
 msgid "Swedish"
@@ -9990,7 +9990,7 @@ msgstr "Символы\tAlt+Shift+Y"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:472
 msgid "Symbols that are entered or copied here will appear in the symbols sidebar so they can be entered into the worksheet easily."
-msgstr ""
+msgstr "Символы, которые будут введены или скопированы сюда, появятся на боковой панели символов; так их будет проще помещать на лист."
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:778
 msgid "Symmetric function: f(x)=f(-x)"
@@ -10018,7 +10018,7 @@ msgstr "Содержание\tAlt+Shift+T"
 
 #: ../../src/wizards/DrawWiz.cpp:561
 msgid "Take surface color from steepness"
-msgstr ""
+msgstr "Выбирать цвет поверхности по наклону"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:229
 msgid "Tamil"
@@ -10026,7 +10026,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:196
 msgid "Tau"
-msgstr ""
+msgstr "Τ"
 
 #: ../../src/MaximaCommandMenus.cpp:181
 msgid "Taylor series"
@@ -10062,7 +10062,7 @@ msgstr "Указывает Maxima показывать справку для ?, 
 
 #: ../../src/dialogs/ConfigDialogue.cpp:148
 msgid "Tells maxima where to store the result of compiling libraries"
-msgstr ""
+msgstr "Определяет, где Maxima сохраняет результат сборки библиотек"
 
 #: ../../src/ToolBar.cpp:481 ../../src/sidebars/FormatSidebar.cpp:45
 msgid "Text"
@@ -10074,7 +10074,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:738
 msgid "Text Only"
-msgstr ""
+msgstr "Только текст"
 
 #: ../../src/Styles.cpp:122
 msgid "Text cell background"
@@ -10082,7 +10082,7 @@ msgstr "Фон текстового поля"
 
 #: ../../src/dialogs/TipOfTheDay.cpp:219
 msgid "Text cells can hold citations that as marked as such by beginning a line with \" > \". The number of spaces in front of the \">\" determines the indentation level, as it does with bullet lists."
-msgstr ""
+msgstr "Текстовые поля могут содержать цитаты, обозначенные как таковые с помощью «>» в начале строки. Количество пробелов перед «>» определяет уровень отступа, как и в случае маркированных списков."
 
 #: ../../src/MaximaCommandMenus.cpp:3001
 msgid "Text snippet"
@@ -10105,7 +10105,7 @@ msgstr "У процесса Maxima не предусмотрен сегмент 
 
 #: ../../src/dialogs/ConfigDialogue.cpp:392
 msgid "The URL MathJaX.js should be downloaded from by our HTML export."
-msgstr ""
+msgstr "URL-адрес, с которого следует получить MathJaX.js при экспорте в HTML."
 
 #: ../../src/cells/TextCell.cpp:336
 msgid "The [] or the part() command tried to access a list or matrix element that doesn't exist."
@@ -10113,7 +10113,7 @@ msgstr ""
 
 #: ../../src/sidebars/DrawSidebar.cpp:106
 msgid "The accuracy versus speed tradeoff"
-msgstr ""
+msgstr "Баланс между точностью и скоростью"
 
 #: ../../src/cells/TextCell.cpp:357
 msgid "The argument of a function was of the wrong type. Most probably an equation was expected but was lacking an \"=\"."
@@ -10137,7 +10137,7 @@ msgstr "Классические операции, для которых обы�
 
 #: ../../src/sidebars/DrawSidebar.cpp:91
 msgid "The color of the next line to draw"
-msgstr ""
+msgstr "Цвет следующей линии"
 
 #: ../../src/MaximaCommandMenus.cpp:4005
 msgid "The comma-separated contents of the struct fields"
@@ -10157,48 +10157,48 @@ msgstr "Текущий мастер"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:415
 msgid "The default height for embedded plots. Can be read out or overridden by the maxima variable wxplot_size."
-msgstr ""
+msgstr "Высота по умолчанию для встроенных графиков. Может быть прочитана или переопределена переменной Maxima wxplot_size."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:492
 msgid "The default port used for communication between Maxima and wxMaxima."
-msgstr ""
+msgstr "Порт, используемый по умолчанию для связи программ Maxima и wxMaxima."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:412
 msgid "The default width for embedded plots. Can be read out or overridden by the maxima variable wxplot_size"
-msgstr ""
+msgstr "Ширина по умолчанию для встроенных графиков. Может быть прочитана или переопределена переменной Maxima wxplot_size"
 
 #: ../../src/sidebars/DrawSidebar.cpp:74
 msgid "The diagram title"
-msgstr ""
+msgstr "Заголовок диаграммы"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2401
 #, c-format
 msgid "The directory %s with maxima's startup file doesn't exist. Trying to create it..."
-msgstr ""
+msgstr "Каталог %s с файлом запуска Maxima не существует. Попытка создать его..."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:150
 msgid "The directory containing the startup files, any user libraries and, if MAXIMA_OBJDIR isn't set the subdirectory with the results from compiling maxima libraries."
-msgstr ""
+msgstr "Каталог, который содержит файлы запуска, пользовательские библиотеки и, если подкаталог не установлен с помощью MAXIMA_OBJDIR, результаты сборки библиотек Maxima."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:154
 msgid "The directory maxima places temporary files in, for example plots that are to be included in the worksheet."
-msgstr ""
+msgstr "Каталог, в котором размещаются временные файлы Maxima, например графики, которые будут включены в лист."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:157
 msgid "The directory the compiled versions of maxima are placed in"
-msgstr ""
+msgstr "Каталог, в котором размещаются скомпилированные версии Maxima"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:159
 msgid "The directory the maxima manual can be found in"
-msgstr ""
+msgstr "Каталог, в котором находится руководство пользователя Maxima"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:160
 msgid "The directory the user's home directory is in"
-msgstr ""
+msgstr "Каталог, в котором находится домашний каталог пользователя"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:475
 msgid "The document class LaTeX is instructed to use for our documents."
-msgstr ""
+msgstr "Класс документа, который LaTeX должен использовать для создаваемых документов."
 
 #: ../../src/MaximaCommandMenus.cpp:1832
 msgid "The equation to fit the data to"
@@ -10215,7 +10215,7 @@ msgstr ""
 
 #: ../../src/sidebars/DrawSidebar.cpp:96
 msgid "The fill color for the next objects"
-msgstr ""
+msgstr "Цвет заливки для следующих объектов"
 
 #: ../../src/cells/TextCell.cpp:354
 msgid "The first argument of subst() isn't an equation or a list of equations. Most probably it was lacking an \"=\"."
@@ -10227,7 +10227,7 @@ msgstr "Вызов функции, аргументы которой следу�
 
 #: ../../src/sidebars/DrawSidebar.cpp:100
 msgid "The grid in the background of the diagram"
-msgstr ""
+msgstr "Сетка на фоне диаграммы"
 
 #: ../../src/wxMaximaFrame.cpp:1332
 msgid "The half of the equation that is to the left of the \"=\""
@@ -10262,11 +10262,11 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:223
 msgid "The key combination Shift+Space results in a non-breakable space."
-msgstr ""
+msgstr "Комбинация клавиш Shift+Пробел позволяет создать неразрывный пробел."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:162
 msgid "The list of directories the operating system looks for programs in"
-msgstr ""
+msgstr "Список каталогов, в которых операционная система выполняет поиск программ"
 
 #: ../../src/cells/TextCell.cpp:293
 msgid "The list of time-dependent variables to solve to doesn't match the time-dependent variables the list of dgls contains."
@@ -10278,7 +10278,7 @@ msgstr "Список переменных, содержащихся в кажд�
 
 #: ../../src/dialogs/TipOfTheDay.cpp:166
 msgid "The load() command of Maxima versions >5.38 is able to load .wxm files as library of Maxima's commands."
-msgstr ""
+msgstr "Начиная с версии 5.38 программы Maxima, с помощью команды load() можно загружать файлы .wxm как библиотеки команд Maxima."
 
 #: ../../src/wxMaximaFrame.cpp:228
 msgid "The main toolbar"
@@ -10294,7 +10294,7 @@ msgstr "Руководство по wxMaxima"
 
 #: ../../src/dialogs/MaxSizeChooser.cpp:59
 msgid "The maximum size for this image. Values <= 0 mean: Unspecified."
-msgstr ""
+msgstr "Максимальный размер изображения. Значения, которые меньше или равны нулю, означают «не задано»."
 
 #: ../../src/MaximaCommandMenus.cpp:3937
 msgid "The name of a function we don't want to be evaluated here"
@@ -10326,11 +10326,11 @@ msgstr "Имя переменной, которая будет содержат�
 
 #: ../../src/sidebars/DrawSidebar.cpp:86
 msgid "The next plot's title"
-msgstr ""
+msgstr "Заголовок следующего графика"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:494
 msgid "The number of recently opened files that is to be remembered."
-msgstr ""
+msgstr "Сохраняемое количество последних открытых файлов."
 
 #: ../../src/MaximaCommandMenus.cpp:1471
 msgid "The number of the item which is stepped from \"Index Start\" to \"Index End\"."
@@ -10338,16 +10338,16 @@ msgstr "Номер элемента, для которого выполняет�
 
 #: ../../src/dialogs/ConfigDialogue.cpp:477
 msgid "The options the document class LaTeX is instructed to use for our documents gets."
-msgstr ""
+msgstr "Параметры класса документа, который LaTeX должен использовать для создаваемых документов."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1065
 #: ../../src/dialogs/ConfigDialogue.cpp:1112
 msgid "The part of the output of these commands that isn't declared as \"math\" might be suppressed by wxMaxima. As always maxima commands are required to end in a \";\" or a \"$\""
-msgstr ""
+msgstr "Часть вывода этих команд, которая не объявлена как «math», может подавляться wxMaxima. Как и всегда, команды Maxima должны заканчиваться символом «;» или «$»"
 
 #: ../../src/dialogs/ResolutionChooser.cpp:51
 msgid "The resolution for this image."
-msgstr ""
+msgstr "Разрешение этого изображения."
 
 #: ../../src/cells/TextCell.cpp:182
 msgid "The result was indefinite, which might be infinity, both plus or minus infinity or something additionally potentially involving a complex infinity."
@@ -10410,7 +10410,7 @@ msgstr "Чтобы это сработало, переменная решени�
 
 #: ../../src/sidebars/DrawSidebar.cpp:58
 msgid "The standard plot command: Plot an equation as a curve"
-msgstr ""
+msgstr "Стандартная команда построения графика: построить график уравнения в виде кривой"
 
 #: ../../src/cells/TextCell.cpp:267
 msgid "The value of few special variables is assigned by Maxima and cannot be changed by the user. Also a few constructs aren't variable names and therefore cannot be written to."
@@ -10446,7 +10446,7 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:95
 msgid "There are many resources about Maxima and wxMaxima on the internet. Visit https://wxMaxima-developers.github.io/wxmaxima/help.html for more information and to find tutorials on using wxMaxima and Maxima."
-msgstr ""
+msgstr "В Интернете существует множество ресурсов, посвящённых Maxima и wxMaxima. Посетите страницу https://wxMaxima-developers.github.io/wxmaxima/help.html для получения дополнительной информации об использовании wxMaxima и Maxima."
 
 #: ../../src/dialogs/TipOfTheDay.cpp:251
 msgid "There is a discussion forum for wxMaxima at https://github.com/wxMaxima-developers/wxmaxima/discussions.\n"
@@ -10496,7 +10496,7 @@ msgstr "Ошибка в XML, который должен описывать со
 
 #: ../../src/sidebars/GreekSidebar.cpp:185
 msgid "Theta"
-msgstr ""
+msgstr "θ"
 
 #: ../../src/dialogs/LicenseDialog.cpp:85
 msgid "Third-party notices"
@@ -10517,7 +10517,7 @@ msgstr "Этот файл генерируется wxMaxima\n"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1097
 msgid "This file won't be read by maxima if maxima is used without wxMaxima. In order to add startup commands that are executed in this case, too, please add them to maxima-init.mac, instead."
-msgstr ""
+msgstr "Этот файл не будет прочитан программой Maxima, которая используется без wxMaxima. Чтобы добавить команды запуска, которые будут выполняться и в этом случае, сохраните их в файле maxima-init.mac."
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:764
 msgid "This function will return even integers"
@@ -10550,7 +10550,7 @@ msgstr ""
 #: ../../src/wizards/DrawWiz.cpp:471
 #, c-format
 msgid "This wizard setups a %iD scene."
-msgstr ""
+msgstr "Этот мастер настраивает %iD-сцену."
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:752
 msgid "Throw an error if this symbol is used before assigning it any contents"
@@ -10558,11 +10558,11 @@ msgstr "Вывести сообщение об ошибке, если этот �
 
 #: ../../src/wizards/Plot2dWiz.cpp:65 ../../src/wizards/Plot2dWiz.cpp:505
 msgid "Ticks:"
-msgstr ""
+msgstr "Число точек:"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1359
 msgid "Time [in Minutes] between autosaves"
-msgstr ""
+msgstr "Время [в минутах] между автоматическими сохранениями"
 
 #: ../../src/MaximaCommandMenus.cpp:267 ../../src/MaximaCommandMenus.cpp:3487
 msgid "Times:"
@@ -10570,7 +10570,7 @@ msgstr "Умножить:"
 
 #: ../../src/dialogs/TipOfTheDay.cpp:49 ../../src/dialogs/TipOfTheDay.cpp:267
 msgid "Tip of the day"
-msgstr ""
+msgstr "Совет дня"
 
 #: ../../src/ToolBar.cpp:482 ../../src/sidebars/FormatSidebar.cpp:48
 msgid "Title"
@@ -10586,7 +10586,7 @@ msgstr "Поле заголовка (Заголовок 1)"
 
 #: ../../src/dialogs/TipOfTheDay.cpp:89
 msgid "Title, section and subsection cells can be folded to hide their contents. To fold or unfold, click in the square next to the cell. If you shift-click, all sublevels of that cell will also fold/unfold."
-msgstr ""
+msgstr "Заголовки, разделы и подразделы могут быть свёрнуты для скрытия их элементов. Для выполнения свёртывания/развёртывания щёлкните внутри квадрата рядом с полем. Если удерживать клавишу Shift при щелчке мышью, все вложенные элементы также будут свёрнуты/развёрнуты."
 
 #: ../../src/wxMaximaFrame.cpp:1831
 msgid "To &Bigfloat"
@@ -10614,19 +10614,19 @@ msgstr "В точное число"
 
 #: ../../src/dialogs/TipOfTheDay.cpp:124
 msgid "To plot in polar coordinates, select 'set polar' in the Options entry for Plot2d dialog. You can also plot in spherical and cylindrical coordinates in 3D."
-msgstr ""
+msgstr "Чтобы построить график в полярных координатах, установите их («set polar») в опциях диалога «Двумерный график». Для трёх измерений можно также выбрать сферические и цилиндрические координаты."
 
 #: ../../src/dialogs/TipOfTheDay.cpp:131
 msgid "To put parentheses around an expression, select it, and press '(' or ')' depending on where you want the cursor to appear afterwards."
-msgstr ""
+msgstr "Чтобы заключить выражение в скобки, выделите его и нажмите клавишу «(» или «)» (в зависимости от того, где должен появиться курсор)."
 
 #: ../../src/dialogs/TipOfTheDay.cpp:137
 msgid "To save the size and position of wxMaxima windows between session, use 'Edit->Configure' dialog."
-msgstr ""
+msgstr "Диалоговое окно «Правка->Настройка» позволяет настроить запоминание размера и положения окна wxMaxima между сеансами."
 
 #: ../../src/dialogs/TipOfTheDay.cpp:51
 msgid "To start using wxMaxima right away, start typing your command. An input cell should appear. Then press Shift-Enter to evaluate your command."
-msgstr ""
+msgstr "Сразу после запуска wxMaxima можно начинать вводить команды (поле ввода появится автоматически). Затем нажмите Shift+Enter для выполнения команды."
 
 #: ../../src/MaximaCommandMenus.cpp:318 ../../src/wizards/IntegrateWiz.cpp:47
 #: ../../src/wizards/Plot2dWiz.cpp:51 ../../src/wizards/Plot2dWiz.cpp:61
@@ -10637,7 +10637,7 @@ msgstr "К:"
 
 #: ../../src/sidebars/TableOfContents.cpp:579
 msgid "Toc levels shown here"
-msgstr ""
+msgstr "Здесь показаны уровни содержания"
 
 #: ../../src/wxMaximaFrame.cpp:862 ../../src/wxMaximaFrame.cpp:865
 msgid "Toggle full screen editing"
@@ -10669,7 +10669,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1991
 msgid "Top"
-msgstr ""
+msgstr "Сверху"
 
 #: ../../src/MaximaCommandMenus.cpp:1382
 msgid "Top end"
@@ -10815,7 +10815,7 @@ msgstr "Попытка запуска сокета, к которому може
 
 #: ../../src/dialogs/ConfigDialogue.cpp:230
 msgid "Turkish"
-msgstr ""
+msgstr "Турецкий"
 
 #: ../../src/wxMaximaFrame.cpp:1965
 msgid "Tutorials"
@@ -10831,7 +10831,7 @@ msgstr "Тип"
 
 #: ../../src/cells/EditorCell.cpp:4550
 msgid "Type in text"
-msgstr ""
+msgstr "Введите текст"
 
 #: ../../src/MaximaCommandMenus.cpp:3992 ../../src/wizards/MatWiz.cpp:158
 msgid "Type:"
@@ -10851,7 +10851,7 @@ msgstr "UTF8 в точку кода Юникода..."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:231
 msgid "Ukrainian"
-msgstr ""
+msgstr "Украинский"
 
 #: ../../src/wxMaxima.cpp:3164
 msgid "Un-closed parenthesis"
@@ -10878,15 +10878,15 @@ msgstr "Снять определение"
 #: ../../src/sidebars/VariablesPane.cpp:303
 #: ../../src/sidebars/VariablesPane.cpp:386
 msgid "Undefined"
-msgstr ""
+msgstr "Не определено"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2115
 msgid "Underlined"
-msgstr ""
+msgstr "Подчёркивание"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:745
 msgid "Underscore converts to subscripts:"
-msgstr ""
+msgstr "Нижнее подчёркивание преобразует в нижний индекс:"
 
 #: ../../src/ToolBar.cpp:354 ../../src/ToolBar.cpp:357
 msgid "Undo"
@@ -10919,7 +10919,7 @@ msgstr "Развернуть все свёрнутые разделы"
 
 #: ../../src/sidebars/TableOfContents.cpp:507
 msgid "Unhide"
-msgstr ""
+msgstr "Показать"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:665
 msgid "Unhide Heading 5"
@@ -10975,7 +10975,7 @@ msgstr "Точку кода Юникода в код utf8"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:180
 msgid "Unicode symbols:"
-msgstr ""
+msgstr "Символы Юникода:"
 
 #: ../../src/MaximaCommandMenus.cpp:3890
 msgid "Unlike in other programming language return() only exits from the current loop or block(), not from the whole function."
@@ -10991,11 +10991,11 @@ msgstr "Незавершённая строка."
 
 #: ../../src/wizards/ActualValuesStorageWiz.cpp:43
 msgid "Until then the actual values for all variables can be kept in a list."
-msgstr ""
+msgstr "До этого момента фактические значения всех переменных будут храниться в списке."
 
 #: ../../src/dialogs/DiffFrame.cpp:429 ../../src/dialogs/FindReplacePane.cpp:80
 msgid "Up"
-msgstr ""
+msgstr "Вверх"
 
 #: ../../src/MaximaEvaluator.cpp:629
 msgid "Updating maxima's configuration"
@@ -11018,7 +11018,7 @@ msgstr "Верхняя граница:"
 
 #: ../../src/sidebars/GreekSidebar.cpp:197
 msgid "Upsilon"
-msgstr ""
+msgstr "Υ"
 
 #: ../../src/wxMaximaFrame.cpp:829
 msgid "Use \"<\" and \">\" as parenthesis for matrices"
@@ -11030,7 +11030,7 @@ msgstr ""
 
 #: ../../src/wizards/SumWiz.cpp:69
 msgid "Use Gosper algorithm"
-msgstr ""
+msgstr "Использовать алгоритм Госпера"
 
 #: ../../src/sidebars/RegexCtrl.cpp:133
 msgid "Use RegEx filtering"
@@ -11054,11 +11054,11 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:485
 msgid "Use centered dot and Minus, not Star and Hyphen"
-msgstr ""
+msgstr "Использовать точку и минус, а не звёздочку и дефис"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:849
 msgid "Use centered dot character for multiplication"
-msgstr ""
+msgstr "Использовать точку как символ умножения"
 
 #: ../../src/wxMaximaFrame.cpp:1745
 msgid "Use list"
@@ -11082,11 +11082,11 @@ msgstr "Использовать поле структуры..."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:425
 msgid "Use the \"partial derivative\" symbol to represent the fraction that represents a diff() when exporting LaTeX"
-msgstr ""
+msgstr "Использовать символ «частная производная» для дроби, которая представляет diff(), при экспорте в LaTeX"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2052
 msgid "Use unicode Math Symbols, if available"
-msgstr ""
+msgstr "Использовать математические символы Юникода (если доступно)"
 
 #: ../../src/wxMaximaFrame.cpp:832
 msgid "Use vertical lines instead of parenthesis for matrices"
@@ -11101,7 +11101,7 @@ msgstr "Только пользовательские метки"
 #: ../../src/dialogs/ConfigDialogue.cpp:1480
 #: ../../src/dialogs/MaximaNotStartingDialog.cpp:54
 msgid "User specified"
-msgstr ""
+msgstr "Задаётся пользователем"
 
 #: ../../src/Styles.cpp:110
 msgid "User-defined labels"
@@ -11109,7 +11109,7 @@ msgstr "Пользовательские метки"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:770
 msgid "User-defined labels if available"
-msgstr ""
+msgstr "Пользовательские метки (если доступно)"
 
 #: ../../src/MaximaManual.cpp:500
 msgid "Using Maxima help file from wxMaxima configuration file (helpFile=...))"
@@ -11147,7 +11147,7 @@ msgstr "Проверено, что XML-представление докумен
 #: ../../src/dialogs/ConfigDialogue.cpp:542
 #: ../../src/wizards/ActualValuesStorageWiz.cpp:49
 msgid "Value"
-msgstr ""
+msgstr "Значение"
 
 #: ../../src/MaximaCommandMenus.cpp:756
 msgid "Value at a given point"
@@ -11187,15 +11187,15 @@ msgstr "Переменная"
 
 #: ../../src/wizards/DrawWiz.cpp:61 ../../src/wizards/DrawWiz.cpp:166
 msgid "Variable for the x value"
-msgstr ""
+msgstr "Переменная для значения x"
 
 #: ../../src/wizards/DrawWiz.cpp:78 ../../src/wizards/DrawWiz.cpp:181
 msgid "Variable for the y value"
-msgstr ""
+msgstr "Переменная для значения y"
 
 #: ../../src/wizards/DrawWiz.cpp:198
 msgid "Variable for the z value"
-msgstr ""
+msgstr "Переменная для значения z"
 
 #: ../../src/MaximaCommandMenus.cpp:1586 ../../src/MaximaCommandMenus.cpp:2990
 #: ../../src/MaximaCommandMenus.cpp:2996
@@ -11243,7 +11243,7 @@ msgstr "Переменные:"
 
 #: ../../src/sidebars/StatSidebar.cpp:58
 msgid "Variance..."
-msgstr ""
+msgstr "Дисперсия..."
 
 #: ../../src/WXMXformat.cpp:339
 msgid "Verified that we are able to read the whole .zip archive we produced."
@@ -11271,7 +11271,7 @@ msgstr "Ожидание окончания работы потока, анал�
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1410
 msgid "Warn if an inactive window is idle"
-msgstr ""
+msgstr "Показывать предупреждение при бездействии неактивного окна"
 
 #: ../../src/MathParser.cpp:1343 ../../src/MaximaFileIO.cpp:536
 #: ../../src/MaximaResponseReader.cpp:361 ../../src/wxMaxima.cpp:1583
@@ -11291,7 +11291,7 @@ msgstr "Предупреждение: не удалось создать %s, к�
 
 #: ../../src/cells/GroupCell.cpp:400 ../../src/cells/GroupCell.cpp:406
 msgid "Warning: Lookalike chars: "
-msgstr ""
+msgstr "Предупреждение: похожие символы:"
 
 #: ../../src/wxMaximaFrame.cpp:1583
 msgid "Warning: No test if the argument of the log is complex, positive or negative"
@@ -11316,7 +11316,7 @@ msgstr "Что делать:"
 
 #: ../../src/dialogs/TipOfTheDay.cpp:134
 msgid "When applying functions with one argument from menus, the default argument is '%'. To apply the function to some other value, select it in the document before executing a menu command."
-msgstr ""
+msgstr "Если с помощью меню применяется функция с одним аргументом, аргументом по умолчанию является «%». Чтобы применить функцию к какому-либо другому значению, необходимо выбрать его в документе перед использованием команды меню."
 
 #: ../../src/wxMaximaFrame.cpp:1092
 msgid "When to invoke the lisp compiler's debugger"
@@ -11332,7 +11332,7 @@ msgstr "Цикл while..."
 
 #: ../../src/dialogs/TipOfTheDay.cpp:243
 msgid "While wxMaxima is programmed mostly in C++, it also uses some Lisp code. You can help to improve wxMaxima, if you have knowledge of Common Lisp."
-msgstr ""
+msgstr "Программа wxMaxima написана в основном на языке C++, но в ней также используется и код на Lisp. Программисты, знакомые с Common Lisp, могут помочь в совершенствовании wxMaxima."
 
 #: ../../src/MaximaFileIO.cpp:780
 msgid "Whole document (*.wxmx)|*.wxmx|The input, readable by load() (maxima > 5.38) (*.wxm)|*.wxm|All Files (*.*)|*"
@@ -11344,7 +11344,7 @@ msgstr "Попытаться сгенерировать трассировку �
 
 #: ../../src/dialogs/ConfigDialogue.cpp:280
 msgid "Worksheet"
-msgstr ""
+msgstr "Лист"
 
 #: ../../src/MaximaResponseReader.cpp:117
 #, c-format
@@ -11365,7 +11365,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:428
 msgid "Wrap equations exported by the \"copy as LaTeX\" feature between \\[ and \\] as equation markers"
-msgstr ""
+msgstr "Заключать уравнения, экспортированные с помощью опции «Копировать как LaTeX», в \\[ и \\] в качестве обозначений уравнений"
 
 #: ../../src/worksheet/Worksheet.cpp:5190
 msgid "Wrapped search"
@@ -11387,7 +11387,7 @@ msgstr "Записана информация о типе MIME"
 #: ../../src/wizards/DrawWiz.cpp:961 ../../src/wizards/DrawWiz.cpp:974
 #: ../../src/wizards/DrawWiz.cpp:977
 msgid "X"
-msgstr ""
+msgstr "X"
 
 #: ../../src/MathParser.cpp:1279
 msgid "XML nesting limit exceeded"
@@ -11395,35 +11395,35 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:191
 msgid "Xi"
-msgstr ""
+msgstr "Ξ"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:728
 msgid "Yes"
-msgstr ""
+msgstr "Да"
 
 #: ../../src/dialogs/TipOfTheDay.cpp:64
 msgid "You can access the last output using the variable '%'. You can access the output of previous commands using variables '%on' where n is the number of output."
-msgstr ""
+msgstr "Самый последний результат вычисления обозначается «%». Результат любого другого предыдущего вычисления обозначается «%on», где n — порядковый номер вычисления."
 
 #: ../../src/dialogs/TipOfTheDay.cpp:118
 msgid "You can evaluate your whole document by using 'Cell->Evaluate All Cells' menu command or the appropriate key shortcut. The cells will be evaluated in the order they appear in the document."
-msgstr ""
+msgstr "Можно вычислить весь документ с помощью команды меню «Поле->Вычислить все поля» или соответствующей комбинации клавиш. Поля будут вычисляться в порядке их появления в документе."
 
 #: ../../src/dialogs/TipOfTheDay.cpp:98
 msgid "You can get help on a Maxima function by selecting or clicking on the function name and pressing F1. wxMaxima will search the help index for the selection or the word under the cursor."
-msgstr ""
+msgstr "Можно получить справку по функции Maxima; выделите функцию или щёлкните её имя и нажмите клавишу F1. Появится диалоговое окно с результатами поиска выделенной функции."
 
 #: ../../src/dialogs/TipOfTheDay.cpp:92
 msgid "You can hide output part of cells by clicking in the triangle on the left side of cells. This works on text cells also."
-msgstr ""
+msgstr "Можно скрыть область вывода поля, щёлкнув на треугольнике в левой части поля. Это действие работает и для текстовых полей."
 
 #: ../../src/dialogs/TipOfTheDay.cpp:81
 msgid "You can insert different types of 'cells' in wxMaxima documents using the 'Cell' menu. Note that only 'input cells' can be evaluated, while others are used for commenting and structuring your calculations."
-msgstr ""
+msgstr "Можно вставлять в документы wxMaxima различные типы «полей» с помощью меню «Поле». Следует учитывать, что вычислены могут быть только «поля ввода», в то время как другие типы полей используются для комментирования и структурирования вычислений."
 
 #: ../../src/dialogs/TipOfTheDay.cpp:112
 msgid "You can select multiple cells either with a mouse - click'n'drag from between cells or from a cell bracket on the left - or with a keyboard - hold down Shift while moving the horizontal cursor - and then operate on selection. This comes in handy when you want to delete or evaluate multiple cells."
-msgstr ""
+msgstr "Можно выбрать несколько полей с помощью мыши (путём перетаскивания с зажатой левой кнопкой) или клавиатуры (перемещайте горизонтальный курсор, удерживая клавишу Shift) и затем выполнять над ними различные действия. Это может быть полезно, если требуется вычислить или удалить несколько полей. "
 
 #: ../../src/dialogs/TipOfTheDay.cpp:232
 msgid "You found a bug in wxMaxima? Please report it at https://github.com/wxMaxima-developers/wxmaxima/issues\n"
@@ -11433,7 +11433,7 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:238
 msgid "You got an idea for an improvement of wxMaxima? Great! Please submit your idea at https://github.com/wxMaxima-developers/wxmaxima/issues. "
-msgstr ""
+msgstr "Предложения по улучшению wxMaxima можно предоставить по этому адресу: https://github.com/wxMaxima-developers/wxmaxima/issues. "
 
 #: ../../src/wxMaxima.cpp:3402 ../../src/wxMaxima.cpp:3456
 #, c-format
@@ -11451,7 +11451,7 @@ msgstr "Вы используете последнюю версию wxMaxima."
 
 #: ../../src/sidebars/GreekSidebar.cpp:183
 msgid "Zeta"
-msgstr ""
+msgstr "Ζ"
 
 #: ../../src/wxMaximaFrame.cpp:842
 msgid "Zoom &In\tCtrl++"
@@ -11479,11 +11479,11 @@ msgstr "[ не сохранено* ]"
 
 #: ../../src/wizards/DrawWiz.cpp:819 ../../src/wizards/DrawWiz.cpp:825
 msgid "[[x_1,x_2,...],[y_1,y_2,...]]"
-msgstr ""
+msgstr "[[x_1,x_2,...],[y_1,y_2,...]]"
 
 #: ../../src/wizards/DrawWiz.cpp:814
 msgid "[x_1, x_2,...] or [x_1, x_2,...],[y_1, y_2,...] or matrix([x_1,y_1],[x_2,y_2],...)"
-msgstr ""
+msgstr "[x_1, x_2,...] или [x_1, x_2,...],[y_1, y_2,...], или matrix([x_1,y_1],[x_2,y_2],...)"
 
 #: ../../src/wizards/ListSortWiz.cpp:46
 msgid "a<b (Maxima default)"
@@ -11491,15 +11491,15 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:151
 msgid "alpha"
-msgstr ""
+msgstr "α"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:95
 msgid "and"
-msgstr ""
+msgstr "и"
 
 #: ../../src/wizards/MatWiz.cpp:160
 msgid "antisymmetric"
-msgstr ""
+msgstr "антисимметричная"
 
 #: ../../src/wxMaximaFrame.cpp:1727
 msgid "apply function to each element"
@@ -11523,11 +11523,11 @@ msgstr "как хранилище для фактических значений
 
 #: ../../src/sidebars/GreekSidebar.cpp:152
 msgid "beta"
-msgstr ""
+msgstr "β"
 
 #: ../../src/wizards/LimitWiz.cpp:42
 msgid "both sides"
-msgstr ""
+msgstr "двусторонний"
 
 #: ../../src/wxMaximaFrame.cpp:1173
 msgid "char to Ascii code..."
@@ -11535,7 +11535,7 @@ msgstr "символ в код ASCII..."
 
 #: ../../src/sidebars/GreekSidebar.cpp:172
 msgid "chi"
-msgstr ""
+msgstr "χ"
 
 #: ../../src/MaximaFileIO.cpp:318
 #, c-format
@@ -11545,15 +11545,15 @@ msgstr ""
 #: ../../src/wizards/Plot2dWiz.cpp:70 ../../src/wizards/Plot2dWiz.cpp:372
 #: ../../src/wizards/Plot3dWiz.cpp:61 ../../src/wizards/Plot3dWiz.cpp:358
 msgid "default"
-msgstr ""
+msgstr "по умолчанию"
 
 #: ../../src/sidebars/GreekSidebar.cpp:154
 msgid "delta"
-msgstr ""
+msgstr "δ"
 
 #: ../../src/wizards/MatWiz.cpp:159
 msgid "diagonal"
-msgstr ""
+msgstr "диагональная"
 
 #: ../../src/cells/FracCell.cpp:73
 msgid "diff(): Cannot find the multiplication sign I should hide"
@@ -11569,19 +11569,19 @@ msgstr "Выполнить для каждого элемента"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:92
 msgid "empty"
-msgstr ""
+msgstr "пустое множество"
 
 #: ../../src/sidebars/GreekSidebar.cpp:155
 msgid "epsilon"
-msgstr ""
+msgstr "ε"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:100
 msgid "equivalent"
-msgstr ""
+msgstr "эквивалентно"
 
 #: ../../src/sidebars/GreekSidebar.cpp:157
 msgid "eta"
-msgstr ""
+msgstr "η"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:799
 msgid "ev() shall evaluate this automatically"
@@ -11589,7 +11589,7 @@ msgstr "ev() автоматически вычислит это"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:88
 msgid "exists"
-msgstr ""
+msgstr "существует"
 
 #: ../../src/MaximaCommandMenus.cpp:3942
 msgid "expression:"
@@ -11631,11 +11631,11 @@ msgstr "функция"
 
 #: ../../src/sidebars/GreekSidebar.cpp:153
 msgid "gamma"
-msgstr ""
+msgstr "γ"
 
 #: ../../src/wizards/MatWiz.cpp:159
 msgid "general"
-msgstr ""
+msgstr "общая"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1630
 msgid "gnuplot: Without command console"
@@ -11643,11 +11643,11 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:118
 msgid "greater than or equal"
-msgstr ""
+msgstr "больше или равно"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:87
 msgid "in"
-msgstr ""
+msgstr "принадлежит"
 
 #: ../../src/wxMaximaFrame.cpp:784
 msgid "in 2D"
@@ -11658,31 +11658,31 @@ msgstr "в 2D"
 #: ../../src/wizards/Plot3dWiz.cpp:61 ../../src/wizards/Plot3dWiz.cpp:194
 #: ../../src/wizards/Plot3dWiz.cpp:358 ../../src/wizards/Plot3dWiz.cpp:386
 msgid "inline"
-msgstr ""
+msgstr "встроенный"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:104
 msgid "intersection"
-msgstr ""
+msgstr "пересечение"
 
 #: ../../src/sidebars/GreekSidebar.cpp:159
 msgid "iota"
-msgstr ""
+msgstr "ι"
 
 #: ../../src/sidebars/GreekSidebar.cpp:160
 msgid "kappa"
-msgstr ""
+msgstr "ϰ"
 
 #: ../../src/sidebars/GreekSidebar.cpp:161
 msgid "lambda"
-msgstr ""
+msgstr "λ"
 
 #: ../../src/wizards/LimitWiz.cpp:42
 msgid "left"
-msgstr ""
+msgstr "слева"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:117
 msgid "less or equal"
-msgstr ""
+msgstr "меньше или равно"
 
 #: ../../src/MaximaCommandMenus.cpp:1567
 msgid "list"
@@ -11690,11 +11690,11 @@ msgstr "список"
 
 #: ../../src/wizards/Plot2dWiz.cpp:54 ../../src/wizards/Plot2dWiz.cpp:64
 msgid "logscale"
-msgstr ""
+msgstr "логарифм. масштаб"
 
 #: ../../src/wizards/DrawWiz.cpp:822
 msgid "matrix([x_1,x_2,...],[y_1,y_2,...])"
-msgstr ""
+msgstr "matrix([x_1,x_2,...],[y_1,y_2,...])"
 
 #: ../../src/wxMaximaFrame.cpp:1439
 msgid "max(abs(A(i,j))) (complex)"
@@ -11706,15 +11706,15 @@ msgstr "max(abs(A(i,j))) (вещественное)"
 
 #: ../../src/sidebars/GreekSidebar.cpp:162
 msgid "mu"
-msgstr ""
+msgstr "μ"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:120
 msgid "much greater than"
-msgstr ""
+msgstr "намного больше чем"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:119
 msgid "much less than"
-msgstr ""
+msgstr "намного меньше чем"
 
 #: ../../src/MaximaCommandMenus.cpp:1232
 msgid "m×n Matrix A:"
@@ -11727,35 +11727,35 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:112
 msgid "nabla sign"
-msgstr ""
+msgstr "знак набла"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:98
 msgid "nand"
-msgstr ""
+msgstr "не-и"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:772
 msgid "nary: f(x, f(y,z)) = foo(x,y,z)"
-msgstr ""
+msgstr "nary: f(x, f(y,z)) = foo(x,y,z)"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:99
 msgid "nor"
-msgstr ""
+msgstr "или-не"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:102
 msgid "not"
-msgstr ""
+msgstr "не"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:116
 msgid "not bytewise identical"
-msgstr ""
+msgstr "не идентично побайтово"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:108
 msgid "not subset"
-msgstr ""
+msgstr "не подмножество"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:107
 msgid "not subset or equal"
-msgstr ""
+msgstr "не подмножество или равно"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:796
 msgid "noun: Not evaluated by default"
@@ -11767,7 +11767,7 @@ msgstr "n-й"
 
 #: ../../src/sidebars/GreekSidebar.cpp:163
 msgid "nu"
-msgstr ""
+msgstr "ν"
 
 #: ../../src/MaximaCommandMenus.cpp:1233
 msgid "n×1 Matrix b:"
@@ -11775,15 +11775,15 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:174
 msgid "omega"
-msgstr ""
+msgstr "ω"
 
 #: ../../src/sidebars/GreekSidebar.cpp:165
 msgid "omicron"
-msgstr ""
+msgstr "ο"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:96
 msgid "or"
-msgstr ""
+msgstr "или"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:793
 msgid "outative: f(2*x) = 2*f(x)"
@@ -11800,19 +11800,19 @@ msgstr "часть:"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:111
 msgid "partial sign"
-msgstr ""
+msgstr "знак частной производной"
 
 #: ../../src/sidebars/GreekSidebar.cpp:171
 msgid "phi"
-msgstr ""
+msgstr "φ"
 
 #: ../../src/sidebars/GreekSidebar.cpp:166
 msgid "pi"
-msgstr ""
+msgstr "π"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:101
 msgid "plus or minus"
-msgstr ""
+msgstr "плюс-минус"
 
 #: ../../src/MaximaCommandMenus.cpp:196
 msgid "point:"
@@ -11837,11 +11837,11 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:115
 msgid "proportional to"
-msgstr ""
+msgstr "пропорционально"
 
 #: ../../src/sidebars/GreekSidebar.cpp:173
 msgid "psi"
-msgstr ""
+msgstr "ψ"
 
 #: ../../src/MaximaCommandMenus.cpp:642
 msgid "radcan() is a powerful tools for simplification trigonometric functions but needs to be taken with care: If a function has more than one branch radcan uses the one that looks like it would fit best, not necessarily the one that makes sense for the problem that resulted in the Expression that is to be simplified."
@@ -11869,31 +11869,31 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:167
 msgid "rho"
-msgstr ""
+msgstr "ρ"
 
 #: ../../src/wizards/LimitWiz.cpp:42
 msgid "right"
-msgstr ""
+msgstr "справа"
 
 #: ../../src/wizards/DrawWiz.cpp:310
 msgid "secondary x axis label"
-msgstr ""
+msgstr "метка вторичной оси x"
 
 #: ../../src/wizards/DrawWiz.cpp:315
 msgid "secondary x range (automatic if incomplete)"
-msgstr ""
+msgstr "вторичный диапазон по x (автоматически, если неполный)"
 
 #: ../../src/wizards/DrawWiz.cpp:325
 msgid "secondary y axis label"
-msgstr ""
+msgstr "метка вторичной оси y"
 
 #: ../../src/wizards/DrawWiz.cpp:330
 msgid "secondary y range (automatic if incomplete)"
-msgstr ""
+msgstr "вторичный диапазон по y (автоматически, если неполный)"
 
 #: ../../src/sidebars/GreekSidebar.cpp:168
 msgid "sigma"
-msgstr ""
+msgstr "σ"
 
 #: ../../src/MaximaCommandMenus.cpp:3447
 msgid "solve() will solve a list of equations only if for n independent equations there are n variables to solve to.\n"
@@ -11917,19 +11917,19 @@ msgstr "решает уравнение вида\n"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:81
 msgid "sqrt (needs parenthesis for its argument to work as a Maxima command)"
-msgstr ""
+msgstr "sqrt (для аргумента нужны скобки, чтобы можно было использовать функцию в качестве команды Maxima)"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:106
 msgid "subset"
-msgstr ""
+msgstr "подмножество"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:105
 msgid "subset or equal"
-msgstr ""
+msgstr "подмножество или равно"
 
 #: ../../src/wizards/MatWiz.cpp:160
 msgid "symmetric"
-msgstr ""
+msgstr "симметричная"
 
 #: ../../src/MaximaCommandMenus.cpp:970
 msgid "t:"
@@ -11937,7 +11937,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:169
 msgid "tau"
-msgstr ""
+msgstr "τ"
 
 #: ../../src/cells/TextCell.cpp:340
 msgid "the [] operator tried to extract an element of a list, a matrix, an equation or an array. But instead of an integer number something was used whose numerical value is unknown or not an integer.\n"
@@ -11946,31 +11946,31 @@ msgstr ""
 
 #: ../../src/wizards/DrawWiz.cpp:725
 msgid "the x and the y coordinate."
-msgstr ""
+msgstr "координаты x и y."
 
 #: ../../src/wizards/DrawWiz.cpp:729
 msgid "the x, the y and the z coordinate."
-msgstr ""
+msgstr "координаты x, y и z."
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:89
 msgid "there is no"
-msgstr ""
+msgstr "нет"
 
 #: ../../src/sidebars/GreekSidebar.cpp:158
 msgid "theta"
-msgstr ""
+msgstr "θ"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:78
 msgid "to the power of 2"
-msgstr ""
+msgstr "в квадрате"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:79
 msgid "to the power of 3"
-msgstr ""
+msgstr "в кубе"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:103
 msgid "union"
-msgstr ""
+msgstr "объединение"
 
 #: ../../src/wxMaximaFrame.cpp:1109
 msgid "unnamed function (lambda)..."
@@ -11987,7 +11987,7 @@ msgstr "без названия"
 
 #: ../../src/sidebars/GreekSidebar.cpp:170
 msgid "upsilon"
-msgstr ""
+msgstr "υ"
 
 #: ../../src/wxMaximaFrame.cpp:1737
 msgid "use as function arguments"
@@ -12025,7 +12025,7 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:159
 msgid "wxMaxima can be made to execute commands at every start-up by placing them in a text file with the name wxmaxima.rc in the user directory. This directory can be found by typing maxima_userdir;"
-msgstr ""
+msgstr "Можно настроить wxMaxima на выполнение команд при каждом запуске — разместите их в текстовом файле с именем wxmaxima.rc в каталоге пользователя. Каталог пользователя можно найти путём ввода maxima_userdir;"
 
 #: ../../src/MaximaFileIO.cpp:398
 msgid "wxMaxima cannot read the xml contents of "
@@ -12034,7 +12034,7 @@ msgstr "wxMaxima не удалось прочесть содержимое XML "
 #: ../../src/dialogs/ConfigDialogue.cpp:142
 #: ../../src/dialogs/ConfigDialogue.cpp:311
 msgid "wxMaxima configuration"
-msgstr ""
+msgstr "Конфигурация wxMaxima"
 
 #: ../../src/MaximaProcessManager.cpp:209
 msgid "wxMaxima could not start a server.\n\n"
@@ -12046,7 +12046,7 @@ msgstr "wxMaxima не удалось выполнить запуск серве�
 
 #: ../../src/dialogs/TipOfTheDay.cpp:127
 msgid "wxMaxima dialogs set default values for inputs entries, one of which is '%'. If you have made a selection in your document, the selection will be used instead of '%'."
-msgstr ""
+msgstr "В диалоговых окнах wxMaxima для входных параметров предусмотрены стандартные значения, обычно «%». Если вы сделали выделение в документе, оно будет использовано вместо «%»."
 
 #: ../../src/MaximaCommandMenus.cpp:4544
 msgid "wxMaxima document"
@@ -12077,19 +12077,19 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:240
 msgid "wxMaxima is programmed in C++ using the wxWidgets toolkit and uses CMake as build system. You can contribute to wxMaxima, if you have some knowledge with this environment."
-msgstr ""
+msgstr "Программа wxMaxima написана на языке C++ с помощью набора средств wxWidgets. В качестве системы сборки используется CMake. Программисты, знакомые с этой средой разработки, могут помочь в совершенствовании wxMaxima."
 
 #: ../../src/dialogs/TipOfTheDay.cpp:228
 msgid "wxMaxima needs more developers. It is an open source project where you can contribute. Join the wxMaxima development at: https://github.com/wxMaxima-developers/wxmaxima"
-msgstr ""
+msgstr "Проекту wxMaxima требуется участие разработчиков. Исходный код программы открыт, вы можете внести свой вклад в его разработку. Присоединяйтесь к разработке wxMaxima: https://githubcom/wxMaxima-developers/wxmaxima"
 
 #: ../../src/dialogs/TipOfTheDay.cpp:224
 msgid "wxMaxima needs more translators. We do not speak every language. Help us to translate wxMaxima and the manual to your language. Join the wxMaxima development at: https://github.com/wxMaxima-developers/wxmaxima"
-msgstr ""
+msgstr "Проекту wxMaxima требуется участие переводчиков — помогите нам перевести программу и руководство пользователя на ваш язык. Присоединяйтесь к разработке wxMaxima: https://github.com/wxMaxima-developers/wxmaxima"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:407
 msgid "wxMaxima normally stores the gnuplot sources for every plot made using draw() in order to be able to open plots interactively in gnuplot later. This setting defines the limit [in Megabytes per plot] for this feature."
-msgstr ""
+msgstr "Обычно wxMaxima сохраняет исходники Gnuplot для каждого графика, созданного с помощью draw() — это позволяет в дальнейшем интерактивно открывать графики в Gnuplot. Этот параметр определяет предельное количество памяти [в мегабайтах на график], которое выделяется для этой возможности."
 
 #: ../../src/dialogs/TipOfTheDay.cpp:172
 msgid "wxMaxima provides the \"table_form\" command that shows lists in an alternative form. One example would be:\n\n"
@@ -12108,7 +12108,7 @@ msgstr "wxMaxima запоминает ответы с прошлого выпо�
 
 #: ../../src/dialogs/ConfigDialogue.cpp:481
 msgid "wxMaxima remembers the answers to maxima's questions. If this checkbox is set it automatically offers to enter the last answer to this question the user has input."
-msgstr ""
+msgstr "wxMaxima запоминает ответы на вопросы Maxima. Если этот флажок установлен, программа автоматически предложит последний введённый пользователем ответ на вопрос."
 
 #: ../../src/wxMaximaFrame.cpp:1933
 msgid "wxMaxima shows help in a browser"
@@ -12120,7 +12120,7 @@ msgstr "wxMaxima отображает справку на боковой пан�
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1095
 msgid "wxMaxima startup file location: "
-msgstr ""
+msgstr "Расположение файла запуска wxMaxima: "
 
 #: ../../src/wxMaximaFrame.cpp:119
 #, c-format
@@ -12172,11 +12172,11 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:709
 msgid "x"
-msgstr ""
+msgstr "x"
 
 #: ../../src/wizards/DrawWiz.cpp:266
 msgid "x axis label"
-msgstr ""
+msgstr "метка оси x"
 
 #: ../../src/MaximaCommandMenus.cpp:2021
 msgid "x direction [in multiples of the tick frequency]"
@@ -12184,11 +12184,11 @@ msgstr "направление x [в единицах частоты делен�
 
 #: ../../src/wizards/DrawWiz.cpp:269
 msgid "x range (automatic if incomplete)"
-msgstr ""
+msgstr "диапазон по x (автоматически, если неполный)"
 
 #: ../../src/sidebars/GreekSidebar.cpp:164
 msgid "xi"
-msgstr ""
+msgstr "χ"
 
 #: ../../src/MaximaFileIO.cpp:408 ../../src/MaximaFileIO.cpp:566
 msgid "xml contained in the file claims not to be a wxMaxima worksheet. "
@@ -12196,11 +12196,11 @@ msgstr "XML, включённый в файл, сообщает, что не я�
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:97
 msgid "xor"
-msgstr ""
+msgstr "искл. или"
 
 #: ../../src/wizards/DrawWiz.cpp:279
 msgid "y axis label"
-msgstr ""
+msgstr "метка оси y"
 
 #: ../../src/MaximaCommandMenus.cpp:2022
 msgid "y direction [in multiples of the tick frequency]"
@@ -12208,7 +12208,7 @@ msgstr "направление y [в единицах частоты делен�
 
 #: ../../src/wizards/DrawWiz.cpp:282
 msgid "y range (automatic if incomplete)"
-msgstr ""
+msgstr "диапазон по y (автоматически, если неполный)"
 
 #: ../../src/MaximaCommandMenus.cpp:970
 msgid "y:"
@@ -12216,15 +12216,15 @@ msgstr ""
 
 #: ../../src/wizards/DrawWiz.cpp:294
 msgid "z axis label"
-msgstr ""
+msgstr "метка оси z"
 
 #: ../../src/wizards/DrawWiz.cpp:298
 msgid "z range (automatic if incomplete)"
-msgstr ""
+msgstr "диапазон по z (автоматически, если неполный)"
 
 #: ../../src/sidebars/GreekSidebar.cpp:156
 msgid "zeta"
-msgstr ""
+msgstr "ζ"
 
 #. type: Title #
 #: ../../info/wxmaxima.md:1

--- a/locales/wxMaxima/tr.po
+++ b/locales/wxMaxima/tr.po
@@ -56,7 +56,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1568
 msgid "      -X \"--dynamic-space-size <int>\""
-msgstr ""
+msgstr " -X \"--dynamic-space-size <int>\""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1572
 msgid "      -X '--control-stack-size <int>'"
@@ -64,11 +64,11 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1571
 msgid "      -X '--dynamic-space-size <int>'"
-msgstr ""
+msgstr " -X '--dynamic-space-size <int>'"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1551
 msgid "      -l <name>"
-msgstr ""
+msgstr " -I <isim>"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1557
 msgid "      -u <versionnumber>"
@@ -166,7 +166,7 @@ msgstr ""
 #: ../../src/cells/ImgCell.cpp:212 ../../src/cells/ImgCell.cpp:214
 #: ../../src/cells/ImgCell.cpp:216
 msgid " (Graphics) "
-msgstr ""
+msgstr " (Grafikler) "
 
 #: ../../src/cells/EditorCell.cpp:3551 ../../src/cells/EditorCell.cpp:3820
 #: ../../src/cells/EditorCell.cpp:3945
@@ -176,7 +176,7 @@ msgstr ""
 
 #: ../../src/cells/EditorCell.cpp:3553
 msgid " ... + 1 hidden line"
-msgstr ""
+msgstr " ... + 1 gizlenmiş satır"
 
 #: ../../src/dialogs/TipOfTheDay.cpp:273
 msgid " Did you know? "
@@ -192,15 +192,15 @@ msgstr ""
 
 #: ../../src/wizards/DrawWiz.cpp:964 ../../src/wizards/DrawWiz.cpp:980
 msgid " samples"
-msgstr ""
+msgstr " Örnekler"
 
 #: ../../src/wizards/DrawWiz.cpp:929 ../../src/wizards/DrawWiz.cpp:945
 msgid " samples, on demand split "
-msgstr ""
+msgstr " talep üzerine örnekler "
 
 #: ../../src/wizards/DrawWiz.cpp:933 ../../src/wizards/DrawWiz.cpp:952
 msgid " times"
-msgstr ""
+msgstr " kere"
 
 #: ../../src/MaximaCommandMenus.cpp:4413
 msgid "\".\" = \"The current directory\"\n"
@@ -214,7 +214,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1208
 msgid "\"Copy LaTeX\" adds equation markers"
-msgstr ""
+msgstr "\"Copy LaTeX\"denklem işaretlerini ekler"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:446
 msgid "\"MathML (rendered by the browser)\" is the recommended choice: every current browser renders MathML natively and instantly, and the exported page needs no JavaScript and makes no requests to any external server.\n"
@@ -228,7 +228,7 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:90
 msgid "\"implies\" symbol"
-msgstr ""
+msgstr "\"uygular\" işareti"
 
 #: ../../src/dialogs/DiffFrame.cpp:306
 #, c-format
@@ -315,7 +315,7 @@ msgstr "&Kopyala\tCtrl+C"
 
 #: ../../src/wizards/IntegrateWiz.cpp:39
 msgid "&Definite integration"
-msgstr ""
+msgstr "&Belirli İntegral"
 
 #: ../../src/wxMaximaFrame.cpp:1658
 msgid "&Demoivre"
@@ -431,11 +431,11 @@ msgstr ""
 
 #: ../../src/wizards/IntegrateWiz.cpp:52
 msgid "&Numerical integration"
-msgstr ""
+msgstr "&Numerik İntegral"
 
 #: ../../src/wizards/SumWiz.cpp:44
 msgid "&Nusum"
-msgstr ""
+msgstr "&Nusum"
 
 #: ../../src/main.cpp:675
 msgid "&Open\tCtrl+O"
@@ -451,7 +451,7 @@ msgstr "&Grafik Çiz"
 
 #: ../../src/wizards/SeriesWiz.cpp:45
 msgid "&Power series"
-msgstr ""
+msgstr "&Kuvvet Serileri"
 
 #: ../../src/wxMaximaFrame.cpp:655
 msgid "&Print...\tCtrl+P"
@@ -459,7 +459,7 @@ msgstr "&Yazdır...\tCtrl+P"
 
 #: ../../src/wizards/SubstituteWiz.cpp:38
 msgid "&Rational"
-msgstr ""
+msgstr "&Rasyonel"
 
 #: ../../src/wxMaximaFrame.cpp:1631
 msgid "&Reduce Trigonometric"
@@ -491,11 +491,11 @@ msgstr "&Çöz..."
 
 #: ../../src/wizards/Plot2dWiz.cpp:42
 msgid "&Special"
-msgstr ""
+msgstr "&Özel"
 
 #: ../../src/wizards/LimitWiz.cpp:45
 msgid "&Taylor series"
-msgstr ""
+msgstr "&Taylor Serileri"
 
 #: ../../src/wxMaximaFrame.cpp:1069
 msgid "&Time Display"
@@ -515,7 +515,7 @@ msgstr ""
 
 #: ../../src/wizards/Plot3dWiz.cpp:79
 msgid "&pm3d"
-msgstr ""
+msgstr "&pm3B"
 
 #: ../../src/cells/AnimationCell.cpp:475
 msgid "(Animation)"
@@ -547,11 +547,11 @@ msgstr ""
 
 #: ../../src/sidebars/VariablesPane.cpp:254
 msgid "(Not a valid variable name)"
-msgstr ""
+msgstr "Geçerli bir değişken adı değil"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:183
 msgid "(Use default language)"
-msgstr ""
+msgstr "(Varsayılan dili kullan)"
 
 #: ../../src/MaximaCommandMenus.cpp:440
 msgid "(f(x),x,a,b)), Epsilon algorithm"
@@ -585,7 +585,7 @@ msgstr ""
 #: ../../src/wizards/DrawWiz.cpp:303 ../../src/wizards/DrawWiz.cpp:320
 #: ../../src/wizards/DrawWiz.cpp:335
 msgid "-"
-msgstr ""
+msgstr "-"
 
 #: ../../src/wizards/IntegrateWiz.cpp:192
 #: ../../src/wizards/IntegrateWiz.cpp:202
@@ -593,7 +593,7 @@ msgstr ""
 #: ../../src/wizards/IntegrateWiz.cpp:217 ../../src/wizards/LimitWiz.cpp:132
 #: ../../src/wizards/LimitWiz.cpp:142
 msgid "- Infinity"
-msgstr ""
+msgstr "- Sonsuz"
 
 #: ../../src/MaximaOutputAppender.cpp:116
 msgid "... [suppressed additional lines as the output is longer than allowed in the wxMaxima configuration] "
@@ -609,11 +609,11 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:77
 msgid "1/2"
-msgstr ""
+msgstr "1/2"
 
 #: ../../src/sidebars/DrawSidebar.cpp:45
 msgid "2D"
-msgstr ""
+msgstr "2B"
 
 #: ../../src/wxMaximaFrame.cpp:1346
 msgid "2D Array to Matrix..."
@@ -637,7 +637,7 @@ msgstr ""
 
 #: ../../src/sidebars/DrawSidebar.cpp:49
 msgid "3D"
-msgstr ""
+msgstr "3B"
 
 #: ../../src/wxMaxima.cpp:1833
 #, c-format
@@ -650,7 +650,7 @@ msgstr "A \":lisp\" birinci komut gönderme hatalı olduğunda bir \"finished-bi
 
 #: ../../src/dialogs/TipOfTheDay.cpp:102
 msgid "A 'horizontal cursor' was introduced in wxMaxima 0.8.0. It looks like a horizontal line between cells. It indicates where a new cell will appear if you type or paste text or execute a menu command."
-msgstr ""
+msgstr "WxMaxima 0.8.0 sürümünde -yatay imleç-  kullanıldı. Hücreler arasında yatay bir çizgiye benzemektedir. Yazdığınızda yada bir yazıyı yapıştırdığınızda yada  bir komutu çalıştırdığınız yerde görülür."
 
 #: ../../src/MaximaCommandMenus.cpp:3039
 msgid "A Ctrl-F event"
@@ -676,7 +676,7 @@ msgstr ""
 
 #: ../../src/wizards/ListSortWiz.cpp:63
 msgid "A function f(a,b), named"
-msgstr ""
+msgstr "Bir f(a,b) fonksiyonu, ismi"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:784
 msgid "A function returning integers"
@@ -688,7 +688,7 @@ msgstr ""
 
 #: ../../src/wizards/DrawWiz.cpp:164
 msgid "A good example equation would be x^2+y^2=1"
-msgstr ""
+msgstr "İyi bir örnek denklem x ^ 2 + y ^ 2 = 1 olacaktır"
 
 #: ../../src/cells/GroupCell.cpp:2193 ../../src/cells/GroupCell.cpp:2196
 msgid "A heading"
@@ -716,11 +716,11 @@ msgstr ""
 
 #: ../../src/cells/GroupCell.cpp:2175
 msgid "A page break"
-msgstr ""
+msgstr "Bir sayfa kesmesi"
 
 #: ../../src/dialogs/TipOfTheDay.cpp:168
 msgid "A plot to be embedded into the work sheet by preceding its name with a \"wx\". \"draw\" can be replaced by \"wxdraw\", plot by \"wxplot\" etc."
-msgstr ""
+msgstr "Çizdirmek istediğiniz grafikleri çalışma sayfasına yerleştirilmiş olarakistiyorsanız, draw yada plot komutlarının önüne \"wx\" koyarak; \"wxdraw\", \"wxplot\" şeklinde yazmalısınız."
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:735
 msgid "A rational variable"
@@ -732,7 +732,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:436
 msgid "A scale factor for the printout. Helpful for printing big equations on small pdf pages."
-msgstr ""
+msgstr "Çıktı için ölçek faktörü. Küçük pdf sayfalarına büyük denklemler yazdırmak için yararlıdır."
 
 #: ../../src/wxMaximaFrame.cpp:1671
 msgid "A search-and-replace for equations"
@@ -740,27 +740,27 @@ msgstr ""
 
 #: ../../src/cells/EditorCell.cpp:4522 ../../src/cells/GroupCell.cpp:2184
 msgid "A section heading"
-msgstr ""
+msgstr "Bir Bölüm başlığı"
 
 #: ../../src/wizards/DrawWiz.cpp:479
 msgid "A static plot"
-msgstr ""
+msgstr "Statik bir çizim"
 
 #: ../../src/cells/EditorCell.cpp:4534
 msgid "A sub-sub-sub-subsection heading"
-msgstr ""
+msgstr "Bir alt alt-alt-alt bölüm başlığı"
 
 #: ../../src/cells/EditorCell.cpp:4531
 msgid "A sub-sub-subsection heading"
-msgstr ""
+msgstr "Bir alt alt-alt-alt-bölüm başlığı"
 
 #: ../../src/cells/EditorCell.cpp:4528 ../../src/cells/GroupCell.cpp:2190
 msgid "A sub-subsection heading"
-msgstr ""
+msgstr "Alt-alt bölüm başlığı"
 
 #: ../../src/cells/EditorCell.cpp:4525 ../../src/cells/GroupCell.cpp:2187
 msgid "A subsection heading"
-msgstr ""
+msgstr "Alt-Bölüm Hücresi"
 
 #: ../../src/wxMaximaFrame.cpp:1673
 msgid "A subst with basic maths knowledge"
@@ -768,7 +768,7 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:239
 msgid "A symbol from the configuration dialogue"
-msgstr ""
+msgstr "Yapılandırma diyaloğundan bir sembol"
 
 #: ../../src/cells/GroupCell.cpp:2181
 msgid "A text cell"
@@ -805,7 +805,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1618
 msgid "Abort evaluation on error"
-msgstr ""
+msgstr "Hata oluştuğunda değerlendirmeyi durdur"
 
 #: ../../src/MaximaEvaluator.cpp:214
 #, c-format
@@ -838,7 +838,7 @@ msgstr ""
 
 #: ../../src/sidebars/DrawSidebar.cpp:103
 msgid "Accuracy"
-msgstr ""
+msgstr "Doğruluk"
 
 #: ../../src/wxMaximaFrame.cpp:1405
 msgid "Ad&joint Matrix"
@@ -858,7 +858,7 @@ msgstr "Listenin başına yeni bir madde ekleyin. Yığın oluşturmak için kul
 
 #: ../../src/sidebars/VariablesPane.cpp:228
 msgid "Add all"
-msgstr ""
+msgstr "Hepsini topla"
 
 #: ../../src/MaximaCommandMenus.cpp:1621
 msgid "Add an element to the end of a list"
@@ -878,11 +878,11 @@ msgstr "Rasyonel sadeleştiriciye eşitlik ekle"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:204
 msgid "Add more symbols"
-msgstr ""
+msgstr "Daha fazla sembol ekle"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1262
 msgid "Add the .wxmx file to the HTML export"
-msgstr ""
+msgstr ".wxmx dosyasını HTML çıkarımına ekle"
 
 #: ../../src/wxMaximaFrame.cpp:1049
 msgid "Add to &Path..."
@@ -890,7 +890,7 @@ msgstr "&Yola ekle..."
 
 #: ../../src/sidebars/UnicodeSidebar.cpp:105
 msgid "Add to symbols Sidebar"
-msgstr ""
+msgstr "Semboller Kenar Çubuğuna Ekle"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:304
 #: ../../src/worksheet/WorksheetContextMenu.cpp:337
@@ -901,7 +901,7 @@ msgstr "İzleme listesine ekle"
 #: ../../src/sidebars/XmlInspector.cpp:147
 #, c-format
 msgid "Added much text (%li chars) to the XML inspector."
-msgstr ""
+msgstr "XML denetçisine çok fazla metin (% li karakter) eklendi."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1896
 msgid "Additional clipboard formats to put on the clipboard on ordinary copy"
@@ -909,15 +909,15 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:393
 msgid "Additional commands to be added to the preamble of LaTeX output for pdftex."
-msgstr ""
+msgstr "LaTeX in pdftex önsözüne eklenebilecek ek komutlar."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1187
 msgid "Additional lines for the TeX preamble:"
-msgstr ""
+msgstr "TeX önsözü için ek satırlar:"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:389
 msgid "Additional parameters for Maxima (e.g. -l clisp)."
-msgstr ""
+msgstr "Maxima için ek parametreler (örnek: -l clisp)"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1543
 msgid "Additional parameters for Maxima (restart Maxima after changes)"
@@ -925,7 +925,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1318
 msgid "Additional symbols for the \"symbols\" sidebar:"
-msgstr ""
+msgstr "\"Semboller\" kenar çubuğu için ek semboller:"
 
 #: ../../src/wxMaximaFrame.cpp:1599
 msgid "Additionally: log(a*b)=log(a)+log(b)"
@@ -985,7 +985,7 @@ msgstr "Açılabilecek tüm dosya türleri (*.wxm, *.wxmx, *.mac, *.out, *.xml)|
 
 #: ../../src/dialogs/ConfigDialogue.cpp:750
 msgid "All variable names"
-msgstr ""
+msgstr "Tüm değişken isimleri"
 
 #: ../../src/wxMaximaFrame.cpp:770
 msgid "All visible sidebars"
@@ -1013,7 +1013,7 @@ msgstr ""
 
 #: ../../src/dialogs/BinaryNameCtrl.cpp:69
 msgid "All|*"
-msgstr ""
+msgstr "Hepsi|*"
 
 #: ../../src/wxMaximaFrame.cpp:800
 msgid "Always after underscores"
@@ -1033,7 +1033,7 @@ msgstr "Her zaman tüm sayı basamaklarını göster"
 
 #: ../../src/wizards/DrawWiz.cpp:484
 msgid "An animation with multiple frames"
-msgstr ""
+msgstr "Birden fazla çerçeve içeren bir animasyon"
 
 #: ../../src/cells/GroupCell.cpp:2202
 msgid "An image cell"
@@ -1190,7 +1190,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1397
 msgid "Ask to save untitled documents"
-msgstr ""
+msgstr "İsim verilmemiş belgeyi kaydederken sor"
 
 #: ../../src/dialogs/MaximaNotStartingDialog.cpp:36
 msgid "Asking the user for the location of a working maxima binary"
@@ -1214,7 +1214,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:897
 msgid "Auto-indent new lines"
-msgstr ""
+msgstr "Otomatik girintili yeni satırlar"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:893
 msgid "Auto-insert closing parenthesis"
@@ -1224,11 +1224,11 @@ msgstr ""
 #: ../../src/dialogs/ConfigDialogue.cpp:1472
 #: ../../src/dialogs/MaximaNotStartingDialog.cpp:43
 msgid "Autodetect"
-msgstr ""
+msgstr "Otomatik tespit"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1236
 msgid "Automatic"
-msgstr ""
+msgstr "Otomatik"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:391
 msgid "Automatic labels"
@@ -1237,7 +1237,7 @@ msgstr "Otomatik etiketler"
 #: ../../src/dialogs/ConfigDialogue.cpp:769
 #, c-format
 msgid "Automatic labels (%i1, %o1,...)"
-msgstr ""
+msgstr "Otomatik etiketler (%i1, %o1,...)"
 
 #: ../../src/wxMaximaFrame.cpp:986
 msgid "Automatically answer questions"
@@ -1284,15 +1284,15 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:734
 msgid "Autowrap long lines:"
-msgstr ""
+msgstr "Uzun satırları otomatik olarak kısalt:"
 
 #: ../../src/sidebars/DrawSidebar.cpp:75
 msgid "Axis"
-msgstr ""
+msgstr "Eksenler"
 
 #: ../../src/wizards/BC2Wiz.cpp:59
 msgid "BC2"
-msgstr ""
+msgstr "SŞ2"
 
 #: ../../src/MaximaManual.cpp:559
 msgid "Background task that compiles the Manual anchors scheduled."
@@ -1300,7 +1300,7 @@ msgstr ""
 
 #: ../../src/sidebars/StatSidebar.cpp:91
 msgid "Barsplot..."
-msgstr ""
+msgstr "Sütun Diyagramı..."
 
 #: ../../src/wxMaximaFrame.cpp:1384
 msgid "Basic matrix operations"
@@ -1339,27 +1339,27 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:141
 msgid "Besides the global undo functionality that is active when the cursor is between cells, wxMaxima has a per-cell undo function that is active if the cursor is inside a cell. Pressing Ctrl+Z inside a cell can therefore been used for a fine-pitch undo that doesn't affect latter changes made in other cells."
-msgstr ""
+msgstr "İmleç hücreler arasında olduğunda geri alma işlemi yapılabildiği gibi, İmlecin bir hücrenin içinde aktif olduğu durumlarda da wxMaxima, hücre  geri alma işlemi yapabilir. Bir hücre içinde Ctrl+Z basarak diğer hücrelerdeki değişiklikleri etkilemeyen ince ayar bir geri alma işlemi yapabilir."
 
 #: ../../src/sidebars/GreekSidebar.cpp:179
 msgid "Beta"
-msgstr ""
+msgstr "Beta"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1898
 msgid "Bitmap"
-msgstr ""
+msgstr "Bitmap"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1273
 msgid "Bitmap scale for export:"
-msgstr ""
+msgstr "Çıkarım için Bitmap ölçüsü:"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1223
 msgid "Bitmaps"
-msgstr ""
+msgstr "'Bitmap'ler"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2109
 msgid "Bold"
-msgstr ""
+msgstr "Koyu"
 
 #: ../../src/wxMaxima.cpp:2259
 msgid "Both horizontal and vertical cursor active at the same time"
@@ -1383,13 +1383,13 @@ msgstr ""
 
 #: ../../src/sidebars/StatSidebar.cpp:97
 msgid "Boxplot..."
-msgstr ""
+msgstr "Kutu Diyagram..."
 
 #: ../../src/dialogs/BinaryNameCtrl.cpp:42 ../../src/wizards/CsvWiz.cpp:57
 #: ../../src/wizards/CsvWiz.cpp:131 ../../src/wizards/Plot2dWiz.cpp:114
 #: ../../src/wizards/Plot3dWiz.cpp:109
 msgid "Browse"
-msgstr ""
+msgstr "Gözat"
 
 #: ../../src/wxMathml.cpp:101
 msgid "Bug: After removing the whitespace wxMathml.lisp is shorter than expected!"
@@ -1438,7 +1438,7 @@ msgstr "Hata: HTML çıktısı geçerli bir XML değil"
 
 #: ../../src/cells/Cell.cpp:289
 msgid "Bug: Math Cell that claims to have no group Cell it belongs to"
-msgstr ""
+msgstr "Hata: Math hücresi ait olduğu bir Grup hücresi olmadığını düşünüyor"
 
 #: ../../src/Configuration.h:741
 msgid "Bug: Maximum number of digits that is to be displayed is too low!"
@@ -1450,7 +1450,7 @@ msgstr "Hata: Eksik içerik"
 
 #: ../../src/cells/GroupCell.cpp:1498
 msgid "Bug: No image counter to write to!"
-msgstr ""
+msgstr "Hata : Yazılacak görüntü sayacı yok!"
 
 #: ../../src/cells/AnimationCell.cpp:543 ../../src/cells/EditorCell.cpp:2968
 #: ../../src/cells/ImgCell.cpp:353 ../../src/graphical_io/BitmapOut.cpp:161
@@ -1469,7 +1469,7 @@ msgstr "Hata:Pano zaten açılmış"
 
 #: ../../src/cells/EditorCell.cpp:3051
 msgid "Bug: The clipboard isn't open on pasting into an editor cell"
-msgstr ""
+msgstr "Hata:Pano, bir düzenleyici hücresine yapıştırmaya açık değil"
 
 #: ../../src/cells/GroupCell.cpp:2288
 msgid "Bug: The predecessor to a GroupCell is not a GroupCell."
@@ -1481,7 +1481,7 @@ msgstr ""
 
 #: ../../src/cells/GroupCell.cpp:340
 msgid "Bug: Trying to append NULL to a group cell."
-msgstr ""
+msgstr "Hata: Hücresi olmayan bir hücre içeriğini yazmaya çalışıyor."
 
 #: ../../src/worksheet/Worksheet.cpp:5939
 msgid "Bug: Trying to move a title out by one sectioning unit"
@@ -1505,7 +1505,7 @@ msgstr "Hata: Hücre içeriği değişiklikleri ve hücre ekleme durumlarının 
 
 #: ../../src/cells/EditorCell.cpp:4541
 msgid "Bug: Unknown type of text"
-msgstr ""
+msgstr "Hata: Bilinmeyen metin türü"
 
 #: ../../src/cells/EditorCell.cpp:3981 ../../src/cells/TextCell.cpp:479
 msgid "Bug: dc == NULL"
@@ -1513,11 +1513,11 @@ msgstr ""
 
 #: ../../src/cells/EditorCell.cpp:2637
 msgid "Bug: x position of cell is unknown!"
-msgstr ""
+msgstr "Hata: hücrenin x konumu bilinmiyor!"
 
 #: ../../src/cells/EditorCell.cpp:2638
 msgid "Bug: y position of cell is unknown!"
-msgstr ""
+msgstr "Hata: hücrenin y konumu bilinmiyor!"
 
 #: ../../src/wxMaximaFrame.cpp:1985
 msgid "Build &Info"
@@ -1530,7 +1530,7 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:54
 msgid "By default, Shift-Enter is used to evaluate commands, while Enter is used for multiline input. This behaviour can be changed in 'Edit->Configure' dialog by checking 'Enter evaluates cells'. This switches the roles of these two key commands."
-msgstr ""
+msgstr "Varsayılan olarak -Enter- tuşu bir alt satıra geçmek için kullanılırken -Shift+Enter kullanıcı tarafından girilen komutların Maxima tarafından  değerlendirilmesi \\ hesaplanması için kullanılır. Değerlendirme için sadece -Enter- tuşu kullanılmak istenirse 'Düzenle-> Yapılandır'a bastıktan sonra açılan pencerede 'Enter' tuşu komutları değerlendirir 'sekmesi tıklanmalıdır. Tersi için tekrar tıklanarak işaret kaldırılır."
 
 #: ../../src/MaximaCommandMenus.cpp:4087
 msgid "Byte:"
@@ -1724,20 +1724,20 @@ msgstr ""
 
 #: ../../src/cells/EditorCell.cpp:2991
 msgid "Cannot put the copied text on the clipboard"
-msgstr ""
+msgstr "Kopyalanan metin panoya yerleştirilemiyor"
 
 #: ../../src/cells/EditorCell.cpp:2984
 msgid "Cannot put the copied text on the clipboard (1st try)"
-msgstr ""
+msgstr "Kopyalanan metin panoya yerleştirilemiyor (1. deneme)"
 
 #: ../../src/cells/EditorCell.cpp:2988
 msgid "Cannot put the copied text on the clipboard (2nd try)"
-msgstr ""
+msgstr "Kopyalanan metin panoya yerleştirilemiyor (2. deneme)"
 
 #: ../../src/graphical_io/OutCommon.cpp:98
 #, c-format
 msgid "Cannot remove the file %s"
-msgstr ""
+msgstr "%s dosyasını silemiyor"
 
 #: ../../src/sidebars/History.cpp:258
 #, c-format
@@ -1768,11 +1768,11 @@ msgstr "Maxima binary dosyaları başlatılamıyor"
 
 #: ../../src/sidebars/MathSidebar.cpp:62
 msgid "Canonical (tr)"
-msgstr ""
+msgstr "Kanonik (trig)"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:188
 msgid "Catalan"
-msgstr ""
+msgstr "Katalanca"
 
 #: ../../src/MaximaCommandMenus.cpp:466
 msgid "Cauchy principal value of f(x)/(x-c), finite interval"
@@ -1829,7 +1829,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:859
 msgid "Change names of greek letters to greek letters"
-msgstr ""
+msgstr "Yunan harflerinin adlarını Yunan harfleriyle değiştir"
 
 #: ../../src/wxMaximaFrame.cpp:1073
 msgid "Change the 2d display algorithm used to display math output"
@@ -1837,7 +1837,7 @@ msgstr "'Matemetiksel çıktı (sonuç)'ları göstermek için kullanılan 2B al
 
 #: ../../src/dialogs/ConfigDialogue.cpp:489
 msgid "Change the text \"alpha\" and \"beta\" to the corresponding greek letter?"
-msgstr ""
+msgstr "\"Alfa\" ve \"beta\" metnini karşılık gelen Yunanca harfle değiştir?"
 
 #: ../../src/MaximaCommandMenus.cpp:136
 msgid "Change variable"
@@ -1918,15 +1918,15 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:199
 msgid "Chi"
-msgstr ""
+msgstr "Chi"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:189
 msgid "Chinese (Simplified)"
-msgstr ""
+msgstr "Çince (Sadeleştirilmiş)"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:190
 msgid "Chinese (traditional)"
-msgstr ""
+msgstr "Çince (geleneksel)"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1554
 msgid "Choose a Lisp Maxima was compiled with"
@@ -1942,7 +1942,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2100
 msgid "Choose font"
-msgstr ""
+msgstr "Yazı tipi şeç"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:793
 msgid "Choose how mathematical output is formatted:\n"
@@ -1953,7 +1953,7 @@ msgstr ""
 
 #: ../../src/wizards/PlotFormatWiz.cpp:31
 msgid "Choose new plot format:"
-msgstr ""
+msgstr "Yeni grafik çizim formatı seç:"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2432
 #, c-format
@@ -2127,7 +2127,7 @@ msgstr ""
 
 #: ../../src/wizards/MatWiz.cpp:155
 msgid "Columns:"
-msgstr ""
+msgstr "Sütunlar:"
 
 #: ../../src/wxMaximaFrame.cpp:1621
 msgid "Combine factorials in an expression"
@@ -2143,11 +2143,11 @@ msgstr "Virgül kapatılan bir parantezden hemen sonra gelir"
 
 #: ../../src/wizards/Plot2dWiz.cpp:626
 msgid "Comma separated x coordinates"
-msgstr ""
+msgstr "Virgülle ayrılmış x koordinatları"
 
 #: ../../src/wizards/Plot2dWiz.cpp:627
 msgid "Comma separated y coordinates"
-msgstr ""
+msgstr "Virgülle ayrılmış y koordinatları"
 
 #: ../../src/MaximaCommandMenus.cpp:4071
 msgid "Comma-separated arguments"
@@ -2233,11 +2233,11 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1145
 msgid "Commands that are executed at every start of maxima."
-msgstr ""
+msgstr "Her yeni başlamada gerçekleştirilecek Maxima komutları."
 
 #: ../../src/cells/EditorCell.cpp:4538
 msgid "Comment (ordinary worksheet text that isn't fed to maxima)"
-msgstr ""
+msgstr "Yorum(maximayla uyumlu olmayan çalışma sayfası metni)"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:465
 msgid "Comment Selection"
@@ -2373,7 +2373,7 @@ msgstr "Şart:"
 #: ../../src/dialogs/ConfigDialogue.cpp:2641
 #: ../../src/dialogs/ConfigDialogue.cpp:2647
 msgid "Config file (*.ini)|*.ini"
-msgstr ""
+msgstr "Config dosyası (*.ini)|*.ini"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2539
 #, c-format
@@ -2382,7 +2382,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2607
 msgid "Configuration warning"
-msgstr ""
+msgstr "Yapılandırma uyarısı"
 
 #: ../../src/ToolBar.cpp:367 ../../src/ToolBar.cpp:369
 #: ../../src/wxMaximaFrame.cpp:722 ../../src/wxMaximaFrame.cpp:724
@@ -2391,7 +2391,7 @@ msgstr "'wxMaxima'yı' yapılandır"
 
 #: ../../src/wizards/DrawWiz.cpp:829
 msgid "Connect the dots"
-msgstr ""
+msgstr "Noktaları birleştir"
 
 #: ../../src/MaximaProcessManager.cpp:163
 msgid "Connection attempt, but connection failed."
@@ -2405,7 +2405,7 @@ msgstr "Maxima bağlantısı kesildi."
 #: ../../src/wizards/IntegrateWiz.cpp:208 ../../src/wizards/LimitWiz.cpp:133
 #: ../../src/wizards/SeriesWiz.cpp:105
 msgid "Constant"
-msgstr ""
+msgstr "Sabit"
 
 #: ../../src/MaximaCommandMenus.cpp:1102
 msgid "Construct a fraction"
@@ -2417,7 +2417,7 @@ msgstr ""
 
 #: ../../src/sidebars/VariablesPane.cpp:58
 msgid "Contents"
-msgstr ""
+msgstr "İçerik"
 
 #: ../../src/MaximaCommandMenus.cpp:3970
 msgid "Contents:"
@@ -2433,27 +2433,27 @@ msgstr "Bağlama-duyarlı Yardım &Help\tF1"
 
 #: ../../src/sidebars/DrawSidebar.cpp:80
 msgid "Contour"
-msgstr ""
+msgstr "Eşyükselti eğrisi"
 
 #: ../../src/sidebars/DrawSidebar.cpp:101
 msgid "Contour lines for 3d plots"
-msgstr ""
+msgstr "3B çizimler için eşyükselti eğrileri"
 
 #: ../../src/wizards/DrawWiz.cpp:648
 msgid "Contour lines on surface and Bottom"
-msgstr ""
+msgstr "Yüzeyde ve Altta Eşyükselti eğrileri"
 
 #: ../../src/wizards/DrawWiz.cpp:644
 msgid "Contour lines on the Bottom"
-msgstr ""
+msgstr "Alttaki eşyükselti eğrileri"
 
 #: ../../src/wizards/DrawWiz.cpp:641
 msgid "Contour lines on the Surface"
-msgstr ""
+msgstr "Yüzeydeki eşyükselti eğrileri"
 
 #: ../../src/wizards/DrawWiz.cpp:629
 msgid "Contour lines settings for the following 3d plots"
-msgstr ""
+msgstr "Bir sonraki 3B grafikler için eşyükselti eğrileri ayarları"
 
 #: ../../src/wxMaximaFrame.cpp:1579
 msgid "Contract Logarithms"
@@ -2855,7 +2855,7 @@ msgstr "Virgülle ayrılmış öğelerden  liste oluştur"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1389
 msgid "Create scalable plots."
-msgstr ""
+msgstr "Ölçeklenebilir grafikler oluşturun."
 
 #: ../../src/wxMaximaFrame.cpp:1116
 msgid "Create struct..."
@@ -2879,7 +2879,7 @@ msgstr ""
 
 #: ../../src/worksheet/Worksheet.cpp:6115
 msgid "Cursor"
-msgstr ""
+msgstr "İmleç"
 
 #: ../../src/Styles.cpp:126
 msgid "Cursor color"
@@ -2901,11 +2901,11 @@ msgstr "Seçimi kes"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:193
 msgid "Czech"
-msgstr ""
+msgstr "Çekçe"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:194
 msgid "Danish"
-msgstr ""
+msgstr "Danimarkaca"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2069
 msgid "Dark"
@@ -2921,7 +2921,7 @@ msgstr "Veri dosyası (*.csv, *.tab, *.txt)|*.csv;*.tab;*.txt"
 
 #: ../../src/wizards/DrawWiz.cpp:810
 msgid "Data format"
-msgstr ""
+msgstr "Veri Formatı"
 
 #: ../../src/MaximaCommandMenus.cpp:1767 ../../src/MaximaCommandMenus.cpp:1772
 #: ../../src/MaximaCommandMenus.cpp:1777 ../../src/MaximaCommandMenus.cpp:1781
@@ -2975,15 +2975,15 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1336
 msgid "Default animation framerate:"
-msgstr ""
+msgstr "Varsayılan animasyon kare hızı:"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:717
 msgid "Default plot size for new maxima sessions:"
-msgstr ""
+msgstr "Yeni 'maxima' oturumları için varsayılan çizim boyutu:"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1534
 msgid "Default port for communication with wxMaxima:"
-msgstr ""
+msgstr "'wxMaxima' ile iletişim için varsayılan port:"
 
 #: ../../src/MaximaCommandMenus.cpp:3946
 msgid "Define a function"
@@ -3023,7 +3023,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:404
 msgid "Define the default speed (in frames per second) animations are played back with."
-msgstr ""
+msgstr "Oynatılacak animasyonunu varsayılan çerçeve hızını (saniyedeki çerçeve sayısı) tanımlayın."
 
 #: ../../src/wxMaximaFrame.cpp:1114
 msgid "Define variable..."
@@ -3096,7 +3096,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:181
 msgid "Delta"
-msgstr ""
+msgstr "Delta"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:110
 #: ../../src/worksheet/WorksheetContextMenu.cpp:558
@@ -3122,7 +3122,7 @@ msgstr ""
 
 #: ../../src/wizards/SeriesWiz.cpp:42
 msgid "Depth:"
-msgstr ""
+msgstr "Derinlik:"
 
 #: ../../src/MaximaCommandMenus.cpp:994
 msgid "Derivate of y at that point:"
@@ -3157,7 +3157,7 @@ msgstr ""
 
 #: ../../src/sidebars/StatSidebar.cpp:61
 msgid "Deviation..."
-msgstr ""
+msgstr "Sapma..."
 
 #: ../../src/wxMaximaFrame.cpp:1534
 msgid "Di&vide Polynomials..."
@@ -3169,7 +3169,7 @@ msgstr ""
 
 #: ../../src/sidebars/DrawSidebar.cpp:71
 msgid "Diagram title"
-msgstr ""
+msgstr "Diyagram başlığı"
 
 #: ../../src/sidebars/HelpBrowser.cpp:51
 msgid "Didn't find an installed offline manual."
@@ -3189,7 +3189,7 @@ msgstr ""
 
 #: ../../src/sidebars/MathSidebar.cpp:80
 msgid "Diff..."
-msgstr ""
+msgstr "Diferansiyel.."
 
 #: ../../src/dialogs/DiffFrame.cpp:308
 #, c-format
@@ -3218,7 +3218,7 @@ msgstr ""
 
 #: ../../src/wizards/LimitWiz.cpp:41
 msgid "Direction:"
-msgstr ""
+msgstr "Uyarı:"
 
 #: ../../src/wxMaximaFrame.cpp:1246
 msgid "Directory operations"
@@ -3230,7 +3230,7 @@ msgstr ""
 
 #: ../../src/wizards/Plot2dWiz.cpp:418 ../../src/wizards/Plot2dWiz.cpp:619
 msgid "Discrete plot"
-msgstr ""
+msgstr "Kesikli çizim"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:699
 msgid "Display"
@@ -3357,11 +3357,11 @@ msgstr "'wxMaxima'nın' daha yeni bir sürümü ile kaydedildi. Lütfen wxMaxima
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1170
 msgid "Documentclass for TeX export:"
-msgstr ""
+msgstr "TeX çıkarımı için belge sınıfı:"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1178
 msgid "Documentclass options:"
-msgstr ""
+msgstr "Belge sınıfı seçenekleri:"
 
 #: ../../src/wxMaximaFrame.cpp:807
 msgid "Don't autosubscript after an underscore"
@@ -3407,19 +3407,19 @@ msgstr ""
 
 #: ../../src/dialogs/DiffFrame.cpp:428 ../../src/dialogs/FindReplacePane.cpp:83
 msgid "Down"
-msgstr ""
+msgstr "Aşağı"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:185
 msgid "Drag-and-drop unicode symbols here"
-msgstr ""
+msgstr "Unicode sembolleri buraya sürükle ve bırak"
 
 #: ../../src/wizards/DrawWiz.cpp:155
 msgid "Draw all points where an equation is true."
-msgstr ""
+msgstr "Bir denklemin doğru olduğu tüm noktaları çizin."
 
 #: ../../src/wizards/DrawWiz.cpp:802
 msgid "Draw points"
-msgstr ""
+msgstr "Noktaları çiz"
 
 #: ../../src/MaximaCommandMenus.cpp:1536
 msgid "Drop the first n list elements"
@@ -3539,7 +3539,7 @@ msgstr "Bilinmeyen bir soket olayıyla karşılaştı."
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:129
 msgid "End of proof"
-msgstr ""
+msgstr "İspat ın sonu"
 
 #: ../../src/MaximaCommandMenus.cpp:1024
 msgid "End of t:"
@@ -3547,19 +3547,19 @@ msgstr ""
 
 #: ../../src/wizards/DrawWiz.cpp:71 ../../src/wizards/DrawWiz.cpp:176
 msgid "End of the x value"
-msgstr ""
+msgstr "'x' değerinin sou"
 
 #: ../../src/wizards/DrawWiz.cpp:88 ../../src/wizards/DrawWiz.cpp:191
 msgid "End of the y value"
-msgstr ""
+msgstr "'y' değerinin sonu"
 
 #: ../../src/wizards/DrawWiz.cpp:208
 msgid "End of the z value"
-msgstr ""
+msgstr "'z' değerinin sonu"
 
 #: ../../src/wizards/DrawWiz.cpp:760
 msgid "End value of the parameter"
-msgstr ""
+msgstr "Parametrenin son değeri"
 
 #: ../../src/MaximaResponseReader.cpp:432
 #: ../../src/MaximaResponseReader.cpp:586
@@ -3572,19 +3572,19 @@ msgstr "Mühendislik formatı (12.1e6 vb.)"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:196
 msgid "English"
-msgstr ""
+msgstr "İngilizce"
 
 #: ../../src/wizards/DrawWiz.cpp:552
 msgid "Enhanced 3D settings:"
-msgstr ""
+msgstr "Geliştirilmiş 3B ayarları:"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1919
 msgid "Enhanced meta file (emf)"
-msgstr ""
+msgstr "Geliştirilmiş meta dosyası (emf)"
 
 #: ../../src/sidebars/StatSidebar.cpp:106
 msgid "Enter Matrix..."
-msgstr ""
+msgstr "Matris Girin.."
 
 #: ../../src/MaximaCommandMenus.cpp:2255
 msgid "Enter UUID to jump to:"
@@ -3604,7 +3604,7 @@ msgstr "Rasyonel sadeleştirilmek üzere bir denklem girin:"
 
 #: ../../src/wizards/SystemWiz.cpp:50
 msgid "Enter comma separated list of variables."
-msgstr ""
+msgstr "Değişkenlerin listesini 'virgülle ayrılmış' olarak girin."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:921
 msgid "Enter evaluates cells, Ctrl+Enter adds newlines"
@@ -3624,7 +3624,7 @@ msgstr "Yeni ondalık-hassasiyeti belirleyin:"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:388
 msgid "Enter the path to the Maxima executable."
-msgstr ""
+msgstr "Maxima'nın uygulayabileceği şekilde girin."
 
 #: ../../src/MaximaCommandMenus.cpp:1103
 msgid "Enumerator:"
@@ -3640,7 +3640,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:182
 msgid "Epsilon"
-msgstr ""
+msgstr "Epsilon"
 
 #: ../../src/MaximaCommandMenus.cpp:299
 msgid "Epsilon:"
@@ -3679,7 +3679,7 @@ msgstr "Denklem:"
 
 #: ../../src/dialogs/TipOfTheDay.cpp:196
 msgid "Equations have several advantages over functions. For example they can be manipulated with factor(), expand() and similar functions. They can easily be introduced one into another. Also they are always printed out as 2D maths."
-msgstr ""
+msgstr "Denklemler fonksiyonlara göre birçok avantajı vardır. Örneğin denklemler factor()(= çarpanlarına ayır), expand () (= genişlet) komutlarıyla başka bir form da oluşturlabilir Bunun yanında denklemler her zaman 2B math olarak yazdırılabilir."
 
 #: ../../src/MaximaFileIO.cpp:64 ../../src/MaximaFileIO.cpp:121
 #: ../../src/MaximaFileIO.cpp:130 ../../src/MaximaFileIO.cpp:399
@@ -3733,11 +3733,11 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:184
 msgid "Eta"
-msgstr ""
+msgstr "Eta"
 
 #: ../../src/sidebars/TableOfContents.cpp:513
 msgid "Evaluate"
-msgstr ""
+msgstr "Değerlendir"
 
 #: ../../src/wxMaximaFrame.cpp:1689
 msgid "Evaluate &Noun Forms..."
@@ -3871,11 +3871,11 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2659
 msgid "Example text"
-msgstr ""
+msgstr "Örnek Metin"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1547
 msgid "Examples:"
-msgstr ""
+msgstr "Örnekler:"
 
 #: ../../src/wxMaximaFrame.cpp:1740
 msgid "Execute a command for each element of the list"
@@ -3887,11 +3887,11 @@ msgstr ""
 
 #: ../../src/sidebars/MathSidebar.cpp:53
 msgid "Expand"
-msgstr ""
+msgstr "Genişlet"
 
 #: ../../src/sidebars/MathSidebar.cpp:68
 msgid "Expand (tr)"
-msgstr ""
+msgstr "Genişlet (trig.)"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:356
 msgid "Expand Expression"
@@ -3968,7 +3968,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1218
 msgid "Export equations to HTML as:"
-msgstr ""
+msgstr "Eşitlikleri HTML'ye ..... formatında çıkart:"
 
 #: ../../src/wxMaximaFrame.cpp:600
 msgid "Export failed."
@@ -4050,19 +4050,19 @@ msgstr ""
 
 #: ../../src/wizards/DrawWiz.cpp:733
 msgid "Expression that calculates the x value"
-msgstr ""
+msgstr "X değerini hesaplayan ifade"
 
 #: ../../src/wizards/DrawWiz.cpp:738
 msgid "Expression that calculates the y value"
-msgstr ""
+msgstr "Y değerini hesaplayan ifade"
 
 #: ../../src/wizards/DrawWiz.cpp:744
 msgid "Expression that calculates the z value"
-msgstr ""
+msgstr "Z değerini hesaplayan ifade"
 
 #: ../../src/wizards/DrawWiz.cpp:56
 msgid "Expression to plot"
-msgstr ""
+msgstr "Çizimi yapılacak olan İfade"
 
 #: ../../src/wxMaximaFrame.cpp:1122
 msgid "Expression to string..."
@@ -4217,7 +4217,7 @@ msgstr ""
 
 #: ../../src/sidebars/MathSidebar.cpp:50
 msgid "Factor"
-msgstr ""
+msgstr "Çarpan"
 
 #: ../../src/wxMaximaFrame.cpp:1558
 msgid "Factor Complex"
@@ -4292,7 +4292,7 @@ msgstr ""
 #: ../../src/cells/GroupCell.cpp:2115
 #, c-format
 msgid "Figure %d:"
-msgstr ""
+msgstr "Şekil %d:"
 
 #: ../../src/main.cpp:678
 msgid "File"
@@ -4344,7 +4344,7 @@ msgstr ""
 
 #: ../../src/sidebars/DrawSidebar.cpp:93
 msgid "Fill color"
-msgstr ""
+msgstr "Renk doldur"
 
 #: ../../src/ToolBar.cpp:401 ../../src/ToolBar.cpp:403
 msgid "Find"
@@ -4465,7 +4465,7 @@ msgstr ""
 
 #: ../../src/dialogs/FindReplacePane.cpp:46
 msgid "Find:"
-msgstr ""
+msgstr "Bul:"
 
 #: ../../src/wxMaximaFrame.cpp:1869
 msgid "Fine-tune the display of engineering-format numbers"
@@ -4473,7 +4473,7 @@ msgstr "Mühendislik formatı numaralarının görüntüsüne ince ayar yapın"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:197
 msgid "Finnish"
-msgstr ""
+msgstr "Fince"
 
 #: ../../src/wxMaximaFrame.cpp:1749
 msgid "First"
@@ -4486,11 +4486,11 @@ msgstr "Ölçüm verilerine eğrilerin yerleştirilmesi"
 #: ../../src/dialogs/ConfigDialogue.cpp:1404
 #, c-format
 msgid "Fix reordered reference indices (of %i, %o) before saving"
-msgstr ""
+msgstr "Kaydetmeden önce yeniden düzenlenmiş referans indislerini (of %i, %o) onar"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:873
 msgid "Fixed font in text controls"
-msgstr ""
+msgstr "Metin kontrolünde değişmez yazı tipi"
 
 #: ../../src/MaximaCommandMenus.cpp:4039
 msgid "Flush stream"
@@ -4518,11 +4518,11 @@ msgstr ""
 
 #: ../../src/wizards/DrawWiz.cpp:341
 msgid "Following plots use secondary x axis"
-msgstr ""
+msgstr "Aşağıdaki grafiklerde ikincil x ekseni kullanılıyor"
 
 #: ../../src/wizards/DrawWiz.cpp:347
 msgid "Following plots use secondary y axis"
-msgstr ""
+msgstr "Aşağıdaki grafiklerde ikincil y ekseni kullanılıyor"
 
 #: ../../src/sidebars/PerformanceSidebar.cpp:37
 msgid "Font cache hits:"
@@ -4534,11 +4534,11 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2047
 msgid "Fonts"
-msgstr ""
+msgstr "Yazı Tipleri"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:442
 msgid "For each Text-, Sectioning or code cell wxMaxima can display a bracket showing the extend of the cell and allowing to fold it. This setting now tells if this bracket is to be printed, as well."
-msgstr ""
+msgstr "Her Metin-, Bölümleme veya kod hücresi için wxMaxima, hücrenin genişliğini gösteren ve katlanmasına izin veren bir köşeli parantez görüntüleyebilir. Bu ayar artık bu köşeli parantez de yazdırılıp yazdırılmayacağını açıklamaktadır."
 
 #: ../../src/ToolBar.cpp:495
 msgid "For faster creation of cells the following shortcuts exist:\n\n"
@@ -4570,7 +4570,7 @@ msgstr ""
 
 #: ../../src/wizards/Plot2dWiz.cpp:69 ../../src/wizards/Plot3dWiz.cpp:60
 msgid "Format:"
-msgstr ""
+msgstr "Format:"
 
 #: ../../src/worksheet/Worksheet.cpp:301 ../../src/wxMaxima.cpp:3521
 msgid "Forwarding the keyboard focus to a text control"
@@ -4615,15 +4615,15 @@ msgstr ""
 
 #: ../../src/wizards/DrawWiz.cpp:488
 msgid "Frame counter"
-msgstr ""
+msgstr "Çerçeve sayacı"
 
 #: ../../src/wizards/DrawWiz.cpp:499
 msgid "Frame counter end"
-msgstr ""
+msgstr "Çerçeve sayacı sonlandır"
 
 #: ../../src/wizards/DrawWiz.cpp:494
 msgid "Frame counter start"
-msgstr ""
+msgstr "Çerçeve hızı bşlat"
 
 #: ../../src/MaximaCommandMenus.cpp:102
 msgid "Frame rate"
@@ -4635,7 +4635,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:198
 msgid "French"
-msgstr ""
+msgstr "Fransızca"
 
 #: ../../src/wxMaximaFrame.cpp:1447
 msgid "Frobenius Norm sqrt(sum((A(i,j))^2)) (complex)"
@@ -4718,11 +4718,11 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:199
 msgid "Galician"
-msgstr ""
+msgstr "Galiçyaca"
 
 #: ../../src/sidebars/GreekSidebar.cpp:180
 msgid "Gamma"
-msgstr ""
+msgstr "Gamma"
 
 #: ../../src/wxMaximaFrame.cpp:316
 msgid "General Math"
@@ -4774,7 +4774,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:201
 msgid "German"
-msgstr ""
+msgstr "Almanca"
 
 #: ../../src/wxMaximaFrame.cpp:1656
 msgid "Get &Imaginary Part"
@@ -4862,7 +4862,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:202
 msgid "Greek"
-msgstr ""
+msgstr "Yunanca"
 
 #: ../../src/wxMaximaFrame.cpp:281
 msgid "Greek Letters"
@@ -4874,11 +4874,11 @@ msgstr "Yunanca harfler\tAlt+Shift+G"
 
 #: ../../src/sidebars/DrawSidebar.cpp:97
 msgid "Grid"
-msgstr ""
+msgstr "Izgara"
 
 #: ../../src/wizards/Plot3dWiz.cpp:52
 msgid "Grid:"
-msgstr ""
+msgstr "Izgara:"
 
 #: ../../src/wxMaximaFrame.cpp:1852
 msgid "Guess an exact number that could be meant by this float"
@@ -4953,7 +4953,7 @@ msgstr ""
 
 #: ../../src/sidebars/TableOfContents.cpp:510
 msgid "Hide"
-msgstr ""
+msgstr "Gizle"
 
 #: ../../src/ToolBar.cpp:471 ../../src/ToolBar.cpp:473
 msgid "Hide Code"
@@ -4993,7 +4993,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:487
 msgid "Hide all multiplication signs that aren't really necessary for understanding the equation"
-msgstr ""
+msgstr "Denklemi anlamak için gerçekten gerekli olmayan tüm çarpma işaretlerini gizle"
 
 #: ../../src/wxMaximaFrame.cpp:767
 msgid "Hide all panes"
@@ -5013,15 +5013,15 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:854
 msgid "Hide multiplication signs, if possible"
-msgstr ""
+msgstr "Mümkünse çarpma işaretlerini gizle"
 
 #: ../../src/wizards/DrawWiz.cpp:555
 msgid "Hide objects behind the surface"
-msgstr ""
+msgstr "Yüzeyin arkasındaki nesneleri gizle"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:502
 msgid "Hide the brackets that mark the extend of the worksheet cells at the worksheet's right side and that contain the \"hide\" button of the cell if the cells aren't active."
-msgstr ""
+msgstr "Eğer hücreler aktif değilse,çalışma sayfasının sağ tarafındaki içerik parantezlerinive \"hide\" komutunu içeren gizle butonunu gösterme."
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:702
 #: ../../src/worksheet/WorksheetContextMenu.cpp:835
@@ -5055,7 +5055,7 @@ msgstr ""
 
 #: ../../src/sidebars/StatSidebar.cpp:85
 msgid "Histogram..."
-msgstr ""
+msgstr "Histogram..."
 
 #: ../../src/wxMaximaFrame.cpp:246
 msgid "History"
@@ -5067,7 +5067,7 @@ msgstr "Geçmiş\tAlt+Shift+I"
 
 #: ../../src/dialogs/TipOfTheDay.cpp:105
 msgid "Horizontal cursor works like a normal cursor, but it operates on cells: press up or down arrow to move it, holding down Shift while moving will select cells, pressing backspace or delete twice will delete a cell next to it."
-msgstr ""
+msgstr "Yatay imleç normal bir imleç gibidir davranır,ancak hücrelerde çalışır  : hareket ettirmek için yukarı-aşağı okuna basın ; aynı anda Shift e basmakla 'hücreleri seçer, backspace tuşuna basarak yada delete tuşuna iki defa basmakla yanındaki hücreyi siler."
 
 #: ../../src/wxMaximaFrame.cpp:1563
 msgid "Horner's rule"
@@ -5087,7 +5087,7 @@ msgstr "Yeni denklemler nasıl gösterilir"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:205
 msgid "Hungarian"
-msgstr ""
+msgstr "Macarca"
 
 #: ../../src/wxMaximaFrame.cpp:1147
 msgid "I/O"
@@ -5095,7 +5095,7 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:121
 msgid "Identical to"
-msgstr ""
+msgstr "'e ye benzer"
 
 #: ../../src/MaximaCommandMenus.cpp:3874
 msgid "If a program doesn't need local variables, Maxima allows putting the commands between parentheses. The result of the last operation is the return value of the program."
@@ -5127,27 +5127,27 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:375
 msgid "If multiple cells are evaluated in one go: Abort evaluation if wxMaxima detects that maxima has encountered any error."
-msgstr ""
+msgstr "Bir seferde birden fazla hücreler değerlendirilirse: wxMaxima maxima'nın bir hatayla karşılaştığını belirlediğinde değerlendirmeyi durdur."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:727
 msgid "If not extremely long"
-msgstr ""
+msgstr "Eğer çok çok uzun değilse"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:726
 msgid "If not very long"
-msgstr ""
+msgstr "Eğer çok uzun değilse"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:418
 msgid "If numbers are getting longer than this number of digits they will be displayed abbreviated by an ellipsis."
-msgstr ""
+msgstr "Sayılar bu basamak sayısından daha uzun olduğunda üç nokta ile kısaltılarak gösterilir."
 
 #: ../../src/dialogs/TipOfTheDay.cpp:181
 msgid "If the \"Autosave\" functionality is enabled in the configuration dialogue wxMaxima acts like mobile apps that backup the file every few minutes and save it on closing."
-msgstr ""
+msgstr "Eğer, Yapılandırma da \"Otomatik Kaydet\" etkinleştirilmediysewxMaxima belgenizi bir kaç dakikada bir ve çıkışta da  otomatik olarak kaydeder."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:396
 msgid "If the font provides big parenthesis symbols: Use them when big parenthesis are needed for maths display."
-msgstr ""
+msgstr "Yazı tipi büyük parantez simgeleri sağlıyorsa: Büyük parantez matematik ekran için gerek duyulduğunda kullanın."
 
 #: ../../src/cells/TextCell.cpp:327
 msgid "If the thing maxima complains about actually looks like a polynomial you can try running it through ratdisrep() in order to fix that problem."
@@ -5161,11 +5161,11 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:399
 msgid "If this checkbox is checked wxMaxima automatically saves the file closing and every few minutes giving wxMaxima a more cellphone-app-like feel as the file is virtually always saved. If this checkbox is unchecked from time to time a backup is made in the temp folder instead."
-msgstr ""
+msgstr "Bu onay kutusu işaretlenirse, wxMaxima otomatik olarak dosya kapanmasını kaydeder ve wxMaxima'ya dosya neredeyse her zaman kaydedildiği için daha fazla cep telefonu uygulaması benzeri bir his verir. Bu onay kutusunun işareti kaldırılırsa, geçici klasörde yedekleme yapılır."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:378
 msgid "If this checkbox is set a new code cell is opened as soon as maxima requests data. If it isn't set a new code cell is opened in this case as soon as the user starts typing in code."
-msgstr ""
+msgstr "Bu onay kutusu ayarlanırsa, maxima veri istediği anda yeni bir kod hücresi açılır. Ayarlanmadıysa, kullanıcı kod yazmaya başlar başlamaz bu durumda yeni bir kod hücresi açılır."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:372
 msgid "If this checkbox isn't checked the current command is sent to maxima only on pressing Ctrl+Enter"
@@ -5182,7 +5182,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:439
 msgid "If this option is set the .wxmx source of the current file is copied to a place a link to is put into the result of an export."
-msgstr ""
+msgstr "Bu seçeneği belirttiğiniz takdirde geçerli dosyanın .wxmx kaynağına bir bağlantı verme sonucu koyduğun bir yere kopyalanır."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1873
 msgid "If unset, Maxima's output is announced to the screen reader as maths in a linear text form. Set this option if your screen reader can speak MathML properly."
@@ -5194,11 +5194,11 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:76
 msgid "If you type an operator (one of +*/^=,) as the first symbol in an input cell, % will be automatically inserted before the operator, as on a graphing calculator. You can disable this feature from the 'Edit->Configure' dialog."
-msgstr ""
+msgstr "Komut çizgisine bir girdi olarak bir işlemci gireseniz ( +*/^=, den birsini) grafik çizen hesap makinelerinde olduğu gibi % işareti işlemciden önce otomatik olarak eklenecektir Bu 'Düzen->Yapılandır'  a girilerek düzeltilebilir."
 
 #: ../../src/dialogs/TipOfTheDay.cpp:122
 msgid "If your calculation is taking too long to evaluate, you can try 'Maxima->Interrupt' or 'Maxima->Restart Maxima' menu commands."
-msgstr ""
+msgstr "Eğer hesaplamalarınızı yapmak uzun zaman alıyorsa (bir sorun var demektir) Mkomut menüsünden Maxima-> Interrupt (Yarıda Kes) yada Maxima-> Restart Maxima (Maximayı Yeninden Başlat) yapın."
 
 #: ../../src/MaximaManual.cpp:420
 msgid "Ignoring the cache version for the manual anchors."
@@ -5206,7 +5206,7 @@ msgstr ""
 
 #: ../../src/sidebars/FormatSidebar.cpp:66
 msgid "Image"
-msgstr ""
+msgstr "Resim"
 
 #: ../../src/Image.cpp:110
 msgid "Image data had zero length!"
@@ -5228,7 +5228,7 @@ msgstr ""
 
 #: ../../src/sidebars/DrawSidebar.cpp:60
 msgid "Implicit Plot"
-msgstr ""
+msgstr "Kapalı Çizim"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1028
 msgid "Import settings"
@@ -5274,7 +5274,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:421
 msgid "In the LaTeX output: Put exponents after an eventual subscript instead of above it. Might increase readability for some fonts and short subscripts."
-msgstr ""
+msgstr "LaTeX çıkarımlarında: Üs ifadelerini indisin üstüne değil de indisten sonra koyun.Kısa indislerin ve bazı fontların okunabilinirliğini arttırabilir."
 
 #: ../../src/MaximaCommandMenus.cpp:1869
 msgid "Include columns:"
@@ -5286,15 +5286,15 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:884
 msgid "Incremental Search"
-msgstr ""
+msgstr "Artan arama"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:844
 msgid "Indent equations by the label width"
-msgstr ""
+msgstr "Denklemleri etiket genişliğine göre girinti"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:512
 msgid "Indent maths so all lines are in par with the first line that starts after the label."
-msgstr ""
+msgstr "Matematiği girinti, böylece tüm satırlar etiketten sonra başlayan ilk satırla aynı olur."
 
 #: ../../src/sidebars/TableOfContents.cpp:583
 msgid "Indentation"
@@ -5335,7 +5335,7 @@ msgstr ""
 #: ../../src/wizards/IntegrateWiz.cpp:215 ../../src/wizards/LimitWiz.cpp:132
 #: ../../src/wizards/LimitWiz.cpp:140
 msgid "Infinity"
-msgstr ""
+msgstr "Sonsuz"
 
 #: ../../src/wxMaximaFrame.cpp:1986
 msgid "Info about Maxima build"
@@ -5393,7 +5393,7 @@ msgstr "Ekle"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:889
 msgid "Insert % before an operator at the beginning of a cell"
-msgstr ""
+msgstr "Bir hücrenin başında bir işlemciden önce % ekle"
 
 #: ../../src/wxMaximaFrame.cpp:939
 msgid "Insert &Section Cell\tCtrl+3"
@@ -5541,11 +5541,11 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:749
 msgid "Integers and single letters"
-msgstr ""
+msgstr "Tamsayılar ve tek harfler"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:113
 msgid "Integral sign"
-msgstr ""
+msgstr "İntegral işareti"
 
 #: ../../src/MaximaCommandMenus.cpp:149 ../../src/MaximaCommandMenus.cpp:170
 msgid "Integral/Sum:"
@@ -5579,7 +5579,7 @@ msgstr "İntegralini Al..."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:834
 msgid "Intelligently hide cell brackets"
-msgstr ""
+msgstr "Hücre parantezlerini otomatik gizle"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:881
 msgid "Interaction"
@@ -5587,7 +5587,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1349
 msgid "Interactive popup memory limit [MB/plot]:"
-msgstr ""
+msgstr "Etkileşimli açılır pencere bellek sınırı [MB / çizim]:"
 
 #: ../../src/wxMaximaFrame.cpp:1774
 msgid "Interleave"
@@ -5669,7 +5669,7 @@ msgstr "Ters Laplace Dönüşümü..."
 
 #: ../../src/sidebars/GreekSidebar.cpp:186
 msgid "Iota"
-msgstr ""
+msgstr "Iota"
 
 #: ../../src/MaximaCommandMenus.cpp:4150
 msgid "Is Char 1 greater than Char2, if case is ignored?"
@@ -5785,7 +5785,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:498
 msgid "Issue a notification if maxima finishes calculating while the wxMaxima window isn't in focus."
-msgstr ""
+msgstr "WxMaxima penceresinde Maxima hesaplamayı bitirirse bildirin."
 
 #: ../../src/worksheet/Worksheet.cpp:4237
 msgid "Issuing the active cell's undo function"
@@ -5797,7 +5797,7 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:185
 msgid "It is possible to add custom symbols to the \"symbols\" sidebar by copying them into the respective field in the configuration dialogue."
-msgstr ""
+msgstr "\"Semboller\" kenar çubuğuna, Yapılandırma sekmesindeki ilgili alana kopyalayarak özel semboller eklemek mümkündür."
 
 #: ../../src/dialogs/TipOfTheDay.cpp:152
 msgid "It is possible to define reusable Maxima libraries with wxMaxima that can be later loaded by using the load() function. All that has to be done is to export a file in the .mac or to save it in the .wxm format. Note, though, that a few special characters like the \"not equal\" symbol for \"#\" are handled by wxMaxima, not by Maxima and therefore cannot be recognized on load()."
@@ -5805,19 +5805,19 @@ msgstr ""
 
 #: ../../src/wizards/DrawWiz.cpp:476
 msgid "It needs to be filled with objects to draw afterwards."
-msgstr ""
+msgstr "Daha sonra çizmek için nesnelerle doldurulması gerekir."
 
 #: ../../src/wizards/ActualValuesStorageWiz.cpp:38
 msgid "It therefore makes sense to apply the known values for variables as late as possible."
-msgstr ""
+msgstr "Bilinen değerlerin değişkenlere olabildiğince geç uygulanması mantıklıdır."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:207
 msgid "Italian"
-msgstr ""
+msgstr "İtalyanca"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2111
 msgid "Italic"
-msgstr ""
+msgstr "İtalik"
 
 #: ../../src/MaximaCommandMenus.cpp:1617 ../../src/MaximaCommandMenus.cpp:1623
 msgid "Item"
@@ -5829,7 +5829,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:208
 msgid "Japanese"
-msgstr ""
+msgstr "Japonca"
 
 #: ../../src/MaximaCommandMenus.cpp:2255
 msgid "Jump to UUID"
@@ -5857,16 +5857,16 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:210
 msgid "Kabyle"
-msgstr ""
+msgstr "Berberi dili"
 
 #: ../../src/sidebars/GreekSidebar.cpp:187
 msgid "Kappa"
-msgstr ""
+msgstr "Kappa"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:864
 #, c-format
 msgid "Keep percent sign with special symbols: %e, %i, etc."
-msgstr ""
+msgstr "Özel sembolleri yüzde işareti ile yaz: %e, %i, v.b."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:212
 msgid "Korean"
@@ -5898,15 +5898,15 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1199
 msgid "LaTeX: Place exponents after, instead above subscripts"
-msgstr ""
+msgstr "LaTeX: Üs ifadelerini indislerin üstüne değil sonrasına yerleştirin"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1204
 msgid "LaTeX: Use the \"partial derivative\" symbol to represent diff()"
-msgstr ""
+msgstr "LaTeX: diff() 'ı göstermek için \"kısmi türev\" ı kullan."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:758
 msgid "Label width:"
-msgstr ""
+msgstr "Etiket genişliği:"
 
 #: ../../src/wxMaximaFrame.cpp:1059
 msgid "Labels"
@@ -5925,11 +5925,11 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:470
 msgid "Language used for wxMaxima GUI."
-msgstr ""
+msgstr "WxMaxima arayüzü için kullanılan dil."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1311
 msgid "Language:"
-msgstr ""
+msgstr "Dil:"
 
 #: ../../src/MaximaCommandMenus.cpp:251
 msgid "Laplace"
@@ -5976,7 +5976,7 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:126
 msgid "Leads to"
-msgstr ""
+msgstr "'e yol açar"
 
 #: ../../src/wxMaximaFrame.cpp:1530
 msgid "Least Common Multiple..."
@@ -5988,7 +5988,7 @@ msgstr "En Az Karelere uydur"
 
 #: ../../src/sidebars/StatSidebar.cpp:79
 msgid "Least Squares Fit..."
-msgstr ""
+msgstr "En Az Karelere uydur..."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2007
 msgid "Left"
@@ -6030,7 +6030,7 @@ msgstr ""
 #: ../../src/dialogs/LicenseDialog.cpp:63
 #: ../../src/dialogs/LicenseDialog.cpp:77
 msgid "License"
-msgstr ""
+msgstr "Lisans"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2068
 msgid "Light"
@@ -6046,15 +6046,15 @@ msgstr ""
 
 #: ../../src/sidebars/MathSidebar.cpp:86
 msgid "Limit..."
-msgstr ""
+msgstr "Limit..."
 
 #: ../../src/sidebars/DrawSidebar.cpp:88
 msgid "Line color"
-msgstr ""
+msgstr "Çizgi rengi"
 
 #: ../../src/sidebars/StatSidebar.cpp:76
 msgid "Linear Regression..."
-msgstr ""
+msgstr "Doğrusal Regresyon..."
 
 #: ../../src/MaximaCommandMenus.cpp:4068
 msgid "Lisp format string:"
@@ -6102,15 +6102,15 @@ msgstr ""
 
 #: ../../src/wizards/ListSortWiz.cpp:34
 msgid "List name:"
-msgstr ""
+msgstr "Dizin adı:"
 
 #: ../../src/sidebars/VariablesPane.cpp:188
 msgid "List of arrays"
-msgstr ""
+msgstr "Dizilerin listesi"
 
 #: ../../src/sidebars/VariablesPane.cpp:191
 msgid "List of changed options"
-msgstr ""
+msgstr "Değiştirilen seçeneklerin listesi"
 
 #: ../../src/MaximaCommandMenus.cpp:4197
 msgid "List of char to String"
@@ -6134,31 +6134,31 @@ msgstr ""
 
 #: ../../src/sidebars/VariablesPane.cpp:200
 msgid "List of structs"
-msgstr ""
+msgstr "Yapıların listesi"
 
 #: ../../src/sidebars/VariablesPane.cpp:197
 msgid "List of user aliases"
-msgstr ""
+msgstr "Kullanıcı takma adları listesi"
 
 #: ../../src/sidebars/VariablesPane.cpp:185
 msgid "List of user functions"
-msgstr ""
+msgstr "Kullanıcı fonksiyonlarının listesi"
 
 #: ../../src/sidebars/VariablesPane.cpp:194
 msgid "List of user rules"
-msgstr ""
+msgstr "Kullanıcı kurallarının listesi"
 
 #: ../../src/sidebars/VariablesPane.cpp:182
 msgid "List of user variables"
-msgstr ""
+msgstr "Kullanıcı değişkenlerinin listesi"
 
 #: ../../src/sidebars/VariablesPane.cpp:206
 msgid "List of user-defined derivatives"
-msgstr ""
+msgstr "Kullanıcı tanımlı türevlerin listesi"
 
 #: ../../src/sidebars/VariablesPane.cpp:216
 msgid "List of user-defined let rule packages"
-msgstr ""
+msgstr "Kullanıcı tanımlı izin kuralı paketlerinin listesi"
 
 #: ../../src/sidebars/VariablesPane.cpp:212
 msgid "List of user-defined macros"
@@ -6166,7 +6166,7 @@ msgstr ""
 
 #: ../../src/sidebars/VariablesPane.cpp:209
 msgid "List of user-defined properties"
-msgstr ""
+msgstr "Kullanıcı tanımlı özelliklerin listesi"
 
 #: ../../src/MaximaCommandMenus.cpp:1575
 msgid "List with values"
@@ -6187,7 +6187,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2162
 msgid "Load"
-msgstr ""
+msgstr "Yükle"
 
 #: ../../src/MaximaCommandMenus.cpp:2356
 msgid "Load Package"
@@ -6227,7 +6227,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2645
 msgid "Load style from file"
-msgstr ""
+msgstr "Sitili dosyadan yükle"
 
 #: ../../src/wxMaximaFrame.cpp:1232
 msgid "Load the file/dir operations (operatingsystem)"
@@ -6243,7 +6243,7 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:128
 msgid "Long Right arrow"
-msgstr ""
+msgstr "Uzun sağ ok"
 
 #: ../../src/MaximaCommandMenus.cpp:1409
 msgid "Loop variable"
@@ -6263,7 +6263,7 @@ msgstr ""
 
 #: ../../src/sidebars/XmlInspector.cpp:104
 msgid "MAXIMA RESPONSE:"
-msgstr ""
+msgstr "MAXİMA YANITI:"
 
 #: ../../src/MaximaCommandMenus.cpp:3965
 msgid "Macro contents:"
@@ -6327,7 +6327,7 @@ msgstr ""
 
 #: ../../src/dialogs/FindReplacePane.cpp:71
 msgid "Match Case"
-msgstr ""
+msgstr "Büyük küçük harfe duyarlı"
 
 #: ../../src/Styles.cpp:139
 msgid "Math Default"
@@ -6339,7 +6339,7 @@ msgstr ""
 
 #: ../../src/cells/Cell.cpp:1490
 msgid "Math output"
-msgstr ""
+msgstr "Matematik çıktısı"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1221
 msgid "MathML (rendered by the browser)"
@@ -6351,11 +6351,11 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1906
 msgid "MathML as HTML"
-msgstr ""
+msgstr "HTML olarak MathML"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1902
 msgid "MathML description"
-msgstr ""
+msgstr "MathML tanımı"
 
 #: ../../src/wxMaximaFrame.cpp:307
 msgid "Mathematical Symbols"
@@ -6435,7 +6435,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:281
 msgid "Maxima"
-msgstr ""
+msgstr "Maxima"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1433
 msgid "Maxima Location"
@@ -6472,7 +6472,7 @@ msgstr ""
 
 #: ../../src/cells/EditorCell.cpp:4516
 msgid "Maxima code"
-msgstr ""
+msgstr "Maxima kodu"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1110
 msgid "Maxima commands to be executed at every start of Maxima"
@@ -6560,11 +6560,11 @@ msgstr "Maxima süreci beklenmedik şekilde sona erdi."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1437
 msgid "Maxima program:"
-msgstr ""
+msgstr "Maxima programı:"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:382
 msgid "Maxima provides no \"forget all\" command that flushes all settings a maxima session could make. wxMaxima therefore normally defaults to starting a fresh maxima process every time the worksheet is to be re-evaluated. As this needs a little bit of time this switch allows to disable this behavior."
-msgstr ""
+msgstr "Maxima, bir maxima oturumunun yapabileceği tüm ayarları silecek hiçbir \"hepsini unut\" komutunu sağlamaz. Bu nedenle, wxMaxima, çalışma sayfası yeniden değerlendirilmek üzere her seferinde yeni bir Maxima işlemi başlatmayı varsayılanı yapar. Bu biraz zaman gerektirdiğinden, bu anahtar bu davranışı devre dışı bırakmaya izin verir."
 
 #: ../../src/Styles.cpp:108
 msgid "Maxima question labels"
@@ -6616,11 +6616,11 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1143
 msgid "Maxima startup file location: "
-msgstr ""
+msgstr "Maxima başlangıç dosya konumu: "
 
 #: ../../src/dialogs/TipOfTheDay.cpp:68
 msgid "Maxima supports three types of numbers: exact fractions (which can be generated for example by typing 1/10), IEEE floating-point numbers (0.2) and arbitrary precision big floats (1b-1). Note that, owing to their nature as binary (not decimal) numbers, there is for example no way to generate an IEEE floating-point number that exactly equals 0.1. If floating-point numbers are used instead of fractions, Maxima will therefore sometimes have to introduce a (very small) error and use things like 3602879701896397/36028797018963968 for 0.1."
-msgstr ""
+msgstr "Maxima üç tür sayıyı destekler: tam kesirler (1/10 şeklinde üretilebilinirler), IEEE kayan-nokta sayılar (örn: 0.2) ve (arbitrary precision big floats) gelişigüzel duyarlılığı olan büyük sayılar.(1b-1). Sahip olduğu ikili (binary) doğası, ondalıklı değil, 0.1 i kesin olarak veren bir IEEE kayan nokta sayısı üretmek mümkün olmadığına dikkat etmeli.Kesirler yerine kayan- nokta sayıları kullanmışsa, Maxima çooooook küçük hatalar verebilir. örnek : 0.1 için 3602879701896397/36028797018963968 verebilir."
 
 #: ../../src/wxMaximaFrame.cpp:1265
 msgid "Maxima to other language"
@@ -6732,7 +6732,7 @@ msgstr ""
 
 #: ../../src/wizards/ActualValuesStorageWiz.cpp:34
 msgid "Maxima's power lies in symbolic operations."
-msgstr ""
+msgstr "Maxima'nın gücü sembolik işlem yapmasında yatar."
 
 #: ../../src/StatusBar.cpp:365
 msgid "Maxima's reader is in Lisp mode (after to_lisp()).\n"
@@ -6796,15 +6796,15 @@ msgstr ""
 
 #: ../../src/sidebars/StatSidebar.cpp:70
 msgid "Mean Difference Test..."
-msgstr ""
+msgstr "Ortalama Fark Testi..."
 
 #: ../../src/sidebars/StatSidebar.cpp:67
 msgid "Mean Test..."
-msgstr ""
+msgstr "Ortalama Testi..."
 
 #: ../../src/sidebars/StatSidebar.cpp:52
 msgid "Mean..."
-msgstr ""
+msgstr "Ortalama..."
 
 #: ../../src/MaximaCommandMenus.cpp:1806
 msgid "Mean:"
@@ -6812,7 +6812,7 @@ msgstr "Ortalama:"
 
 #: ../../src/sidebars/StatSidebar.cpp:55
 msgid "Median..."
-msgstr ""
+msgstr "Medyan..."
 
 #: ../../src/wxMaximaFrame.cpp:1961
 msgid "Memoizing"
@@ -6833,7 +6833,7 @@ msgstr "Maxima'nın stdout (standard çıkış) ın dan mesaj: "
 
 #: ../../src/wizards/IntegrateWiz.cpp:55
 msgid "Method:"
-msgstr ""
+msgstr "Metod:"
 
 #: ../../src/wxMaximaFrame.cpp:1360
 msgid "Methods of generating a matrix"
@@ -6900,7 +6900,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:189
 msgid "Mu"
-msgstr ""
+msgstr "Mü"
 
 #: ../../src/wxMaximaFrame.cpp:1386
 msgid "Multiplication, exponent and similar"
@@ -6924,7 +6924,7 @@ msgstr ""
 
 #: ../../src/wizards/DrawWiz.cpp:750
 msgid "Name of the parameter"
-msgstr ""
+msgstr "Paramatrenin ismi"
 
 #: ../../src/MaximaCommandMenus.cpp:1019
 msgid "Name of x:"
@@ -6932,7 +6932,7 @@ msgstr ""
 
 #: ../../src/wizards/MatWiz.cpp:163
 msgid "Name:"
-msgstr ""
+msgstr "İsim:"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:216
 msgid "Nepali"
@@ -6995,7 +6995,7 @@ msgstr "Yeni belge"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:901
 msgid "New lines: Jump to text"
-msgstr ""
+msgstr "Yeni satırlar: Metne git"
 
 #: ../../src/MaximaResponseReader.cpp:1015
 #, c-format
@@ -7008,7 +7008,7 @@ msgstr ""
 
 #: ../../src/wizards/SubstituteWiz.cpp:35
 msgid "New value:"
-msgstr ""
+msgstr "Yeni Değer:"
 
 #: ../../src/MaximaCommandMenus.cpp:151 ../../src/MaximaCommandMenus.cpp:171
 #: ../../src/MaximaCommandMenus.cpp:254 ../../src/MaximaCommandMenus.cpp:259
@@ -7046,7 +7046,7 @@ msgstr ""
 
 #: ../../src/wizards/DrawWiz.cpp:636
 msgid "No contour lines"
-msgstr ""
+msgstr "Eşyükselti çizgisi yok"
 
 #: ../../src/dialogs/DiffFrame.cpp:304
 msgid "No differences"
@@ -7083,11 +7083,11 @@ msgstr "Eşleşme bulunamadı!"
 
 #: ../../src/wizards/DrawWiz.cpp:651
 msgid "No plot, only contour lines"
-msgstr ""
+msgstr "Çizim yok, sadece kontur çizgileri"
 
 #: ../../src/wizards/DrawWiz.cpp:837
 msgid "No points"
-msgstr ""
+msgstr "Noktasız"
 
 #: ../../src/MaximaResponseReader.cpp:145
 msgid "No topics found in topic flag"
@@ -7103,7 +7103,7 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:179
 msgid "Non-builtin symbols"
-msgstr ""
+msgstr "Yerleşik olmayan semboller"
 
 #: ../../src/wxMaximaFrame.cpp:834
 msgid "None"
@@ -7111,7 +7111,7 @@ msgstr ""
 
 #: ../../src/sidebars/StatSidebar.cpp:73
 msgid "Normality Test..."
-msgstr ""
+msgstr "Normallik Testiı..."
 
 #: ../../src/cells/TextCell.cpp:271
 msgid "Normally computers use floating-point numbers that can be handled incredibly fast while being accurate to dozens of digits. They will, though, introduce a small error into some common numbers. For example 0.1 is represented as 3602879701896397/36028797018963968.\n"
@@ -7122,11 +7122,11 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:431
 msgid "Normally html expects images to be rather low-res but space saving. These images tend to look rather blurry when viewed on modern screens. Therefore this setting was introduces that selects the factor by which the HTML export increases the resolution in respect to the default value."
-msgstr ""
+msgstr "Normal olarak html resimlerin yer kaplamayan düşük çözünürlüklü olamasını bekler. Modern ekranlarda bu resimlerin net görüntüsü olmaz. Buradan HTML çıkarımlarındaki çözünürlük arttırımını belirleyebilirsiniz."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:217
 msgid "Norwegian"
-msgstr ""
+msgstr "Norveçce"
 
 #: ../../src/MaximaCommandMenus.cpp:1351
 msgid "Not a valid matrix dimension!"
@@ -7162,7 +7162,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:190
 msgid "Nu"
-msgstr ""
+msgstr "Nü"
 
 #: ../../src/MaximaCommandMenus.cpp:177
 msgid "Num. deg:"
@@ -7313,7 +7313,7 @@ msgstr ""
 
 #: ../../src/wizards/SubstituteWiz.cpp:32
 msgid "Old value:"
-msgstr ""
+msgstr "Eski değer:"
 
 #: ../../src/MaximaCommandMenus.cpp:151 ../../src/MaximaCommandMenus.cpp:172
 #: ../../src/MaximaCommandMenus.cpp:253 ../../src/MaximaCommandMenus.cpp:259
@@ -7322,11 +7322,11 @@ msgstr "Eski Değişken:"
 
 #: ../../src/sidebars/GreekSidebar.cpp:201
 msgid "Omega"
-msgstr ""
+msgstr "Omega"
 
 #: ../../src/sidebars/GreekSidebar.cpp:192
 msgid "Omicron"
-msgstr ""
+msgstr "Omega (küçük)"
 
 #: ../../src/wxMaximaFrame.cpp:1089
 msgid "On all errors"
@@ -7350,7 +7350,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:771
 msgid "Only user-defined labels"
-msgstr ""
+msgstr "Sadece kullanıcı-tanımlı etiketler"
 
 #: ../../src/MaximaCommandMenus.cpp:2197 ../../src/ToolBar.cpp:330
 #: ../../src/ToolBar.cpp:333 ../../src/main.cpp:882
@@ -7359,7 +7359,7 @@ msgstr "Aç"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:905
 msgid "Open a cell when Maxima expects input"
-msgstr ""
+msgstr "Maxima girdi beklerken yeni bir hücre aç"
 
 #: ../../src/wxMaximaFrame.cpp:629
 msgid "Open a document"
@@ -7433,7 +7433,7 @@ msgstr ""
 
 #: ../../src/wizards/DrawWiz.cpp:97
 msgid "Optional: A 2nd expression that defines a region to fill"
-msgstr ""
+msgstr "Dosyayı açıyor"
 
 #: ../../src/ToolBar.cpp:367 ../../src/ToolBar.cpp:369
 #: ../../src/dialogs/ConfigDialogue.cpp:284
@@ -7442,7 +7442,7 @@ msgstr "Seçenekler"
 
 #: ../../src/wizards/Plot2dWiz.cpp:75 ../../src/wizards/Plot3dWiz.cpp:66
 msgid "Options:"
-msgstr ""
+msgstr "Seçenekler:"
 
 #: ../../src/dialogs/FindReplacePane.cpp:109
 msgid "Output"
@@ -7503,7 +7503,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:458
 msgid "PNG images can be read by old wxMaxima versions - but aren't really scalable."
-msgstr ""
+msgstr "PNG görüntüleri eski wxMaxima sürümleri tarafından okunabilir - ancak gerçekten ölçeklenebilir değildir."
 
 #: ../../src/MaximaCommandMenus.cpp:175
 msgid "Pade approximation"
@@ -7515,7 +7515,7 @@ msgstr "Bir Taylor Serisinin Padé Yaklaşımı"
 
 #: ../../src/sidebars/FormatSidebar.cpp:69
 msgid "Pagebreak"
-msgstr ""
+msgstr "Sayfa sonu"
 
 #: ../../src/wxMaximaFrame.cpp:1674
 msgid "Parallel Substitute..."
@@ -7527,7 +7527,7 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:124
 msgid "Parallel to"
-msgstr ""
+msgstr "'e paralel"
 
 #: ../../src/MaximaCommandMenus.cpp:3991
 msgid "Parameter name:"
@@ -7539,11 +7539,11 @@ msgstr ""
 
 #: ../../src/sidebars/DrawSidebar.cpp:64
 msgid "Parametric Plot"
-msgstr ""
+msgstr "Parametrik Grafik çizimi"
 
 #: ../../src/wizards/Plot2dWiz.cpp:417 ../../src/wizards/Plot2dWiz.cpp:523
 msgid "Parametric plot"
-msgstr ""
+msgstr "Parametrik Çizim"
 
 #: ../../src/MaximaCommandMenus.cpp:4211
 msgid "Parse string"
@@ -7597,7 +7597,7 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:125
 msgid "Perpendicular to"
-msgstr ""
+msgstr "'e dik"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:218
 msgid "Persian"
@@ -7605,15 +7605,15 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:198
 msgid "Phi"
-msgstr ""
+msgstr "Phi"
 
 #: ../../src/sidebars/GreekSidebar.cpp:193
 msgid "Pi"
-msgstr ""
+msgstr "Pi"
 
 #: ../../src/sidebars/StatSidebar.cpp:94
 msgid "Piechart..."
-msgstr ""
+msgstr "Pasta dilimi..."
 
 #: ../../src/wxMaxima.cpp:1585
 msgid "Please configure wxMaxima with 'Edit->Configure'."
@@ -7621,7 +7621,7 @@ msgstr "Lütfen wxMaxima'yı 'Düzenle-> Yapılandır' ile yapılandırınız."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2606
 msgid "Please restart wxMaxima for changes to take effect!"
-msgstr ""
+msgstr "Değişikliklerin uygulanabilmesi için wxMaxima'yı yeniden başlat!"
 
 #: ../../src/MaximaCommandMenus.cpp:2250
 msgid "Please select exactly 2 or 3 files."
@@ -7662,16 +7662,16 @@ msgstr "3B Grafik..."
 
 #: ../../src/wizards/DrawWiz.cpp:713
 msgid "Plot a parametric curve"
-msgstr ""
+msgstr "Parametrik ir ifadeyi çiz"
 
 #: ../../src/wizards/DrawWiz.cpp:45 ../../src/wizards/DrawWiz.cpp:148
 #: ../../src/wizards/DrawWiz.cpp:255
 msgid "Plot an explicit expression"
-msgstr ""
+msgstr "Açık bir ifadeyi çizmek"
 
 #: ../../src/wizards/DrawWiz.cpp:53
 msgid "Plot an expression, for example sin(x) or (x+1)^2."
-msgstr ""
+msgstr "Bir ifadenin grafiğini çiz örnek: sin(x) ya da (x+1)^2."
 
 #: ../../src/MaximaCommandMenus.cpp:1776
 msgid "Plot as bars"
@@ -7695,11 +7695,11 @@ msgstr "3 Boyutlu Grafik çiz"
 
 #: ../../src/sidebars/DrawSidebar.cpp:83
 msgid "Plot name"
-msgstr ""
+msgstr "Çizimin adı"
 
 #: ../../src/wizards/Plot2dWiz.cpp:84 ../../src/wizards/Plot3dWiz.cpp:80
 msgid "Plot to file:"
-msgstr ""
+msgstr "Grafiği Bir Dosyaya çiz:"
 
 #: ../../src/wxMaximaFrame.cpp:341 ../../src/wxMaximaFrame.cpp:749
 msgid "Plot using Draw"
@@ -7719,7 +7719,7 @@ msgstr ""
 
 #: ../../src/wizards/DrawWiz.cpp:842
 msgid "Point type:"
-msgstr ""
+msgstr "Nokta Türü:"
 
 #: ../../src/MaximaCommandMenus.cpp:186 ../../src/MaximaCommandMenus.cpp:1090
 #: ../../src/wizards/BC2Wiz.cpp:33 ../../src/wizards/BC2Wiz.cpp:39
@@ -7729,11 +7729,11 @@ msgstr "Nokta:"
 
 #: ../../src/sidebars/DrawSidebar.cpp:67
 msgid "Points"
-msgstr ""
+msgstr "Noktalar"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:219
 msgid "Polish"
-msgstr ""
+msgstr "Polonyaca"
 
 #: ../../src/MaximaCommandMenus.cpp:215 ../../src/MaximaCommandMenus.cpp:220
 #: ../../src/MaximaCommandMenus.cpp:225
@@ -7769,7 +7769,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:221
 msgid "Portuguese (Brazilian)"
-msgstr ""
+msgstr "Portekizce (Brezilya)"
 
 #: ../../src/wxMaximaFrame.cpp:1223
 msgid "Position of a match"
@@ -7785,7 +7785,7 @@ msgstr ""
 
 #: ../../src/wizards/Plot2dWiz.cpp:474 ../../src/wizards/Plot3dWiz.cpp:422
 msgid "Postscript file (*.eps)|*.eps|All|*"
-msgstr ""
+msgstr "Postscript Dosyası (*.eps)|*.eps|Hepsi|*"
 
 #: ../../src/MaximaCommandMenus.cpp:190
 msgid "Power series"
@@ -7833,7 +7833,7 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:146
 msgid "Pressing Ctrl+Space or Ctrl+Tab starts an autocomplete function that can not only complete all functions that are integrated into the Maxima core and their parameters: It also knows about parameters from currently loaded packages and from functions that are defined in the current file."
-msgstr ""
+msgstr "Ctrl+Space ya da Ctrl+Tab a basılması otomatik tamamlama işlevini başlatır. Sadece maxima çekirdeğine ve parametrelerine entegre edilmiş olanlara değil aynı anda hali hazırda yüklenmiş olan paketlerdeki ve dosyadaki parametreleri de ele alır."
 
 #: ../../src/wxMaximaFrame.cpp:961
 msgid "Previous Command\tAlt+Up"
@@ -7870,11 +7870,11 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1968
 msgid "Print scale:"
-msgstr ""
+msgstr "Yazdırma ölçüsü:"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1981
 msgid "Print the cell brackets [drawn to their left]"
-msgstr ""
+msgstr "Hücre parantezlerini yazdır."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:287
 msgid "Printout settings"
@@ -7937,7 +7937,7 @@ msgstr "Çarpım"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:123
 msgid "Product sign"
-msgstr ""
+msgstr "Çarpım işareti"
 
 #: ../../src/wxMaximaFrame.cpp:1129
 msgid "Program"
@@ -7961,7 +7961,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:200
 msgid "Psi"
-msgstr ""
+msgstr "Psi"
 
 #: ../../src/wxMaximaFrame.cpp:1788
 msgid "Push"
@@ -7985,7 +7985,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1910
 msgid "RTF with OMML maths"
-msgstr ""
+msgstr "OMML matematiği ile RTF"
 
 #: ../../src/MaximaCommandMenus.cpp:207
 msgid "Range radius:"
@@ -8047,7 +8047,7 @@ msgstr ""
 
 #: ../../src/sidebars/StatSidebar.cpp:103
 msgid "Read Matrix..."
-msgstr ""
+msgstr "Matrisi Oku...."
 
 #: ../../src/MaximaCommandMenus.cpp:4008
 msgid "Read a structure field"
@@ -8176,7 +8176,7 @@ msgstr "Maxima'nın ilk istemini aldı:% s"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1327
 msgid "Recent files list length:"
-msgstr ""
+msgstr "Geçmiş dosyalar listesi uzunluğu:"
 
 #: ../../src/wxMaximaFrame.cpp:634
 msgid "Recover unsaved"
@@ -8184,7 +8184,7 @@ msgstr ""
 
 #: ../../src/sidebars/MathSidebar.cpp:56
 msgid "Rectform"
-msgstr ""
+msgstr "Kartezyen Form"
 
 #: ../../src/wxMaximaFrame.cpp:1677
 msgid "Recursive Substitute..."
@@ -8208,7 +8208,7 @@ msgstr "Son değişkliği Yinele"
 
 #: ../../src/sidebars/MathSidebar.cpp:71
 msgid "Reduce (tr)"
-msgstr ""
+msgstr "İndirge (trig.)"
 
 #: ../../src/wxMaximaFrame.cpp:1632
 msgid "Reduce trigonometric expression"
@@ -8279,7 +8279,7 @@ msgstr ""
 
 #: ../../src/sidebars/VariablesPane.cpp:220
 msgid "Remove"
-msgstr ""
+msgstr "Kaldır"
 
 #: ../../src/wxMaximaFrame.cpp:917
 msgid "Remove All Output"
@@ -8295,7 +8295,7 @@ msgstr ""
 
 #: ../../src/sidebars/VariablesPane.cpp:225
 msgid "Remove all"
-msgstr ""
+msgstr "Hepsini kaldır"
 
 #: ../../src/wxMaximaFrame.cpp:1785
 msgid "Remove all list elements that appear twice in a row. Normally used in conjunction with sort."
@@ -8375,7 +8375,7 @@ msgstr ""
 
 #: ../../src/dialogs/FindReplacePane.cpp:117
 msgid "Replace All"
-msgstr ""
+msgstr "Tümünü Yeniden Yerleştir"
 
 #: ../../src/MaximaCommandMenus.cpp:4350
 msgid "Replace all regex matches"
@@ -8404,7 +8404,7 @@ msgstr ""
 
 #: ../../src/dialogs/FindReplacePane.cpp:62
 msgid "Replacement:"
-msgstr ""
+msgstr "Yeniden yerleştirme:"
 
 #: ../../src/MaximaCommandMenus.cpp:768
 msgid "Replaces the subexpression that part(expr, n_1, n_2, ...) would select by a new value. The part numbers form a path: n_1 selects a part of the expression, n_2 a part of that, and so on."
@@ -8519,7 +8519,7 @@ msgstr ""
 
 #: ../../src/wizards/DrawWiz.cpp:836
 msgid "Reuse last"
-msgstr ""
+msgstr "En sonu kullan"
 
 #: ../../src/wxMaximaFrame.cpp:1780
 msgid "Reverse"
@@ -8543,7 +8543,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:194
 msgid "Rho"
-msgstr ""
+msgstr "Rho"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2015
 msgid "Right"
@@ -8556,7 +8556,7 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:127
 msgid "Right arrow"
-msgstr ""
+msgstr "Sağ ok"
 
 #: ../../src/MaximaCommandMenus.cpp:1380
 msgid "Right end"
@@ -8596,7 +8596,7 @@ msgstr ""
 
 #: ../../src/wizards/MatWiz.cpp:152
 msgid "Rows:"
-msgstr ""
+msgstr "Satırlar:"
 
 #: ../../src/MaximaCommandMenus.cpp:1391
 msgid "Rule"
@@ -8666,7 +8666,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:223
 msgid "Russian"
-msgstr ""
+msgstr "Rusça"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1578
 msgid "SBCL: use <int>Mbytes of heap"
@@ -8678,11 +8678,11 @@ msgstr ""
 
 #: ../../src/sidebars/XmlInspector.cpp:78
 msgid "SENT TO MAXIMA:"
-msgstr ""
+msgstr "MAXİMA YA GÖNDERİLDİ:"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1224
 msgid "SVG graphics"
-msgstr ""
+msgstr "SVG Grafikleri"
 
 #: ../../src/MaximaCommandMenus.cpp:1810
 msgid "Sample 1:"
@@ -8698,19 +8698,19 @@ msgstr "Örnek:"
 
 #: ../../src/wizards/DrawWiz.cpp:956
 msgid "Samples for explicit and parametric plots:"
-msgstr ""
+msgstr "Açık ve parametrik çizim örnekleri:"
 
 #: ../../src/wizards/DrawWiz.cpp:969
 msgid "Samples for implicit plots and regions:"
-msgstr ""
+msgstr "Kapalı fonksiyon çizimleri ve bölgeler için örnekler:"
 
 #: ../../src/wizards/DrawWiz.cpp:937
 msgid "Samples for implicit plots:"
-msgstr ""
+msgstr "Kapalı fonksiyon çizimleri için örnekler:"
 
 #: ../../src/wizards/DrawWiz.cpp:924
 msgid "Samples on a line:"
-msgstr ""
+msgstr "Bir çizgi üzerindeki örnekler:"
 
 #: ../../src/ToolBar.cpp:331 ../../src/ToolBar.cpp:334
 #: ../../src/dialogs/ConfigDialogue.cpp:2163 ../../src/wxMaxima.cpp:3507
@@ -8768,7 +8768,7 @@ msgstr "Belgeyi Farklı Kaydet"
 
 #: ../../src/wizards/Plot2dWiz.cpp:473 ../../src/wizards/Plot3dWiz.cpp:421
 msgid "Save plot to file"
-msgstr ""
+msgstr "Grafiği Dosyaya Kaydet"
 
 #: ../../src/wxMaximaFrame.cpp:713
 msgid "Save selection from document to an image file"
@@ -8780,11 +8780,11 @@ msgstr "Seçileni Dosyaya Kaydet"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2640
 msgid "Save style to file"
-msgstr ""
+msgstr "Stili dosyaya Kaydet"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1384
 msgid "Save the worksheet automatically"
-msgstr ""
+msgstr "Çalışma sayfasını otomatik olarak kaydet"
 
 #: ../../src/MaximaFileIO.cpp:873
 msgid "Saving failed!"
@@ -8800,7 +8800,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1914
 msgid "Scalable Vector Graphics (svg)"
-msgstr ""
+msgstr "Ölçülenebilir Vektör Grafikleri (svg)"
 
 #: ../../src/MaximaCommandMenus.cpp:3536
 msgid "Scalable Vector image (*.svg)|*.svg|Compressed Scalable Vector Image (*.svgz)|*.svgz|PNG image (*.png)|*.png|JPEG image (*.jpg)|*.jpg|GIF image (*.gif)|*.gif|Windows bitmap (*.bmp)|*.bmp|"
@@ -8812,7 +8812,7 @@ msgstr "Dağılım Grafiği"
 
 #: ../../src/sidebars/StatSidebar.cpp:88
 msgid "Scatterplot..."
-msgstr ""
+msgstr "Dağılım Grafiği..."
 
 #: ../../src/Autocomplete.cpp:157
 msgid "Scheduling a background task that compiles a new list of autocompletable maxima commands."
@@ -8860,7 +8860,7 @@ msgstr ""
 
 #: ../../src/wizards/DrawWiz.cpp:158
 msgid "See also the speed <-> accuracy button."
-msgstr ""
+msgstr "Ayrıca bkz. Hız <-> doğruluk düğmesi."
 
 #: ../../src/MaximaCommandMenus.cpp:4030
 msgid "Seek to position"
@@ -8876,7 +8876,7 @@ msgstr "Görünüşe göre maxima paylaşım dosyalarına sahip paket kurulu de�
 
 #: ../../src/sidebars/TableOfContents.cpp:511
 msgid "Select"
-msgstr ""
+msgstr "Seç"
 
 #: ../../src/MaximaCommandMenus.cpp:2239
 msgid "Select 2 or 3 files to compare"
@@ -8903,7 +8903,7 @@ msgstr "Alt Örnek Seç"
 #: ../../src/wizards/IntegrateWiz.cpp:208 ../../src/wizards/LimitWiz.cpp:133
 #: ../../src/wizards/SeriesWiz.cpp:105
 msgid "Select a constant"
-msgstr ""
+msgstr "Bir Sabit Seç"
 
 #: ../../src/ToolBar.cpp:390 ../../src/ToolBar.cpp:392
 #: ../../src/wxMaximaFrame.cpp:710
@@ -8924,7 +8924,7 @@ msgstr "Matematik Gösterim Algoritmasını Seç"
 
 #: ../../src/dialogs/TipOfTheDay.cpp:109
 msgid "Selecting a part of an output and right-clicking on the selection will bring up a menu with convenient functions that will operate on the selection."
-msgstr ""
+msgstr "Çıktının bir bölümünü seçip fareyi sağ tıkladığınızdaseçilen bölüm ile yapılabilecekler menüsü gelir."
 
 #: ../../src/Styles.cpp:127
 msgid "Selection color"
@@ -9012,7 +9012,7 @@ msgstr "BüyükKayanSayı &Hassasiyeti Belirt..."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:479
 msgid "Set fixed font in text controls."
-msgstr ""
+msgstr "Metin Kontrolünde Değişmez Yazı Tipi ayarla."
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:68
 #: ../../src/worksheet/WorksheetContextMenu.cpp:250
@@ -9029,7 +9029,7 @@ msgstr ""
 
 #: ../../src/dialogs/MaxSizeChooser.cpp:29
 msgid "Set maximum image size [in mm]"
-msgstr ""
+msgstr "Resim boyutlarını ayarla [mm olarak]"
 
 #: ../../src/wxMaximaFrame.cpp:1810
 msgid "Set plot format"
@@ -9106,20 +9106,20 @@ msgstr ""
 
 #: ../../src/wizards/DrawWiz.cpp:546
 msgid "Settings for the following 3d plots"
-msgstr ""
+msgstr "Bir sonraki 3B grafiklerin ayarları"
 
 #: ../../src/wizards/DrawWiz.cpp:462
 #, c-format
 msgid "Setup a %iD scene"
-msgstr ""
+msgstr "%iD sahnesi ayarla"
 
 #: ../../src/sidebars/DrawSidebar.cpp:48
 msgid "Setup a 2D plot"
-msgstr ""
+msgstr "2B bir çizim ayarla"
 
 #: ../../src/sidebars/DrawSidebar.cpp:52
 msgid "Setup a 3D plot"
-msgstr ""
+msgstr "3B bir çizim ayarla"
 
 #: ../../src/wxMaximaFrame.cpp:1326
 msgid "Setup atvalues for solving ODE with Laplace transformation"
@@ -9131,11 +9131,11 @@ msgstr "Modül Hesaplamasını Kur"
 
 #: ../../src/sidebars/DrawSidebar.cpp:78
 msgid "Setup the axis"
-msgstr ""
+msgstr "Eksenleri ayarla"
 
 #: ../../src/wizards/DrawWiz.cpp:263
 msgid "Setup the axis for the current plot."
-msgstr ""
+msgstr "Geçerli çizim için eksenleri ayarla."
 
 #: ../../src/MaximaCommandMenus.cpp:411
 msgid "Setup the engineering format"
@@ -9183,7 +9183,7 @@ msgstr "'...:'ya benzer bütün komutları göster:"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:206
 msgid "Show all unicode symbols"
-msgstr ""
+msgstr "Tüm unicode sembollerini göster"
 
 #: ../../src/MaximaCommandMenus.cpp:2111
 msgid "Show an example for the command:"
@@ -9231,7 +9231,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:766
 msgid "Show labels:"
-msgstr ""
+msgstr "Etiketleri göster:"
 
 #: ../../src/wxMaximaFrame.cpp:787
 msgid "Show lisp representation"
@@ -9239,11 +9239,11 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:465
 msgid "Show long expressions in wxMaxima document."
-msgstr ""
+msgstr "WxMaxima Belgesinde Uzun İfadeleri Göster."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:722
 msgid "Show long expressions:"
-msgstr ""
+msgstr "Uzun ifadeleri göster:"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:377
 msgid "Show max. 100 digits"
@@ -9307,7 +9307,7 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:288
 msgid "Show tips at Startup"
-msgstr ""
+msgstr "Başlangıçta ipuçlarını göster"
 
 #: ../../src/wxMaximaFrame.cpp:1040 ../../src/wxMaximaFrame.cpp:1045
 msgid "Show used + to-be-freed memory"
@@ -9332,7 +9332,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:195
 msgid "Sigma"
-msgstr ""
+msgstr "Sigma"
 
 #: ../../src/dialogs/FindReplacePane.cpp:88
 msgid "Simple"
@@ -9344,7 +9344,7 @@ msgstr ""
 
 #: ../../src/sidebars/MathSidebar.cpp:44
 msgid "Simplify"
-msgstr ""
+msgstr "Sadeleştir"
 
 #: ../../src/wxMaximaFrame.cpp:1550
 msgid "Simplify &Radicals..."
@@ -9352,11 +9352,11 @@ msgstr ""
 
 #: ../../src/sidebars/MathSidebar.cpp:47
 msgid "Simplify (r)"
-msgstr ""
+msgstr "Sadeleştir(özd)"
 
 #: ../../src/sidebars/MathSidebar.cpp:65
 msgid "Simplify (tr)"
-msgstr ""
+msgstr "Sadeleştir (trig_özd)"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:352
 msgid "Simplify Expression"
@@ -9396,7 +9396,7 @@ msgstr ""
 
 #: ../../src/wizards/SumWiz.cpp:68
 msgid "Simplify the sum"
-msgstr ""
+msgstr "Toplamı Sadeleştir"
 
 #: ../../src/wxMaximaFrame.cpp:1629
 msgid "Simplify trigonometric expression"
@@ -9461,7 +9461,7 @@ msgstr ""
 
 #: ../../src/wizards/BC2Wiz.cpp:30
 msgid "Solution:"
-msgstr ""
+msgstr "Çözüm:"
 
 #: ../../src/MaximaCommandMenus.cpp:3446
 msgid "Solve"
@@ -9501,7 +9501,7 @@ msgstr "ADDyi Laplace ile Çöz..."
 
 #: ../../src/sidebars/MathSidebar.cpp:77
 msgid "Solve ODE..."
-msgstr ""
+msgstr "ADD Çöz..."
 
 #: ../../src/wxMaximaFrame.cpp:1432
 msgid "Solve a linear equation system using dgesv"
@@ -9608,7 +9608,7 @@ msgstr "Sırala"
 
 #: ../../src/wizards/ListSortWiz.cpp:41
 msgid "Sort Criterion:"
-msgstr ""
+msgstr "Sıralama kriteri:"
 
 #: ../../src/MaximaCommandMenus.cpp:1500
 msgid "Sort a list"
@@ -9628,16 +9628,16 @@ msgstr "Kaynak dizin:"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:227
 msgid "Spanish"
-msgstr ""
+msgstr "İspanyolca"
 
 #: ../../src/wizards/IntegrateWiz.cpp:44 ../../src/wizards/IntegrateWiz.cpp:50
 #: ../../src/wizards/LimitWiz.cpp:38 ../../src/wizards/SeriesWiz.cpp:39
 msgid "Special"
-msgstr ""
+msgstr "Özel"
 
 #: ../../src/wizards/DrawWiz.cpp:918
 msgid "Speed versus accuracy"
-msgstr ""
+msgstr "Hıza karşı hassasiyet"
 
 #: ../../src/MaximaCommandMenus.cpp:4241
 msgid "Split"
@@ -9677,7 +9677,7 @@ msgstr "Animasyonu Başlat"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1622
 msgid "Start a new maxima for each re-evaluation"
-msgstr ""
+msgstr "Her tekrar değerlendirme için yeni bir maxima başlat"
 
 #: ../../src/MaximaCommandMenus.cpp:1023
 msgid "Start of t:"
@@ -9685,15 +9685,15 @@ msgstr ""
 
 #: ../../src/wizards/DrawWiz.cpp:66 ../../src/wizards/DrawWiz.cpp:171
 msgid "Start of the x value"
-msgstr ""
+msgstr "X değerinin başlangıcı"
 
 #: ../../src/wizards/DrawWiz.cpp:83 ../../src/wizards/DrawWiz.cpp:186
 msgid "Start of the y value"
-msgstr ""
+msgstr "'y' değerinin başlangıcı"
 
 #: ../../src/wizards/DrawWiz.cpp:203
 msgid "Start of the z value"
-msgstr ""
+msgstr "'z' değerinin başlangıcı"
 
 #: ../../src/ToolBar.cpp:507 ../../src/ToolBar.cpp:519
 msgid "Start or Stop animation"
@@ -9705,11 +9705,11 @@ msgstr "Seçtiğiniz with_slider komutlarıyla oluşturulan animasyonu Başlat y
 
 #: ../../src/dialogs/ConfigDialogue.cpp:496
 msgid "Start searching while the phrase to search for is still being typed."
-msgstr ""
+msgstr "Aramak istediğiniz ifade yazmaya devam ederken aramayı başlat."
 
 #: ../../src/wizards/DrawWiz.cpp:755
 msgid "Start value of the parameter"
-msgstr ""
+msgstr "Parametrenin başlangıç ​​değeri"
 
 #: ../../src/wxMaxima.cpp:403
 msgid "Starting Maxima process failed"
@@ -9734,7 +9734,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:286
 msgid "Startup commands"
-msgstr ""
+msgstr "Başlangıç komutları"
 
 #: ../../src/wxMaximaFrame.cpp:266
 msgid "Statistics"
@@ -9844,15 +9844,15 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:282
 msgid "Style"
-msgstr ""
+msgstr "Stil"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2082
 msgid "Styles"
-msgstr ""
+msgstr "Stiller"
 
 #: ../../src/sidebars/StatSidebar.cpp:112
 msgid "Subsample..."
-msgstr ""
+msgstr "Alt Örnek..."
 
 #: ../../src/ToolBar.cpp:484 ../../src/sidebars/FormatSidebar.cpp:54
 msgid "Subsection"
@@ -9872,7 +9872,7 @@ msgstr ""
 
 #: ../../src/sidebars/MathSidebar.cpp:59
 msgid "Subst..."
-msgstr ""
+msgstr "Yerine koy..."
 
 #: ../../src/MaximaCommandMenus.cpp:715 ../../src/MaximaCommandMenus.cpp:3490
 #: ../../src/MaximaCommandMenus.cpp:4500 ../../src/wizards/SubstituteWiz.cpp:53
@@ -9948,7 +9948,7 @@ msgstr "Toplam"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:122
 msgid "Sum sign"
-msgstr ""
+msgstr "Toplam işareti"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:228
 msgid "Swedish"
@@ -9977,7 +9977,7 @@ msgstr "Semboller\tAlt+Shift+Y"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:472
 msgid "Symbols that are entered or copied here will appear in the symbols sidebar so they can be entered into the worksheet easily."
-msgstr ""
+msgstr "Buraya girilen veya kopyalanan simgeler simgeler kenar çubuğunda görünürve çalışma sayfasına kolayca girilebilirler."
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:778
 msgid "Symmetric function: f(x)=f(-x)"
@@ -10005,7 +10005,7 @@ msgstr "İçerik Tablosu \tAlt+Shift+T"
 
 #: ../../src/wizards/DrawWiz.cpp:561
 msgid "Take surface color from steepness"
-msgstr ""
+msgstr "Yüzey rengini diklikten alın"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:229
 msgid "Tamil"
@@ -10013,7 +10013,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:196
 msgid "Tau"
-msgstr ""
+msgstr "Tau"
 
 #: ../../src/MaximaCommandMenus.cpp:181
 msgid "Taylor series"
@@ -10061,7 +10061,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:738
 msgid "Text Only"
-msgstr ""
+msgstr "Sadece metin"
 
 #: ../../src/Styles.cpp:122
 msgid "Text cell background"
@@ -10092,7 +10092,7 @@ msgstr "Maxima işlemi, kesme sinyali gönderebileceğimiz paylaşılan bir bell
 
 #: ../../src/dialogs/ConfigDialogue.cpp:392
 msgid "The URL MathJaX.js should be downloaded from by our HTML export."
-msgstr ""
+msgstr "MathJaX URL ' si bizim HTML (olarak) 'Çıkart'tan indirilmeli."
 
 #: ../../src/cells/TextCell.cpp:336
 msgid "The [] or the part() command tried to access a list or matrix element that doesn't exist."
@@ -10100,7 +10100,7 @@ msgstr ""
 
 #: ../../src/sidebars/DrawSidebar.cpp:106
 msgid "The accuracy versus speed tradeoff"
-msgstr ""
+msgstr "Doğruluk, hız değişimlerine karşı"
 
 #: ../../src/cells/TextCell.cpp:357
 msgid "The argument of a function was of the wrong type. Most probably an equation was expected but was lacking an \"=\"."
@@ -10124,7 +10124,7 @@ msgstr ""
 
 #: ../../src/sidebars/DrawSidebar.cpp:91
 msgid "The color of the next line to draw"
-msgstr ""
+msgstr "Çizilecek bir sonraki çizginin rengi"
 
 #: ../../src/MaximaCommandMenus.cpp:4005
 msgid "The comma-separated contents of the struct fields"
@@ -10144,24 +10144,24 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:415
 msgid "The default height for embedded plots. Can be read out or overridden by the maxima variable wxplot_size."
-msgstr ""
+msgstr "Çalışma yaprağına gömülü çizimlerde varsayılan yükseklik. wxplot_size komutu ile geçersiz kılınabilir."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:492
 msgid "The default port used for communication between Maxima and wxMaxima."
-msgstr ""
+msgstr "Maxima ile wxMaxima'nın iletişiminde kullanılan bağlantı noktası."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:412
 msgid "The default width for embedded plots. Can be read out or overridden by the maxima variable wxplot_size"
-msgstr ""
+msgstr "Sayfaya gömülü grafikler için varsayılan genişlik. wxplot_size maxima değişkeni tarafından değerlendirilebilir veya geçersiz kılınabilir"
 
 #: ../../src/sidebars/DrawSidebar.cpp:74
 msgid "The diagram title"
-msgstr ""
+msgstr "Diyagram başlığı"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2401
 #, c-format
 msgid "The directory %s with maxima's startup file doesn't exist. Trying to create it..."
-msgstr ""
+msgstr "Maxima'nın başlangıç ​​dosyasında% s dizini mevcut değil. Yaratmaya çalışıyorum ..."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:150
 msgid "The directory containing the startup files, any user libraries and, if MAXIMA_OBJDIR isn't set the subdirectory with the results from compiling maxima libraries."
@@ -10185,7 +10185,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:475
 msgid "The document class LaTeX is instructed to use for our documents."
-msgstr ""
+msgstr "LaTeX belge sınıfı bizim belgelerimizi kullanmak için yönlendirilir."
 
 #: ../../src/MaximaCommandMenus.cpp:1832
 msgid "The equation to fit the data to"
@@ -10202,7 +10202,7 @@ msgstr ""
 
 #: ../../src/sidebars/DrawSidebar.cpp:96
 msgid "The fill color for the next objects"
-msgstr ""
+msgstr "Sonraki nesneler için dolgu rengi"
 
 #: ../../src/cells/TextCell.cpp:354
 msgid "The first argument of subst() isn't an equation or a list of equations. Most probably it was lacking an \"=\"."
@@ -10214,7 +10214,7 @@ msgstr "Çıkarmak için argümanları olan işlev çağrısı"
 
 #: ../../src/sidebars/DrawSidebar.cpp:100
 msgid "The grid in the background of the diagram"
-msgstr ""
+msgstr "Diyagramın arkasındaki ızgara"
 
 #: ../../src/wxMaximaFrame.cpp:1332
 msgid "The half of the equation that is to the left of the \"=\""
@@ -10249,7 +10249,7 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:223
 msgid "The key combination Shift+Space results in a non-breakable space."
-msgstr ""
+msgstr "Shift + Space tuş bileşimi, kırılamaz bir alanla sonuçlanır."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:162
 msgid "The list of directories the operating system looks for programs in"
@@ -10281,7 +10281,7 @@ msgstr ""
 
 #: ../../src/dialogs/MaxSizeChooser.cpp:59
 msgid "The maximum size for this image. Values <= 0 mean: Unspecified."
-msgstr ""
+msgstr "Bu resim için maksimum boyut. Değerler <= 0 ortalama: Belirtilmemiş."
 
 #: ../../src/MaximaCommandMenus.cpp:3937
 msgid "The name of a function we don't want to be evaluated here"
@@ -10313,11 +10313,11 @@ msgstr ""
 
 #: ../../src/sidebars/DrawSidebar.cpp:86
 msgid "The next plot's title"
-msgstr ""
+msgstr "Sonraki çizimin başlığı"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:494
 msgid "The number of recently opened files that is to be remembered."
-msgstr ""
+msgstr "Yakın geçmişte gösterilecek en son açılan dosya sayısı."
 
 #: ../../src/MaximaCommandMenus.cpp:1471
 msgid "The number of the item which is stepped from \"Index Start\" to \"Index End\"."
@@ -10325,12 +10325,12 @@ msgstr "\"İndeks sonu\" ndan \"İndeks Başlat\" a kadar  öğenin sayısı."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:477
 msgid "The options the document class LaTeX is instructed to use for our documents gets."
-msgstr ""
+msgstr "LaTeX belge sınıfının belgelerimiz için kullanması için talimat verilen seçenekler."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1065
 #: ../../src/dialogs/ConfigDialogue.cpp:1112
 msgid "The part of the output of these commands that isn't declared as \"math\" might be suppressed by wxMaxima. As always maxima commands are required to end in a \";\" or a \"$\""
-msgstr ""
+msgstr "Bu komutların çıktılarının \"matematik\" olarak bildirilmeyen kısmı wxMaxima tarafından sıkıştırılabilir. Her zaman olduğu gibi, maxima komutlarının \";\" veya bir \"$\" ile bitmesi gerekir."
 
 #: ../../src/dialogs/ResolutionChooser.cpp:51
 msgid "The resolution for this image."
@@ -10393,7 +10393,7 @@ msgstr ""
 
 #: ../../src/sidebars/DrawSidebar.cpp:58
 msgid "The standard plot command: Plot an equation as a curve"
-msgstr ""
+msgstr "Standart çizim komutu: Bir denklemi eğri olarak çizme"
 
 #: ../../src/cells/TextCell.cpp:267
 msgid "The value of few special variables is assigned by Maxima and cannot be changed by the user. Also a few constructs aren't variable names and therefore cannot be written to."
@@ -10429,7 +10429,7 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:95
 msgid "There are many resources about Maxima and wxMaxima on the internet. Visit https://wxMaxima-developers.github.io/wxmaxima/help.html for more information and to find tutorials on using wxMaxima and Maxima."
-msgstr ""
+msgstr "İnternette Maxima ve wxMaxima ile ilgili birçok kaynak var. Daha fazla bilgi ve wxMaxima ve Maxima'yı kullanma hakkında öğreticiler bulmak  için https://wxMaxima-developers.github.io/wxmaxima/help.html adresini ziyaret edin ."
 
 #: ../../src/dialogs/TipOfTheDay.cpp:251
 msgid "There is a discussion forum for wxMaxima at https://github.com/wxMaxima-developers/wxmaxima/discussions.\n"
@@ -10473,7 +10473,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:185
 msgid "Theta"
-msgstr ""
+msgstr "Teta"
 
 #: ../../src/dialogs/LicenseDialog.cpp:85
 msgid "Third-party notices"
@@ -10492,7 +10492,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1097
 msgid "This file won't be read by maxima if maxima is used without wxMaxima. In order to add startup commands that are executed in this case, too, please add them to maxima-init.mac, instead."
-msgstr ""
+msgstr "Maxima wxMaxima olmadan kullanılıyorsa, bu dosya maxima tarafından okunmaz. Bu durumda da yürütülen başlangıç ​​komutlarını eklemek için, lütfen bunları yerine maxima-init.mac dosyasına ekleyin."
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:764
 msgid "This function will return even integers"
@@ -10525,7 +10525,7 @@ msgstr ""
 #: ../../src/wizards/DrawWiz.cpp:471
 #, c-format
 msgid "This wizard setups a %iD scene."
-msgstr ""
+msgstr "Bu sihirbaz% iD sahnesi düzenliyor."
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:752
 msgid "Throw an error if this symbol is used before assigning it any contents"
@@ -10533,7 +10533,7 @@ msgstr ""
 
 #: ../../src/wizards/Plot2dWiz.cpp:65 ../../src/wizards/Plot2dWiz.cpp:505
 msgid "Ticks:"
-msgstr ""
+msgstr "İnce nokta ayarları:"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1359
 msgid "Time [in Minutes] between autosaves"
@@ -10545,7 +10545,7 @@ msgstr "Kaç kez :"
 
 #: ../../src/dialogs/TipOfTheDay.cpp:49 ../../src/dialogs/TipOfTheDay.cpp:267
 msgid "Tip of the day"
-msgstr ""
+msgstr "Günün ipucu"
 
 #: ../../src/ToolBar.cpp:482 ../../src/sidebars/FormatSidebar.cpp:48
 msgid "Title"
@@ -10561,7 +10561,7 @@ msgstr "Başlık Hücresi (Başlık 1)"
 
 #: ../../src/dialogs/TipOfTheDay.cpp:89
 msgid "Title, section and subsection cells can be folded to hide their contents. To fold or unfold, click in the square next to the cell. If you shift-click, all sublevels of that cell will also fold/unfold."
-msgstr ""
+msgstr "Başlık, bölüm ve alt-bölüm hücrelerinin içerikleri GİZLE ile gizlenebilir. GİZLE yada GÖSTER için hücereye bitişik kareyi tıklayın. Shift+tık yaparsanız o hücrenin bütün alt seviyeleri GİZLE\\GÖSTER komutuna uyar."
 
 #: ../../src/wxMaximaFrame.cpp:1831
 msgid "To &Bigfloat"
@@ -10589,19 +10589,19 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:124
 msgid "To plot in polar coordinates, select 'set polar' in the Options entry for Plot2d dialog. You can also plot in spherical and cylindrical coordinates in 3D."
-msgstr ""
+msgstr "Kutupsal Koordinatlarda 2B grafik çizimi için 2B Grafik kutusunda, Seçeneklerde 'set polar'(='kutupsala ayarla') yı seçiniz. Aynı şekilde 3B Grafik çizimlerini silindirik ve küresel koordinatlarda da yapabilirsiniz."
 
 #: ../../src/dialogs/TipOfTheDay.cpp:131
 msgid "To put parentheses around an expression, select it, and press '(' or ')' depending on where you want the cursor to appear afterwards."
-msgstr ""
+msgstr "Bir ifadeyi parantez içine almak için ifadeyi işaretleyip '(' yada ')' ya basılır. İmleç parantezin kapandığı yerde olur."
 
 #: ../../src/dialogs/TipOfTheDay.cpp:137
 msgid "To save the size and position of wxMaxima windows between session, use 'Edit->Configure' dialog."
-msgstr ""
+msgstr "Yeni oturumlar için wxMaxima pencersinin boyutunu ve konumunu kaydetmek isterseniz 'Düzenle-> Yapılandır' menüsünden ilgili kutuyu tklayın."
 
 #: ../../src/dialogs/TipOfTheDay.cpp:51
 msgid "To start using wxMaxima right away, start typing your command. An input cell should appear. Then press Shift-Enter to evaluate your command."
-msgstr ""
+msgstr "'wxMaxima'yı', Girdilerinizi yazarak hemen kullanmaya başlayabilirsiniz. wxMaxima simgesini tıklayıp program açıldığında bir Girdi hücresi oluşur ve işleminiz bitince Shift+Enter a basarak Maxima'nın Girdinizi değerlendirmesini sağlayabilirsiniz."
 
 #: ../../src/MaximaCommandMenus.cpp:318 ../../src/wizards/IntegrateWiz.cpp:47
 #: ../../src/wizards/Plot2dWiz.cpp:51 ../../src/wizards/Plot2dWiz.cpp:61
@@ -10781,7 +10781,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:230
 msgid "Turkish"
-msgstr ""
+msgstr "Türkçe"
 
 #: ../../src/wxMaximaFrame.cpp:1965
 msgid "Tutorials"
@@ -10797,7 +10797,7 @@ msgstr "Tip"
 
 #: ../../src/cells/EditorCell.cpp:4550
 msgid "Type in text"
-msgstr ""
+msgstr "Metin içine yaz"
 
 #: ../../src/MaximaCommandMenus.cpp:3992 ../../src/wizards/MatWiz.cpp:158
 msgid "Type:"
@@ -10817,7 +10817,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:231
 msgid "Ukrainian"
-msgstr ""
+msgstr "Ukraynaca"
 
 #: ../../src/wxMaxima.cpp:3164
 msgid "Un-closed parenthesis"
@@ -10844,15 +10844,15 @@ msgstr ""
 #: ../../src/sidebars/VariablesPane.cpp:303
 #: ../../src/sidebars/VariablesPane.cpp:386
 msgid "Undefined"
-msgstr ""
+msgstr "Tanımsız"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2115
 msgid "Underlined"
-msgstr ""
+msgstr "Altı Çizili"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:745
 msgid "Underscore converts to subscripts:"
-msgstr ""
+msgstr "Alt çizgi, alt simgelere dönüştürür:"
 
 #: ../../src/ToolBar.cpp:354 ../../src/ToolBar.cpp:357
 msgid "Undo"
@@ -10885,7 +10885,7 @@ msgstr "Klasörlenmiş bütün kısımları Klasörden Çıkar"
 
 #: ../../src/sidebars/TableOfContents.cpp:507
 msgid "Unhide"
-msgstr ""
+msgstr "Göster"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:665
 msgid "Unhide Heading 5"
@@ -10941,7 +10941,7 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:180
 msgid "Unicode symbols:"
-msgstr ""
+msgstr "Unicode sembolleri:"
 
 #: ../../src/MaximaCommandMenus.cpp:3890
 msgid "Unlike in other programming language return() only exits from the current loop or block(), not from the whole function."
@@ -10957,11 +10957,11 @@ msgstr "Sonlandırılmamış dizin."
 
 #: ../../src/wizards/ActualValuesStorageWiz.cpp:43
 msgid "Until then the actual values for all variables can be kept in a list."
-msgstr ""
+msgstr "O zamana kadar tüm değişkenlerin gerçek değerleri bir listede tutulabilir."
 
 #: ../../src/dialogs/DiffFrame.cpp:429 ../../src/dialogs/FindReplacePane.cpp:80
 msgid "Up"
-msgstr ""
+msgstr "Yukarı"
 
 #: ../../src/MaximaEvaluator.cpp:629
 msgid "Updating maxima's configuration"
@@ -10984,7 +10984,7 @@ msgstr "Üst Sınır:"
 
 #: ../../src/sidebars/GreekSidebar.cpp:197
 msgid "Upsilon"
-msgstr ""
+msgstr "Upsilon"
 
 #: ../../src/wxMaximaFrame.cpp:829
 msgid "Use \"<\" and \">\" as parenthesis for matrices"
@@ -10996,7 +10996,7 @@ msgstr ""
 
 #: ../../src/wizards/SumWiz.cpp:69
 msgid "Use Gosper algorithm"
-msgstr ""
+msgstr "Gosper Algoritmasını Kullan"
 
 #: ../../src/sidebars/RegexCtrl.cpp:133
 msgid "Use RegEx filtering"
@@ -11020,11 +11020,11 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:485
 msgid "Use centered dot and Minus, not Star and Hyphen"
-msgstr ""
+msgstr "Ortalanmış nokta ve eksiyi kullan Yıldız ve kısa çizgiyi değil"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:849
 msgid "Use centered dot character for multiplication"
-msgstr ""
+msgstr "Çarpma işareti gösterimi için 'ortada nokta'; \".\" yı kullan"
 
 #: ../../src/wxMaximaFrame.cpp:1745
 msgid "Use list"
@@ -11048,11 +11048,11 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:425
 msgid "Use the \"partial derivative\" symbol to represent the fraction that represents a diff() when exporting LaTeX"
-msgstr ""
+msgstr "LaTeX olarak çıkarım yaparken bir diff() kesirinde \" kısmi türev\" işaretini kullan"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2052
 msgid "Use unicode Math Symbols, if available"
-msgstr ""
+msgstr "Uygunsa Unicode Matematik sembollerini kullan"
 
 #: ../../src/wxMaximaFrame.cpp:832
 msgid "Use vertical lines instead of parenthesis for matrices"
@@ -11067,7 +11067,7 @@ msgstr "Yalnızca kullanıcı etiketleri"
 #: ../../src/dialogs/ConfigDialogue.cpp:1480
 #: ../../src/dialogs/MaximaNotStartingDialog.cpp:54
 msgid "User specified"
-msgstr ""
+msgstr "Kullanıcıya özel"
 
 #: ../../src/Styles.cpp:110
 msgid "User-defined labels"
@@ -11075,7 +11075,7 @@ msgstr "Kullanıcı tanımlı etiketler"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:770
 msgid "User-defined labels if available"
-msgstr ""
+msgstr "Eğer mümkünse kullanıcı tanımlı etiketler"
 
 #: ../../src/MaximaManual.cpp:500
 msgid "Using Maxima help file from wxMaxima configuration file (helpFile=...))"
@@ -11113,7 +11113,7 @@ msgstr ""
 #: ../../src/dialogs/ConfigDialogue.cpp:542
 #: ../../src/wizards/ActualValuesStorageWiz.cpp:49
 msgid "Value"
-msgstr ""
+msgstr "Değer"
 
 #: ../../src/MaximaCommandMenus.cpp:756
 msgid "Value at a given point"
@@ -11153,15 +11153,15 @@ msgstr "Değişken"
 
 #: ../../src/wizards/DrawWiz.cpp:61 ../../src/wizards/DrawWiz.cpp:166
 msgid "Variable for the x value"
-msgstr ""
+msgstr "X değeri için değişken"
 
 #: ../../src/wizards/DrawWiz.cpp:78 ../../src/wizards/DrawWiz.cpp:181
 msgid "Variable for the y value"
-msgstr ""
+msgstr "'y' değeri için değişken"
 
 #: ../../src/wizards/DrawWiz.cpp:198
 msgid "Variable for the z value"
-msgstr ""
+msgstr "'z' değeri için değişken"
 
 #: ../../src/MaximaCommandMenus.cpp:1586 ../../src/MaximaCommandMenus.cpp:2990
 #: ../../src/MaximaCommandMenus.cpp:2996
@@ -11209,7 +11209,7 @@ msgstr "Değişken(ler):"
 
 #: ../../src/sidebars/StatSidebar.cpp:58
 msgid "Variance..."
-msgstr ""
+msgstr "Varyans..."
 
 #: ../../src/WXMXformat.cpp:339
 msgid "Verified that we are able to read the whole .zip archive we produced."
@@ -11237,7 +11237,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1410
 msgid "Warn if an inactive window is idle"
-msgstr ""
+msgstr "Etkin olmayan bir pencere boşta kalırsa uyar"
 
 #: ../../src/MathParser.cpp:1343 ../../src/MaximaFileIO.cpp:536
 #: ../../src/MaximaResponseReader.cpp:361 ../../src/wxMaxima.cpp:1583
@@ -11256,7 +11256,7 @@ msgstr ""
 
 #: ../../src/cells/GroupCell.cpp:400 ../../src/cells/GroupCell.cpp:406
 msgid "Warning: Lookalike chars: "
-msgstr ""
+msgstr "Uyarı: Benzer karakterler: "
 
 #: ../../src/wxMaximaFrame.cpp:1583
 msgid "Warning: No test if the argument of the log is complex, positive or negative"
@@ -11281,7 +11281,7 @@ msgstr "Ne yapalım:"
 
 #: ../../src/dialogs/TipOfTheDay.cpp:134
 msgid "When applying functions with one argument from menus, the default argument is '%'. To apply the function to some other value, select it in the document before executing a menu command."
-msgstr ""
+msgstr "Menülerdeki tek argümanlı bir fonksiyonu tıkladığınızda, komut çizgisinde fonksiyonun işleme koyacağı argüman yerinde, varsayılan olarak, '%' belirir.fonksiyonun argümanı olarak '%' yerine başka bir değer girebilir yada belgenizden bir ifadeyi seçebilirsiniz. Ayrıca Maxima, '%'yı bir önceki ÇIKTI satırında olanları argüman olarak kabul eder."
 
 #: ../../src/wxMaximaFrame.cpp:1092
 msgid "When to invoke the lisp compiler's debugger"
@@ -11309,7 +11309,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:280
 msgid "Worksheet"
-msgstr ""
+msgstr "Çalışma Yaprağı"
 
 #: ../../src/MaximaResponseReader.cpp:117
 #, c-format
@@ -11330,7 +11330,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:428
 msgid "Wrap equations exported by the \"copy as LaTeX\" feature between \\[ and \\] as equation markers"
-msgstr ""
+msgstr "Eşitlik işaretleri olarak \\ [and \\] arasındaki \"LaTeX olarak kopyala\" özelliği tarafından verilen denklemleri sarın"
 
 #: ../../src/worksheet/Worksheet.cpp:5190
 msgid "Wrapped search"
@@ -11352,7 +11352,7 @@ msgstr ""
 #: ../../src/wizards/DrawWiz.cpp:961 ../../src/wizards/DrawWiz.cpp:974
 #: ../../src/wizards/DrawWiz.cpp:977
 msgid "X"
-msgstr ""
+msgstr "X"
 
 #: ../../src/MathParser.cpp:1279
 msgid "XML nesting limit exceeded"
@@ -11360,19 +11360,19 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:191
 msgid "Xi"
-msgstr ""
+msgstr "Xi"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:728
 msgid "Yes"
-msgstr ""
+msgstr "Evet"
 
 #: ../../src/dialogs/TipOfTheDay.cpp:64
 msgid "You can access the last output using the variable '%'. You can access the output of previous commands using variables '%on' where n is the number of output."
-msgstr ""
+msgstr "Son ÇIKTI'ya '%' ı kullanarak ulaşabilirsiniz.Herhangibir ÇIKTI satırındaki bir ÇIKTI'ya '%on'formülüyle ulaşabilirsiniz'%on' ifadesinde 'o' output=ÇİKTI 'n' de ÇIKTI satırı numarasıdır ÖRN: %o6 =Altıncı ÇIKTI satırı."
 
 #: ../../src/dialogs/TipOfTheDay.cpp:118
 msgid "You can evaluate your whole document by using 'Cell->Evaluate All Cells' menu command or the appropriate key shortcut. The cells will be evaluated in the order they appear in the document."
-msgstr ""
+msgstr "Belgenizdeki tüm komutları 'Hücre->Bütün Hücreleri Değerlendir' i tıklayarak yada kısayolu kullanarak değerlendirme şlemini yapabilirsiniz.Belgeenizdeki tüm -metin yada komut -hücreleri yazıldıkları sırayla değerlendirilir."
 
 #: ../../src/dialogs/TipOfTheDay.cpp:98
 msgid "You can get help on a Maxima function by selecting or clicking on the function name and pressing F1. wxMaxima will search the help index for the selection or the word under the cursor."
@@ -11380,15 +11380,15 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:92
 msgid "You can hide output part of cells by clicking in the triangle on the left side of cells. This works on text cells also."
-msgstr ""
+msgstr "Solundaki üçgeni tıklayarak hücrelerin ÇIKTI kısımlarını gizleyebilirsiniz Bu durum metin hücreleri için de geçerlidir."
 
 #: ../../src/dialogs/TipOfTheDay.cpp:81
 msgid "You can insert different types of 'cells' in wxMaxima documents using the 'Cell' menu. Note that only 'input cells' can be evaluated, while others are used for commenting and structuring your calculations."
-msgstr ""
+msgstr "'Hücre' menüsünü kullanarak wxMaxima belgelerine farklı tipte 'hücreler' ekleyebilirsiniz. Yalnızca 'giriş hücrelerinin' değerlendirilebileceğini göz önünde bulundurun,\ndiğerleri ise hesaplamalarınızı yorumlamak ve yapılandırmak için kullanılır."
 
 #: ../../src/dialogs/TipOfTheDay.cpp:112
 msgid "You can select multiple cells either with a mouse - click'n'drag from between cells or from a cell bracket on the left - or with a keyboard - hold down Shift while moving the horizontal cursor - and then operate on selection. This comes in handy when you want to delete or evaluate multiple cells."
-msgstr ""
+msgstr "Belgenizde birden çok satırı şu yollarla seçebilirsiniz: 1- Fare ile sol tıklayıp aşağıya soldaki parantezlerin yada satırların üzerinden sürüyerek  2- Klavyeden aşağı-yukarı ok larını Shift e basıp yatay imleçi hareket ettirerek.Seçtikten sonra Shift+Enter ile Değerlendir yapabilir yada silebilirsiniz. Bu tarz bir kullanım olanağı size kolaylık sağlar."
 
 #: ../../src/dialogs/TipOfTheDay.cpp:232
 msgid "You found a bug in wxMaxima? Please report it at https://github.com/wxMaxima-developers/wxmaxima/issues\n"
@@ -11416,7 +11416,7 @@ msgstr "Kullandığınız wxMaxima günceldir."
 
 #: ../../src/sidebars/GreekSidebar.cpp:183
 msgid "Zeta"
-msgstr ""
+msgstr "Zeta"
 
 #: ../../src/wxMaximaFrame.cpp:842
 msgid "Zoom &In\tCtrl++"
@@ -11444,11 +11444,11 @@ msgstr "[Kaydedilmemiş*]"
 
 #: ../../src/wizards/DrawWiz.cpp:819 ../../src/wizards/DrawWiz.cpp:825
 msgid "[[x_1,x_2,...],[y_1,y_2,...]]"
-msgstr ""
+msgstr "[[x_1,x_2,...],[y_1,y_2,...]]"
 
 #: ../../src/wizards/DrawWiz.cpp:814
 msgid "[x_1, x_2,...] or [x_1, x_2,...],[y_1, y_2,...] or matrix([x_1,y_1],[x_2,y_2],...)"
-msgstr ""
+msgstr "[x_1, x_2,...] veya [x_1, x_2,...],[y_1, y_2,...] yad matrix([x_1,y_1],[x_2,y_2],...)"
 
 #: ../../src/wizards/ListSortWiz.cpp:46
 msgid "a<b (Maxima default)"
@@ -11456,15 +11456,15 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:151
 msgid "alpha"
-msgstr ""
+msgstr "alfa"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:95
 msgid "and"
-msgstr ""
+msgstr "ve"
 
 #: ../../src/wizards/MatWiz.cpp:160
 msgid "antisymmetric"
-msgstr ""
+msgstr "antisimetrik"
 
 #: ../../src/wxMaximaFrame.cpp:1727
 msgid "apply function to each element"
@@ -11488,11 +11488,11 @@ msgstr "değişkenler için gerçek değerler için depo olarak"
 
 #: ../../src/sidebars/GreekSidebar.cpp:152
 msgid "beta"
-msgstr ""
+msgstr "beta"
 
 #: ../../src/wizards/LimitWiz.cpp:42
 msgid "both sides"
-msgstr ""
+msgstr "iki taraf"
 
 #: ../../src/wxMaximaFrame.cpp:1173
 msgid "char to Ascii code..."
@@ -11500,7 +11500,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:172
 msgid "chi"
-msgstr ""
+msgstr "orkide"
 
 #: ../../src/MaximaFileIO.cpp:318
 #, c-format
@@ -11510,15 +11510,15 @@ msgstr ""
 #: ../../src/wizards/Plot2dWiz.cpp:70 ../../src/wizards/Plot2dWiz.cpp:372
 #: ../../src/wizards/Plot3dWiz.cpp:61 ../../src/wizards/Plot3dWiz.cpp:358
 msgid "default"
-msgstr ""
+msgstr "varsayılan"
 
 #: ../../src/sidebars/GreekSidebar.cpp:154
 msgid "delta"
-msgstr ""
+msgstr "delta"
 
 #: ../../src/wizards/MatWiz.cpp:159
 msgid "diagonal"
-msgstr ""
+msgstr "çarpraz"
 
 #: ../../src/cells/FracCell.cpp:73
 msgid "diff(): Cannot find the multiplication sign I should hide"
@@ -11534,19 +11534,19 @@ msgstr "her bir öge için yap"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:92
 msgid "empty"
-msgstr ""
+msgstr "boş"
 
 #: ../../src/sidebars/GreekSidebar.cpp:155
 msgid "epsilon"
-msgstr ""
+msgstr "epsilon"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:100
 msgid "equivalent"
-msgstr ""
+msgstr "denk"
 
 #: ../../src/sidebars/GreekSidebar.cpp:157
 msgid "eta"
-msgstr ""
+msgstr "eta"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:799
 msgid "ev() shall evaluate this automatically"
@@ -11554,7 +11554,7 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:88
 msgid "exists"
-msgstr ""
+msgstr "var"
 
 #: ../../src/MaximaCommandMenus.cpp:3942
 msgid "expression:"
@@ -11596,11 +11596,11 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:153
 msgid "gamma"
-msgstr ""
+msgstr "gama"
 
 #: ../../src/wizards/MatWiz.cpp:159
 msgid "general"
-msgstr ""
+msgstr "genel"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1630
 msgid "gnuplot: Without command console"
@@ -11608,11 +11608,11 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:118
 msgid "greater than or equal"
-msgstr ""
+msgstr "büyük ya da eşit"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:87
 msgid "in"
-msgstr ""
+msgstr "içinde"
 
 #: ../../src/wxMaximaFrame.cpp:784
 msgid "in 2D"
@@ -11623,31 +11623,31 @@ msgstr "2B de"
 #: ../../src/wizards/Plot3dWiz.cpp:61 ../../src/wizards/Plot3dWiz.cpp:194
 #: ../../src/wizards/Plot3dWiz.cpp:358 ../../src/wizards/Plot3dWiz.cpp:386
 msgid "inline"
-msgstr ""
+msgstr "satır içi"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:104
 msgid "intersection"
-msgstr ""
+msgstr "kesişim"
 
 #: ../../src/sidebars/GreekSidebar.cpp:159
 msgid "iota"
-msgstr ""
+msgstr "yota harfi"
 
 #: ../../src/sidebars/GreekSidebar.cpp:160
 msgid "kappa"
-msgstr ""
+msgstr "kappa harfi"
 
 #: ../../src/sidebars/GreekSidebar.cpp:161
 msgid "lambda"
-msgstr ""
+msgstr "lambda"
 
 #: ../../src/wizards/LimitWiz.cpp:42
 msgid "left"
-msgstr ""
+msgstr "sol"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:117
 msgid "less or equal"
-msgstr ""
+msgstr "az ya da eşit"
 
 #: ../../src/MaximaCommandMenus.cpp:1567
 msgid "list"
@@ -11655,11 +11655,11 @@ msgstr ""
 
 #: ../../src/wizards/Plot2dWiz.cpp:54 ../../src/wizards/Plot2dWiz.cpp:64
 msgid "logscale"
-msgstr ""
+msgstr "log ölçeği"
 
 #: ../../src/wizards/DrawWiz.cpp:822
 msgid "matrix([x_1,x_2,...],[y_1,y_2,...])"
-msgstr ""
+msgstr "matrix([x_1,x_2,...],[y_1,y_2,...])"
 
 #: ../../src/wxMaximaFrame.cpp:1439
 msgid "max(abs(A(i,j))) (complex)"
@@ -11671,15 +11671,15 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:162
 msgid "mu"
-msgstr ""
+msgstr "mü"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:120
 msgid "much greater than"
-msgstr ""
+msgstr "'den daha büyük"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:119
 msgid "much less than"
-msgstr ""
+msgstr "'den çok daha az"
 
 #: ../../src/MaximaCommandMenus.cpp:1232
 msgid "m×n Matrix A:"
@@ -11692,11 +11692,11 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:112
 msgid "nabla sign"
-msgstr ""
+msgstr "nabla işareti"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:98
 msgid "nand"
-msgstr ""
+msgstr "nand"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:772
 msgid "nary: f(x, f(y,z)) = foo(x,y,z)"
@@ -11704,23 +11704,23 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:99
 msgid "nor"
-msgstr ""
+msgstr "ya da"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:102
 msgid "not"
-msgstr ""
+msgstr "değil"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:116
 msgid "not bytewise identical"
-msgstr ""
+msgstr "bayt olarak aynısı değil"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:108
 msgid "not subset"
-msgstr ""
+msgstr "alt küme değil"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:107
 msgid "not subset or equal"
-msgstr ""
+msgstr "alt küme değil ya da eşit"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:796
 msgid "noun: Not evaluated by default"
@@ -11732,7 +11732,7 @@ msgstr ".nci"
 
 #: ../../src/sidebars/GreekSidebar.cpp:163
 msgid "nu"
-msgstr ""
+msgstr "nü"
 
 #: ../../src/MaximaCommandMenus.cpp:1233
 msgid "n×1 Matrix b:"
@@ -11740,15 +11740,15 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:174
 msgid "omega"
-msgstr ""
+msgstr "omega"
 
 #: ../../src/sidebars/GreekSidebar.cpp:165
 msgid "omicron"
-msgstr ""
+msgstr "omicron -o- harfi"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:96
 msgid "or"
-msgstr ""
+msgstr "ya da"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:793
 msgid "outative: f(2*x) = 2*f(x)"
@@ -11765,19 +11765,19 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:111
 msgid "partial sign"
-msgstr ""
+msgstr "kısmi türev  işareti"
 
 #: ../../src/sidebars/GreekSidebar.cpp:171
 msgid "phi"
-msgstr ""
+msgstr "phi"
 
 #: ../../src/sidebars/GreekSidebar.cpp:166
 msgid "pi"
-msgstr ""
+msgstr "pi"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:101
 msgid "plus or minus"
-msgstr ""
+msgstr "artı yada eksi"
 
 #: ../../src/MaximaCommandMenus.cpp:196
 msgid "point:"
@@ -11802,11 +11802,11 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:115
 msgid "proportional to"
-msgstr ""
+msgstr "'e ile doğru orantılı"
 
 #: ../../src/sidebars/GreekSidebar.cpp:173
 msgid "psi"
-msgstr ""
+msgstr "psi"
 
 #: ../../src/MaximaCommandMenus.cpp:642
 msgid "radcan() is a powerful tools for simplification trigonometric functions but needs to be taken with care: If a function has more than one branch radcan uses the one that looks like it would fit best, not necessarily the one that makes sense for the problem that resulted in the Expression that is to be simplified."
@@ -11834,31 +11834,31 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:167
 msgid "rho"
-msgstr ""
+msgstr "ro"
 
 #: ../../src/wizards/LimitWiz.cpp:42
 msgid "right"
-msgstr ""
+msgstr "sağ"
 
 #: ../../src/wizards/DrawWiz.cpp:310
 msgid "secondary x axis label"
-msgstr ""
+msgstr "ikincil x ekseni etiketi"
 
 #: ../../src/wizards/DrawWiz.cpp:315
 msgid "secondary x range (automatic if incomplete)"
-msgstr ""
+msgstr "ikincil x aralığı (eksikse otomatik)"
 
 #: ../../src/wizards/DrawWiz.cpp:325
 msgid "secondary y axis label"
-msgstr ""
+msgstr "ikincil y ekseni etiketi"
 
 #: ../../src/wizards/DrawWiz.cpp:330
 msgid "secondary y range (automatic if incomplete)"
-msgstr ""
+msgstr "ikincil y aralığı (eksikse otomatik)"
 
 #: ../../src/sidebars/GreekSidebar.cpp:168
 msgid "sigma"
-msgstr ""
+msgstr "sigma"
 
 #: ../../src/MaximaCommandMenus.cpp:3447
 msgid "solve() will solve a list of equations only if for n independent equations there are n variables to solve to.\n"
@@ -11879,19 +11879,19 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:81
 msgid "sqrt (needs parenthesis for its argument to work as a Maxima command)"
-msgstr ""
+msgstr "sqrt (bağımsız değişkeninin bir Maxima komutu olarak çalışması için parantez gerekir)"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:106
 msgid "subset"
-msgstr ""
+msgstr "alt küme"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:105
 msgid "subset or equal"
-msgstr ""
+msgstr "alt küme ya da eşit"
 
 #: ../../src/wizards/MatWiz.cpp:160
 msgid "symmetric"
-msgstr ""
+msgstr "simetrik"
 
 #: ../../src/MaximaCommandMenus.cpp:970
 msgid "t:"
@@ -11899,7 +11899,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:169
 msgid "tau"
-msgstr ""
+msgstr "tau"
 
 #: ../../src/cells/TextCell.cpp:340
 msgid "the [] operator tried to extract an element of a list, a matrix, an equation or an array. But instead of an integer number something was used whose numerical value is unknown or not an integer.\n"
@@ -11908,31 +11908,31 @@ msgstr ""
 
 #: ../../src/wizards/DrawWiz.cpp:725
 msgid "the x and the y coordinate."
-msgstr ""
+msgstr "x ve y koordinatları."
 
 #: ../../src/wizards/DrawWiz.cpp:729
 msgid "the x, the y and the z coordinate."
-msgstr ""
+msgstr "x,y ve z koordinatları."
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:89
 msgid "there is no"
-msgstr ""
+msgstr "bulunmuyor"
 
 #: ../../src/sidebars/GreekSidebar.cpp:158
 msgid "theta"
-msgstr ""
+msgstr "theta"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:78
 msgid "to the power of 2"
-msgstr ""
+msgstr "2. kuvveti"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:79
 msgid "to the power of 3"
-msgstr ""
+msgstr "3. kuvveti"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:103
 msgid "union"
-msgstr ""
+msgstr "birleşim"
 
 #: ../../src/wxMaximaFrame.cpp:1109
 msgid "unnamed function (lambda)..."
@@ -11949,7 +11949,7 @@ msgstr "başlıksız"
 
 #: ../../src/sidebars/GreekSidebar.cpp:170
 msgid "upsilon"
-msgstr ""
+msgstr "upsilon"
 
 #: ../../src/wxMaximaFrame.cpp:1737
 msgid "use as function arguments"
@@ -11996,7 +11996,7 @@ msgstr "wxMaxima xml içeriğini okuyamıyor "
 #: ../../src/dialogs/ConfigDialogue.cpp:142
 #: ../../src/dialogs/ConfigDialogue.cpp:311
 msgid "wxMaxima configuration"
-msgstr ""
+msgstr "wxMaxima'nın yapılandırması"
 
 #: ../../src/MaximaProcessManager.cpp:209
 msgid "wxMaxima could not start a server.\n\n"
@@ -12006,7 +12006,7 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:127
 msgid "wxMaxima dialogs set default values for inputs entries, one of which is '%'. If you have made a selection in your document, the selection will be used instead of '%'."
-msgstr ""
+msgstr "'%' işareti wxMaxima bilgi kutucuklarının GİRDİ lerde varsayılan olarak kullanılır. Eğer siz belgenizde bir seçme yaptıysanız seçtiğiniz bölüm (lar) '%' yerine kullanılır."
 
 #: ../../src/MaximaCommandMenus.cpp:4544
 msgid "wxMaxima document"
@@ -12041,15 +12041,15 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:228
 msgid "wxMaxima needs more developers. It is an open source project where you can contribute. Join the wxMaxima development at: https://github.com/wxMaxima-developers/wxmaxima"
-msgstr ""
+msgstr "wxMaxima daha fazla geliştiriciye ihtiyaç duyuyor. Katkıda bulunabileceğiniz açık kaynaklı bir projedir. WxMaxima geliştirmesine şu adresten katılın: https://github.com/wxMaxima-developers/wxmaxima"
 
 #: ../../src/dialogs/TipOfTheDay.cpp:224
 msgid "wxMaxima needs more translators. We do not speak every language. Help us to translate wxMaxima and the manual to your language. Join the wxMaxima development at: https://github.com/wxMaxima-developers/wxmaxima"
-msgstr ""
+msgstr "wxMaxima daha fazla çevirmene ihtiyaç duyuyor. Her dili konuşmuyoruz. WxMaxima ve kılavuzu dilinize çevirmemize yardımcı olun. WxMaxima geliştirmesine şu adresten katılın: https://github.com/wxMaxima-developers/wxmaxima"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:407
 msgid "wxMaxima normally stores the gnuplot sources for every plot made using draw() in order to be able to open plots interactively in gnuplot later. This setting defines the limit [in Megabytes per plot] for this feature."
-msgstr ""
+msgstr "wxMaxima normalde gnuplot'ta daha sonra gnuplot'ta etkileşimli olarak açılabilmek için draw () kullanılarak yapılan her çizim için gnuplot kaynaklarını saklar. Bu ayar, bu özellik için [çizim başına Megabayt cinsinden] sınırı tanımlar."
 
 #: ../../src/dialogs/TipOfTheDay.cpp:172
 msgid "wxMaxima provides the \"table_form\" command that shows lists in an alternative form. One example would be:\n\n"
@@ -12068,7 +12068,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:481
 msgid "wxMaxima remembers the answers to maxima's questions. If this checkbox is set it automatically offers to enter the last answer to this question the user has input."
-msgstr ""
+msgstr "wxMaxima, maxima'nın sorularının cevaplarını hatırlar. Bu onay kutusu ayarlanırsa, kullanıcının girdiği bu sorunun son cevabını otomatik olarak girmeyi önerir."
 
 #: ../../src/wxMaximaFrame.cpp:1933
 msgid "wxMaxima shows help in a browser"
@@ -12080,7 +12080,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1095
 msgid "wxMaxima startup file location: "
-msgstr ""
+msgstr "wxMaxima başlangıç dosyası konumu: "
 
 #: ../../src/wxMaximaFrame.cpp:119
 #, c-format
@@ -12132,11 +12132,11 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:709
 msgid "x"
-msgstr ""
+msgstr "x"
 
 #: ../../src/wizards/DrawWiz.cpp:266
 msgid "x axis label"
-msgstr ""
+msgstr "x ekseni etiketi"
 
 #: ../../src/MaximaCommandMenus.cpp:2021
 msgid "x direction [in multiples of the tick frequency]"
@@ -12144,11 +12144,11 @@ msgstr "x yönü [tik frekansının katları]"
 
 #: ../../src/wizards/DrawWiz.cpp:269
 msgid "x range (automatic if incomplete)"
-msgstr ""
+msgstr "x aralığı (eksikse otomatik)"
 
 #: ../../src/sidebars/GreekSidebar.cpp:164
 msgid "xi"
-msgstr ""
+msgstr "xi"
 
 #: ../../src/MaximaFileIO.cpp:408 ../../src/MaximaFileIO.cpp:566
 msgid "xml contained in the file claims not to be a wxMaxima worksheet. "
@@ -12156,11 +12156,11 @@ msgstr "dosyada bulunan xml, bir wxMaxima çalışma sayfası olmamasını talep
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:97
 msgid "xor"
-msgstr ""
+msgstr "xor"
 
 #: ../../src/wizards/DrawWiz.cpp:279
 msgid "y axis label"
-msgstr ""
+msgstr "y ekseni etiketi"
 
 #: ../../src/MaximaCommandMenus.cpp:2022
 msgid "y direction [in multiples of the tick frequency]"
@@ -12168,7 +12168,7 @@ msgstr "y yönü [tik frekansının katları]"
 
 #: ../../src/wizards/DrawWiz.cpp:282
 msgid "y range (automatic if incomplete)"
-msgstr ""
+msgstr "y aralığı (eksikse otomatik)"
 
 #: ../../src/MaximaCommandMenus.cpp:970
 msgid "y:"
@@ -12176,15 +12176,15 @@ msgstr ""
 
 #: ../../src/wizards/DrawWiz.cpp:294
 msgid "z axis label"
-msgstr ""
+msgstr "z ekseni etiketi"
 
 #: ../../src/wizards/DrawWiz.cpp:298
 msgid "z range (automatic if incomplete)"
-msgstr ""
+msgstr "z aralığı (eksikse otomatik)"
 
 #: ../../src/sidebars/GreekSidebar.cpp:156
 msgid "zeta"
-msgstr ""
+msgstr "zeta"
 
 #. type: Title #
 #: ../../info/wxmaxima.md:1

--- a/locales/wxMaxima/uk.po
+++ b/locales/wxMaxima/uk.po
@@ -53,23 +53,23 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1569
 msgid "      -X \"--control-stack-size <int>\""
-msgstr ""
+msgstr "      -X \"--control-stack-size <ціле число>\""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1568
 msgid "      -X \"--dynamic-space-size <int>\""
-msgstr ""
+msgstr "      -X \"--dynamic-space-size <ціле число>\""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1572
 msgid "      -X '--control-stack-size <int>'"
-msgstr ""
+msgstr "      -X '--control-stack-size <ціле число>'"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1571
 msgid "      -X '--dynamic-space-size <int>'"
-msgstr ""
+msgstr "      -X '--dynamic-space-size <ціле число>'"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1551
 msgid "      -l <name>"
-msgstr ""
+msgstr "      -l <назва>"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1557
 msgid "      -u <versionnumber>"
@@ -167,7 +167,7 @@ msgstr ""
 #: ../../src/cells/ImgCell.cpp:212 ../../src/cells/ImgCell.cpp:214
 #: ../../src/cells/ImgCell.cpp:216
 msgid " (Graphics) "
-msgstr ""
+msgstr " (графіка) "
 
 #: ../../src/cells/EditorCell.cpp:3551 ../../src/cells/EditorCell.cpp:3820
 #: ../../src/cells/EditorCell.cpp:3945
@@ -177,7 +177,7 @@ msgstr ""
 
 #: ../../src/cells/EditorCell.cpp:3553
 msgid " ... + 1 hidden line"
-msgstr ""
+msgstr " ... + 1 прихований рядок"
 
 #: ../../src/dialogs/TipOfTheDay.cpp:273
 msgid " Did you know? "
@@ -193,15 +193,15 @@ msgstr " Помилка, якщо a є комплексним"
 
 #: ../../src/wizards/DrawWiz.cpp:964 ../../src/wizards/DrawWiz.cpp:980
 msgid " samples"
-msgstr ""
+msgstr " вибірок"
 
 #: ../../src/wizards/DrawWiz.cpp:929 ../../src/wizards/DrawWiz.cpp:945
 msgid " samples, on demand split "
-msgstr ""
+msgstr " вибірок, поділ на вимогу "
 
 #: ../../src/wizards/DrawWiz.cpp:933 ../../src/wizards/DrawWiz.cpp:952
 msgid " times"
-msgstr ""
+msgstr " разів"
 
 #: ../../src/MaximaCommandMenus.cpp:4413
 msgid "\".\" = \"The current directory\"\n"
@@ -216,7 +216,7 @@ msgstr "«..» означає «на один каталог вище»."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1208
 msgid "\"Copy LaTeX\" adds equation markers"
-msgstr ""
+msgstr "«Копіювати як LaTeX» додає позначки рівняння"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:446
 msgid "\"MathML (rendered by the browser)\" is the recommended choice: every current browser renders MathML natively and instantly, and the exported page needs no JavaScript and makes no requests to any external server.\n"
@@ -226,11 +226,11 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:930
 msgid "\"Numpad Enter\" always evaluates cells"
-msgstr ""
+msgstr "Enter з цифрової панелі завжди обчислює комірки"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:90
 msgid "\"implies\" symbol"
-msgstr ""
+msgstr "символ «слідує»"
 
 #: ../../src/dialogs/DiffFrame.cpp:306
 #, c-format
@@ -245,7 +245,7 @@ msgstr ""
 #: ../../src/sidebars/TableOfContents.cpp:570
 #, c-format
 msgid "%li Levels"
-msgstr ""
+msgstr "%li рівнів"
 
 #: ../../src/worksheet/Worksheet.cpp:423
 #, c-format
@@ -317,7 +317,7 @@ msgstr "&Копіювати\tCtrl+C"
 
 #: ../../src/wizards/IntegrateWiz.cpp:39
 msgid "&Definite integration"
-msgstr ""
+msgstr "&Визначене інтегрування"
 
 #: ../../src/wxMaximaFrame.cpp:1658
 msgid "&Demoivre"
@@ -433,11 +433,11 @@ msgstr "Ч&ислове виведення"
 
 #: ../../src/wizards/IntegrateWiz.cpp:52
 msgid "&Numerical integration"
-msgstr ""
+msgstr "&Числове інтегрування"
 
 #: ../../src/wizards/SumWiz.cpp:44
 msgid "&Nusum"
-msgstr ""
+msgstr "&Підсумовування (nusum)"
 
 #: ../../src/main.cpp:675
 msgid "&Open\tCtrl+O"
@@ -453,7 +453,7 @@ msgstr "&Креслення"
 
 #: ../../src/wizards/SeriesWiz.cpp:45
 msgid "&Power series"
-msgstr ""
+msgstr "С&тепеневий ряд"
 
 #: ../../src/wxMaximaFrame.cpp:655
 msgid "&Print...\tCtrl+P"
@@ -461,7 +461,7 @@ msgstr "На&друкувати\tCtrl+P"
 
 #: ../../src/wizards/SubstituteWiz.cpp:38
 msgid "&Rational"
-msgstr ""
+msgstr "&Раціональний вираз"
 
 #: ../../src/wxMaximaFrame.cpp:1631
 msgid "&Reduce Trigonometric"
@@ -493,11 +493,11 @@ msgstr "&Розв'язати…"
 
 #: ../../src/wizards/Plot2dWiz.cpp:42
 msgid "&Special"
-msgstr ""
+msgstr "&Додатково"
 
 #: ../../src/wizards/LimitWiz.cpp:45
 msgid "&Taylor series"
-msgstr ""
+msgstr "Ряд &Тейлора"
 
 #: ../../src/wxMaximaFrame.cpp:1069
 msgid "&Time Display"
@@ -517,7 +517,7 @@ msgstr "З&мінні"
 
 #: ../../src/wizards/Plot3dWiz.cpp:79
 msgid "&pm3d"
-msgstr ""
+msgstr "&pm3d"
 
 #: ../../src/cells/AnimationCell.cpp:475
 msgid "(Animation)"
@@ -545,15 +545,15 @@ msgstr ""
 
 #: ../../src/sidebars/CharButton.cpp:211
 msgid "(Might not be displayed correctly in at least one of the worksheet fonts)"
-msgstr ""
+msgstr "(Може бути показано неправильно при використанні принаймні одного зі шрифтів робочого аркуша)"
 
 #: ../../src/sidebars/VariablesPane.cpp:254
 msgid "(Not a valid variable name)"
-msgstr ""
+msgstr "(Не є коректною назвою змінної)"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:183
 msgid "(Use default language)"
-msgstr ""
+msgstr "(Використовувати типову мову)"
 
 #: ../../src/MaximaCommandMenus.cpp:440
 msgid "(f(x),x,a,b)), Epsilon algorithm"
@@ -587,7 +587,7 @@ msgstr "(f(x),x,y) із сингулярностями і розривами"
 #: ../../src/wizards/DrawWiz.cpp:303 ../../src/wizards/DrawWiz.cpp:320
 #: ../../src/wizards/DrawWiz.cpp:335
 msgid "-"
-msgstr ""
+msgstr "-"
 
 #: ../../src/wizards/IntegrateWiz.cpp:192
 #: ../../src/wizards/IntegrateWiz.cpp:202
@@ -595,7 +595,7 @@ msgstr ""
 #: ../../src/wizards/IntegrateWiz.cpp:217 ../../src/wizards/LimitWiz.cpp:132
 #: ../../src/wizards/LimitWiz.cpp:142
 msgid "- Infinity"
-msgstr ""
+msgstr "– нескінченність"
 
 #: ../../src/MaximaOutputAppender.cpp:116
 msgid "... [suppressed additional lines as the output is longer than allowed in the wxMaxima configuration] "
@@ -607,15 +607,15 @@ msgstr "Дані буфера обміну .wxm із несподіваним з
 
 #: ../../src/sidebars/TableOfContents.cpp:567
 msgid "1 Level"
-msgstr ""
+msgstr "1 рівень"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:77
 msgid "1/2"
-msgstr ""
+msgstr "1/2"
 
 #: ../../src/sidebars/DrawSidebar.cpp:45
 msgid "2D"
-msgstr ""
+msgstr "Двовимірний"
 
 #: ../../src/wxMaximaFrame.cpp:1346
 msgid "2D Array to Matrix..."
@@ -639,7 +639,7 @@ msgstr ""
 
 #: ../../src/sidebars/DrawSidebar.cpp:49
 msgid "3D"
-msgstr ""
+msgstr "Тривимірний"
 
 #: ../../src/wxMaxima.cpp:1833
 #, c-format
@@ -652,7 +652,7 @@ msgstr "Перша команда «:lisp» іноді не може надіс�
 
 #: ../../src/dialogs/TipOfTheDay.cpp:102
 msgid "A 'horizontal cursor' was introduced in wxMaxima 0.8.0. It looks like a horizontal line between cells. It indicates where a new cell will appear if you type or paste text or execute a menu command."
-msgstr ""
+msgstr "У wxMaxima 0.8.0 було реалізовано «горизонтальний курсор». Він виглядає як горизонтальна лінія між комірками. Такий курсор позначає місце, де з'явиться нова комірка, якщо ви введете або вставите текст чи скористаєтеся якимось пунктом меню."
 
 #: ../../src/MaximaCommandMenus.cpp:3039
 msgid "A Ctrl-F event"
@@ -678,7 +678,7 @@ msgstr "Подія пошуку, %s"
 
 #: ../../src/wizards/ListSortWiz.cpp:63
 msgid "A function f(a,b), named"
-msgstr ""
+msgstr "Функція f(a,b), іменована"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:784
 msgid "A function returning integers"
@@ -690,7 +690,7 @@ msgstr "Функція, яка повертає додатні числа"
 
 #: ../../src/wizards/DrawWiz.cpp:164
 msgid "A good example equation would be x^2+y^2=1"
-msgstr ""
+msgstr "Прикладом рівняння є x^2+y^2=1"
 
 #: ../../src/cells/GroupCell.cpp:2193 ../../src/cells/GroupCell.cpp:2196
 msgid "A heading"
@@ -714,15 +714,15 @@ msgstr "Матриця, у якій кожен рядок є набором зм
 
 #: ../../src/dialogs/TipOfTheDay.cpp:84
 msgid "A new document format has been introduced in wxMaxima 0.8.2 that saves not only your input and text commentaries, but also the outputs of your calculations. When saving your document, select 'Whole document (*.wxmx)' format."
-msgstr ""
+msgstr "У wxMaxima 0.8.2 було реалізовано новий формат документів, у якому можливе збереження не лише введених вами команд і текстових коментарів, але і результатів обчислень. Під час збереження вашого документа виберіть формат «увесь документ (*.wxmx)»."
 
 #: ../../src/cells/GroupCell.cpp:2175
 msgid "A page break"
-msgstr ""
+msgstr "Розрив сторінки"
 
 #: ../../src/dialogs/TipOfTheDay.cpp:168
 msgid "A plot to be embedded into the work sheet by preceding its name with a \"wx\". \"draw\" can be replaced by \"wxdraw\", plot by \"wxplot\" etc."
-msgstr ""
+msgstr "Креслення, яке слід вбудувати до робочого аркуша, з додаванням до назви префікса «wx». «draw» може бути замінено на «wxdraw», «plot» — на «wxplot» тощо."
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:735
 msgid "A rational variable"
@@ -734,7 +734,7 @@ msgstr "Функція із правою асоціативністю"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:436
 msgid "A scale factor for the printout. Helpful for printing big equations on small pdf pages."
-msgstr ""
+msgstr "Масштаб для друку. Корисно для друку великих рівнянь на маленьких сторінках pdf."
 
 #: ../../src/wxMaximaFrame.cpp:1671
 msgid "A search-and-replace for equations"
@@ -742,27 +742,27 @@ msgstr "Пошук із заміною для рівнянь"
 
 #: ../../src/cells/EditorCell.cpp:4522 ../../src/cells/GroupCell.cpp:2184
 msgid "A section heading"
-msgstr ""
+msgstr "Заголовок розділу"
 
 #: ../../src/wizards/DrawWiz.cpp:479
 msgid "A static plot"
-msgstr ""
+msgstr "Статичний графік"
 
 #: ../../src/cells/EditorCell.cpp:4534
 msgid "A sub-sub-sub-subsection heading"
-msgstr ""
+msgstr "Заголовок під-під-під-підрозділу"
 
 #: ../../src/cells/EditorCell.cpp:4531
 msgid "A sub-sub-subsection heading"
-msgstr ""
+msgstr "Заголовок під-під-підрозділу"
 
 #: ../../src/cells/EditorCell.cpp:4528 ../../src/cells/GroupCell.cpp:2190
 msgid "A sub-subsection heading"
-msgstr ""
+msgstr "Заголовок підпідрозділу"
 
 #: ../../src/cells/EditorCell.cpp:4525 ../../src/cells/GroupCell.cpp:2187
 msgid "A subsection heading"
-msgstr ""
+msgstr "Заголовок підрозділу"
 
 #: ../../src/wxMaximaFrame.cpp:1673
 msgid "A subst with basic maths knowledge"
@@ -770,7 +770,7 @@ msgstr "Заміна із базовими знаннями з математи�
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:239
 msgid "A symbol from the configuration dialogue"
-msgstr ""
+msgstr "Символ із діалогового вікна налаштовування"
 
 #: ../../src/cells/GroupCell.cpp:2181
 msgid "A text cell"
@@ -807,7 +807,7 @@ msgstr "математичні символи ASCII"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1618
 msgid "Abort evaluation on error"
-msgstr ""
+msgstr "Перервати обчислення, якщо трапиться помилка"
 
 #: ../../src/MaximaEvaluator.cpp:214
 #, c-format
@@ -840,7 +840,7 @@ msgstr ""
 
 #: ../../src/sidebars/DrawSidebar.cpp:103
 msgid "Accuracy"
-msgstr ""
+msgstr "Точність"
 
 #: ../../src/wxMaximaFrame.cpp:1405
 msgid "Ad&joint Matrix"
@@ -860,7 +860,7 @@ msgstr "Додати новий пункт на початку списку. К�
 
 #: ../../src/sidebars/VariablesPane.cpp:228
 msgid "Add all"
-msgstr ""
+msgstr "Додати всі"
 
 #: ../../src/MaximaCommandMenus.cpp:1621
 msgid "Add an element to the end of a list"
@@ -880,11 +880,11 @@ msgstr "Додати рівність до спрощувача раціонал
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:204
 msgid "Add more symbols"
-msgstr ""
+msgstr "Додати символи"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1262
 msgid "Add the .wxmx file to the HTML export"
-msgstr ""
+msgstr "Додати файл .wxmx до експортованого HTML"
 
 #: ../../src/wxMaximaFrame.cpp:1049
 msgid "Add to &Path..."
@@ -892,7 +892,7 @@ msgstr "Додати до &шляху…"
 
 #: ../../src/sidebars/UnicodeSidebar.cpp:105
 msgid "Add to symbols Sidebar"
-msgstr ""
+msgstr "Додати символи на бічну панель"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:304
 #: ../../src/worksheet/WorksheetContextMenu.cpp:337
@@ -903,23 +903,23 @@ msgstr "Додати до списку спостереження"
 #: ../../src/sidebars/XmlInspector.cpp:147
 #, c-format
 msgid "Added much text (%li chars) to the XML inspector."
-msgstr ""
+msgstr "У інспектор XML додано забагато тексту (%li символів)."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1896
 msgid "Additional clipboard formats to put on the clipboard on ordinary copy"
-msgstr ""
+msgstr "Додаткові формат буфера для вставляння даних при звичайному копіюванні"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:393
 msgid "Additional commands to be added to the preamble of LaTeX output for pdftex."
-msgstr ""
+msgstr "Додаткові команди, які слід додати до преамбули коду LaTeX для pdftex."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1187
 msgid "Additional lines for the TeX preamble:"
-msgstr ""
+msgstr "Додаткові рядки до преамбули TeX:"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:389
 msgid "Additional parameters for Maxima (e.g. -l clisp)."
-msgstr ""
+msgstr "Додаткові параметри команди Maxima (наприклад -l clisp)."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1543
 msgid "Additional parameters for Maxima (restart Maxima after changes)"
@@ -927,7 +927,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1318
 msgid "Additional symbols for the \"symbols\" sidebar:"
-msgstr ""
+msgstr "Додаткові символи для бічної панелі «символи»:"
 
 #: ../../src/wxMaximaFrame.cpp:1599
 msgid "Additionally: log(a*b)=log(a)+log(b)"
@@ -971,7 +971,7 @@ msgstr "Замінники"
 
 #: ../../src/sidebars/TableOfContents.cpp:572
 msgid "All Levels"
-msgstr ""
+msgstr "Усі рівні"
 
 #: ../../src/wxMaximaFrame.cpp:1751
 msgid "All but the 1st n elements"
@@ -987,7 +987,7 @@ msgstr "усі придатні типи (*.wxm, *.wxmx, *.mac, *.out, *.xml)|*.
 
 #: ../../src/dialogs/ConfigDialogue.cpp:750
 msgid "All variable names"
-msgstr ""
+msgstr "Усі назви змінних"
 
 #: ../../src/wxMaximaFrame.cpp:770
 msgid "All visible sidebars"
@@ -1015,7 +1015,7 @@ msgstr ""
 
 #: ../../src/dialogs/BinaryNameCtrl.cpp:69
 msgid "All|*"
-msgstr ""
+msgstr "Всі|*"
 
 #: ../../src/wxMaximaFrame.cpp:800
 msgid "Always after underscores"
@@ -1035,7 +1035,7 @@ msgstr "Завжди показувати усі цифри"
 
 #: ../../src/wizards/DrawWiz.cpp:484
 msgid "An animation with multiple frames"
-msgstr ""
+msgstr "Анімація із декількома кадрами"
 
 #: ../../src/cells/GroupCell.cpp:2202
 msgid "An image cell"
@@ -1193,7 +1193,7 @@ msgstr "Код ASCII на символ…"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1397
 msgid "Ask to save untitled documents"
-msgstr ""
+msgstr "Запитувати щодо збереження документів без назв"
 
 #: ../../src/dialogs/MaximaNotStartingDialog.cpp:36
 msgid "Asking the user for the location of a working maxima binary"
@@ -1217,21 +1217,21 @@ msgstr "Увага! Для довгих списків видобування в
 
 #: ../../src/dialogs/ConfigDialogue.cpp:897
 msgid "Auto-indent new lines"
-msgstr ""
+msgstr "Автовідступ у нових рядках"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:893
 msgid "Auto-insert closing parenthesis"
-msgstr ""
+msgstr "Автоматично закривати круглі дужки"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1441
 #: ../../src/dialogs/ConfigDialogue.cpp:1472
 #: ../../src/dialogs/MaximaNotStartingDialog.cpp:43
 msgid "Autodetect"
-msgstr ""
+msgstr "Автоматичне визначення"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1236
 msgid "Automatic"
-msgstr ""
+msgstr "Автоматично"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:391
 msgid "Automatic labels"
@@ -1240,7 +1240,7 @@ msgstr "Автоматичні мітки"
 #: ../../src/dialogs/ConfigDialogue.cpp:769
 #, c-format
 msgid "Automatic labels (%i1, %o1,...)"
-msgstr ""
+msgstr "Автоматичні мітки (%i1, %o1,...)"
 
 #: ../../src/wxMaximaFrame.cpp:986
 msgid "Automatically answer questions"
@@ -1252,7 +1252,7 @@ msgstr "Автоматично заповнювати відповіді, які
 
 #: ../../src/dialogs/ConfigDialogue.cpp:460
 msgid "Automatically insert a closing parenthesis the moment the user enters an opening one."
-msgstr ""
+msgstr "Автоматично вставляти завершальну дужку у момент, коли користувач вводить початкову."
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:235
 #: ../../src/worksheet/WorksheetContextMenu.cpp:610
@@ -1287,15 +1287,15 @@ msgstr "Переводити цю змінну у нижній індекс ав
 
 #: ../../src/dialogs/ConfigDialogue.cpp:734
 msgid "Autowrap long lines:"
-msgstr ""
+msgstr "Автоматичне перенесення довгих рядків:"
 
 #: ../../src/sidebars/DrawSidebar.cpp:75
 msgid "Axis"
-msgstr ""
+msgstr "Вісь"
 
 #: ../../src/wizards/BC2Wiz.cpp:59
 msgid "BC2"
-msgstr ""
+msgstr "BC2"
 
 #: ../../src/MaximaManual.cpp:559
 msgid "Background task that compiles the Manual anchors scheduled."
@@ -1303,7 +1303,7 @@ msgstr ""
 
 #: ../../src/sidebars/StatSidebar.cpp:91
 msgid "Barsplot..."
-msgstr ""
+msgstr "Стовпчикова діаграма…"
 
 #: ../../src/wxMaximaFrame.cpp:1384
 msgid "Basic matrix operations"
@@ -1342,27 +1342,27 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:141
 msgid "Besides the global undo functionality that is active when the cursor is between cells, wxMaxima has a per-cell undo function that is active if the cursor is inside a cell. Pressing Ctrl+Z inside a cell can therefore been used for a fine-pitch undo that doesn't affect latter changes made in other cells."
-msgstr ""
+msgstr "Окрім загальних можливостей скасовування дій, коли курсор перебуває між комірками wxMaxima, передбачено можливість скасовування дій у кожній комірці окремо, доки курсор перебуває у межах комірки. Натисканням Ctrl+Z у окремій комірці можна скасувати дії саме у цій комірці, без впливу на пізніші зміни, внесені у інших комірках."
 
 #: ../../src/sidebars/GreekSidebar.cpp:179
 msgid "Beta"
-msgstr ""
+msgstr "Β"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1898
 msgid "Bitmap"
-msgstr ""
+msgstr "Растр"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1273
 msgid "Bitmap scale for export:"
-msgstr ""
+msgstr "Масштаб растра для експортування:"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1223
 msgid "Bitmaps"
-msgstr ""
+msgstr "Растрові зображення"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2109
 msgid "Bold"
-msgstr ""
+msgstr "Жирний"
 
 #: ../../src/wxMaxima.cpp:2259
 msgid "Both horizontal and vertical cursor active at the same time"
@@ -1370,7 +1370,7 @@ msgstr "Активними є одночасно горизонтальний і
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1999
 msgid "Bottom"
-msgstr ""
+msgstr "Внизу"
 
 #: ../../src/MaximaCommandMenus.cpp:1381
 msgid "Bottom end"
@@ -1386,13 +1386,13 @@ msgstr ""
 
 #: ../../src/sidebars/StatSidebar.cpp:97
 msgid "Boxplot..."
-msgstr ""
+msgstr "Скринькова діаграма…"
 
 #: ../../src/dialogs/BinaryNameCtrl.cpp:42 ../../src/wizards/CsvWiz.cpp:57
 #: ../../src/wizards/CsvWiz.cpp:131 ../../src/wizards/Plot2dWiz.cpp:114
 #: ../../src/wizards/Plot3dWiz.cpp:109
 msgid "Browse"
-msgstr ""
+msgstr "Перегляд"
 
 #: ../../src/wxMathml.cpp:101
 msgid "Bug: After removing the whitespace wxMathml.lisp is shorter than expected!"
@@ -1441,7 +1441,7 @@ msgstr "Вада: виведені дані HTML не є коректними д
 
 #: ../../src/cells/Cell.cpp:289
 msgid "Bug: Math Cell that claims to have no group Cell it belongs to"
-msgstr ""
+msgstr "Вада: комірка рівняння, у якої немає групи комірок, до якої ця комірка належить"
 
 #: ../../src/Configuration.h:741
 msgid "Bug: Maximum number of digits that is to be displayed is too low!"
@@ -1453,7 +1453,7 @@ msgstr "Вада: немає вмісту"
 
 #: ../../src/cells/GroupCell.cpp:1498
 msgid "Bug: No image counter to write to!"
-msgstr ""
+msgstr "Вада: немає лічильника зображень для запису даних!"
 
 #: ../../src/cells/AnimationCell.cpp:543 ../../src/cells/EditorCell.cpp:2968
 #: ../../src/cells/ImgCell.cpp:353 ../../src/graphical_io/BitmapOut.cpp:161
@@ -1472,7 +1472,7 @@ msgstr "Вада: буфер обміну вже відкрито"
 
 #: ../../src/cells/EditorCell.cpp:3051
 msgid "Bug: The clipboard isn't open on pasting into an editor cell"
-msgstr ""
+msgstr "Вада: буфер обміну не відкрито для вставляння до комірки редактора"
 
 #: ../../src/cells/GroupCell.cpp:2288
 msgid "Bug: The predecessor to a GroupCell is not a GroupCell."
@@ -1484,7 +1484,7 @@ msgstr ""
 
 #: ../../src/cells/GroupCell.cpp:340
 msgid "Bug: Trying to append NULL to a group cell."
-msgstr ""
+msgstr "Вада: спроба дописування NULL до комірки групи."
 
 #: ../../src/worksheet/Worksheet.cpp:5939
 msgid "Bug: Trying to move a title out by one sectioning unit"
@@ -1508,7 +1508,7 @@ msgstr "Вада: дія зі скасування із одночасною з�
 
 #: ../../src/cells/EditorCell.cpp:4541
 msgid "Bug: Unknown type of text"
-msgstr ""
+msgstr "Вада: невідомий тип тексту"
 
 #: ../../src/cells/EditorCell.cpp:3981 ../../src/cells/TextCell.cpp:479
 msgid "Bug: dc == NULL"
@@ -1516,11 +1516,11 @@ msgstr ""
 
 #: ../../src/cells/EditorCell.cpp:2637
 msgid "Bug: x position of cell is unknown!"
-msgstr ""
+msgstr "Вада: позиція комірки за x є невідомою!"
 
 #: ../../src/cells/EditorCell.cpp:2638
 msgid "Bug: y position of cell is unknown!"
-msgstr ""
+msgstr "Вада: позиція комірки за y є невідомою!"
 
 #: ../../src/wxMaximaFrame.cpp:1985
 msgid "Build &Info"
@@ -1533,7 +1533,7 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:54
 msgid "By default, Shift-Enter is used to evaluate commands, while Enter is used for multiline input. This behaviour can be changed in 'Edit->Configure' dialog by checking 'Enter evaluates cells'. This switches the roles of these two key commands."
-msgstr ""
+msgstr "Типово, для виконання команд використовується комбінація клавіш Shift-Enter, а Enter використовується для введення багаторядкових блоків тексту. Таку поведінку програми можна змінити за допомогою діалогового вікна «Зміни → Налаштувати»: позначте пункт «Enter для обчислення у комірках». За допомогою цього пункту ви зможете поміняти місцями призначення клавіатурних скорочень."
 
 #: ../../src/MaximaCommandMenus.cpp:4087
 msgid "Byte:"
@@ -1558,7 +1558,7 @@ msgstr ""
 #: ../../src/cells/FontVariantCache.cpp:96
 #, c-format
 msgid "Caching font variant: %s"
-msgstr ""
+msgstr "Кешуємо варіант шрифту: %s"
 
 #: ../../src/wxMaximaFrame.cpp:1519
 msgid "Calculate &Product..."
@@ -1703,7 +1703,7 @@ msgstr ""
 #: ../../src/cells/FontVariantCache.cpp:85
 #, c-format
 msgid "Cannot create a font based on %s. Falling back to a default font."
-msgstr ""
+msgstr "Не вдалося створити шрифт на основі %s. Повертаємося до типового шрифту."
 
 #: ../../src/MaximaProcessManager.cpp:368
 msgid "Cannot find a maxima binary and no binary chosen in the config dialogue."
@@ -1727,20 +1727,20 @@ msgstr "Не вдалося обробити компонент номера в�
 
 #: ../../src/cells/EditorCell.cpp:2991
 msgid "Cannot put the copied text on the clipboard"
-msgstr ""
+msgstr "Не вдалося розмістити скопійований текст у буфері обміну даними"
 
 #: ../../src/cells/EditorCell.cpp:2984
 msgid "Cannot put the copied text on the clipboard (1st try)"
-msgstr ""
+msgstr "Не вдалося розмістити скопійований текст у буфері обміну даними (перша спроба)"
 
 #: ../../src/cells/EditorCell.cpp:2988
 msgid "Cannot put the copied text on the clipboard (2nd try)"
-msgstr ""
+msgstr "Не вдалося розмістити скопійований текст у буфері обміну даними (друга спроба)"
 
 #: ../../src/graphical_io/OutCommon.cpp:98
 #, c-format
 msgid "Cannot remove the file %s"
-msgstr ""
+msgstr "Не вдалося вилучити файл %s"
 
 #: ../../src/sidebars/History.cpp:258
 #, c-format
@@ -1771,11 +1771,11 @@ msgstr "Не вдалося запустити виконуваний файл m
 
 #: ../../src/sidebars/MathSidebar.cpp:62
 msgid "Canonical (tr)"
-msgstr ""
+msgstr "Канонічна форма (триг)"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:188
 msgid "Catalan"
-msgstr ""
+msgstr "каталонська"
 
 #: ../../src/MaximaCommandMenus.cpp:466
 msgid "Cauchy principal value of f(x)/(x-c), finite interval"
@@ -1832,7 +1832,7 @@ msgstr "Змінити каталог…"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:859
 msgid "Change names of greek letters to greek letters"
-msgstr ""
+msgstr "Замінити назви грецьких літер на записи грецькою абеткою"
 
 #: ../../src/wxMaximaFrame.cpp:1073
 msgid "Change the 2d display algorithm used to display math output"
@@ -1840,7 +1840,7 @@ msgstr "Змінити алгоритм показу плоского зобра
 
 #: ../../src/dialogs/ConfigDialogue.cpp:489
 msgid "Change the text \"alpha\" and \"beta\" to the corresponding greek letter?"
-msgstr ""
+msgstr "Замінити текстові записи «alpha» і «beta» на відповідні грецькі літери?"
 
 #: ../../src/MaximaCommandMenus.cpp:136
 msgid "Change variable"
@@ -1860,7 +1860,7 @@ msgstr "Замінити змінну в інтегралі або сумі і �
 
 #: ../../src/dialogs/ChangeLogDialog.cpp:37
 msgid "ChangeLog"
-msgstr ""
+msgstr "Журнал змін"
 
 #: ../../src/wxMaximaFrame.cpp:1060
 msgid "Changed option variables"
@@ -1921,15 +1921,15 @@ msgstr "Перевірити, чи не випущено новішу версі
 
 #: ../../src/sidebars/GreekSidebar.cpp:199
 msgid "Chi"
-msgstr ""
+msgstr "Χ"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:189
 msgid "Chinese (Simplified)"
-msgstr ""
+msgstr "китайська (спрощена)"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:190
 msgid "Chinese (traditional)"
-msgstr ""
+msgstr "китайська (традиційна)"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1554
 msgid "Choose a Lisp Maxima was compiled with"
@@ -1941,11 +1941,11 @@ msgstr ""
 
 #: ../../src/sidebars/HelpBrowser.cpp:204
 msgid "Choose between the following help topics:"
-msgstr ""
+msgstr "Виберіть між такими темами довідки:"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2100
 msgid "Choose font"
-msgstr ""
+msgstr "Вибрати шрифт"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:793
 msgid "Choose how mathematical output is formatted:\n"
@@ -1956,12 +1956,12 @@ msgstr ""
 
 #: ../../src/wizards/PlotFormatWiz.cpp:31
 msgid "Choose new plot format:"
-msgstr ""
+msgstr "Вкажіть новий формат графіків:"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2432
 #, c-format
 msgid "Choose the %s Font"
-msgstr ""
+msgstr "Виберіть шрифт %s"
 
 #: ../../src/wxMaximaFrame.cpp:837
 msgid "Choose the parenthesis type for Matrices"
@@ -1997,7 +1997,7 @@ msgstr ""
 
 #: ../../src/sidebars/History.cpp:116
 msgid "Clear all history"
-msgstr ""
+msgstr "Спорожнити увесь журнал"
 
 #: ../../src/wxMaximaFrame.cpp:1034
 msgid "Clear all labels"
@@ -2029,16 +2029,16 @@ msgstr ""
 
 #: ../../src/sidebars/History.cpp:115
 msgid "Clear the selection"
-msgstr ""
+msgstr "Зняти позначення"
 
 #: ../../src/cells/FontVariantCache.cpp:44
 #, c-format
 msgid "Cleared font cache for font %s"
-msgstr ""
+msgstr "Спорожнено кеш шрифтів для шрифту %s"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1926
 msgid "Clipboard format parameters"
-msgstr ""
+msgstr "Параметри форматування буфера обміну"
 
 #: ../../src/wxMaximaFrame.cpp:637
 msgid "Close\tCtrl+W"
@@ -2130,7 +2130,7 @@ msgstr ""
 
 #: ../../src/wizards/MatWiz.cpp:155
 msgid "Columns:"
-msgstr ""
+msgstr "Стовпців:"
 
 #: ../../src/wxMaximaFrame.cpp:1621
 msgid "Combine factorials in an expression"
@@ -2146,11 +2146,11 @@ msgstr "За комою одразу вказано завершальну ду�
 
 #: ../../src/wizards/Plot2dWiz.cpp:626
 msgid "Comma separated x coordinates"
-msgstr ""
+msgstr "Список координат за віссю x, відокремлених комами"
 
 #: ../../src/wizards/Plot2dWiz.cpp:627
 msgid "Comma separated y coordinates"
-msgstr ""
+msgstr "Список координат за віссю y, відокремлених комами"
 
 #: ../../src/MaximaCommandMenus.cpp:4071
 msgid "Comma-separated arguments"
@@ -2236,11 +2236,11 @@ msgstr "Команда:"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1145
 msgid "Commands that are executed at every start of maxima."
-msgstr ""
+msgstr "Команди, які виконуються під час кожного запуску maxima."
 
 #: ../../src/cells/EditorCell.cpp:4538
 msgid "Comment (ordinary worksheet text that isn't fed to maxima)"
-msgstr ""
+msgstr "Коментар (звичайний текст на робочому аркуші, який не передаватиметься maxima)"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:465
 msgid "Comment Selection"
@@ -2376,16 +2376,16 @@ msgstr "Умова:"
 #: ../../src/dialogs/ConfigDialogue.cpp:2641
 #: ../../src/dialogs/ConfigDialogue.cpp:2647
 msgid "Config file (*.ini)|*.ini"
-msgstr ""
+msgstr "Файл налаштувань (*.ini)|*.ini"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2539
 #, c-format
 msgid "Config item \"%s\" was of an unknown type"
-msgstr ""
+msgstr "Запис налаштувань «%s» належить до невідомого типу"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2607
 msgid "Configuration warning"
-msgstr ""
+msgstr "Попередження щодо налаштувань"
 
 #: ../../src/ToolBar.cpp:367 ../../src/ToolBar.cpp:369
 #: ../../src/wxMaximaFrame.cpp:722 ../../src/wxMaximaFrame.cpp:724
@@ -2394,7 +2394,7 @@ msgstr "Налаштувати wxMaxima"
 
 #: ../../src/wizards/DrawWiz.cpp:829
 msgid "Connect the dots"
-msgstr ""
+msgstr "З'єднати крапки"
 
 #: ../../src/MaximaProcessManager.cpp:163
 msgid "Connection attempt, but connection failed."
@@ -2408,7 +2408,7 @@ msgstr "Втрачено з'єднання із Maxima."
 #: ../../src/wizards/IntegrateWiz.cpp:208 ../../src/wizards/LimitWiz.cpp:133
 #: ../../src/wizards/SeriesWiz.cpp:105
 msgid "Constant"
-msgstr ""
+msgstr "Стала"
 
 #: ../../src/MaximaCommandMenus.cpp:1102
 msgid "Construct a fraction"
@@ -2420,7 +2420,7 @@ msgstr "Побудувати дріб…"
 
 #: ../../src/sidebars/VariablesPane.cpp:58
 msgid "Contents"
-msgstr ""
+msgstr "Зміст"
 
 #: ../../src/MaximaCommandMenus.cpp:3970
 msgid "Contents:"
@@ -2436,27 +2436,27 @@ msgstr "&Контекстна довідка\tF1"
 
 #: ../../src/sidebars/DrawSidebar.cpp:80
 msgid "Contour"
-msgstr ""
+msgstr "Контур"
 
 #: ../../src/sidebars/DrawSidebar.cpp:101
 msgid "Contour lines for 3d plots"
-msgstr ""
+msgstr "Контурні лінії для просторових графіків"
 
 #: ../../src/wizards/DrawWiz.cpp:648
 msgid "Contour lines on surface and Bottom"
-msgstr ""
+msgstr "Контурні лінії на поверхні і внизу"
 
 #: ../../src/wizards/DrawWiz.cpp:644
 msgid "Contour lines on the Bottom"
-msgstr ""
+msgstr "Контурні лінії внизу"
 
 #: ../../src/wizards/DrawWiz.cpp:641
 msgid "Contour lines on the Surface"
-msgstr ""
+msgstr "Контурні лінії на поверхні"
 
 #: ../../src/wizards/DrawWiz.cpp:629
 msgid "Contour lines settings for the following 3d plots"
-msgstr ""
+msgstr "Параметри контурних ліній для наступних просторових графіків"
 
 #: ../../src/wxMaximaFrame.cpp:1579
 msgid "Contract Logarithms"
@@ -2541,30 +2541,30 @@ msgstr "Перетворювати у &алгебраїчну форму"
 #: ../../src/sidebars/TableOfContents.cpp:522
 #: ../../src/sidebars/TableOfContents.cpp:543
 msgid "Convert to Heading 5"
-msgstr ""
+msgstr "Перетворити на заголовок 5"
 
 #: ../../src/sidebars/TableOfContents.cpp:519
 msgid "Convert to Heading 6"
-msgstr ""
+msgstr "Перетворити на заголовок 6"
 
 #: ../../src/sidebars/TableOfContents.cpp:531
 #: ../../src/sidebars/TableOfContents.cpp:552
 msgid "Convert to Section"
-msgstr ""
+msgstr "Перетворити на розділ"
 
 #: ../../src/sidebars/TableOfContents.cpp:525
 #: ../../src/sidebars/TableOfContents.cpp:546
 msgid "Convert to Sub-Subsection"
-msgstr ""
+msgstr "Перетворити на підпідрозділ"
 
 #: ../../src/sidebars/TableOfContents.cpp:528
 #: ../../src/sidebars/TableOfContents.cpp:549
 msgid "Convert to Subsection"
-msgstr ""
+msgstr "Перетворити на підрозділ"
 
 #: ../../src/sidebars/TableOfContents.cpp:555
 msgid "Convert to Title"
-msgstr ""
+msgstr "Перетворити на заголовок"
 
 #: ../../src/wxMaximaFrame.cpp:1200
 msgid "Convert to downcase..."
@@ -2750,22 +2750,22 @@ msgstr "Кнопка копіювання, вирізання та вставл�
 #: ../../src/dialogs/ConfigDialogue.cpp:2523
 #, c-format
 msgid "Copying config bool \"%s\""
-msgstr ""
+msgstr "Копіюємо булеве значення налаштувань «%s»"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2533
 #, c-format
 msgid "Copying config float \"%s\""
-msgstr ""
+msgstr "Копіюємо значення із рухомою крапкою налаштувань «%s»"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2528
 #, c-format
 msgid "Copying config int \"%s\""
-msgstr ""
+msgstr "Копіюємо ціле значення налаштувань «%s»"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2518
 #, c-format
 msgid "Copying config string \"%s\""
-msgstr ""
+msgstr "Копіюємо рядкове значення налаштувань «%s»"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:191
 msgid "Corsican"
@@ -2858,7 +2858,7 @@ msgstr "Створити список на основі елементів, ві
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1389
 msgid "Create scalable plots."
-msgstr ""
+msgstr "Створювати масштабовані креслення."
 
 #: ../../src/wxMaximaFrame.cpp:1116
 msgid "Create struct..."
@@ -2882,7 +2882,7 @@ msgstr ""
 
 #: ../../src/worksheet/Worksheet.cpp:6115
 msgid "Cursor"
-msgstr ""
+msgstr "Курсор"
 
 #: ../../src/Styles.cpp:126
 msgid "Cursor color"
@@ -2904,11 +2904,11 @@ msgstr "Вирізати позначене"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:193
 msgid "Czech"
-msgstr ""
+msgstr "чеська"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:194
 msgid "Danish"
-msgstr ""
+msgstr "данська"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2069
 msgid "Dark"
@@ -2924,7 +2924,7 @@ msgstr "Файл даних (*.csv, *.tab, *.txt)|*.csv;*.tab;*.txt"
 
 #: ../../src/wizards/DrawWiz.cpp:810
 msgid "Data format"
-msgstr ""
+msgstr "Формат даних"
 
 #: ../../src/MaximaCommandMenus.cpp:1767 ../../src/MaximaCommandMenus.cpp:1772
 #: ../../src/MaximaCommandMenus.cpp:1777 ../../src/MaximaCommandMenus.cpp:1781
@@ -2978,15 +2978,15 @@ msgstr "Спадна функція f(x)<x"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1336
 msgid "Default animation framerate:"
-msgstr ""
+msgstr "Типова частота кадрів анімації:"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:717
 msgid "Default plot size for new maxima sessions:"
-msgstr ""
+msgstr "Типовий розмір креслень для нових сеансів maxima:"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1534
 msgid "Default port for communication with wxMaxima:"
-msgstr ""
+msgstr "Типовий порт для обміну даними з wxMaxima:"
 
 #: ../../src/MaximaCommandMenus.cpp:3946
 msgid "Define a function"
@@ -3026,7 +3026,7 @@ msgstr "Визначити структуру…"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:404
 msgid "Define the default speed (in frames per second) animations are played back with."
-msgstr ""
+msgstr "Визначити типову швидкість (у кадрах за секунду) для відтворення анімацій."
 
 #: ../../src/wxMaximaFrame.cpp:1114
 msgid "Define variable..."
@@ -3099,7 +3099,7 @@ msgstr "Роздільник:"
 
 #: ../../src/sidebars/GreekSidebar.cpp:181
 msgid "Delta"
-msgstr ""
+msgstr "Δ"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:110
 #: ../../src/worksheet/WorksheetContextMenu.cpp:558
@@ -3125,7 +3125,7 @@ msgstr "Залежності"
 
 #: ../../src/wizards/SeriesWiz.cpp:42
 msgid "Depth:"
-msgstr ""
+msgstr "Глибина:"
 
 #: ../../src/MaximaCommandMenus.cpp:994
 msgid "Derivate of y at that point:"
@@ -3160,7 +3160,7 @@ msgstr ""
 
 #: ../../src/sidebars/StatSidebar.cpp:61
 msgid "Deviation..."
-msgstr ""
+msgstr "Відхилення…"
 
 #: ../../src/wxMaximaFrame.cpp:1534
 msgid "Di&vide Polynomials..."
@@ -3172,11 +3172,11 @@ msgstr ""
 
 #: ../../src/sidebars/DrawSidebar.cpp:71
 msgid "Diagram title"
-msgstr ""
+msgstr "Заголовок діаграми"
 
 #: ../../src/sidebars/HelpBrowser.cpp:51
 msgid "Didn't find an installed offline manual."
-msgstr ""
+msgstr "Не вдалося знайти встановлений автономний підручник."
 
 #: ../../src/MaximaManual.cpp:534
 msgid "Didn't find the maxima HTML manual."
@@ -3192,7 +3192,7 @@ msgstr ""
 
 #: ../../src/sidebars/MathSidebar.cpp:80
 msgid "Diff..."
-msgstr ""
+msgstr "Диференціювати…"
 
 #: ../../src/dialogs/DiffFrame.cpp:308
 #, c-format
@@ -3221,7 +3221,7 @@ msgstr "Продиференціювати вираз n разів"
 
 #: ../../src/wizards/LimitWiz.cpp:41
 msgid "Direction:"
-msgstr ""
+msgstr "Напрямок:"
 
 #: ../../src/wxMaximaFrame.cpp:1246
 msgid "Directory operations"
@@ -3233,11 +3233,11 @@ msgstr ""
 
 #: ../../src/wizards/Plot2dWiz.cpp:418 ../../src/wizards/Plot2dWiz.cpp:619
 msgid "Discrete plot"
-msgstr ""
+msgstr "Графік дискретної функції"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:699
 msgid "Display"
-msgstr ""
+msgstr "Показ"
 
 #: ../../src/wxMaximaFrame.cpp:1075
 msgid "Display Te&X Form"
@@ -3249,11 +3249,11 @@ msgstr "Спосіб виведення"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:827
 msgid "Display all and allow linebreaks in long numbers"
-msgstr ""
+msgstr "Показувати все і дозволити розривати рядки із довгими числами"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:820
 msgid "Display all digits"
-msgstr ""
+msgstr "Показувати усі цифри"
 
 #: ../../src/wxMaximaFrame.cpp:788
 msgid "Display an expression as maxima's internal lisp representation"
@@ -3281,7 +3281,7 @@ msgstr "Показати останній результат у форматі T
 
 #: ../../src/dialogs/ConfigDialogue.cpp:804
 msgid "Display of long numbers"
-msgstr ""
+msgstr "Показ довгих чисел"
 
 #: ../../src/ToolBar.cpp:580
 #, c-format
@@ -3360,11 +3360,11 @@ msgstr "Документ було збережено за допомогою н�
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1170
 msgid "Documentclass for TeX export:"
-msgstr ""
+msgstr "Клас документа для експортування до TeX:"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1178
 msgid "Documentclass options:"
-msgstr ""
+msgstr "Параметри класу документів:"
 
 #: ../../src/wxMaximaFrame.cpp:807
 msgid "Don't autosubscript after an underscore"
@@ -3410,19 +3410,19 @@ msgstr "Не використовувати дужки для матриць"
 
 #: ../../src/dialogs/DiffFrame.cpp:428 ../../src/dialogs/FindReplacePane.cpp:83
 msgid "Down"
-msgstr ""
+msgstr "Нижче"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:185
 msgid "Drag-and-drop unicode symbols here"
-msgstr ""
+msgstr "Сюди можна перетягнути і скинути символи Юнікод"
 
 #: ../../src/wizards/DrawWiz.cpp:155
 msgid "Draw all points where an equation is true."
-msgstr ""
+msgstr "Накреслити усі точки, де справджується рівняння."
 
 #: ../../src/wizards/DrawWiz.cpp:802
 msgid "Draw points"
-msgstr ""
+msgstr "Накреслити точки"
 
 #: ../../src/MaximaCommandMenus.cpp:1536
 msgid "Drop the first n list elements"
@@ -3542,7 +3542,7 @@ msgstr "Сталася невідома подія із сокетом."
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:129
 msgid "End of proof"
-msgstr ""
+msgstr "Кінець доведення"
 
 #: ../../src/MaximaCommandMenus.cpp:1024
 msgid "End of t:"
@@ -3550,19 +3550,19 @@ msgstr "Кінець за t:"
 
 #: ../../src/wizards/DrawWiz.cpp:71 ../../src/wizards/DrawWiz.cpp:176
 msgid "End of the x value"
-msgstr ""
+msgstr "Кінцеве значення x"
 
 #: ../../src/wizards/DrawWiz.cpp:88 ../../src/wizards/DrawWiz.cpp:191
 msgid "End of the y value"
-msgstr ""
+msgstr "Кінцеве значення y"
 
 #: ../../src/wizards/DrawWiz.cpp:208
 msgid "End of the z value"
-msgstr ""
+msgstr "Кінцеве значення z"
 
 #: ../../src/wizards/DrawWiz.cpp:760
 msgid "End value of the parameter"
-msgstr ""
+msgstr "Кінцеве значення параметра"
 
 #: ../../src/MaximaResponseReader.cpp:432
 #: ../../src/MaximaResponseReader.cpp:586
@@ -3575,19 +3575,19 @@ msgstr "Науковий формат (12.1e6 тощо)"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:196
 msgid "English"
-msgstr ""
+msgstr "англійська"
 
 #: ../../src/wizards/DrawWiz.cpp:552
 msgid "Enhanced 3D settings:"
-msgstr ""
+msgstr "Розширені параметр просторового:"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1919
 msgid "Enhanced meta file (emf)"
-msgstr ""
+msgstr "Удосконалений метафайл (emf)"
 
 #: ../../src/sidebars/StatSidebar.cpp:106
 msgid "Enter Matrix..."
-msgstr ""
+msgstr "Ввести матрицю…"
 
 #: ../../src/MaximaCommandMenus.cpp:2255
 msgid "Enter UUID to jump to:"
@@ -3599,7 +3599,7 @@ msgstr "Введення матриці"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:925
 msgid "Enter adds newlines, Ctrl+Enter evaluates cells"
-msgstr ""
+msgstr "Enter додає розриви рядків, Ctrl+Enter — обчислення у комірках"
 
 #: ../../src/MaximaCommandMenus.cpp:873
 msgid "Enter an equation for rational simplification:"
@@ -3607,11 +3607,11 @@ msgstr "Введіть рівняння для раціонального спр
 
 #: ../../src/wizards/SystemWiz.cpp:50
 msgid "Enter comma separated list of variables."
-msgstr ""
+msgstr "Введіть список змінних, відокремлених комами."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:921
 msgid "Enter evaluates cells, Ctrl+Enter adds newlines"
-msgstr ""
+msgstr "Enter — обчислення у комірках, Ctrl+Enter додає розрив рядка"
 
 #: ../../src/MaximaCommandMenus.cpp:1357
 msgid "Enter matrix"
@@ -3627,7 +3627,7 @@ msgstr "Вкажіть нову підвищену точність:"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:388
 msgid "Enter the path to the Maxima executable."
-msgstr ""
+msgstr "Вкажіть шлях до виконуваного файла Maxima."
 
 #: ../../src/MaximaCommandMenus.cpp:1103
 msgid "Enumerator:"
@@ -3639,11 +3639,11 @@ msgstr "Змінні середовища"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1605
 msgid "Environment variables for maxima"
-msgstr ""
+msgstr "Змінні середовища для maxima"
 
 #: ../../src/sidebars/GreekSidebar.cpp:182
 msgid "Epsilon"
-msgstr ""
+msgstr "Ε"
 
 #: ../../src/MaximaCommandMenus.cpp:299
 msgid "Epsilon:"
@@ -3682,7 +3682,7 @@ msgstr "Рівняння:"
 
 #: ../../src/dialogs/TipOfTheDay.cpp:196
 msgid "Equations have several advantages over functions. For example they can be manipulated with factor(), expand() and similar functions. They can easily be introduced one into another. Also they are always printed out as 2D maths."
-msgstr ""
+msgstr "У рівнянь є декілька переваг над функціями. Наприклад, рівняння можна обробляти за допомогою функцій factor(), expand() тощо. Рівняння можна дуже просто вставляти одне в інше. Крім того, рівняння завжди виводяться як звичайні формули."
 
 #: ../../src/MaximaFileIO.cpp:64 ../../src/MaximaFileIO.cpp:121
 #: ../../src/MaximaFileIO.cpp:130 ../../src/MaximaFileIO.cpp:399
@@ -3738,11 +3738,11 @@ msgstr "Екранує усі спеціальні символи у рядку.
 
 #: ../../src/sidebars/GreekSidebar.cpp:184
 msgid "Eta"
-msgstr ""
+msgstr "Η"
 
 #: ../../src/sidebars/TableOfContents.cpp:513
 msgid "Evaluate"
-msgstr ""
+msgstr "Обчислити"
 
 #: ../../src/wxMaximaFrame.cpp:1689
 msgid "Evaluate &Noun Forms..."
@@ -3876,11 +3876,11 @@ msgstr "Парне число"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2659
 msgid "Example text"
-msgstr ""
+msgstr "Текст прикладу"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1547
 msgid "Examples:"
-msgstr ""
+msgstr "Приклади:"
 
 #: ../../src/wxMaximaFrame.cpp:1740
 msgid "Execute a command for each element of the list"
@@ -3892,11 +3892,11 @@ msgstr "Вийти"
 
 #: ../../src/sidebars/MathSidebar.cpp:53
 msgid "Expand"
-msgstr ""
+msgstr "Розкрити"
 
 #: ../../src/sidebars/MathSidebar.cpp:68
 msgid "Expand (tr)"
-msgstr ""
+msgstr "Розкрити (триг)"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:356
 msgid "Expand Expression"
@@ -3941,7 +3941,7 @@ msgstr "Експорт"
 
 #: ../../src/sidebars/History.cpp:152
 msgid "Export As"
-msgstr ""
+msgstr "Експортувати як"
 
 #: ../../src/wxMaximaFrame.cpp:1742
 msgid "Export List to csv file..."
@@ -3957,15 +3957,15 @@ msgstr "Експортувати матрицю до файла CSV"
 
 #: ../../src/sidebars/History.cpp:102
 msgid "Export all history to a .mac file"
-msgstr ""
+msgstr "Експортувати увесь журнал до файла .mac"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1016
 msgid "Export all settings"
-msgstr ""
+msgstr "Експортувати усі параметри"
 
 #: ../../src/sidebars/History.cpp:105
 msgid "Export commands from the current maxima session to a .mac file"
-msgstr ""
+msgstr "Експортувати команди з поточного сеансу maxima до файла .mac"
 
 #: ../../src/wxMaximaFrame.cpp:652
 msgid "Export document to a HTML or LaTeX file"
@@ -3973,7 +3973,7 @@ msgstr "Експортувати документ до файла HTML або ф
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1218
 msgid "Export equations to HTML as:"
-msgstr ""
+msgstr "Експортувати рівняння до HTML як:"
 
 #: ../../src/wxMaximaFrame.cpp:600
 msgid "Export failed."
@@ -3989,7 +3989,7 @@ msgstr ""
 
 #: ../../src/sidebars/History.cpp:108
 msgid "Export selected commands to a .mac file"
-msgstr ""
+msgstr "Експортувати позначені команди до файла .mac"
 
 #: ../../src/wxMaximaFrame.cpp:588
 msgid "Export successful."
@@ -4001,11 +4001,11 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1022
 msgid "Export the style settings"
-msgstr ""
+msgstr "Експортувати параметри стилю"
 
 #: ../../src/sidebars/History.cpp:111
 msgid "Export visible commands to a .mac file"
-msgstr ""
+msgstr "Експортувати видимі команди до файла .mac"
 
 #: ../../src/MaximaCommandMenus.cpp:3417
 #, c-format
@@ -4019,7 +4019,7 @@ msgstr ""
 
 #: ../../src/sidebars/History.cpp:228
 msgid "Exporting to .mac file failed!"
-msgstr ""
+msgstr "Не вдалося експортувати дані до файла .mac!"
 
 #: ../../src/MaximaCommandMenus.cpp:2343
 msgid "Exporting to HTML failed!"
@@ -4055,19 +4055,19 @@ msgstr "Вираз або список виразів, які відокремл
 
 #: ../../src/wizards/DrawWiz.cpp:733
 msgid "Expression that calculates the x value"
-msgstr ""
+msgstr "Вираз для обчислення значення x"
 
 #: ../../src/wizards/DrawWiz.cpp:738
 msgid "Expression that calculates the y value"
-msgstr ""
+msgstr "Вираз для обчислення значення y"
 
 #: ../../src/wizards/DrawWiz.cpp:744
 msgid "Expression that calculates the z value"
-msgstr ""
+msgstr "Вираз для обчислення значення z"
 
 #: ../../src/wizards/DrawWiz.cpp:56
 msgid "Expression to plot"
-msgstr ""
+msgstr "Вираз для креслення"
 
 #: ../../src/wxMaximaFrame.cpp:1122
 msgid "Expression to string..."
@@ -4222,7 +4222,7 @@ msgstr "Видобуває прямокутник з двовимірного м
 
 #: ../../src/sidebars/MathSidebar.cpp:50
 msgid "Factor"
-msgstr ""
+msgstr "Розкласти на множники"
 
 #: ../../src/wxMaximaFrame.cpp:1558
 msgid "Factor Complex"
@@ -4297,7 +4297,7 @@ msgstr "Поля:"
 #: ../../src/cells/GroupCell.cpp:2115
 #, c-format
 msgid "Figure %d:"
-msgstr ""
+msgstr "Рисунок %d:"
 
 #: ../../src/main.cpp:678
 msgid "File"
@@ -4349,7 +4349,7 @@ msgstr "Назва файла або список назв файлів, від�
 
 #: ../../src/sidebars/DrawSidebar.cpp:93
 msgid "Fill color"
-msgstr ""
+msgstr "Заповнення кольором"
 
 #: ../../src/ToolBar.cpp:401 ../../src/ToolBar.cpp:403
 msgid "Find"
@@ -4470,7 +4470,7 @@ msgstr "Знайти максимальну суму значень за мод�
 
 #: ../../src/dialogs/FindReplacePane.cpp:46
 msgid "Find:"
-msgstr ""
+msgstr "Знайти:"
 
 #: ../../src/wxMaximaFrame.cpp:1869
 msgid "Fine-tune the display of engineering-format numbers"
@@ -4478,7 +4478,7 @@ msgstr "Скоригувати показ чисел у науковому фо�
 
 #: ../../src/dialogs/ConfigDialogue.cpp:197
 msgid "Finnish"
-msgstr ""
+msgstr "фінська"
 
 #: ../../src/wxMaximaFrame.cpp:1749
 msgid "First"
@@ -4491,11 +4491,11 @@ msgstr "Криві апроксимації для даних вимірюван
 #: ../../src/dialogs/ConfigDialogue.cpp:1404
 #, c-format
 msgid "Fix reordered reference indices (of %i, %o) before saving"
-msgstr ""
+msgstr "Виправити перевпорядковані індекси посилань (%i, %o) до збереження"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:873
 msgid "Fixed font in text controls"
-msgstr ""
+msgstr "Шрифт сталої ширини у текстових мітках"
 
 #: ../../src/MaximaCommandMenus.cpp:4039
 msgid "Flush stream"
@@ -4523,11 +4523,11 @@ msgstr ""
 
 #: ../../src/wizards/DrawWiz.cpp:341
 msgid "Following plots use secondary x axis"
-msgstr ""
+msgstr "Наступні графіки використовують вторинну вісь x"
 
 #: ../../src/wizards/DrawWiz.cpp:347
 msgid "Following plots use secondary y axis"
-msgstr ""
+msgstr "Наступні графіки використовують вторинну вісь y"
 
 #: ../../src/sidebars/PerformanceSidebar.cpp:37
 msgid "Font cache hits:"
@@ -4539,11 +4539,11 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2047
 msgid "Fonts"
-msgstr ""
+msgstr "Шрифти"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:442
 msgid "For each Text-, Sectioning or code cell wxMaxima can display a bracket showing the extend of the cell and allowing to fold it. This setting now tells if this bracket is to be printed, as well."
-msgstr ""
+msgstr "Для кожної текстової комірки, комірки розділу або комірки з кодом wxMaxima може показувати дужку, що позначає продовження комірки і надає змогу її згорнути. За допомогою цього параметра можна визначити, чи слід виводити таку дужку на друк."
 
 #: ../../src/ToolBar.cpp:495
 msgid "For faster creation of cells the following shortcuts exist:\n\n"
@@ -4575,7 +4575,7 @@ msgstr "Цикл for…"
 
 #: ../../src/wizards/Plot2dWiz.cpp:69 ../../src/wizards/Plot3dWiz.cpp:60
 msgid "Format:"
-msgstr ""
+msgstr "Формат:"
 
 #: ../../src/worksheet/Worksheet.cpp:301 ../../src/wxMaxima.cpp:3521
 msgid "Forwarding the keyboard focus to a text control"
@@ -4620,15 +4620,15 @@ msgstr ""
 
 #: ../../src/wizards/DrawWiz.cpp:488
 msgid "Frame counter"
-msgstr ""
+msgstr "Лічильник кадрів"
 
 #: ../../src/wizards/DrawWiz.cpp:499
 msgid "Frame counter end"
-msgstr ""
+msgstr "Кінець лічильника кадрів"
 
 #: ../../src/wizards/DrawWiz.cpp:494
 msgid "Frame counter start"
-msgstr ""
+msgstr "Початок лічильника кадрів"
 
 #: ../../src/MaximaCommandMenus.cpp:102
 msgid "Frame rate"
@@ -4640,7 +4640,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:198
 msgid "French"
-msgstr ""
+msgstr "французька"
 
 #: ../../src/wxMaximaFrame.cpp:1447
 msgid "Frobenius Norm sqrt(sum((A(i,j))^2)) (complex)"
@@ -4723,11 +4723,11 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:199
 msgid "Galician"
-msgstr ""
+msgstr "галісійська"
 
 #: ../../src/sidebars/GreekSidebar.cpp:180
 msgid "Gamma"
-msgstr ""
+msgstr "Γ"
 
 #: ../../src/wxMaximaFrame.cpp:316
 msgid "General Math"
@@ -4779,7 +4779,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:201
 msgid "German"
-msgstr ""
+msgstr "німецька"
 
 #: ../../src/wxMaximaFrame.cpp:1656
 msgid "Get &Imaginary Part"
@@ -4867,7 +4867,7 @@ msgstr "Є більшим, якщо ігнорувати регістр…"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:202
 msgid "Greek"
-msgstr ""
+msgstr "грецька"
 
 #: ../../src/wxMaximaFrame.cpp:281
 msgid "Greek Letters"
@@ -4879,11 +4879,11 @@ msgstr "Грецькі літери\tAlt+Shift+G"
 
 #: ../../src/sidebars/DrawSidebar.cpp:97
 msgid "Grid"
-msgstr ""
+msgstr "Сітка"
 
 #: ../../src/wizards/Plot3dWiz.cpp:52
 msgid "Grid:"
-msgstr ""
+msgstr "Сітка:"
 
 #: ../../src/wxMaximaFrame.cpp:1852
 msgid "Guess an exact number that could be meant by this float"
@@ -4891,7 +4891,7 @@ msgstr "Вгадати точне число, яке могло б бути пр
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1215
 msgid "HTML"
-msgstr ""
+msgstr "HTML"
 
 #: ../../src/MaximaCommandMenus.cpp:2279
 msgid "HTML file (*.html)|*.html|maxima batch file (*.mac)|*.mac|LaTeX file (*.tex)|*.tex"
@@ -4939,7 +4939,7 @@ msgstr "Довідка"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1461
 msgid "Help browser:"
-msgstr ""
+msgstr "Перегляд довідки:"
 
 #: ../../src/ToolBar.cpp:835
 msgid "Help button"
@@ -4958,7 +4958,7 @@ msgstr ""
 
 #: ../../src/sidebars/TableOfContents.cpp:510
 msgid "Hide"
-msgstr ""
+msgstr "Приховати"
 
 #: ../../src/ToolBar.cpp:471 ../../src/ToolBar.cpp:473
 msgid "Hide Code"
@@ -4998,7 +4998,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:487
 msgid "Hide all multiplication signs that aren't really necessary for understanding the equation"
-msgstr ""
+msgstr "Приховувати усі символи множення, які не є обов'язковими для розуміння рівняння"
 
 #: ../../src/wxMaximaFrame.cpp:767
 msgid "Hide all panes"
@@ -5018,15 +5018,15 @@ msgstr "Приховувати крапки множення"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:854
 msgid "Hide multiplication signs, if possible"
-msgstr ""
+msgstr "Приховувати, якщо можна, знаки множення"
 
 #: ../../src/wizards/DrawWiz.cpp:555
 msgid "Hide objects behind the surface"
-msgstr ""
+msgstr "Приховувати об'єкти за поверхнею"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:502
 msgid "Hide the brackets that mark the extend of the worksheet cells at the worksheet's right side and that contain the \"hide\" button of the cell if the cells aren't active."
-msgstr ""
+msgstr "Приховати дужки, які позначають продовження комірок робочого аркуша на правому полі і містять кнопку приховування комірки, якщо комірки не є активними."
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:702
 #: ../../src/worksheet/WorksheetContextMenu.cpp:835
@@ -5044,11 +5044,11 @@ msgstr "Підсвітити (box)"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:869
 msgid "Highlight the matching parenthesis"
-msgstr ""
+msgstr "Підсвічувати парні дужки"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:463
 msgid "Highlight the opening or closing parenthesis for the parenthesis the cursor is at."
-msgstr ""
+msgstr "Підсвічувати відповідну початкову і кінцеву дужки для дужки, на якій перебуває курсор."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:204
 msgid "Hindi"
@@ -5060,7 +5060,7 @@ msgstr "Гістограма"
 
 #: ../../src/sidebars/StatSidebar.cpp:85
 msgid "Histogram..."
-msgstr ""
+msgstr "Гістограма…"
 
 #: ../../src/wxMaximaFrame.cpp:246
 msgid "History"
@@ -5072,7 +5072,7 @@ msgstr "Журнал\tAlt+Shift+I"
 
 #: ../../src/dialogs/TipOfTheDay.cpp:105
 msgid "Horizontal cursor works like a normal cursor, but it operates on cells: press up or down arrow to move it, holding down Shift while moving will select cells, pressing backspace or delete twice will delete a cell next to it."
-msgstr ""
+msgstr "Горизонтальний курсор працює як звичайний курсор, але виконує дії над комірками: пересувати курсор можна клавішами зі стрілками вниз і вгору, утримування клавіші Shift під час пересування курсора призводить до позначення комірок, натискання клавіші Backspace або подвійне натискання клавіші Delete призводить до вилучення вмісту комірки поряд з курсором."
 
 #: ../../src/wxMaximaFrame.cpp:1563
 msgid "Horner's rule"
@@ -5080,7 +5080,7 @@ msgstr "Правило Горнера"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:918
 msgid "Hotkeys for sending commands to maxima"
-msgstr ""
+msgstr "Комбінації клавіш для надсилання команд maxima"
 
 #: ../../src/MaximaCommandMenus.cpp:398
 msgid "How many digits to show:"
@@ -5092,7 +5092,7 @@ msgstr "Як показувати нові рівняння"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:205
 msgid "Hungarian"
-msgstr ""
+msgstr "угорська"
 
 #: ../../src/wxMaximaFrame.cpp:1147
 msgid "I/O"
@@ -5100,7 +5100,7 @@ msgstr "В/В"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:121
 msgid "Identical to"
-msgstr ""
+msgstr "Ідентичний до"
 
 #: ../../src/MaximaCommandMenus.cpp:3874
 msgid "If a program doesn't need local variables, Maxima allows putting the commands between parentheses. The result of the last operation is the return value of the program."
@@ -5108,51 +5108,51 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:145
 msgid "If maxima versions compiled with different lisps are installed: The name of the lisp to use by default"
-msgstr ""
+msgstr "Якщо встановлено версії maxima, які зібрано різними компіляторами Lisp: назва Lisp, які слід типово використовувати"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:174
 msgid "If maxima was compiled by GCL: Garbage Collect at minimum allocation past this heapsize"
-msgstr ""
+msgstr "Якщо maxima було зібрано з GCL: збирати «сміття» лише після того, як мінімальний розподіл перевищить цей розмір «купи»"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:171
 msgid "If maxima was compiled by GCL: Minimum allocation fraction between Garbage Collects"
-msgstr ""
+msgstr "Якщо maxima було зібрано з GCL: мінімальна частка розподілу пам'яті між збираннями «сміття»"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:168
 msgid "If maxima was compiled by GCL: Only garbage collect past this heapsize fraction of working mem"
-msgstr ""
+msgstr "Якщо maxima було зібрано з GCL: збирати «сміття» лише після того, як частка «купи» перевищить це значення у робочій пам'яті"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:180
 msgid "If maxima was compiled by GCL: Share the allocated memory between gcl processes. Allows more than one gcl-compiled maxima to run at the same time, but might provoke crashes."
-msgstr ""
+msgstr "Якщо maxima було зібрано з GCL: спільно використовувати розподілену пам'ять між процесами gcl. Уможливлює запуск декількох зібраних за допомогою gcl екземплярів maxima одночасно, але може провокувати аварійні завершення роботи."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:177
 msgid "If maxima was compiled by GCL: The fraction of the total installed RAM to reserve for maxima"
-msgstr ""
+msgstr "Якщо maxima було зібрано з GCL: частка загальної встановленої оперативної пам'яті, яку слід зарезервувати для maxima"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:375
 msgid "If multiple cells are evaluated in one go: Abort evaluation if wxMaxima detects that maxima has encountered any error."
-msgstr ""
+msgstr "Якщо виконується обчислення у декількох комірках послідовно: перервати обчислення, якщо wxMaxima буде виявлено, що обробка у maxima призвела до помилки."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:727
 msgid "If not extremely long"
-msgstr ""
+msgstr "Якщо не надзвичайно довго"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:726
 msgid "If not very long"
-msgstr ""
+msgstr "Якщо не дуже довго"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:418
 msgid "If numbers are getting longer than this number of digits they will be displayed abbreviated by an ellipsis."
-msgstr ""
+msgstr "Якщо кількість цифр у числі перевищуватиме вказану, їх буде обрізано, а решту показано трикрапкою."
 
 #: ../../src/dialogs/TipOfTheDay.cpp:181
 msgid "If the \"Autosave\" functionality is enabled in the configuration dialogue wxMaxima acts like mobile apps that backup the file every few minutes and save it on closing."
-msgstr ""
+msgstr "Якщо у діалоговому вікні налаштовування увімкнено можливість «Автозбереження», wxMaxima працюватиме як мобільні програми, які створюють резервну копію файлів кожні декілька хвилин і зберігають файли під час завершення роботи."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:396
 msgid "If the font provides big parenthesis symbols: Use them when big parenthesis are needed for maths display."
-msgstr ""
+msgstr "Якщо у шрифті є символи для великих дужок, використовувати їх для показу великих дужок у формулах."
 
 #: ../../src/cells/TextCell.cpp:327
 msgid "If the thing maxima complains about actually looks like a polynomial you can try running it through ratdisrep() in order to fix that problem."
@@ -5168,15 +5168,15 @@ msgstr "Якщо тип параметра функції є відомим, п�
 
 #: ../../src/dialogs/ConfigDialogue.cpp:399
 msgid "If this checkbox is checked wxMaxima automatically saves the file closing and every few minutes giving wxMaxima a more cellphone-app-like feel as the file is virtually always saved. If this checkbox is unchecked from time to time a backup is made in the temp folder instead."
-msgstr ""
+msgstr "Якщо позначено цей пункт, wxMaxima автоматично зберігатиме файл при закритті і кожні декілька хвилин. Це надасть wxMaxima подібної до мобільного телефону поведінки, оскільки файл майже завжди перебуватиме у збереженому стані. Якщо цей пункт не буде позначено, програма час від часу створюватиме резервну копію файла у теці тимчасових даних."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:378
 msgid "If this checkbox is set a new code cell is opened as soon as maxima requests data. If it isn't set a new code cell is opened in this case as soon as the user starts typing in code."
-msgstr ""
+msgstr "Якщо буде позначено цей пункт, програма відкриватиме нову комірку коду кожного разу, коли maxima надсилатиме запит щодо даних. Якщо пункт не позначено, нову комірку коду буде відкрито, коли користувач починатиме вводити код."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:372
 msgid "If this checkbox isn't checked the current command is sent to maxima only on pressing Ctrl+Enter"
-msgstr ""
+msgstr "Якщо цей пункт не позначено, поточну команду буде надіслано до maxima лише після натискання комбінації Ctrl+Enter"
 
 #: ../../src/MathParser.cpp:945
 msgid "If this isn't a function returning a lambda() expression a multiplication sign (*) between closing and opening parenthesis is missing here."
@@ -5189,7 +5189,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:439
 msgid "If this option is set the .wxmx source of the current file is copied to a place a link to is put into the result of an export."
-msgstr ""
+msgstr "Якщо позначено цей пункт, код .wxmx поточного файла буде скопійовано до місця, на яке вказуватиме посилання у експортованому результаті."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1873
 msgid "If unset, Maxima's output is announced to the screen reader as maths in a linear text form. Set this option if your screen reader can speak MathML properly."
@@ -5197,15 +5197,15 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:247
 msgid "If you have ideas, how to improve the design or functionality of wxMaxima, please share your ideas at the issue list or discussion forum at https://github.com/wxMaxima-developers/wxmaxima/."
-msgstr ""
+msgstr "Маєте думки щодо удосконалення дизайну або функціональних можливостей wxMaxima? Будь ласка, поділіться вашими ідеями у списку вад або на форумі обговорення https://github.com/wxMaxima-developers/wxmaxima/."
 
 #: ../../src/dialogs/TipOfTheDay.cpp:76
 msgid "If you type an operator (one of +*/^=,) as the first symbol in an input cell, % will be automatically inserted before the operator, as on a graphing calculator. You can disable this feature from the 'Edit->Configure' dialog."
-msgstr ""
+msgstr "Якщо першим символом у комірці для введення даних ви введете оператор (один із символів +*/^=,), перед оператором буде автоматично додано %, як у калькуляторах. Вимкнути таку поведінку програми можна за допомогою діалогового вікна «Зміни → Налаштувати»."
 
 #: ../../src/dialogs/TipOfTheDay.cpp:122
 msgid "If your calculation is taking too long to evaluate, you can try 'Maxima->Interrupt' or 'Maxima->Restart Maxima' menu commands."
-msgstr ""
+msgstr "Якщо обчислення триває надто довго, ви можете спробувати перервати його за допомогою пунктів меню «Maxima → Перервати» та «Maxima → Перезапустити Maxima»."
 
 #: ../../src/MaximaManual.cpp:420
 msgid "Ignoring the cache version for the manual anchors."
@@ -5213,7 +5213,7 @@ msgstr "Ігноруємо версію кешу для прив'язок у п�
 
 #: ../../src/sidebars/FormatSidebar.cpp:66
 msgid "Image"
-msgstr ""
+msgstr "Зображення"
 
 #: ../../src/Image.cpp:110
 msgid "Image data had zero length!"
@@ -5235,15 +5235,15 @@ msgstr "ImageCell без зображення."
 
 #: ../../src/sidebars/DrawSidebar.cpp:60
 msgid "Implicit Plot"
-msgstr ""
+msgstr "Графік неявної функції"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1028
 msgid "Import settings"
-msgstr ""
+msgstr "Імпортувати параметри"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1013
 msgid "Import+Export"
-msgstr ""
+msgstr "Імпорт+Експорт"
 
 #: ../../src/MathParser.cpp:395
 msgid "Importing compressed gnuplot sources for an animation"
@@ -5278,11 +5278,11 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:214
 msgid "In text cells bullet lists can be created by beginning a line with \" * \". The number of spaces in front of the \"*\" determines the indentation level; Indentation can be continued in the next line by indenting the line using spaces."
-msgstr ""
+msgstr "У текстових комірках списки з позначками можна створити, розпочинаючи рядок з « * ». Кількість пробілів перед символом «*» визначає рівень відступів. Відступи можна продовжити на наступному рядку додавши на його початку потрібну кількість пробілів."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:421
 msgid "In the LaTeX output: Put exponents after an eventual subscript instead of above it. Might increase readability for some fonts and short subscripts."
-msgstr ""
+msgstr "У виведеному коді LaTeX: розташовувати степені після останнього нижнього індексу, а не над ним. Може зробити читання зручнішим для деяких шрифтів та коротких нижніх індексів."
 
 #: ../../src/MaximaCommandMenus.cpp:1869
 msgid "Include columns:"
@@ -5294,15 +5294,15 @@ msgstr "Функція, що зростає, f(x)>x"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:884
 msgid "Incremental Search"
-msgstr ""
+msgstr "Покроковий пошук"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:844
 msgid "Indent equations by the label width"
-msgstr ""
+msgstr "Відступ у рівняннях на ширину мітки"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:512
 msgid "Indent maths so all lines are in par with the first line that starts after the label."
-msgstr ""
+msgstr "Встановити відступ у рівняннях так, щоб усі рядки було вирівняно за першим рядком, який розпочинається після мітки."
 
 #: ../../src/sidebars/TableOfContents.cpp:583
 msgid "Indentation"
@@ -5343,7 +5343,7 @@ msgstr ""
 #: ../../src/wizards/IntegrateWiz.cpp:215 ../../src/wizards/LimitWiz.cpp:132
 #: ../../src/wizards/LimitWiz.cpp:140
 msgid "Infinity"
-msgstr ""
+msgstr "Нескінченність"
 
 #: ../../src/wxMaximaFrame.cpp:1986
 msgid "Info about Maxima build"
@@ -5401,7 +5401,7 @@ msgstr "Вставити"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:889
 msgid "Insert % before an operator at the beginning of a cell"
-msgstr ""
+msgstr "Додавати % перед оператором на початку комірки"
 
 #: ../../src/wxMaximaFrame.cpp:939
 msgid "Insert &Section Cell\tCtrl+3"
@@ -5537,7 +5537,7 @@ msgstr ""
 
 #: ../../src/sidebars/HelpBrowser.cpp:111
 msgid "Instantiating the HTML manual browser"
-msgstr ""
+msgstr "Створюємо екземпляр браузера підручника HTML"
 
 #: ../../src/MaximaProcessManager.cpp:1066
 msgid "Instructed to prefer gnuplot over wgnuplot"
@@ -5549,11 +5549,11 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:749
 msgid "Integers and single letters"
-msgstr ""
+msgstr "Цілі числа і окремі літери"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:113
 msgid "Integral sign"
-msgstr ""
+msgstr "Символ інтеграла"
 
 #: ../../src/MaximaCommandMenus.cpp:149 ../../src/MaximaCommandMenus.cpp:170
 msgid "Integral/Sum:"
@@ -5587,15 +5587,15 @@ msgstr "Проінтегрувати…"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:834
 msgid "Intelligently hide cell brackets"
-msgstr ""
+msgstr "Розумно приховати дужки комірок"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:881
 msgid "Interaction"
-msgstr ""
+msgstr "Взаємодія"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1349
 msgid "Interactive popup memory limit [MB/plot]:"
-msgstr ""
+msgstr "Інтерактивне рухоме обмеження на пам'ять [МБ/креслення]:"
 
 #: ../../src/wxMaximaFrame.cpp:1774
 msgid "Interleave"
@@ -5611,7 +5611,7 @@ msgstr "Накласти два списки"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1465
 msgid "Internal"
-msgstr ""
+msgstr "Внутрішній"
 
 #: ../../src/wxMaximaFrame.cpp:1121
 msgid "Interpret like input..."
@@ -5660,7 +5660,7 @@ msgstr "Впроваджує одне або декілька встановле
 
 #: ../../src/sidebars/RegexCtrl.cpp:40
 msgid "Invalid RegEx!"
-msgstr ""
+msgstr "Некоректний формальний вираз!"
 
 #: ../../src/MathParser.cpp:1338
 #, c-format
@@ -5677,7 +5677,7 @@ msgstr "Обернене п&еретворення Лапласа…"
 
 #: ../../src/sidebars/GreekSidebar.cpp:186
 msgid "Iota"
-msgstr ""
+msgstr "Ι"
 
 #: ../../src/MaximaCommandMenus.cpp:4150
 msgid "Is Char 1 greater than Char2, if case is ignored?"
@@ -5793,7 +5793,7 @@ msgstr "Є верхнім регістром…"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:498
 msgid "Issue a notification if maxima finishes calculating while the wxMaxima window isn't in focus."
-msgstr ""
+msgstr "Видавати сповіщення, якщо maxima завершує обчислення, доки wxMaxima не перебуває у фокусі."
 
 #: ../../src/worksheet/Worksheet.cpp:4237
 msgid "Issuing the active cell's undo function"
@@ -5805,27 +5805,27 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:185
 msgid "It is possible to add custom symbols to the \"symbols\" sidebar by copying them into the respective field in the configuration dialogue."
-msgstr ""
+msgstr "Передбачено можливість додавання нетипових символів на бічну панель «символи». Достатньо скопіювати ці символи до відповідного поля у діалоговому вікні налаштовування."
 
 #: ../../src/dialogs/TipOfTheDay.cpp:152
 msgid "It is possible to define reusable Maxima libraries with wxMaxima that can be later loaded by using the load() function. All that has to be done is to export a file in the .mac or to save it in the .wxm format. Note, though, that a few special characters like the \"not equal\" symbol for \"#\" are handled by wxMaxima, not by Maxima and therefore cannot be recognized on load()."
-msgstr ""
+msgstr "Можна визначити бібліотеки Maxima, які wxMaxima має завантажити за допомогою функції load(). Для цього всього лише треба експортувати відповідні команди до файла у форматі .mac або зберегти їх у форматі .wxm. Втім, зауважте, що деякі спеціальні символи, зокрема символ «не дорівнює» та символ «#» обробляються wxMaxima. Їх не може бути оброблено у Maxima, отже розпізнано функцією load()."
 
 #: ../../src/wizards/DrawWiz.cpp:476
 msgid "It needs to be filled with objects to draw afterwards."
-msgstr ""
+msgstr "Має бути заповнено об'єктами для наступного креслення."
 
 #: ../../src/wizards/ActualValuesStorageWiz.cpp:38
 msgid "It therefore makes sense to apply the known values for variables as late as possible."
-msgstr ""
+msgstr "Тому варто застосовувати відомі значення змінних якомога пізніше."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:207
 msgid "Italian"
-msgstr ""
+msgstr "італійська"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2111
 msgid "Italic"
-msgstr ""
+msgstr "Курсив"
 
 #: ../../src/MaximaCommandMenus.cpp:1617 ../../src/MaximaCommandMenus.cpp:1623
 msgid "Item"
@@ -5837,7 +5837,7 @@ msgstr "Назва ітератора:"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:208
 msgid "Japanese"
-msgstr ""
+msgstr "японська"
 
 #: ../../src/MaximaCommandMenus.cpp:2255
 msgid "Jump to UUID"
@@ -5865,16 +5865,16 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:210
 msgid "Kabyle"
-msgstr ""
+msgstr "кабильська"
 
 #: ../../src/sidebars/GreekSidebar.cpp:187
 msgid "Kappa"
-msgstr ""
+msgstr "Κ"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:864
 #, c-format
 msgid "Keep percent sign with special symbols: %e, %i, etc."
-msgstr ""
+msgstr "Додавати символ відсотків до спеціальних символів: %e, %i тощо"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:212
 msgid "Korean"
@@ -5902,19 +5902,19 @@ msgstr "Норма L[inf] (дійсна)"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1166
 msgid "LaTeX"
-msgstr ""
+msgstr "LaTeX"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1199
 msgid "LaTeX: Place exponents after, instead above subscripts"
-msgstr ""
+msgstr "LaTeX: розташовувати степені за нижніми індексами, а не над ними"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1204
 msgid "LaTeX: Use the \"partial derivative\" symbol to represent diff()"
-msgstr ""
+msgstr "LaTeX: використовувати символ частинної похідної для diff()"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:758
 msgid "Label width:"
-msgstr ""
+msgstr "Ширина мітки:"
 
 #: ../../src/wxMaximaFrame.cpp:1059
 msgid "Labels"
@@ -5935,11 +5935,11 @@ msgstr "Лямбда створює функцію, але не надає їй 
 
 #: ../../src/dialogs/ConfigDialogue.cpp:470
 msgid "Language used for wxMaxima GUI."
-msgstr ""
+msgstr "Мова інтерфейсу wxMaxima."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1311
 msgid "Language:"
-msgstr ""
+msgstr "Мова:"
 
 #: ../../src/MaximaCommandMenus.cpp:251
 msgid "Laplace"
@@ -5986,7 +5986,7 @@ msgstr "Не вдалося запустити типову програму д�
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:126
 msgid "Leads to"
-msgstr ""
+msgstr "Тобто"
 
 #: ../../src/wxMaximaFrame.cpp:1530
 msgid "Least Common Multiple..."
@@ -5998,11 +5998,11 @@ msgstr "Наближення за методом найменших квадра
 
 #: ../../src/sidebars/StatSidebar.cpp:79
 msgid "Least Squares Fit..."
-msgstr ""
+msgstr "Наближення за методом найменших квадратів…"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2007
 msgid "Left"
-msgstr ""
+msgstr "Ліворуч"
 
 #: ../../src/MaximaCommandMenus.cpp:1166 ../../src/MaximaCommandMenus.cpp:1171
 #: ../../src/MaximaCommandMenus.cpp:1191 ../../src/MaximaCommandMenus.cpp:1197
@@ -6035,12 +6035,12 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:163
 msgid "Libraries can be accessed by any wxMaxima process regardless of which directory it runs in, if they are placed in the user directory. This directory can be found by typing maxima_userdir;"
-msgstr ""
+msgstr "Доступ до бібліотек для будь-якого процесу wxMaxima, незалежно від каталогу, у якому він працює, можна забезпечити розташуванням цих бібліотек у каталозі користувача. Визначити потрібний каталог можна за допомогою команди maxima_userdir;"
 
 #: ../../src/dialogs/LicenseDialog.cpp:63
 #: ../../src/dialogs/LicenseDialog.cpp:77
 msgid "License"
-msgstr ""
+msgstr "Ліцензування"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2068
 msgid "Light"
@@ -6056,15 +6056,15 @@ msgstr "Границя"
 
 #: ../../src/sidebars/MathSidebar.cpp:86
 msgid "Limit..."
-msgstr ""
+msgstr "Границя…"
 
 #: ../../src/sidebars/DrawSidebar.cpp:88
 msgid "Line color"
-msgstr ""
+msgstr "Колір лінії"
 
 #: ../../src/sidebars/StatSidebar.cpp:76
 msgid "Linear Regression..."
-msgstr ""
+msgstr "Лінійна регресія…"
 
 #: ../../src/MaximaCommandMenus.cpp:4068
 msgid "Lisp format string:"
@@ -6112,15 +6112,15 @@ msgstr "Вивести список каталогу…"
 
 #: ../../src/wizards/ListSortWiz.cpp:34
 msgid "List name:"
-msgstr ""
+msgstr "Назва списку:"
 
 #: ../../src/sidebars/VariablesPane.cpp:188
 msgid "List of arrays"
-msgstr ""
+msgstr "Список масивів"
 
 #: ../../src/sidebars/VariablesPane.cpp:191
 msgid "List of changed options"
-msgstr ""
+msgstr "Список змінених параметрів"
 
 #: ../../src/MaximaCommandMenus.cpp:4197
 msgid "List of char to String"
@@ -6136,47 +6136,47 @@ msgstr "Список символів:"
 
 #: ../../src/sidebars/VariablesPane.cpp:179
 msgid "List of functional dependencies"
-msgstr ""
+msgstr "Список функціональних залежностей"
 
 #: ../../src/sidebars/VariablesPane.cpp:203
 msgid "List of labels"
-msgstr ""
+msgstr "Список міток"
 
 #: ../../src/sidebars/VariablesPane.cpp:200
 msgid "List of structs"
-msgstr ""
+msgstr "Список структур"
 
 #: ../../src/sidebars/VariablesPane.cpp:197
 msgid "List of user aliases"
-msgstr ""
+msgstr "Список альтернативних команд користувача"
 
 #: ../../src/sidebars/VariablesPane.cpp:185
 msgid "List of user functions"
-msgstr ""
+msgstr "Список функцій користувача"
 
 #: ../../src/sidebars/VariablesPane.cpp:194
 msgid "List of user rules"
-msgstr ""
+msgstr "Список правил користувача"
 
 #: ../../src/sidebars/VariablesPane.cpp:182
 msgid "List of user variables"
-msgstr ""
+msgstr "Список змінних користувача"
 
 #: ../../src/sidebars/VariablesPane.cpp:206
 msgid "List of user-defined derivatives"
-msgstr ""
+msgstr "Список визначених користувачем похідних"
 
 #: ../../src/sidebars/VariablesPane.cpp:216
 msgid "List of user-defined let rule packages"
-msgstr ""
+msgstr "Список let-правил користувача"
 
 #: ../../src/sidebars/VariablesPane.cpp:212
 msgid "List of user-defined macros"
-msgstr ""
+msgstr "Список визначених користувачем макросів"
 
 #: ../../src/sidebars/VariablesPane.cpp:209
 msgid "List of user-defined properties"
-msgstr ""
+msgstr "Список визначених користувачем властивостей"
 
 #: ../../src/MaximaCommandMenus.cpp:1575
 msgid "List with values"
@@ -6197,7 +6197,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2162
 msgid "Load"
-msgstr ""
+msgstr "Завантажити"
 
 #: ../../src/MaximaCommandMenus.cpp:2356
 msgid "Load Package"
@@ -6237,7 +6237,7 @@ msgstr "Завантажити lisp…"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2645
 msgid "Load style from file"
-msgstr ""
+msgstr "Завантажити стиль з файла"
 
 #: ../../src/wxMaximaFrame.cpp:1232
 msgid "Load the file/dir operations (operatingsystem)"
@@ -6253,7 +6253,7 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:128
 msgid "Long Right arrow"
-msgstr ""
+msgstr "Довга стрілка праворуч"
 
 #: ../../src/MaximaCommandMenus.cpp:1409
 msgid "Loop variable"
@@ -6273,7 +6273,7 @@ msgstr "М&атриця"
 
 #: ../../src/sidebars/XmlInspector.cpp:104
 msgid "MAXIMA RESPONSE:"
-msgstr ""
+msgstr "ВІДПОВІДЬ MAXIMA:"
 
 #: ../../src/MaximaCommandMenus.cpp:3965
 msgid "Macro contents:"
@@ -6337,7 +6337,7 @@ msgstr "Відобразити функцію у матрицю з врахув�
 
 #: ../../src/dialogs/FindReplacePane.cpp:71
 msgid "Match Case"
-msgstr ""
+msgstr "З урахуванням регістру"
 
 #: ../../src/Styles.cpp:139
 msgid "Math Default"
@@ -6349,7 +6349,7 @@ msgstr ""
 
 #: ../../src/cells/Cell.cpp:1490
 msgid "Math output"
-msgstr ""
+msgstr "Виведення формул"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1221
 msgid "MathML (rendered by the browser)"
@@ -6361,11 +6361,11 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1906
 msgid "MathML as HTML"
-msgstr ""
+msgstr "MathML як HTML"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1902
 msgid "MathML description"
-msgstr ""
+msgstr "Опис MathML"
 
 #: ../../src/wxMaximaFrame.cpp:307
 msgid "Mathematical Symbols"
@@ -6445,11 +6445,11 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:281
 msgid "Maxima"
-msgstr ""
+msgstr "Maxima"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1433
 msgid "Maxima Location"
-msgstr ""
+msgstr "Розташування Maxima"
 
 #: ../../src/MaximaCommandMenus.cpp:619
 msgid "Maxima allows making functions \"nouns\", which means that they aren't automatically evaluated as soon as Maxima encounters them.\n"
@@ -6483,19 +6483,19 @@ msgstr "Maxima автоматично спрощує вирази, які отр
 
 #: ../../src/cells/EditorCell.cpp:4516
 msgid "Maxima code"
-msgstr ""
+msgstr "Код Maxima"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1110
 msgid "Maxima commands to be executed at every start of Maxima"
-msgstr ""
+msgstr "Команди Maxima, які слід виконувати під час кожного запуску Maxima"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1063
 msgid "Maxima commands to be executed every time wxMaxima starts Maxima"
-msgstr ""
+msgstr "Команди Maxima, які слід виконувати кожного разу, коли wxMaxima запускає Maxima"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1507
 msgid "Maxima configuration"
-msgstr ""
+msgstr "Налаштування Maxima"
 
 #: ../../src/MaximaResponseReader.cpp:346
 msgid "Maxima didn't attempt to authenticate!"
@@ -6571,11 +6571,11 @@ msgstr "Процес Maxima несподівано перервав роботу
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1437
 msgid "Maxima program:"
-msgstr ""
+msgstr "Програма Maxima:"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:382
 msgid "Maxima provides no \"forget all\" command that flushes all settings a maxima session could make. wxMaxima therefore normally defaults to starting a fresh maxima process every time the worksheet is to be re-evaluated. As this needs a little bit of time this switch allows to disable this behavior."
-msgstr ""
+msgstr "У Maxima передбачено команду «забути все», яка вилучає усі параметри поточного сеансу роботи з maxima. Через це wxMaxima зазвичай починає новий сеанс maxima кожного разу, коли надходить команда щодо повторного обчислення робочого аркуша. Оскільки перезапуск maxima потребує певного часу, передбачено цей пункт, за допомогою якого можна вимкнути перезапуск сеансів і заощадити трохи часу."
 
 #: ../../src/Styles.cpp:108
 msgid "Maxima question labels"
@@ -6595,7 +6595,7 @@ msgstr "Maxima надсилає новий набір змінних для сп
 
 #: ../../src/sidebars/History.cpp:153
 msgid "Maxima session (*.mac)|*.mac"
-msgstr ""
+msgstr "сеанс Maxima (*.mac)|*.mac"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1518 ../../src/wxMaximaFrame.cpp:1981
 msgid "Maxima shows help in a browser"
@@ -6627,11 +6627,11 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1143
 msgid "Maxima startup file location: "
-msgstr ""
+msgstr "Розташування файла запуску Maxima: "
 
 #: ../../src/dialogs/TipOfTheDay.cpp:68
 msgid "Maxima supports three types of numbers: exact fractions (which can be generated for example by typing 1/10), IEEE floating-point numbers (0.2) and arbitrary precision big floats (1b-1). Note that, owing to their nature as binary (not decimal) numbers, there is for example no way to generate an IEEE floating-point number that exactly equals 0.1. If floating-point numbers are used instead of fractions, Maxima will therefore sometimes have to introduce a (very small) error and use things like 3602879701896397/36028797018963968 for 0.1."
-msgstr ""
+msgstr "У Maxima передбачено три типи чисел: звичайні дроби (їх можна записати, наприклад так: 1/10), числа IEEE з рухомою крапкою (0.2) та необмежені десяткові дроби довільної точності (1b-1). Зауважте, що через природу двійкових дробів, які не є десятковими числами, наприклад, не можна записати число IEEE з рухомою крапкою, яке точно дорівнюватиме 0.1. Якщо у Maxima використовуються числа з рухомою крапкою, замість звичайних дробів, виникає помилка (дуже мала), тобто використання числа 3602879701896397/36028797018963968 замість 0.1 додає (дуже малу) похибку."
 
 #: ../../src/wxMaximaFrame.cpp:1265
 msgid "Maxima to other language"
@@ -6647,7 +6647,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1615
 msgid "Maxima usage"
-msgstr ""
+msgstr "Використання Maxima"
 
 #: ../../src/MaximaResponseReader.cpp:776
 #, c-format
@@ -6743,7 +6743,7 @@ msgstr ""
 
 #: ../../src/wizards/ActualValuesStorageWiz.cpp:34
 msgid "Maxima's power lies in symbolic operations."
-msgstr ""
+msgstr "Перевага Maxima полягає у символічних обчисленнях."
 
 #: ../../src/StatusBar.cpp:365
 msgid "Maxima's reader is in Lisp mode (after to_lisp()).\n"
@@ -6790,7 +6790,7 @@ msgstr "Максимальне абсолютне значення, яке мо�
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1931
 msgid "Maximum bitmap size on clipboard [Mb]:"
-msgstr ""
+msgstr "Розмір растрового зображення Maximum у буфері [МБ]:"
 
 #: ../../src/MaximaCommandMenus.cpp:488 ../../src/MaximaCommandMenus.cpp:501
 #: ../../src/MaximaCommandMenus.cpp:516 ../../src/MaximaCommandMenus.cpp:530
@@ -6803,19 +6803,19 @@ msgstr "Максимальна показана кількість цифр:"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:811
 msgid "Maximum number of displayed digits:"
-msgstr ""
+msgstr "Максимальна кількість показаних цифр:"
 
 #: ../../src/sidebars/StatSidebar.cpp:70
 msgid "Mean Difference Test..."
-msgstr ""
+msgstr "Перевірка рівності середніх значень…"
 
 #: ../../src/sidebars/StatSidebar.cpp:67
 msgid "Mean Test..."
-msgstr ""
+msgstr "Перевірка рівності середніх…"
 
 #: ../../src/sidebars/StatSidebar.cpp:52
 msgid "Mean..."
-msgstr ""
+msgstr "Середнє…"
 
 #: ../../src/MaximaCommandMenus.cpp:1806
 msgid "Mean:"
@@ -6823,7 +6823,7 @@ msgstr "Середнє:"
 
 #: ../../src/sidebars/StatSidebar.cpp:55
 msgid "Median..."
-msgstr ""
+msgstr "Медіана…"
 
 #: ../../src/wxMaximaFrame.cpp:1961
 msgid "Memoizing"
@@ -6844,7 +6844,7 @@ msgstr "Повідомлення зі stdout Maxima: "
 
 #: ../../src/wizards/IntegrateWiz.cpp:55
 msgid "Method:"
-msgstr ""
+msgstr "Метод:"
 
 #: ../../src/wxMaximaFrame.cpp:1360
 msgid "Methods of generating a matrix"
@@ -6870,11 +6870,11 @@ msgstr "Мінімальне абсолютне значення, яке мож�
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1270
 msgid "Misc"
-msgstr ""
+msgstr "Інше"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1963
 msgid "Misc settings"
-msgstr ""
+msgstr "Різні параметри"
 
 #: ../../src/wxMaxima.cpp:3134 ../../src/wxMaxima.cpp:3136
 msgid "Mismatched parenthesis"
@@ -6911,7 +6911,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:189
 msgid "Mu"
-msgstr ""
+msgstr "Μ"
 
 #: ../../src/wxMaximaFrame.cpp:1386
 msgid "Multiplication, exponent and similar"
@@ -6935,7 +6935,7 @@ msgstr "Назва t:"
 
 #: ../../src/wizards/DrawWiz.cpp:750
 msgid "Name of the parameter"
-msgstr ""
+msgstr "Назва параметра"
 
 #: ../../src/MaximaCommandMenus.cpp:1019
 msgid "Name of x:"
@@ -6943,7 +6943,7 @@ msgstr "Назва x:"
 
 #: ../../src/wizards/MatWiz.cpp:163
 msgid "Name:"
-msgstr ""
+msgstr "Назва:"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:216
 msgid "Nepali"
@@ -7006,7 +7006,7 @@ msgstr "Новий документ"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:901
 msgid "New lines: Jump to text"
-msgstr ""
+msgstr "Нові рядки: перейти до тексту"
 
 #: ../../src/MaximaResponseReader.cpp:1015
 #, c-format
@@ -7019,7 +7019,7 @@ msgstr "Нова частина:"
 
 #: ../../src/wizards/SubstituteWiz.cpp:35
 msgid "New value:"
-msgstr ""
+msgstr "Нове значення:"
 
 #: ../../src/MaximaCommandMenus.cpp:151 ../../src/MaximaCommandMenus.cpp:171
 #: ../../src/MaximaCommandMenus.cpp:254 ../../src/MaximaCommandMenus.cpp:259
@@ -7057,7 +7057,7 @@ msgstr ""
 
 #: ../../src/wizards/DrawWiz.cpp:636
 msgid "No contour lines"
-msgstr ""
+msgstr "Без контурних ліній"
 
 #: ../../src/dialogs/DiffFrame.cpp:304
 msgid "No differences"
@@ -7094,11 +7094,11 @@ msgstr "Не знайдено відповідників."
 
 #: ../../src/wizards/DrawWiz.cpp:651
 msgid "No plot, only contour lines"
-msgstr ""
+msgstr "Без креслення, лише контурні лінії"
 
 #: ../../src/wizards/DrawWiz.cpp:837
 msgid "No points"
-msgstr ""
+msgstr "Без точок"
 
 #: ../../src/MaximaResponseReader.cpp:145
 msgid "No topics found in topic flag"
@@ -7114,7 +7114,7 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:179
 msgid "Non-builtin symbols"
-msgstr ""
+msgstr "Невбудовані символи"
 
 #: ../../src/wxMaximaFrame.cpp:834
 msgid "None"
@@ -7122,7 +7122,7 @@ msgstr "Немає"
 
 #: ../../src/sidebars/StatSidebar.cpp:73
 msgid "Normality Test..."
-msgstr ""
+msgstr "Перевірка нормальності…"
 
 #: ../../src/cells/TextCell.cpp:271
 msgid "Normally computers use floating-point numbers that can be handled incredibly fast while being accurate to dozens of digits. They will, though, introduce a small error into some common numbers. For example 0.1 is represented as 3602879701896397/36028797018963968.\n"
@@ -7133,11 +7133,11 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:431
 msgid "Normally html expects images to be rather low-res but space saving. These images tend to look rather blurry when viewed on modern screens. Therefore this setting was introduces that selects the factor by which the HTML export increases the resolution in respect to the default value."
-msgstr ""
+msgstr "Зазвичай, у html використовуються зображення із досить низькою роздільною здатністю для економії місця на пристрої зберігання даних. На сучасних екранах такі зображення виглядають доволі жалюгідно. Тому, за допомогою цього параметра можна визначити коефіцієнт збільшення роздільної здатності під час експортування до HTML відносно типового значення."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:217
 msgid "Norwegian"
-msgstr ""
+msgstr "норвезька"
 
 #: ../../src/MaximaCommandMenus.cpp:1351
 msgid "Not a valid matrix dimension!"
@@ -7173,7 +7173,7 @@ msgstr "Не запускаємо обробку, оскільки немає п
 
 #: ../../src/sidebars/GreekSidebar.cpp:190
 msgid "Nu"
-msgstr ""
+msgstr "Ν"
 
 #: ../../src/MaximaCommandMenus.cpp:177
 msgid "Num. deg:"
@@ -7316,7 +7316,7 @@ msgstr "Непарне число"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:910
 msgid "Offer answers for questions known from previous runs"
-msgstr ""
+msgstr "Пропонувати відповіді на питання, відомі з попередніх запусків"
 
 #: ../../src/cells/TextCell.cpp:332
 msgid "Often caused by recursive function calls. Some lisps allow increasing the control stack size using command-line arguments."
@@ -7324,7 +7324,7 @@ msgstr ""
 
 #: ../../src/wizards/SubstituteWiz.cpp:32
 msgid "Old value:"
-msgstr ""
+msgstr "Попереднє значення:"
 
 #: ../../src/MaximaCommandMenus.cpp:151 ../../src/MaximaCommandMenus.cpp:172
 #: ../../src/MaximaCommandMenus.cpp:253 ../../src/MaximaCommandMenus.cpp:259
@@ -7333,11 +7333,11 @@ msgstr "Попередня змінна:"
 
 #: ../../src/sidebars/GreekSidebar.cpp:201
 msgid "Omega"
-msgstr ""
+msgstr "Ω"
 
 #: ../../src/sidebars/GreekSidebar.cpp:192
 msgid "Omicron"
-msgstr ""
+msgstr "Ο"
 
 #: ../../src/wxMaximaFrame.cpp:1089
 msgid "On all errors"
@@ -7361,7 +7361,7 @@ msgstr "Лише цілі числа і окремі літери"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:771
 msgid "Only user-defined labels"
-msgstr ""
+msgstr "Лише визначені користувачем мітки"
 
 #: ../../src/MaximaCommandMenus.cpp:2197 ../../src/ToolBar.cpp:330
 #: ../../src/ToolBar.cpp:333 ../../src/main.cpp:882
@@ -7370,7 +7370,7 @@ msgstr "Відкрити"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:905
 msgid "Open a cell when Maxima expects input"
-msgstr ""
+msgstr "Відкрити комірку, якщо Maxima очікує на вхідні дані"
 
 #: ../../src/wxMaximaFrame.cpp:629
 msgid "Open a document"
@@ -7444,7 +7444,7 @@ msgstr "Оптимізувати за пам'яттю"
 
 #: ../../src/wizards/DrawWiz.cpp:97
 msgid "Optional: A 2nd expression that defines a region to fill"
-msgstr ""
+msgstr "Необов'язкове: другий вираз, який визначає область для заповнення"
 
 #: ../../src/ToolBar.cpp:367 ../../src/ToolBar.cpp:369
 #: ../../src/dialogs/ConfigDialogue.cpp:284
@@ -7453,7 +7453,7 @@ msgstr "Параметри"
 
 #: ../../src/wizards/Plot2dWiz.cpp:75 ../../src/wizards/Plot3dWiz.cpp:66
 msgid "Options:"
-msgstr ""
+msgstr "Параметри:"
 
 #: ../../src/dialogs/FindReplacePane.cpp:109
 msgid "Output"
@@ -7514,7 +7514,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:458
 msgid "PNG images can be read by old wxMaxima versions - but aren't really scalable."
-msgstr ""
+msgstr "Зображення PNG можна було читати у старих версіях wxMaxima, але такі зображення не можна масштабувати."
 
 #: ../../src/MaximaCommandMenus.cpp:175
 msgid "Pade approximation"
@@ -7526,7 +7526,7 @@ msgstr "Паде-апроксимація ряду Тейлора"
 
 #: ../../src/sidebars/FormatSidebar.cpp:69
 msgid "Pagebreak"
-msgstr ""
+msgstr "Розрив сторінки"
 
 #: ../../src/wxMaximaFrame.cpp:1674
 msgid "Parallel Substitute..."
@@ -7538,7 +7538,7 @@ msgstr "Паралельне підставляння"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:124
 msgid "Parallel to"
-msgstr ""
+msgstr "Паралельно"
 
 #: ../../src/MaximaCommandMenus.cpp:3991
 msgid "Parameter name:"
@@ -7550,11 +7550,11 @@ msgstr "Параметри:"
 
 #: ../../src/sidebars/DrawSidebar.cpp:64
 msgid "Parametric Plot"
-msgstr ""
+msgstr "Графік параметричної функції"
 
 #: ../../src/wizards/Plot2dWiz.cpp:417 ../../src/wizards/Plot2dWiz.cpp:523
 msgid "Parametric plot"
-msgstr ""
+msgstr "Графік параметричної функції"
 
 #: ../../src/MaximaCommandMenus.cpp:4211
 msgid "Parse string"
@@ -7608,7 +7608,7 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:125
 msgid "Perpendicular to"
-msgstr ""
+msgstr "Перпендикулярно"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:218
 msgid "Persian"
@@ -7616,15 +7616,15 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:198
 msgid "Phi"
-msgstr ""
+msgstr "Φ"
 
 #: ../../src/sidebars/GreekSidebar.cpp:193
 msgid "Pi"
-msgstr ""
+msgstr "Π"
 
 #: ../../src/sidebars/StatSidebar.cpp:94
 msgid "Piechart..."
-msgstr ""
+msgstr "Кругова діаграма…"
 
 #: ../../src/wxMaxima.cpp:1585
 msgid "Please configure wxMaxima with 'Edit->Configure'."
@@ -7632,7 +7632,7 @@ msgstr "Налаштуйте wxMaxima за допомогою пункту ме�
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2606
 msgid "Please restart wxMaxima for changes to take effect!"
-msgstr ""
+msgstr "Для набуття змінами чинності wxMaxima слід перезавантажити!"
 
 #: ../../src/MaximaCommandMenus.cpp:2250
 msgid "Please select exactly 2 or 3 files."
@@ -7673,16 +7673,16 @@ msgstr "Тривимірний графік…"
 
 #: ../../src/wizards/DrawWiz.cpp:713
 msgid "Plot a parametric curve"
-msgstr ""
+msgstr "Накреслити графік функції, заданої параметрично"
 
 #: ../../src/wizards/DrawWiz.cpp:45 ../../src/wizards/DrawWiz.cpp:148
 #: ../../src/wizards/DrawWiz.cpp:255
 msgid "Plot an explicit expression"
-msgstr ""
+msgstr "Графік неявно заданої функції"
 
 #: ../../src/wizards/DrawWiz.cpp:53
 msgid "Plot an expression, for example sin(x) or (x+1)^2."
-msgstr ""
+msgstr "Накреслити графік виразу, наприклад sin(x) або (x+1)^2."
 
 #: ../../src/MaximaCommandMenus.cpp:1776
 msgid "Plot as bars"
@@ -7706,11 +7706,11 @@ msgstr "Тривимірний графік"
 
 #: ../../src/sidebars/DrawSidebar.cpp:83
 msgid "Plot name"
-msgstr ""
+msgstr "Назва графіка"
 
 #: ../../src/wizards/Plot2dWiz.cpp:84 ../../src/wizards/Plot3dWiz.cpp:80
 msgid "Plot to file:"
-msgstr ""
+msgstr "Вивести графік до файла:"
 
 #: ../../src/wxMaximaFrame.cpp:341 ../../src/wxMaximaFrame.cpp:749
 msgid "Plot using Draw"
@@ -7730,7 +7730,7 @@ msgstr "Точка, у якій відоме значення:"
 
 #: ../../src/wizards/DrawWiz.cpp:842
 msgid "Point type:"
-msgstr ""
+msgstr "Тип точки:"
 
 #: ../../src/MaximaCommandMenus.cpp:186 ../../src/MaximaCommandMenus.cpp:1090
 #: ../../src/wizards/BC2Wiz.cpp:33 ../../src/wizards/BC2Wiz.cpp:39
@@ -7740,11 +7740,11 @@ msgstr "Точка:"
 
 #: ../../src/sidebars/DrawSidebar.cpp:67
 msgid "Points"
-msgstr ""
+msgstr "Точки"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:219
 msgid "Polish"
-msgstr ""
+msgstr "польська"
 
 #: ../../src/MaximaCommandMenus.cpp:215 ../../src/MaximaCommandMenus.cpp:220
 #: ../../src/MaximaCommandMenus.cpp:225
@@ -7780,7 +7780,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:221
 msgid "Portuguese (Brazilian)"
-msgstr ""
+msgstr "португальська (Бразилія)"
 
 #: ../../src/wxMaximaFrame.cpp:1223
 msgid "Position of a match"
@@ -7796,7 +7796,7 @@ msgstr ""
 
 #: ../../src/wizards/Plot2dWiz.cpp:474 ../../src/wizards/Plot3dWiz.cpp:422
 msgid "Postscript file (*.eps)|*.eps|All|*"
-msgstr ""
+msgstr "файл Postscript (*.eps)|*.eps|усі файли|*"
 
 #: ../../src/MaximaCommandMenus.cpp:190
 msgid "Power series"
@@ -7816,7 +7816,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1492
 msgid "Prefer the all-in-one-file >1000 page manual"
-msgstr ""
+msgstr "Пріоритет підручника з одного файла і >1000 сторінок"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:389
 msgid "Prefer user labels"
@@ -7844,7 +7844,7 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:146
 msgid "Pressing Ctrl+Space or Ctrl+Tab starts an autocomplete function that can not only complete all functions that are integrated into the Maxima core and their parameters: It also knows about parameters from currently loaded packages and from functions that are defined in the current file."
-msgstr ""
+msgstr "Натискання комбінацій клавіш Ctrl+Пробіл або Ctrl+Tab викликає функцію автоматичного доповнення команд, які вбудовано до обчислювального ядра Maxima та їхніх параметрів. Засіб автоматичного доповнення також може доповнювати команди із поточних завантажених пакунків та функцій, визначених у поточному файлі."
 
 #: ../../src/wxMaximaFrame.cpp:961
 msgid "Previous Command\tAlt+Up"
@@ -7860,7 +7860,7 @@ msgstr "Надрукувати"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1988
 msgid "Print Margins"
-msgstr ""
+msgstr "Поля друку"
 
 #: ../../src/ToolBar.cpp:820
 msgid "Print button"
@@ -7881,15 +7881,15 @@ msgstr "Друкувати числа з рухомою крапкою із ст
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1968
 msgid "Print scale:"
-msgstr ""
+msgstr "Масштаб друку:"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1981
 msgid "Print the cell brackets [drawn to their left]"
-msgstr ""
+msgstr "Виводити дужки комірок [показуються ліворуч]"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:287
 msgid "Printout settings"
-msgstr ""
+msgstr "Параметри друку"
 
 #: ../../src/graphical_io/Printout.cpp:208
 msgid "Printout: Cannot find a suitable point for a page break!"
@@ -7935,7 +7935,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:936
 msgid "Privacy settings"
-msgstr ""
+msgstr "Параметри конфіденційності"
 
 #: ../../src/WXMXformat.cpp:256
 msgid "Produced invalid XML. The erroneous XML data has therefore not been saved but has been put on the clipboard in order to allow debugging it.\n"
@@ -7948,7 +7948,7 @@ msgstr "Добуток"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:123
 msgid "Product sign"
-msgstr ""
+msgstr "Знак добутку"
 
 #: ../../src/wxMaximaFrame.cpp:1129
 msgid "Program"
@@ -7972,7 +7972,7 @@ msgstr "Блок програми без локальних змінних…"
 
 #: ../../src/sidebars/GreekSidebar.cpp:200
 msgid "Psi"
-msgstr ""
+msgstr "Ψ"
 
 #: ../../src/wxMaximaFrame.cpp:1788
 msgid "Push"
@@ -7996,7 +7996,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1910
 msgid "RTF with OMML maths"
-msgstr ""
+msgstr "RTF із формулами у OMML"
 
 #: ../../src/MaximaCommandMenus.cpp:207
 msgid "Range radius:"
@@ -8058,7 +8058,7 @@ msgstr "Прочитати каталог"
 
 #: ../../src/sidebars/StatSidebar.cpp:103
 msgid "Read Matrix..."
-msgstr ""
+msgstr "Прочитати матрицю…"
 
 #: ../../src/MaximaCommandMenus.cpp:4008
 msgid "Read a structure field"
@@ -8074,7 +8074,7 @@ msgstr "Прочитати символ"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2488
 msgid "Read config to file"
-msgstr ""
+msgstr "Прочитати налаштування до файла"
 
 #: ../../src/MaximaCommandMenus.cpp:4405
 msgid "Read environment variable"
@@ -8187,7 +8187,7 @@ msgstr "Отримано перший запит maxima: %s"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1327
 msgid "Recent files list length:"
-msgstr ""
+msgstr "Довжина списку нещодавніх файлів:"
 
 #: ../../src/wxMaximaFrame.cpp:634
 msgid "Recover unsaved"
@@ -8195,7 +8195,7 @@ msgstr "Відновити незбережене"
 
 #: ../../src/sidebars/MathSidebar.cpp:56
 msgid "Rectform"
-msgstr ""
+msgstr "Алгебраїчна форма"
 
 #: ../../src/wxMaximaFrame.cpp:1677
 msgid "Recursive Substitute..."
@@ -8219,7 +8219,7 @@ msgstr "Повторити останню зміну"
 
 #: ../../src/sidebars/MathSidebar.cpp:71
 msgid "Reduce (tr)"
-msgstr ""
+msgstr "Привести (триг)"
 
 #: ../../src/wxMaximaFrame.cpp:1632
 msgid "Reduce trigonometric expression"
@@ -8236,7 +8236,7 @@ msgstr "Відмовлено у надсиланні комірки до maxima:
 
 #: ../../src/dialogs/FindReplacePane.cpp:85
 msgid "Regex"
-msgstr ""
+msgstr "Форм. вираз"
 
 #: ../../src/MaximaCommandMenus.cpp:4335
 msgid "Regex match"
@@ -8269,11 +8269,11 @@ msgstr "Перезавантажити зображення «%s»"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:997
 msgid "Reload all GUI settings from disc"
-msgstr ""
+msgstr "Перезавантажити усі параметр інтерфейсу з диска"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1004
 msgid "Reload the style settings from disc"
-msgstr ""
+msgstr "Перезавантажити усі параметри стилю з диска"
 
 #: ../../src/MaximaCommandMenus.cpp:3212
 #, c-format
@@ -8282,15 +8282,15 @@ msgstr "Перезавантажуємо файл зображення %s."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2573
 msgid "Reloading the configuration from disc"
-msgstr ""
+msgstr "Перезавантажуємо налаштування з диска"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2581
 msgid "Reloading the styles from disc"
-msgstr ""
+msgstr "Перезавантаження стилів з диска"
 
 #: ../../src/sidebars/VariablesPane.cpp:220
 msgid "Remove"
-msgstr ""
+msgstr "Вилучити"
 
 #: ../../src/wxMaximaFrame.cpp:917
 msgid "Remove All Output"
@@ -8306,7 +8306,7 @@ msgstr ""
 
 #: ../../src/sidebars/VariablesPane.cpp:225
 msgid "Remove all"
-msgstr ""
+msgstr "Вилучити всі"
 
 #: ../../src/wxMaximaFrame.cpp:1785
 msgid "Remove all list elements that appear twice in a row. Normally used in conjunction with sort."
@@ -8386,7 +8386,7 @@ msgstr "Повторне поелементне множення"
 
 #: ../../src/dialogs/FindReplacePane.cpp:117
 msgid "Replace All"
-msgstr ""
+msgstr "Замінити всі"
 
 #: ../../src/MaximaCommandMenus.cpp:4350
 msgid "Replace all regex matches"
@@ -8415,7 +8415,7 @@ msgstr "Замінено %li відповідників."
 
 #: ../../src/dialogs/FindReplacePane.cpp:62
 msgid "Replacement:"
-msgstr ""
+msgstr "Заміна:"
 
 #: ../../src/MaximaCommandMenus.cpp:768
 msgid "Replaces the subexpression that part(expr, n_1, n_2, ...) would select by a new value. The part numbers form a path: n_1 selects a part of the expression, n_2 a part of that, and so on."
@@ -8427,7 +8427,7 @@ msgstr "Повідомити про ваду"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:983
 msgid "Reset all GUI settings"
-msgstr ""
+msgstr "Скинути усі параметри графічного інтерфейсу"
 
 #: ../../src/wxMaximaFrame.cpp:1030
 msgid "Reset option variables"
@@ -8435,12 +8435,12 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:990
 msgid "Reset the Style settings"
-msgstr ""
+msgstr "Скинути параметри стилю"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2557
 #: ../../src/dialogs/ConfigDialogue.cpp:2565
 msgid "Resetting all configuration settings"
-msgstr ""
+msgstr "Скидаємо усі параметри налаштування"
 
 #: ../../src/ToolBar.cpp:411 ../../src/ToolBar.cpp:417
 #: ../../src/wxMaximaFrame.cpp:1008
@@ -8530,7 +8530,7 @@ msgstr ""
 
 #: ../../src/wizards/DrawWiz.cpp:836
 msgid "Reuse last"
-msgstr ""
+msgstr "Повторно використати останній"
 
 #: ../../src/wxMaximaFrame.cpp:1780
 msgid "Reverse"
@@ -8546,19 +8546,19 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:295
 msgid "Revert all to defaults"
-msgstr ""
+msgstr "Повернутися всюди до типових"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:980
 msgid "Revert changes"
-msgstr ""
+msgstr "Скасувати зміни"
 
 #: ../../src/sidebars/GreekSidebar.cpp:194
 msgid "Rho"
-msgstr ""
+msgstr "Ρ"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2015
 msgid "Right"
-msgstr ""
+msgstr "Праворуч"
 
 #: ../../src/MaximaCommandMenus.cpp:1167 ../../src/MaximaCommandMenus.cpp:1172
 #: ../../src/MaximaCommandMenus.cpp:1192 ../../src/MaximaCommandMenus.cpp:1198
@@ -8567,7 +8567,7 @@ msgstr "Права матриця:"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:127
 msgid "Right arrow"
-msgstr ""
+msgstr "Стрілка праворуч"
 
 #: ../../src/MaximaCommandMenus.cpp:1380
 msgid "Right end"
@@ -8607,7 +8607,7 @@ msgstr ""
 
 #: ../../src/wizards/MatWiz.cpp:152
 msgid "Rows:"
-msgstr ""
+msgstr "Рядків:"
 
 #: ../../src/MaximaCommandMenus.cpp:1391
 msgid "Rule"
@@ -8677,7 +8677,7 @@ msgstr "Пропускає кожен елемент крізь вираз"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:223
 msgid "Russian"
-msgstr ""
+msgstr "російська"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1578
 msgid "SBCL: use <int>Mbytes of heap"
@@ -8689,11 +8689,11 @@ msgstr ""
 
 #: ../../src/sidebars/XmlInspector.cpp:78
 msgid "SENT TO MAXIMA:"
-msgstr ""
+msgstr "НАДІСЛАНО ДО MAXIMA:"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1224
 msgid "SVG graphics"
-msgstr ""
+msgstr "графіка SVG"
 
 #: ../../src/MaximaCommandMenus.cpp:1810
 msgid "Sample 1:"
@@ -8709,19 +8709,19 @@ msgstr "Вибірка:"
 
 #: ../../src/wizards/DrawWiz.cpp:956
 msgid "Samples for explicit and parametric plots:"
-msgstr ""
+msgstr "Вибірки для неявних і параметричних креслень:"
 
 #: ../../src/wizards/DrawWiz.cpp:969
 msgid "Samples for implicit plots and regions:"
-msgstr ""
+msgstr "Вибірки для неявних креслень та областей:"
 
 #: ../../src/wizards/DrawWiz.cpp:937
 msgid "Samples for implicit plots:"
-msgstr ""
+msgstr "Вибірки для неявних креслень:"
 
 #: ../../src/wizards/DrawWiz.cpp:924
 msgid "Samples on a line:"
-msgstr ""
+msgstr "Вибірок на лінію:"
 
 #: ../../src/ToolBar.cpp:331 ../../src/ToolBar.cpp:334
 #: ../../src/dialogs/ConfigDialogue.cpp:2163 ../../src/wxMaxima.cpp:3507
@@ -8766,7 +8766,7 @@ msgstr "Зберегти як lisp…"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2478
 msgid "Save config to file"
-msgstr ""
+msgstr "Зберегти налаштування до файла"
 
 #: ../../src/ToolBar.cpp:331 ../../src/ToolBar.cpp:334
 #: ../../src/wxMaximaFrame.cpp:639
@@ -8779,7 +8779,7 @@ msgstr "Зберегти документ як"
 
 #: ../../src/wizards/Plot2dWiz.cpp:473 ../../src/wizards/Plot3dWiz.cpp:421
 msgid "Save plot to file"
-msgstr ""
+msgstr "Зберегти графік до файла"
 
 #: ../../src/wxMaximaFrame.cpp:713
 msgid "Save selection from document to an image file"
@@ -8791,11 +8791,11 @@ msgstr "Зберегти позначене до файла"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2640
 msgid "Save style to file"
-msgstr ""
+msgstr "Зберегти стиль до файла"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1384
 msgid "Save the worksheet automatically"
-msgstr ""
+msgstr "Зберігати робочий аркуш автоматично"
 
 #: ../../src/MaximaFileIO.cpp:873
 msgid "Saving failed!"
@@ -8811,7 +8811,7 @@ msgstr "Дані успішно збережено, але файли-резул
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1914
 msgid "Scalable Vector Graphics (svg)"
-msgstr ""
+msgstr "масштабовна векторна графіка (svg)"
 
 #: ../../src/MaximaCommandMenus.cpp:3536
 msgid "Scalable Vector image (*.svg)|*.svg|Compressed Scalable Vector Image (*.svgz)|*.svgz|PNG image (*.png)|*.png|JPEG image (*.jpg)|*.jpg|GIF image (*.gif)|*.gif|Windows bitmap (*.bmp)|*.bmp|"
@@ -8823,7 +8823,7 @@ msgstr "Точкова діаграма"
 
 #: ../../src/sidebars/StatSidebar.cpp:88
 msgid "Scatterplot..."
-msgstr ""
+msgstr "Точкова діаграма…"
 
 #: ../../src/Autocomplete.cpp:157
 msgid "Scheduling a background task that compiles a new list of autocompletable maxima commands."
@@ -8871,7 +8871,7 @@ msgstr ""
 
 #: ../../src/wizards/DrawWiz.cpp:158
 msgid "See also the speed <-> accuracy button."
-msgstr ""
+msgstr "Див. також кнопку «швидкість <-> точність»."
 
 #: ../../src/MaximaCommandMenus.cpp:4030
 msgid "Seek to position"
@@ -8887,7 +8887,7 @@ msgstr "Здається, пакунок із файлами спільного 
 
 #: ../../src/sidebars/TableOfContents.cpp:511
 msgid "Select"
-msgstr ""
+msgstr "Вибрати"
 
 #: ../../src/MaximaCommandMenus.cpp:2239
 msgid "Select 2 or 3 files to compare"
@@ -8914,7 +8914,7 @@ msgstr "Виберіть підвибірку"
 #: ../../src/wizards/IntegrateWiz.cpp:208 ../../src/wizards/LimitWiz.cpp:133
 #: ../../src/wizards/SeriesWiz.cpp:105
 msgid "Select a constant"
-msgstr ""
+msgstr "Виберіть сталу"
 
 #: ../../src/ToolBar.cpp:390 ../../src/ToolBar.cpp:392
 #: ../../src/wxMaximaFrame.cpp:710
@@ -8935,7 +8935,7 @@ msgstr "Виберіть спосіб показу математичних фо
 
 #: ../../src/dialogs/TipOfTheDay.cpp:109
 msgid "Selecting a part of an output and right-clicking on the selection will bring up a menu with convenient functions that will operate on the selection."
-msgstr ""
+msgstr "Якщо ви позначити частину виведених даних і клацнете на ній правою кнопкою миші, програма відкриє меню, за допомогою якого ви зможете отримати доступ до функцій з обробки позначеного фрагмента."
 
 #: ../../src/Styles.cpp:127
 msgid "Selection color"
@@ -9023,7 +9023,7 @@ msgstr "Встановити підвищену то&чність обчисле
 
 #: ../../src/dialogs/ConfigDialogue.cpp:479
 msgid "Set fixed font in text controls."
-msgstr ""
+msgstr "Встановити шрифт сталої ширини для текстових міток."
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:68
 #: ../../src/worksheet/WorksheetContextMenu.cpp:250
@@ -9032,7 +9032,7 @@ msgstr "Встановити роздільну здатність зображ�
 
 #: ../../src/dialogs/ResolutionChooser.cpp:29
 msgid "Set image resolution [in ppi]"
-msgstr ""
+msgstr "Встановити роздільну здатність зображення [у точках на дюйм]"
 
 #: ../../src/wxMaximaFrame.cpp:1547
 msgid "Set main variable..."
@@ -9040,7 +9040,7 @@ msgstr "Встановити основну змінну…"
 
 #: ../../src/dialogs/MaxSizeChooser.cpp:29
 msgid "Set maximum image size [in mm]"
-msgstr ""
+msgstr "Встановити максимальний розмір зображення [у мм]"
 
 #: ../../src/wxMaximaFrame.cpp:1810
 msgid "Set plot format"
@@ -9100,7 +9100,7 @@ msgstr "Встановити масштаб у 80%"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:163
 msgid "Sets the language, line ending type and charset encoding programs will use"
-msgstr ""
+msgstr "Встановлює мову інтерфейсу, тип розривів рядків та кодування символів, яке буде використано у програмах"
 
 #: ../../src/MaximaEvaluator.cpp:574
 #, c-format
@@ -9113,24 +9113,24 @@ msgstr "Встановлення форматів запиту і довідки
 
 #: ../../src/dialogs/ConfigDialogue.cpp:165
 msgid "Setting this to \"cat\" causes gnuplot not to halt if there is much output"
-msgstr ""
+msgstr "Встановлення значення «cat» призведе до того, що gnuplot не припинятиме обробку, якщо виведених даних буде надто багато"
 
 #: ../../src/wizards/DrawWiz.cpp:546
 msgid "Settings for the following 3d plots"
-msgstr ""
+msgstr "Параметри для наступних просторових креслень"
 
 #: ../../src/wizards/DrawWiz.cpp:462
 #, c-format
 msgid "Setup a %iD scene"
-msgstr ""
+msgstr "Налаштувати %iD-сцену"
 
 #: ../../src/sidebars/DrawSidebar.cpp:48
 msgid "Setup a 2D plot"
-msgstr ""
+msgstr "Налаштувати двовимірне креслення"
 
 #: ../../src/sidebars/DrawSidebar.cpp:52
 msgid "Setup a 3D plot"
-msgstr ""
+msgstr "Налаштувати тривимірне креслення"
 
 #: ../../src/wxMaximaFrame.cpp:1326
 msgid "Setup atvalues for solving ODE with Laplace transformation"
@@ -9142,11 +9142,11 @@ msgstr "Встановити обчислення за модулем"
 
 #: ../../src/sidebars/DrawSidebar.cpp:78
 msgid "Setup the axis"
-msgstr ""
+msgstr "Налаштувати вість"
 
 #: ../../src/wizards/DrawWiz.cpp:263
 msgid "Setup the axis for the current plot."
-msgstr ""
+msgstr "Налаштувати вість для поточного креслення."
 
 #: ../../src/MaximaCommandMenus.cpp:411
 msgid "Setup the engineering format"
@@ -9194,7 +9194,7 @@ msgstr "Показати всі команди, подібні до:"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:206
 msgid "Show all unicode symbols"
-msgstr ""
+msgstr "Показати усі символи Юнікод"
 
 #: ../../src/MaximaCommandMenus.cpp:2111
 msgid "Show an example for the command:"
@@ -9206,7 +9206,7 @@ msgstr "Показати приклад використання"
 
 #: ../../src/sidebars/History.cpp:121
 msgid "Show commands from current session only"
-msgstr ""
+msgstr "Показувати команди лише з поточного сеансу"
 
 #: ../../src/wxMaximaFrame.cpp:1921
 msgid "Show commands similar to"
@@ -9242,7 +9242,7 @@ msgstr "Показувати мітки вхідних даних"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:766
 msgid "Show labels:"
-msgstr ""
+msgstr "Показувати мітки:"
 
 #: ../../src/wxMaximaFrame.cpp:787
 msgid "Show lisp representation"
@@ -9250,11 +9250,11 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:465
 msgid "Show long expressions in wxMaxima document."
-msgstr ""
+msgstr "Показувати довгі вирази у документі wxMaxima."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:722
 msgid "Show long expressions:"
-msgstr ""
+msgstr "Показувати довгі вирази:"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:377
 msgid "Show max. 100 digits"
@@ -9318,7 +9318,7 @@ msgstr "Показувати кнопки скасування і повторе
 
 #: ../../src/dialogs/TipOfTheDay.cpp:288
 msgid "Show tips at Startup"
-msgstr ""
+msgstr "Показувати підказки під час запуску"
 
 #: ../../src/wxMaximaFrame.cpp:1040 ../../src/wxMaximaFrame.cpp:1045
 msgid "Show used + to-be-freed memory"
@@ -9343,11 +9343,11 @@ msgstr "Бічні панелі"
 
 #: ../../src/sidebars/GreekSidebar.cpp:195
 msgid "Sigma"
-msgstr ""
+msgstr "Σ"
 
 #: ../../src/dialogs/FindReplacePane.cpp:88
 msgid "Simple"
-msgstr ""
+msgstr "Простий"
 
 #: ../../src/MaximaCommandMenus.cpp:1819
 msgid "Simple linear regression"
@@ -9355,7 +9355,7 @@ msgstr ""
 
 #: ../../src/sidebars/MathSidebar.cpp:44
 msgid "Simplify"
-msgstr ""
+msgstr "Спростити"
 
 #: ../../src/wxMaximaFrame.cpp:1550
 msgid "Simplify &Radicals..."
@@ -9363,11 +9363,11 @@ msgstr "Спростити &радикали…"
 
 #: ../../src/sidebars/MathSidebar.cpp:47
 msgid "Simplify (r)"
-msgstr ""
+msgstr "Спростити (рац)"
 
 #: ../../src/sidebars/MathSidebar.cpp:65
 msgid "Simplify (tr)"
-msgstr ""
+msgstr "Спростити (триг)"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:352
 msgid "Simplify Expression"
@@ -9407,7 +9407,7 @@ msgstr "Спростити суми"
 
 #: ../../src/wizards/SumWiz.cpp:68
 msgid "Simplify the sum"
-msgstr ""
+msgstr "Спростити суму"
 
 #: ../../src/wxMaximaFrame.cpp:1629
 msgid "Simplify trigonometric expression"
@@ -9415,7 +9415,7 @@ msgstr "Спростити тригонометричний вираз"
 
 #: ../../src/dialogs/TipOfTheDay.cpp:139
 msgid "Since wxMaxima 0.8.2 you can also insert images into your documents. Use 'Cell->Insert Image...' menu command."
-msgstr ""
+msgstr "Починаючи з версії wxMaxima 0.8.2, ви можете вставляти до ваших документів зображення. Щоб вставити зображення, скористайтеся пунктом меню «Комірка → Вставити зображення…»."
 
 #: ../../src/wxMaximaFrame.cpp:1433
 msgid "Singular Values"
@@ -9447,7 +9447,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2113
 msgid "Slanted"
-msgstr ""
+msgstr "Нахилений"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:225
 msgid "Slovak"
@@ -9472,7 +9472,7 @@ msgstr "Розв'язок ЗДР:"
 
 #: ../../src/wizards/BC2Wiz.cpp:30
 msgid "Solution:"
-msgstr ""
+msgstr "Розв'язок:"
 
 #: ../../src/MaximaCommandMenus.cpp:3446
 msgid "Solve"
@@ -9512,7 +9512,7 @@ msgstr "Розв'язати ЗДР за допомогою перетворен�
 
 #: ../../src/sidebars/MathSidebar.cpp:77
 msgid "Solve ODE..."
-msgstr ""
+msgstr "Розв'язати ЗДР…"
 
 #: ../../src/wxMaximaFrame.cpp:1432
 msgid "Solve a linear equation system using dgesv"
@@ -9619,7 +9619,7 @@ msgstr "Упорядкувати"
 
 #: ../../src/wizards/ListSortWiz.cpp:41
 msgid "Sort Criterion:"
-msgstr ""
+msgstr "Критерій упорядковування:"
 
 #: ../../src/MaximaCommandMenus.cpp:1500
 msgid "Sort a list"
@@ -9639,16 +9639,16 @@ msgstr "Початковий список:"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:227
 msgid "Spanish"
-msgstr ""
+msgstr "іспанська"
 
 #: ../../src/wizards/IntegrateWiz.cpp:44 ../../src/wizards/IntegrateWiz.cpp:50
 #: ../../src/wizards/LimitWiz.cpp:38 ../../src/wizards/SeriesWiz.cpp:39
 msgid "Special"
-msgstr ""
+msgstr "Додатково"
 
 #: ../../src/wizards/DrawWiz.cpp:918
 msgid "Speed versus accuracy"
-msgstr ""
+msgstr "Швидкість <-> Точність"
 
 #: ../../src/MaximaCommandMenus.cpp:4241
 msgid "Split"
@@ -9676,7 +9676,7 @@ msgstr "Квадратні"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1300
 msgid "Standard Options"
-msgstr ""
+msgstr "Стандартні параметри"
 
 #: ../../src/Styles.cpp:115
 msgid "Standard Text"
@@ -9688,7 +9688,7 @@ msgstr "Почати анімацію"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1622
 msgid "Start a new maxima for each re-evaluation"
-msgstr ""
+msgstr "Запускати новий екземпляр maxima для кожного повторного обчислення"
 
 #: ../../src/MaximaCommandMenus.cpp:1023
 msgid "Start of t:"
@@ -9696,15 +9696,15 @@ msgstr "Початок для t:"
 
 #: ../../src/wizards/DrawWiz.cpp:66 ../../src/wizards/DrawWiz.cpp:171
 msgid "Start of the x value"
-msgstr ""
+msgstr "Початкове значення x"
 
 #: ../../src/wizards/DrawWiz.cpp:83 ../../src/wizards/DrawWiz.cpp:186
 msgid "Start of the y value"
-msgstr ""
+msgstr "Початкове значення y"
 
 #: ../../src/wizards/DrawWiz.cpp:203
 msgid "Start of the z value"
-msgstr ""
+msgstr "Початкове значення z"
 
 #: ../../src/ToolBar.cpp:507 ../../src/ToolBar.cpp:519
 msgid "Start or Stop animation"
@@ -9716,11 +9716,11 @@ msgstr "Розпочати або зупинити поточну позначе
 
 #: ../../src/dialogs/ConfigDialogue.cpp:496
 msgid "Start searching while the phrase to search for is still being typed."
-msgstr ""
+msgstr "Починати пошук, коли критерій пошуку ще продовжують вводити."
 
 #: ../../src/wizards/DrawWiz.cpp:755
 msgid "Start value of the parameter"
-msgstr ""
+msgstr "Початкове значення параметра"
 
 #: ../../src/wxMaxima.cpp:403
 msgid "Starting Maxima process failed"
@@ -9745,7 +9745,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:286
 msgid "Startup commands"
-msgstr ""
+msgstr "Команди запуску"
 
 #: ../../src/wxMaximaFrame.cpp:266
 msgid "Statistics"
@@ -9761,7 +9761,7 @@ msgstr "Ширина кроку:"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:939
 msgid "Store filenames in image cells to enable image reloading after re-opening the worksheet"
-msgstr ""
+msgstr "Зберігати назви файлів у комірках зображень, щоб уможливити перезавантаження після повторного відкриття робочого аркуша"
 
 #: ../../src/wxMaximaFrame.cpp:831
 msgid "Straight lines"
@@ -9787,7 +9787,7 @@ msgstr "Потік:"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2117
 msgid "Strike Through"
-msgstr ""
+msgstr "Перекреслений"
 
 #: ../../src/wxMaximaFrame.cpp:1219
 msgid "String"
@@ -9855,15 +9855,15 @@ msgstr "Структури"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:282
 msgid "Style"
-msgstr ""
+msgstr "Стиль"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2082
 msgid "Styles"
-msgstr ""
+msgstr "Стилі"
 
 #: ../../src/sidebars/StatSidebar.cpp:112
 msgid "Subsample..."
-msgstr ""
+msgstr "Підвибірка…"
 
 #: ../../src/ToolBar.cpp:484 ../../src/sidebars/FormatSidebar.cpp:54
 msgid "Subsection"
@@ -9883,7 +9883,7 @@ msgstr "Subst є кращим методом пошуку і заміни ряд
 
 #: ../../src/sidebars/MathSidebar.cpp:59
 msgid "Subst..."
-msgstr ""
+msgstr "Підставити…"
 
 #: ../../src/MaximaCommandMenus.cpp:715 ../../src/MaximaCommandMenus.cpp:3490
 #: ../../src/MaximaCommandMenus.cpp:4500 ../../src/wizards/SubstituteWiz.cpp:53
@@ -9959,7 +9959,7 @@ msgstr "Сума"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:122
 msgid "Sum sign"
-msgstr ""
+msgstr "Знак суми"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:228
 msgid "Swedish"
@@ -9988,7 +9988,7 @@ msgstr "Символи\tAlt+Shift+Y"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:472
 msgid "Symbols that are entered or copied here will appear in the symbols sidebar so they can be entered into the worksheet easily."
-msgstr ""
+msgstr "Символи, які буде введено або скопійовано сюди, з'являться на бічній панелі символів для спрощення їхнього введення до робочого аркуша."
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:778
 msgid "Symmetric function: f(x)=f(-x)"
@@ -10016,7 +10016,7 @@ msgstr "Зміст\tAlt+Shift+T"
 
 #: ../../src/wizards/DrawWiz.cpp:561
 msgid "Take surface color from steepness"
-msgstr ""
+msgstr "Вибирати колір поверхні за нахилом"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:229
 msgid "Tamil"
@@ -10024,7 +10024,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:196
 msgid "Tau"
-msgstr ""
+msgstr "Τ"
 
 #: ../../src/MaximaCommandMenus.cpp:181
 msgid "Taylor series"
@@ -10060,7 +10060,7 @@ msgstr "Наказує maxima показувати довідку для ком�
 
 #: ../../src/dialogs/ConfigDialogue.cpp:148
 msgid "Tells maxima where to store the result of compiling libraries"
-msgstr ""
+msgstr "Повідомляє maxima, де зберігати результат компіляції бібліотек"
 
 #: ../../src/ToolBar.cpp:481 ../../src/sidebars/FormatSidebar.cpp:45
 msgid "Text"
@@ -10072,7 +10072,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:738
 msgid "Text Only"
-msgstr ""
+msgstr "Лише текст"
 
 #: ../../src/Styles.cpp:122
 msgid "Text cell background"
@@ -10080,7 +10080,7 @@ msgstr "Тло текстової комірки"
 
 #: ../../src/dialogs/TipOfTheDay.cpp:219
 msgid "Text cells can hold citations that as marked as such by beginning a line with \" > \". The number of spaces in front of the \">\" determines the indentation level, as it does with bullet lists."
-msgstr ""
+msgstr "У текстових комірках можуть міститися цитати, які слід позначати, починаючи рядок з « > ». Кількість пробілів перед «>» визначає рівень відступу, так само як у списках із позначками."
 
 #: ../../src/MaximaCommandMenus.cpp:3001
 msgid "Text snippet"
@@ -10103,7 +10103,7 @@ msgstr "У процесі Maxima не передбачено сегмента с
 
 #: ../../src/dialogs/ConfigDialogue.cpp:392
 msgid "The URL MathJaX.js should be downloaded from by our HTML export."
-msgstr ""
+msgstr "Адреса, з якої слід отримати MathJaX.js під час експортування до HTML."
 
 #: ../../src/cells/TextCell.cpp:336
 msgid "The [] or the part() command tried to access a list or matrix element that doesn't exist."
@@ -10111,7 +10111,7 @@ msgstr ""
 
 #: ../../src/sidebars/DrawSidebar.cpp:106
 msgid "The accuracy versus speed tradeoff"
-msgstr ""
+msgstr "Баланс між точністю і швидкістю"
 
 #: ../../src/cells/TextCell.cpp:357
 msgid "The argument of a function was of the wrong type. Most probably an equation was expected but was lacking an \"=\"."
@@ -10135,7 +10135,7 @@ msgstr "Класичні дії, для яких типово використо
 
 #: ../../src/sidebars/DrawSidebar.cpp:91
 msgid "The color of the next line to draw"
-msgstr ""
+msgstr "Колір наступної лінії креслення"
 
 #: ../../src/MaximaCommandMenus.cpp:4005
 msgid "The comma-separated contents of the struct fields"
@@ -10155,48 +10155,48 @@ msgstr "Поточний майстер"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:415
 msgid "The default height for embedded plots. Can be read out or overridden by the maxima variable wxplot_size."
-msgstr ""
+msgstr "Типова висота вбудованих креслень. Їх можна прочитати або перевизначити за допомогою змінної maxima wxplot_size."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:492
 msgid "The default port used for communication between Maxima and wxMaxima."
-msgstr ""
+msgstr "Типовий порт для обміну даними між Maxima та wxMaxima"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:412
 msgid "The default width for embedded plots. Can be read out or overridden by the maxima variable wxplot_size"
-msgstr ""
+msgstr "Типова ширина вбудованих креслень. Їх можна прочитати або перевизначити за допомогою змінної maxima wxplot_size"
 
 #: ../../src/sidebars/DrawSidebar.cpp:74
 msgid "The diagram title"
-msgstr ""
+msgstr "Заголовок діаграми"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2401
 #, c-format
 msgid "The directory %s with maxima's startup file doesn't exist. Trying to create it..."
-msgstr ""
+msgstr "Каталогу %s із файлом запуску maxima не існує. Намагаємося його створити…"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:150
 msgid "The directory containing the startup files, any user libraries and, if MAXIMA_OBJDIR isn't set the subdirectory with the results from compiling maxima libraries."
-msgstr ""
+msgstr "Каталог, у якому містяться файли для запуску, будь-які бібліотеки користувача і, якщо не встановлено MAXIMA_OBJDIR, підкаталог із результатами компіляції бібліотек maxima."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:154
 msgid "The directory maxima places temporary files in, for example plots that are to be included in the worksheet."
-msgstr ""
+msgstr "Каталог, у якому maxima зберігає тимчасові файли, наприклад креслення, які має бути включено до робочого аркуша."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:157
 msgid "The directory the compiled versions of maxima are placed in"
-msgstr ""
+msgstr "Каталог, у якому зберігаються компільовані версії maxima"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:159
 msgid "The directory the maxima manual can be found in"
-msgstr ""
+msgstr "Каталог, у якому можна знайти підручник з maxima"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:160
 msgid "The directory the user's home directory is in"
-msgstr ""
+msgstr "Каталог, у якому розташовано домашній каталог користувача"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:475
 msgid "The document class LaTeX is instructed to use for our documents."
-msgstr ""
+msgstr "Клас документів LaTeX, який слід використовувати для наших документів."
 
 #: ../../src/MaximaCommandMenus.cpp:1832
 msgid "The equation to fit the data to"
@@ -10213,7 +10213,7 @@ msgstr ""
 
 #: ../../src/sidebars/DrawSidebar.cpp:96
 msgid "The fill color for the next objects"
-msgstr ""
+msgstr "Колір заповнення для наступних об'єктів"
 
 #: ../../src/cells/TextCell.cpp:354
 msgid "The first argument of subst() isn't an equation or a list of equations. Most probably it was lacking an \"=\"."
@@ -10225,7 +10225,7 @@ msgstr "Виклик функції, чиї аргументи слід видо
 
 #: ../../src/sidebars/DrawSidebar.cpp:100
 msgid "The grid in the background of the diagram"
-msgstr ""
+msgstr "Сітка у тлі діаграми"
 
 #: ../../src/wxMaximaFrame.cpp:1332
 msgid "The half of the equation that is to the left of the \"=\""
@@ -10259,11 +10259,11 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:223
 msgid "The key combination Shift+Space results in a non-breakable space."
-msgstr ""
+msgstr "Натискання комбінації клавіш Shift+Пробіл вводить нерозривний пробіл."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:162
 msgid "The list of directories the operating system looks for programs in"
-msgstr ""
+msgstr "Список каталогів, у яких операційна система шукає програми"
 
 #: ../../src/cells/TextCell.cpp:293
 msgid "The list of time-dependent variables to solve to doesn't match the time-dependent variables the list of dgls contains."
@@ -10275,7 +10275,7 @@ msgstr "Список змінних, що містяться у кожному �
 
 #: ../../src/dialogs/TipOfTheDay.cpp:166
 msgid "The load() command of Maxima versions >5.38 is able to load .wxm files as library of Maxima's commands."
-msgstr ""
+msgstr "Команда load() у версіях Maxima >5.38 може завантажувати файли .wxm як бібліотеки команд maxima."
 
 #: ../../src/wxMaximaFrame.cpp:228
 msgid "The main toolbar"
@@ -10291,7 +10291,7 @@ msgstr "Підручник з wxMaxima"
 
 #: ../../src/dialogs/MaxSizeChooser.cpp:59
 msgid "The maximum size for this image. Values <= 0 mean: Unspecified."
-msgstr ""
+msgstr "Максимальний розмір цього зображення. Значення <= 0 означають «не визначено»."
 
 #: ../../src/MaximaCommandMenus.cpp:3937
 msgid "The name of a function we don't want to be evaluated here"
@@ -10323,11 +10323,11 @@ msgstr "Назва змінної, у якій міститиметься пот
 
 #: ../../src/sidebars/DrawSidebar.cpp:86
 msgid "The next plot's title"
-msgstr ""
+msgstr "Заголовок наступного креслення"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:494
 msgid "The number of recently opened files that is to be remembered."
-msgstr ""
+msgstr "Кількість останніх відкритих файлів, дані яких слід пам'ятати."
 
 #: ../../src/MaximaCommandMenus.cpp:1471
 msgid "The number of the item which is stepped from \"Index Start\" to \"Index End\"."
@@ -10335,16 +10335,16 @@ msgstr "Номер пункту за кроками від «Початкови�
 
 #: ../../src/dialogs/ConfigDialogue.cpp:477
 msgid "The options the document class LaTeX is instructed to use for our documents gets."
-msgstr ""
+msgstr "Параметри класу документів LaTeX, який слід використовувати для наших документів."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1065
 #: ../../src/dialogs/ConfigDialogue.cpp:1112
 msgid "The part of the output of these commands that isn't declared as \"math\" might be suppressed by wxMaxima. As always maxima commands are required to end in a \";\" or a \"$\""
-msgstr ""
+msgstr "Частину даних, виведених цими командами і не оголошену як «math», могло бути придушено для показу wxMaxima. Як завжди, команди maxima слід завершувати символом «;» або «$»."
 
 #: ../../src/dialogs/ResolutionChooser.cpp:51
 msgid "The resolution for this image."
-msgstr ""
+msgstr "Роздільна здатність цього зображення."
 
 #: ../../src/cells/TextCell.cpp:182
 msgid "The result was indefinite, which might be infinity, both plus or minus infinity or something additionally potentially involving a complex infinity."
@@ -10407,7 +10407,7 @@ msgstr "Щоб це спрацювало, змінну розв'язання с�
 
 #: ../../src/sidebars/DrawSidebar.cpp:58
 msgid "The standard plot command: Plot an equation as a curve"
-msgstr ""
+msgstr "Стандартна команда креслення: накреслити рівняння як криву"
 
 #: ../../src/cells/TextCell.cpp:267
 msgid "The value of few special variables is assigned by Maxima and cannot be changed by the user. Also a few constructs aren't variable names and therefore cannot be written to."
@@ -10442,7 +10442,7 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:95
 msgid "There are many resources about Maxima and wxMaxima on the internet. Visit https://wxMaxima-developers.github.io/wxmaxima/help.html for more information and to find tutorials on using wxMaxima and Maxima."
-msgstr ""
+msgstr "У інтернеті можна знайти багато сторінок, присвячених Maxima та wxMaxima Відвідайте сторінку https://wxMaxima-developers.github.io/wxmaxima/help.html, щоб дізнатися більше і пошукати підручники щодо користування wxMaxima та Maxima."
 
 #: ../../src/dialogs/TipOfTheDay.cpp:251
 msgid "There is a discussion forum for wxMaxima at https://github.com/wxMaxima-developers/wxmaxima/discussions.\n"
@@ -10492,7 +10492,7 @@ msgstr "У XML була помилка, яка має описувати пов�
 
 #: ../../src/sidebars/GreekSidebar.cpp:185
 msgid "Theta"
-msgstr ""
+msgstr "Θ"
 
 #: ../../src/dialogs/LicenseDialog.cpp:85
 msgid "Third-party notices"
@@ -10513,7 +10513,7 @@ msgstr "Цей файл було створено за допомогою wxMaxi
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1097
 msgid "This file won't be read by maxima if maxima is used without wxMaxima. In order to add startup commands that are executed in this case, too, please add them to maxima-init.mac, instead."
-msgstr ""
+msgstr "Цей файл не буде прочитано maxima, якщо maxima використовується без wxMaxima. Щоб додати команди запуску, які виконуватимуться і у цьому випадку, будь ласка, запишіть їх до файла maxima-init.mac."
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:764
 msgid "This function will return even integers"
@@ -10546,7 +10546,7 @@ msgstr ""
 #: ../../src/wizards/DrawWiz.cpp:471
 #, c-format
 msgid "This wizard setups a %iD scene."
-msgstr ""
+msgstr "За допомогою цього майстра можна налаштувати %i-сцену."
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:752
 msgid "Throw an error if this symbol is used before assigning it any contents"
@@ -10554,11 +10554,11 @@ msgstr "Вивести повідомлення про помилку, якщо 
 
 #: ../../src/wizards/Plot2dWiz.cpp:65 ../../src/wizards/Plot2dWiz.cpp:505
 msgid "Ticks:"
-msgstr ""
+msgstr "Число точок:"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1359
 msgid "Time [in Minutes] between autosaves"
-msgstr ""
+msgstr "Час [у хвилинах] між автоматичними збереженнями"
 
 #: ../../src/MaximaCommandMenus.cpp:267 ../../src/MaximaCommandMenus.cpp:3487
 msgid "Times:"
@@ -10566,7 +10566,7 @@ msgstr "Порядок:"
 
 #: ../../src/dialogs/TipOfTheDay.cpp:49 ../../src/dialogs/TipOfTheDay.cpp:267
 msgid "Tip of the day"
-msgstr ""
+msgstr "Підказка дня"
 
 #: ../../src/ToolBar.cpp:482 ../../src/sidebars/FormatSidebar.cpp:48
 msgid "Title"
@@ -10582,7 +10582,7 @@ msgstr "Комірка заголовка (Заголовок 1)"
 
 #: ../../src/dialogs/TipOfTheDay.cpp:89
 msgid "Title, section and subsection cells can be folded to hide their contents. To fold or unfold, click in the square next to the cell. If you shift-click, all sublevels of that cell will also fold/unfold."
-msgstr ""
+msgstr "Вміст комірок заголовка, розділу та підрозділу можна згортати. Щоб згорнути або розгорнути вміст комірки, клацніть лівою кнопкою миші на квадратику поряд з коміркою. Якщо ви під час клацання утримуватимете натиснутою клавішу Shift, буде згорнуто або розгорнуто вміст всіх підлеглих щодо основної комірки комірок."
 
 #: ../../src/wxMaximaFrame.cpp:1831
 msgid "To &Bigfloat"
@@ -10610,19 +10610,19 @@ msgstr "У точне число"
 
 #: ../../src/dialogs/TipOfTheDay.cpp:124
 msgid "To plot in polar coordinates, select 'set polar' in the Options entry for Plot2d dialog. You can also plot in spherical and cylindrical coordinates in 3D."
-msgstr ""
+msgstr "Щоб побудувати графік у полярних координатах, позначте у діалоговому вікні «Двовимірний графік» пункт «set polar» у параметрах графіка. Для поверхонь у просторі можна вибирати сферичні або циліндричні координати."
 
 #: ../../src/dialogs/TipOfTheDay.cpp:131
 msgid "To put parentheses around an expression, select it, and press '(' or ')' depending on where you want the cursor to appear afterwards."
-msgstr ""
+msgstr "Щоб взяти вираз у дужки, позначте його і введіть «(» або «)», залежно від того, де має бути розташовано курсор після взяття виразу у дужки."
 
 #: ../../src/dialogs/TipOfTheDay.cpp:137
 msgid "To save the size and position of wxMaxima windows between session, use 'Edit->Configure' dialog."
-msgstr ""
+msgstr "Наказати wxMaxima зберігати розміри і розташування вікна можна за допомогою діалогового вікна «Зміни → Налаштувати»."
 
 #: ../../src/dialogs/TipOfTheDay.cpp:51
 msgid "To start using wxMaxima right away, start typing your command. An input cell should appear. Then press Shift-Enter to evaluate your command."
-msgstr ""
+msgstr "Після запуску wxMaxima ви можете одразу почати вводити команду. У відповідь програма покаже комірку для введення команди. Натисніть комбінацію клавіш Shift-Enter, щоб наказати програмі виконати команду."
 
 #: ../../src/MaximaCommandMenus.cpp:318 ../../src/wizards/IntegrateWiz.cpp:47
 #: ../../src/wizards/Plot2dWiz.cpp:51 ../../src/wizards/Plot2dWiz.cpp:61
@@ -10633,7 +10633,7 @@ msgstr "До:"
 
 #: ../../src/sidebars/TableOfContents.cpp:579
 msgid "Toc levels shown here"
-msgstr ""
+msgstr "Показати тут рівні змісту"
 
 #: ../../src/wxMaximaFrame.cpp:862 ../../src/wxMaximaFrame.cpp:865
 msgid "Toggle full screen editing"
@@ -10665,7 +10665,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1991
 msgid "Top"
-msgstr ""
+msgstr "Згори"
 
 #: ../../src/MaximaCommandMenus.cpp:1382
 msgid "Top end"
@@ -10806,7 +10806,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:230
 msgid "Turkish"
-msgstr ""
+msgstr "турецька"
 
 #: ../../src/wxMaximaFrame.cpp:1965
 msgid "Tutorials"
@@ -10822,7 +10822,7 @@ msgstr "Тип"
 
 #: ../../src/cells/EditorCell.cpp:4550
 msgid "Type in text"
-msgstr ""
+msgstr "Введіть текст"
 
 #: ../../src/MaximaCommandMenus.cpp:3992 ../../src/wizards/MatWiz.cpp:158
 msgid "Type:"
@@ -10842,7 +10842,7 @@ msgstr "UTF8 до позиції у таблиці Unicode…"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:231
 msgid "Ukrainian"
-msgstr ""
+msgstr "українська"
 
 #: ../../src/wxMaxima.cpp:3164
 msgid "Un-closed parenthesis"
@@ -10869,15 +10869,15 @@ msgstr ""
 #: ../../src/sidebars/VariablesPane.cpp:303
 #: ../../src/sidebars/VariablesPane.cpp:386
 msgid "Undefined"
-msgstr ""
+msgstr "Не визначено"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2115
 msgid "Underlined"
-msgstr ""
+msgstr "Підкреслення"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:745
 msgid "Underscore converts to subscripts:"
-msgstr ""
+msgstr "Символ підкреслювання означає нижній індекс:"
 
 #: ../../src/ToolBar.cpp:354 ../../src/ToolBar.cpp:357
 msgid "Undo"
@@ -10910,7 +10910,7 @@ msgstr "Розгорнути всі згорнути розділи"
 
 #: ../../src/sidebars/TableOfContents.cpp:507
 msgid "Unhide"
-msgstr ""
+msgstr "Скасувати приховування"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:665
 msgid "Unhide Heading 5"
@@ -10966,7 +10966,7 @@ msgstr "Позицію таблиці Unicode до чисел utf8"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:180
 msgid "Unicode symbols:"
-msgstr ""
+msgstr "Символи Юнікод:"
 
 #: ../../src/MaximaCommandMenus.cpp:3890
 msgid "Unlike in other programming language return() only exits from the current loop or block(), not from the whole function."
@@ -10982,11 +10982,11 @@ msgstr "Незавершений рядок."
 
 #: ../../src/wizards/ActualValuesStorageWiz.cpp:43
 msgid "Until then the actual values for all variables can be kept in a list."
-msgstr ""
+msgstr "Доти справжні значення усіх змінних будуть зберігатися у списку."
 
 #: ../../src/dialogs/DiffFrame.cpp:429 ../../src/dialogs/FindReplacePane.cpp:80
 msgid "Up"
-msgstr ""
+msgstr "Вище"
 
 #: ../../src/MaximaEvaluator.cpp:629
 msgid "Updating maxima's configuration"
@@ -11009,7 +11009,7 @@ msgstr "Верхня межа:"
 
 #: ../../src/sidebars/GreekSidebar.cpp:197
 msgid "Upsilon"
-msgstr ""
+msgstr "Υ"
 
 #: ../../src/wxMaximaFrame.cpp:829
 msgid "Use \"<\" and \">\" as parenthesis for matrices"
@@ -11021,7 +11021,7 @@ msgstr ""
 
 #: ../../src/wizards/SumWiz.cpp:69
 msgid "Use Gosper algorithm"
-msgstr ""
+msgstr "Використати алгоритм Госпера"
 
 #: ../../src/sidebars/RegexCtrl.cpp:133
 msgid "Use RegEx filtering"
@@ -11045,11 +11045,11 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:485
 msgid "Use centered dot and Minus, not Star and Hyphen"
-msgstr ""
+msgstr "Використовувати центровану крапку і мінус, а не зірочку і дефіс"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:849
 msgid "Use centered dot character for multiplication"
-msgstr ""
+msgstr "Використовувати крапку для позначення множення"
 
 #: ../../src/wxMaximaFrame.cpp:1745
 msgid "Use list"
@@ -11073,11 +11073,11 @@ msgstr "Скористатися поле структури…"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:425
 msgid "Use the \"partial derivative\" symbol to represent the fraction that represents a diff() when exporting LaTeX"
-msgstr ""
+msgstr "Використовувати символ частинної похідної для дробу, який відповідає diff(), під час експортування до LaTeX"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2052
 msgid "Use unicode Math Symbols, if available"
-msgstr ""
+msgstr "Використовувати математичні символи unicode, якщо доступні"
 
 #: ../../src/wxMaximaFrame.cpp:832
 msgid "Use vertical lines instead of parenthesis for matrices"
@@ -11092,7 +11092,7 @@ msgstr "Лише мітки користувача"
 #: ../../src/dialogs/ConfigDialogue.cpp:1480
 #: ../../src/dialogs/MaximaNotStartingDialog.cpp:54
 msgid "User specified"
-msgstr ""
+msgstr "Вказане користувачем"
 
 #: ../../src/Styles.cpp:110
 msgid "User-defined labels"
@@ -11100,7 +11100,7 @@ msgstr "Визначені користувачем мітки"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:770
 msgid "User-defined labels if available"
-msgstr ""
+msgstr "Визначені користувачем мітки, якщо доступні"
 
 #: ../../src/MaximaManual.cpp:500
 msgid "Using Maxima help file from wxMaxima configuration file (helpFile=...))"
@@ -11138,7 +11138,7 @@ msgstr "Перевірено, що представлення XML докумен
 #: ../../src/dialogs/ConfigDialogue.cpp:542
 #: ../../src/wizards/ActualValuesStorageWiz.cpp:49
 msgid "Value"
-msgstr ""
+msgstr "Значення"
 
 #: ../../src/MaximaCommandMenus.cpp:756
 msgid "Value at a given point"
@@ -11178,15 +11178,15 @@ msgstr "Змінна"
 
 #: ../../src/wizards/DrawWiz.cpp:61 ../../src/wizards/DrawWiz.cpp:166
 msgid "Variable for the x value"
-msgstr ""
+msgstr "Змінна для значення x"
 
 #: ../../src/wizards/DrawWiz.cpp:78 ../../src/wizards/DrawWiz.cpp:181
 msgid "Variable for the y value"
-msgstr ""
+msgstr "Змінна для значення y"
 
 #: ../../src/wizards/DrawWiz.cpp:198
 msgid "Variable for the z value"
-msgstr ""
+msgstr "Змінна для значення z"
 
 #: ../../src/MaximaCommandMenus.cpp:1586 ../../src/MaximaCommandMenus.cpp:2990
 #: ../../src/MaximaCommandMenus.cpp:2996
@@ -11234,7 +11234,7 @@ msgstr "Змінні:"
 
 #: ../../src/sidebars/StatSidebar.cpp:58
 msgid "Variance..."
-msgstr ""
+msgstr "Дисперсія…"
 
 #: ../../src/WXMXformat.cpp:339
 msgid "Verified that we are able to read the whole .zip archive we produced."
@@ -11262,7 +11262,7 @@ msgstr "Очікуємо на завершення потоку обробки, 
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1410
 msgid "Warn if an inactive window is idle"
-msgstr ""
+msgstr "Попереджати, якщо неактивне вікно бездіяльне"
 
 #: ../../src/MathParser.cpp:1343 ../../src/MaximaFileIO.cpp:536
 #: ../../src/MaximaResponseReader.cpp:361 ../../src/wxMaxima.cpp:1583
@@ -11282,7 +11282,7 @@ msgstr "Попередження: не вдалося створити %s, ка�
 
 #: ../../src/cells/GroupCell.cpp:400 ../../src/cells/GroupCell.cpp:406
 msgid "Warning: Lookalike chars: "
-msgstr ""
+msgstr "Попередження: подібні за виглядом символи: "
 
 #: ../../src/wxMaximaFrame.cpp:1583
 msgid "Warning: No test if the argument of the log is complex, positive or negative"
@@ -11307,7 +11307,7 @@ msgstr "Що робити:"
 
 #: ../../src/dialogs/TipOfTheDay.cpp:134
 msgid "When applying functions with one argument from menus, the default argument is '%'. To apply the function to some other value, select it in the document before executing a menu command."
-msgstr ""
+msgstr "При застосуванні функції з одним аргументом з меню, типовим аргументом вважається «%». Якщо слід застосувати функцію до іншого параметра, слід позначити його у документі до використання пункту меню."
 
 #: ../../src/wxMaximaFrame.cpp:1092
 msgid "When to invoke the lisp compiler's debugger"
@@ -11323,7 +11323,7 @@ msgstr "Цикл while…"
 
 #: ../../src/dialogs/TipOfTheDay.cpp:243
 msgid "While wxMaxima is programmed mostly in C++, it also uses some Lisp code. You can help to improve wxMaxima, if you have knowledge of Common Lisp."
-msgstr ""
+msgstr "wxMaxima написано в основному мовою програмування C++, також використано частину коду мовою Lisp. Ви можете допомогти в удосконаленні wxMaxima, якщо знаєте Common Lisp."
 
 #: ../../src/MaximaFileIO.cpp:780
 msgid "Whole document (*.wxmx)|*.wxmx|The input, readable by load() (maxima > 5.38) (*.wxm)|*.wxm|All Files (*.*)|*"
@@ -11335,7 +11335,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:280
 msgid "Worksheet"
-msgstr ""
+msgstr "Робочий аркуш"
 
 #: ../../src/MaximaResponseReader.cpp:117
 #, c-format
@@ -11356,7 +11356,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:428
 msgid "Wrap equations exported by the \"copy as LaTeX\" feature between \\[ and \\] as equation markers"
-msgstr ""
+msgstr "Брати рівняння, експортовані за допомогою пункту «Копіювати як LaTeX», у позначення рівняння, \\[ на початку і \\] наприкінці"
 
 #: ../../src/worksheet/Worksheet.cpp:5190
 msgid "Wrapped search"
@@ -11378,7 +11378,7 @@ msgstr "Записано дані щодо типу MIME"
 #: ../../src/wizards/DrawWiz.cpp:961 ../../src/wizards/DrawWiz.cpp:974
 #: ../../src/wizards/DrawWiz.cpp:977
 msgid "X"
-msgstr ""
+msgstr "X"
 
 #: ../../src/MathParser.cpp:1279
 msgid "XML nesting limit exceeded"
@@ -11386,35 +11386,35 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:191
 msgid "Xi"
-msgstr ""
+msgstr "Ξ"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:728
 msgid "Yes"
-msgstr ""
+msgstr "Так"
 
 #: ../../src/dialogs/TipOfTheDay.cpp:64
 msgid "You can access the last output using the variable '%'. You can access the output of previous commands using variables '%on' where n is the number of output."
-msgstr ""
+msgstr "Результат останнього обчислення позначається «%». Результат будь-якого іншого попереднього обчислення позначається «%on», де n — порядковий номер обчислення."
 
 #: ../../src/dialogs/TipOfTheDay.cpp:118
 msgid "You can evaluate your whole document by using 'Cell->Evaluate All Cells' menu command or the appropriate key shortcut. The cells will be evaluated in the order they appear in the document."
-msgstr ""
+msgstr "Ви можете наказати програмі виконати обчислення одразу у всьому документі за допомогою пункту меню «Комірка → Обчислити усі комірки» або відповідного клавіатурного скорочення. Обчислення у комірках буде виконано відповідного порядку цих комірок у документі."
 
 #: ../../src/dialogs/TipOfTheDay.cpp:98
 msgid "You can get help on a Maxima function by selecting or clicking on the function name and pressing F1. wxMaxima will search the help index for the selection or the word under the cursor."
-msgstr ""
+msgstr "Ви можете отримати довідку щодо функції Maxima: позначте назву функції у документі або клацніть на назві функції і натисніть клавішу F1. wxMaxima виконає пошук у покажчику довідки щодо позначеного тексту або слова під курсором."
 
 #: ../../src/dialogs/TipOfTheDay.cpp:92
 msgid "You can hide output part of cells by clicking in the triangle on the left side of cells. This works on text cells also."
-msgstr ""
+msgstr "Ви можете наказати програмі приховати комірки результатів натисканням трикутничка у лівій частині комірки. У такий же спосіб можна приховувати текстові комірки."
 
 #: ../../src/dialogs/TipOfTheDay.cpp:81
 msgid "You can insert different types of 'cells' in wxMaxima documents using the 'Cell' menu. Note that only 'input cells' can be evaluated, while others are used for commenting and structuring your calculations."
-msgstr ""
+msgstr "За допомогою меню «Комірка» ви можете вставляти до документів wxMaxima комірки різних типів. Зауважте, що обчислення виконуватимуться лише для комірок введення даних, інші ж комірки використовуються для додавання коментарів або структурування ваших обчислень."
 
 #: ../../src/dialogs/TipOfTheDay.cpp:112
 msgid "You can select multiple cells either with a mouse - click'n'drag from between cells or from a cell bracket on the left - or with a keyboard - hold down Shift while moving the horizontal cursor - and then operate on selection. This comes in handy when you want to delete or evaluate multiple cells."
-msgstr ""
+msgstr "Позначити декілька комірок одразу можна або за допомогою вказівника миші: натисніть ліву кнопку миші і перетягніть вказівник між комірками або за дужку комірки ліворуч, — або за допомогою клавіатури: утримуйте натиснутою клавішу Shift і пересувайте горизонтальний курсор, — а потім виконайте дію над позначеним фрагментом. Позначення декількох комірок одразу може бути корисним, якщо вам потрібно вилучити декілька комірок або виконати обчислення у декількох комірках одразу."
 
 #: ../../src/dialogs/TipOfTheDay.cpp:232
 msgid "You found a bug in wxMaxima? Please report it at https://github.com/wxMaxima-developers/wxmaxima/issues\n"
@@ -11424,7 +11424,7 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:238
 msgid "You got an idea for an improvement of wxMaxima? Great! Please submit your idea at https://github.com/wxMaxima-developers/wxmaxima/issues. "
-msgstr ""
+msgstr "Маєте думки щодо удосконалення wxMaxima? Чудово! Будь ласка, повідомте про свою ідею за допомогою сторінки https://github.com/wxMaxima-developers/wxmaxima/issues. "
 
 #: ../../src/wxMaxima.cpp:3402 ../../src/wxMaxima.cpp:3456
 #, c-format
@@ -11442,7 +11442,7 @@ msgstr "Ваша версія wxMaxima є актуальною."
 
 #: ../../src/sidebars/GreekSidebar.cpp:183
 msgid "Zeta"
-msgstr ""
+msgstr "Ζ"
 
 #: ../../src/wxMaximaFrame.cpp:842
 msgid "Zoom &In\tCtrl++"
@@ -11470,11 +11470,11 @@ msgstr "[ не збережено* ]"
 
 #: ../../src/wizards/DrawWiz.cpp:819 ../../src/wizards/DrawWiz.cpp:825
 msgid "[[x_1,x_2,...],[y_1,y_2,...]]"
-msgstr ""
+msgstr "[[x_1,x_2,...],[y_1,y_2,...]]"
 
 #: ../../src/wizards/DrawWiz.cpp:814
 msgid "[x_1, x_2,...] or [x_1, x_2,...],[y_1, y_2,...] or matrix([x_1,y_1],[x_2,y_2],...)"
-msgstr ""
+msgstr "[x_1, x_2,...], або [x_1, x_2,...],[y_1, y_2,...], або matrix([x_1,y_1],[x_2,y_2],...)"
 
 #: ../../src/wizards/ListSortWiz.cpp:46
 msgid "a<b (Maxima default)"
@@ -11482,15 +11482,15 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:151
 msgid "alpha"
-msgstr ""
+msgstr "α"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:95
 msgid "and"
-msgstr ""
+msgstr "і"
 
 #: ../../src/wizards/MatWiz.cpp:160
 msgid "antisymmetric"
-msgstr ""
+msgstr "антисиметрична"
 
 #: ../../src/wxMaximaFrame.cpp:1727
 msgid "apply function to each element"
@@ -11514,11 +11514,11 @@ msgstr "як сховище поточних даних змінних"
 
 #: ../../src/sidebars/GreekSidebar.cpp:152
 msgid "beta"
-msgstr ""
+msgstr "β"
 
 #: ../../src/wizards/LimitWiz.cpp:42
 msgid "both sides"
-msgstr ""
+msgstr "двобічна"
 
 #: ../../src/wxMaximaFrame.cpp:1173
 msgid "char to Ascii code..."
@@ -11526,7 +11526,7 @@ msgstr "Символ до коду ASCII…"
 
 #: ../../src/sidebars/GreekSidebar.cpp:172
 msgid "chi"
-msgstr ""
+msgstr "χ"
 
 #: ../../src/MaximaFileIO.cpp:318
 #, c-format
@@ -11536,15 +11536,15 @@ msgstr ""
 #: ../../src/wizards/Plot2dWiz.cpp:70 ../../src/wizards/Plot2dWiz.cpp:372
 #: ../../src/wizards/Plot3dWiz.cpp:61 ../../src/wizards/Plot3dWiz.cpp:358
 msgid "default"
-msgstr ""
+msgstr "типовий"
 
 #: ../../src/sidebars/GreekSidebar.cpp:154
 msgid "delta"
-msgstr ""
+msgstr "δ"
 
 #: ../../src/wizards/MatWiz.cpp:159
 msgid "diagonal"
-msgstr ""
+msgstr "діагональна"
 
 #: ../../src/cells/FracCell.cpp:73
 msgid "diff(): Cannot find the multiplication sign I should hide"
@@ -11560,19 +11560,19 @@ msgstr "застосувати до усіх елементів"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:92
 msgid "empty"
-msgstr ""
+msgstr "порожня множина"
 
 #: ../../src/sidebars/GreekSidebar.cpp:155
 msgid "epsilon"
-msgstr ""
+msgstr "ε"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:100
 msgid "equivalent"
-msgstr ""
+msgstr "еквівалентно"
 
 #: ../../src/sidebars/GreekSidebar.cpp:157
 msgid "eta"
-msgstr ""
+msgstr "η"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:799
 msgid "ev() shall evaluate this automatically"
@@ -11580,7 +11580,7 @@ msgstr "ev() буде обчислювати це автоматично"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:88
 msgid "exists"
-msgstr ""
+msgstr "існує"
 
 #: ../../src/MaximaCommandMenus.cpp:3942
 msgid "expression:"
@@ -11622,11 +11622,11 @@ msgstr "функція"
 
 #: ../../src/sidebars/GreekSidebar.cpp:153
 msgid "gamma"
-msgstr ""
+msgstr "γ"
 
 #: ../../src/wizards/MatWiz.cpp:159
 msgid "general"
-msgstr ""
+msgstr "загальна"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1630
 msgid "gnuplot: Without command console"
@@ -11634,11 +11634,11 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:118
 msgid "greater than or equal"
-msgstr ""
+msgstr "більше або дорівнює"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:87
 msgid "in"
-msgstr ""
+msgstr "належить"
 
 #: ../../src/wxMaximaFrame.cpp:784
 msgid "in 2D"
@@ -11649,31 +11649,31 @@ msgstr "2 виміри"
 #: ../../src/wizards/Plot3dWiz.cpp:61 ../../src/wizards/Plot3dWiz.cpp:194
 #: ../../src/wizards/Plot3dWiz.cpp:358 ../../src/wizards/Plot3dWiz.cpp:386
 msgid "inline"
-msgstr ""
+msgstr "вбудований"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:104
 msgid "intersection"
-msgstr ""
+msgstr "перетин"
 
 #: ../../src/sidebars/GreekSidebar.cpp:159
 msgid "iota"
-msgstr ""
+msgstr "ι"
 
 #: ../../src/sidebars/GreekSidebar.cpp:160
 msgid "kappa"
-msgstr ""
+msgstr "ϰ"
 
 #: ../../src/sidebars/GreekSidebar.cpp:161
 msgid "lambda"
-msgstr ""
+msgstr "λ"
 
 #: ../../src/wizards/LimitWiz.cpp:42
 msgid "left"
-msgstr ""
+msgstr "ліворуч"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:117
 msgid "less or equal"
-msgstr ""
+msgstr "менше або дорівнює"
 
 #: ../../src/MaximaCommandMenus.cpp:1567
 msgid "list"
@@ -11681,11 +11681,11 @@ msgstr "список"
 
 #: ../../src/wizards/Plot2dWiz.cpp:54 ../../src/wizards/Plot2dWiz.cpp:64
 msgid "logscale"
-msgstr ""
+msgstr "логарифмічна шкала"
 
 #: ../../src/wizards/DrawWiz.cpp:822
 msgid "matrix([x_1,x_2,...],[y_1,y_2,...])"
-msgstr ""
+msgstr "matrix([x_1,x_2,...],[y_1,y_2,...])"
 
 #: ../../src/wxMaximaFrame.cpp:1439
 msgid "max(abs(A(i,j))) (complex)"
@@ -11697,15 +11697,15 @@ msgstr "max(abs(A(i,j))) (дійсне)"
 
 #: ../../src/sidebars/GreekSidebar.cpp:162
 msgid "mu"
-msgstr ""
+msgstr "μ"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:120
 msgid "much greater than"
-msgstr ""
+msgstr "набагато більше"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:119
 msgid "much less than"
-msgstr ""
+msgstr "набагато менше"
 
 #: ../../src/MaximaCommandMenus.cpp:1232
 msgid "m×n Matrix A:"
@@ -11718,11 +11718,11 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:112
 msgid "nabla sign"
-msgstr ""
+msgstr "символ набла"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:98
 msgid "nand"
-msgstr ""
+msgstr "і-ні"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:772
 msgid "nary: f(x, f(y,z)) = foo(x,y,z)"
@@ -11730,23 +11730,23 @@ msgstr "Унарна: f(x, f(y,z)) = foo(x,y,z)"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:99
 msgid "nor"
-msgstr ""
+msgstr "або-ні"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:102
 msgid "not"
-msgstr ""
+msgstr "не"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:116
 msgid "not bytewise identical"
-msgstr ""
+msgstr "не ідентичне за бітами"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:108
 msgid "not subset"
-msgstr ""
+msgstr "не є підмножиною"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:107
 msgid "not subset or equal"
-msgstr ""
+msgstr "не є підмножиною або тією самою множиною"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:796
 msgid "noun: Not evaluated by default"
@@ -11758,7 +11758,7 @@ msgstr "n-й"
 
 #: ../../src/sidebars/GreekSidebar.cpp:163
 msgid "nu"
-msgstr ""
+msgstr "ν"
 
 #: ../../src/MaximaCommandMenus.cpp:1233
 msgid "n×1 Matrix b:"
@@ -11766,15 +11766,15 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:174
 msgid "omega"
-msgstr ""
+msgstr "ω"
 
 #: ../../src/sidebars/GreekSidebar.cpp:165
 msgid "omicron"
-msgstr ""
+msgstr "ο"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:96
 msgid "or"
-msgstr ""
+msgstr "або"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:793
 msgid "outative: f(2*x) = 2*f(x)"
@@ -11791,19 +11791,19 @@ msgstr "частина:"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:111
 msgid "partial sign"
-msgstr ""
+msgstr "символ частинної похідної"
 
 #: ../../src/sidebars/GreekSidebar.cpp:171
 msgid "phi"
-msgstr ""
+msgstr "φ"
 
 #: ../../src/sidebars/GreekSidebar.cpp:166
 msgid "pi"
-msgstr ""
+msgstr "π"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:101
 msgid "plus or minus"
-msgstr ""
+msgstr "плюс чи мінус"
 
 #: ../../src/MaximaCommandMenus.cpp:196
 msgid "point:"
@@ -11828,11 +11828,11 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:115
 msgid "proportional to"
-msgstr ""
+msgstr "пропорційне"
 
 #: ../../src/sidebars/GreekSidebar.cpp:173
 msgid "psi"
-msgstr ""
+msgstr "ψ"
 
 #: ../../src/MaximaCommandMenus.cpp:642
 msgid "radcan() is a powerful tools for simplification trigonometric functions but needs to be taken with care: If a function has more than one branch radcan uses the one that looks like it would fit best, not necessarily the one that makes sense for the problem that resulted in the Expression that is to be simplified."
@@ -11860,31 +11860,31 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:167
 msgid "rho"
-msgstr ""
+msgstr "ρ"
 
 #: ../../src/wizards/LimitWiz.cpp:42
 msgid "right"
-msgstr ""
+msgstr "праворуч"
 
 #: ../../src/wizards/DrawWiz.cpp:310
 msgid "secondary x axis label"
-msgstr ""
+msgstr "мітка вторинної вісі x"
 
 #: ../../src/wizards/DrawWiz.cpp:315
 msgid "secondary x range (automatic if incomplete)"
-msgstr ""
+msgstr "вторинний діапазон за x (автоматично, якщо неповний)"
 
 #: ../../src/wizards/DrawWiz.cpp:325
 msgid "secondary y axis label"
-msgstr ""
+msgstr "мітка вторинної вісі y"
 
 #: ../../src/wizards/DrawWiz.cpp:330
 msgid "secondary y range (automatic if incomplete)"
-msgstr ""
+msgstr "вторинний діапазон за y (автоматично, якщо неповний)"
 
 #: ../../src/sidebars/GreekSidebar.cpp:168
 msgid "sigma"
-msgstr ""
+msgstr "σ"
 
 #: ../../src/MaximaCommandMenus.cpp:3447
 msgid "solve() will solve a list of equations only if for n independent equations there are n variables to solve to.\n"
@@ -11908,19 +11908,19 @@ msgstr "розв'язує рівняння у формі\n"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:81
 msgid "sqrt (needs parenthesis for its argument to work as a Maxima command)"
-msgstr ""
+msgstr "sqrt (потребує дужок навколо аргументу, щоб працювати як команда Maxima)"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:106
 msgid "subset"
-msgstr ""
+msgstr "підмножина"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:105
 msgid "subset or equal"
-msgstr ""
+msgstr "підмножина або та сама множина"
 
 #: ../../src/wizards/MatWiz.cpp:160
 msgid "symmetric"
-msgstr ""
+msgstr "симетрична"
 
 #: ../../src/MaximaCommandMenus.cpp:970
 msgid "t:"
@@ -11928,7 +11928,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:169
 msgid "tau"
-msgstr ""
+msgstr "τ"
 
 #: ../../src/cells/TextCell.cpp:340
 msgid "the [] operator tried to extract an element of a list, a matrix, an equation or an array. But instead of an integer number something was used whose numerical value is unknown or not an integer.\n"
@@ -11937,31 +11937,31 @@ msgstr ""
 
 #: ../../src/wizards/DrawWiz.cpp:725
 msgid "the x and the y coordinate."
-msgstr ""
+msgstr "координата за x і y."
 
 #: ../../src/wizards/DrawWiz.cpp:729
 msgid "the x, the y and the z coordinate."
-msgstr ""
+msgstr "координата за x, y і z."
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:89
 msgid "there is no"
-msgstr ""
+msgstr "немає"
 
 #: ../../src/sidebars/GreekSidebar.cpp:158
 msgid "theta"
-msgstr ""
+msgstr "θ"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:78
 msgid "to the power of 2"
-msgstr ""
+msgstr "у квадраті"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:79
 msgid "to the power of 3"
-msgstr ""
+msgstr "у кубі"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:103
 msgid "union"
-msgstr ""
+msgstr "об'єднання"
 
 #: ../../src/wxMaximaFrame.cpp:1109
 msgid "unnamed function (lambda)..."
@@ -11978,7 +11978,7 @@ msgstr "без назви"
 
 #: ../../src/sidebars/GreekSidebar.cpp:170
 msgid "upsilon"
-msgstr ""
+msgstr "υ"
 
 #: ../../src/wxMaximaFrame.cpp:1737
 msgid "use as function arguments"
@@ -12016,7 +12016,7 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:159
 msgid "wxMaxima can be made to execute commands at every start-up by placing them in a text file with the name wxmaxima.rc in the user directory. This directory can be found by typing maxima_userdir;"
-msgstr ""
+msgstr "wxMaxima можна змусити виконувати певні команди під час кожного запуску, якщо вказати ці команди у текстовому файлів із назвою wxmaxima.rc у домашньому каталозі користувача. Визначити адресу цього каталогу можна за допомогою команди maxima_userdir;"
 
 #: ../../src/MaximaFileIO.cpp:398
 msgid "wxMaxima cannot read the xml contents of "
@@ -12025,7 +12025,7 @@ msgstr "wxMaxima не вдалося прочитати вміст xml "
 #: ../../src/dialogs/ConfigDialogue.cpp:142
 #: ../../src/dialogs/ConfigDialogue.cpp:311
 msgid "wxMaxima configuration"
-msgstr ""
+msgstr "Налаштування wxMaxima"
 
 #: ../../src/MaximaProcessManager.cpp:209
 msgid "wxMaxima could not start a server.\n\n"
@@ -12035,7 +12035,7 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:127
 msgid "wxMaxima dialogs set default values for inputs entries, one of which is '%'. If you have made a selection in your document, the selection will be used instead of '%'."
-msgstr ""
+msgstr "У діалогових вікнах wxMaxima передбачено типові значення для вхідних параметрів, одним з яких є «%». Якщо ви позначите якийсь з фрагментів у вашому документі, замість «%» буде використано цей фрагмент."
 
 #: ../../src/MaximaCommandMenus.cpp:4544
 msgid "wxMaxima document"
@@ -12066,19 +12066,19 @@ msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:240
 msgid "wxMaxima is programmed in C++ using the wxWidgets toolkit and uses CMake as build system. You can contribute to wxMaxima, if you have some knowledge with this environment."
-msgstr ""
+msgstr "wxMaxima написано мовою програмування C++ з використанням набору інструментів wxWidgets і системи збирання CMake. Ви можете зробити внесок у розвиток wxMaxima, якщо знаєтеся на такому середовищі розробки."
 
 #: ../../src/dialogs/TipOfTheDay.cpp:228
 msgid "wxMaxima needs more developers. It is an open source project where you can contribute. Join the wxMaxima development at: https://github.com/wxMaxima-developers/wxmaxima"
-msgstr ""
+msgstr "wxMaxima потрібні нові розробники. Це проєкт із відкритим кодом, до якого ви можете долучитися. Долучайтеся до розробки wxMaxima за допомогою настанов на цій сторінці: https://github.com/wxMaxima-developers/wxmaxima"
 
 #: ../../src/dialogs/TipOfTheDay.cpp:224
 msgid "wxMaxima needs more translators. We do not speak every language. Help us to translate wxMaxima and the manual to your language. Join the wxMaxima development at: https://github.com/wxMaxima-developers/wxmaxima"
-msgstr ""
+msgstr "wxMaxima потрібні перекладачі. Розробники не володіють усіма мовами світу. Допоможіть нам у перекладі інтерфейсу та підручника з wxMaxima вашою рідною мовою. Долучайтеся до перекладу wxMaxima за допомогою настанов на цій сторінці: https://github.com/wxMaxima-developers/wxmaxima"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:407
 msgid "wxMaxima normally stores the gnuplot sources for every plot made using draw() in order to be able to open plots interactively in gnuplot later. This setting defines the limit [in Megabytes per plot] for this feature."
-msgstr ""
+msgstr "Зазвичай, wxMaxima зберігає початковий код gnuplot для усіх креслень, які виконуються за допомогою функції draw() з метою уможливлення наступного інтерактивного відкриття креслень у gnuplot. За допомогою цього параметра можна визначити обмеження (у мегабайтах на одне креслення) для використання цієї можливості."
 
 #: ../../src/dialogs/TipOfTheDay.cpp:172
 msgid "wxMaxima provides the \"table_form\" command that shows lists in an alternative form. One example would be:\n\n"
@@ -12097,7 +12097,7 @@ msgstr "wxMaxima запам'ятовує відповіді з останньо�
 
 #: ../../src/dialogs/ConfigDialogue.cpp:481
 msgid "wxMaxima remembers the answers to maxima's questions. If this checkbox is set it automatically offers to enter the last answer to this question the user has input."
-msgstr ""
+msgstr "wxMaxima запам'ятовує відповіді на питання maxima. Якщо позначено цей пункт, програма автоматично пропонуватиме ввести останню відповідь на питання, яку було введено користувачем."
 
 #: ../../src/wxMaximaFrame.cpp:1933
 msgid "wxMaxima shows help in a browser"
@@ -12109,7 +12109,7 @@ msgstr "wxMaxima показує довідку на бічній панелі"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1095
 msgid "wxMaxima startup file location: "
-msgstr ""
+msgstr "Розташування файла запуску wxMaxima: "
 
 #: ../../src/wxMaximaFrame.cpp:119
 #, c-format
@@ -12161,11 +12161,11 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:709
 msgid "x"
-msgstr ""
+msgstr "x"
 
 #: ../../src/wizards/DrawWiz.cpp:266
 msgid "x axis label"
-msgstr ""
+msgstr "мітка вісі X"
 
 #: ../../src/MaximaCommandMenus.cpp:2021
 msgid "x direction [in multiples of the tick frequency]"
@@ -12173,11 +12173,11 @@ msgstr "напрям x [у одиницях частоти поділок]"
 
 #: ../../src/wizards/DrawWiz.cpp:269
 msgid "x range (automatic if incomplete)"
-msgstr ""
+msgstr "діапазон за x (автоматично, якщо неповний)"
 
 #: ../../src/sidebars/GreekSidebar.cpp:164
 msgid "xi"
-msgstr ""
+msgstr "χ"
 
 #: ../../src/MaximaFileIO.cpp:408 ../../src/MaximaFileIO.cpp:566
 msgid "xml contained in the file claims not to be a wxMaxima worksheet. "
@@ -12185,11 +12185,11 @@ msgstr "xml, що міститься у файлі, вказує на те, що
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:97
 msgid "xor"
-msgstr ""
+msgstr "викл. або"
 
 #: ../../src/wizards/DrawWiz.cpp:279
 msgid "y axis label"
-msgstr ""
+msgstr "мітка вісі Y"
 
 #: ../../src/MaximaCommandMenus.cpp:2022
 msgid "y direction [in multiples of the tick frequency]"
@@ -12197,7 +12197,7 @@ msgstr "напрям y [у одиницях частоти поділок]"
 
 #: ../../src/wizards/DrawWiz.cpp:282
 msgid "y range (automatic if incomplete)"
-msgstr ""
+msgstr "діапазон за y (автоматично, якщо неповний)"
 
 #: ../../src/MaximaCommandMenus.cpp:970
 msgid "y:"
@@ -12205,15 +12205,15 @@ msgstr ""
 
 #: ../../src/wizards/DrawWiz.cpp:294
 msgid "z axis label"
-msgstr ""
+msgstr "мітка вісі z"
 
 #: ../../src/wizards/DrawWiz.cpp:298
 msgid "z range (automatic if incomplete)"
-msgstr ""
+msgstr "діапазон за z (автоматично, якщо неповний)"
 
 #: ../../src/sidebars/GreekSidebar.cpp:156
 msgid "zeta"
-msgstr ""
+msgstr "ζ"
 
 #. type: Title #
 #: ../../info/wxmaxima.md:1

--- a/locales/wxMaxima/zh_CN.po
+++ b/locales/wxMaxima/zh_CN.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: wxMaxima HEAD\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-30 11:38+0200\n"
+"POT-Creation-Date: 2026-08-10 03:42+0000\n"
 "PO-Revision-Date: 2021-01-20 20:14+0800\n"
 "Last-Translator: Liu Rong <rong.liu@mail.bnu.edu.cn>\n"
 "Language-Team: amateur\n"
@@ -23,7 +23,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 2.4.1\n"
 
-#: ../../src/StatusBar.cpp:328
+#: ../../src/StatusBar.cpp:447
 #, c-format
 msgid ""
 "\n"
@@ -34,1457 +34,2377 @@ msgstr ""
 "\n"
 "Maxima 当前的 CPU 占用率为 %3.3f%% 。"
 
-#: ../../src/Image.cpp:690
+#: ../../src/dialogs/AboutDialog.cpp:59
+#, c-format
+msgid ""
+"\n"
+"\n"
+"Operating System: %s\n"
+msgstr ""
+
+#: ../../src/Image.cpp:773
 msgid ""
 "\n"
 "Image was loaded from a .wxmx file"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:5153
+#: ../../src/dialogs/AboutDialog.cpp:57
+#, fuzzy
+msgid ""
+"\n"
+"Not connected to Maxima."
+msgstr "没有连接至 Maxima"
+
+#: ../../src/MaximaEvaluator.cpp:398
+msgid ""
+"\n"
+"Now reads: "
+msgstr ""
+
+#: ../../src/wxMaxima.cpp:1981
 msgid ""
 "\n"
 "Use the menu \"View->Toggle log window\" to show/hide a log window with all debug messages."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:4230
+#: ../../src/dialogs/ConfigDialogue.cpp:1569
+msgid "      -X \"--control-stack-size <int>\""
+msgstr "      -X \"--control-stack-size <int>\""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1568
+msgid "      -X \"--dynamic-space-size <int>\""
+msgstr "      -X \"--dynamic-space-size <int>\""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1572
+msgid "      -X '--control-stack-size <int>'"
+msgstr "      -X '--control-stack-size <int>'"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1571
+msgid "      -X '--dynamic-space-size <int>'"
+msgstr "      -X '--dynamic-space-size <int>'"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1551
+msgid "      -l <name>"
+msgstr "      -l <name>"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1557
+msgid "      -u <versionnumber>"
+msgstr ""
+
+#: ../../src/Configuration.cpp:1397
+#, c-format
+msgid "  Cells converted to 2D: %ld"
+msgstr ""
+
+#: ../../src/Configuration.cpp:1396
+#, c-format
+msgid "  Cells converted to linear: %ld"
+msgstr ""
+
+#: ../../src/Configuration.cpp:1398
+#, c-format
+msgid "  Cells drawn at the wrong font size: %ld"
+msgstr ""
+
+#: ../../src/Configuration.cpp:1388
+#, c-format
+msgid "  Font cache hits: %ld"
+msgstr ""
+
+#: ../../src/Configuration.cpp:1389
+#, c-format
+msgid "  Font cache misses: %ld"
+msgstr ""
+
+#: ../../src/Configuration.cpp:1400
+#, c-format
+msgid "  Full-window worksheet repaints: %ld"
+msgstr ""
+
+#: ../../src/Configuration.cpp:1384
+#, c-format
+msgid "  Manual anchors from built-in: %ld"
+msgstr ""
+
+#: ../../src/Configuration.cpp:1385
+#, c-format
+msgid "  Manual anchors from cache: %ld"
+msgstr ""
+
+#: ../../src/Configuration.cpp:1386
+#, c-format
+msgid "  Manual anchors self-compiled: %ld"
+msgstr ""
+
+#: ../../src/Configuration.cpp:1387
+#, c-format
+msgid "  Maxima processes spawned: %ld"
+msgstr ""
+
+#: ../../src/Configuration.cpp:1394
+#, c-format
+msgid "  Recalculation needed - Cells appended: %ld"
+msgstr ""
+
+#: ../../src/Configuration.cpp:1393
+#, c-format
+msgid "  Recalculation needed - Config changed: %ld"
+msgstr ""
+
+#: ../../src/Configuration.cpp:1395
+#, c-format
+msgid "  Recalculation needed - Editor dirty: %ld"
+msgstr ""
+
+#: ../../src/Configuration.cpp:1390
+#, c-format
+msgid "  Recalculation needed - Font invalid: %ld"
+msgstr ""
+
+#: ../../src/Configuration.cpp:1392
+#, c-format
+msgid "  Recalculation needed - Font mismatch: %ld"
+msgstr ""
+
+#: ../../src/Configuration.cpp:1391
+#, c-format
+msgid "  Recalculation needed - Size invalid: %ld"
+msgstr ""
+
+#: ../../src/Configuration.cpp:1399
+#, c-format
+msgid "  Worksheet repaints: %ld"
+msgstr ""
+
+#: ../../src/MaximaFileIO.cpp:129
 msgid " (File format (WXM version 1, first line of the file) not recognized)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1559
+#: ../../src/cells/ImgCell.cpp:212 ../../src/cells/ImgCell.cpp:214
+#: ../../src/cells/ImgCell.cpp:216
+msgid " (Graphics) "
+msgstr ""
+
+#: ../../src/cells/EditorCell.cpp:3551 ../../src/cells/EditorCell.cpp:3820
+#: ../../src/cells/EditorCell.cpp:3945
+#, c-format
+msgid " ... + %li hidden lines"
+msgstr ""
+
+#: ../../src/cells/EditorCell.cpp:3553
+msgid " ... + 1 hidden line"
+msgstr ""
+
+#: ../../src/dialogs/TipOfTheDay.cpp:273
+msgid " Did you know? "
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:1607
+msgid " Returns the unique elements of the list"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1596
 msgid " Wrong, if a is complex"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7601
+#: ../../src/wizards/DrawWiz.cpp:964 ../../src/wizards/DrawWiz.cpp:980
+msgid " samples"
+msgstr "样本"
+
+#: ../../src/wizards/DrawWiz.cpp:929 ../../src/wizards/DrawWiz.cpp:945
+msgid " samples, on demand split "
+msgstr ""
+
+#: ../../src/wizards/DrawWiz.cpp:933 ../../src/wizards/DrawWiz.cpp:952
+msgid " times"
+msgstr "微分次数"
+
+#: ../../src/MaximaCommandMenus.cpp:4473
 msgid ""
 "\".\" = \"The current directory\"\n"
 "\"..\" = \"One directory up\""
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7557 ../../src/wxMaxima.cpp:7563
-#: ../../src/wxMaxima.cpp:7568
+#: ../../src/MaximaCommandMenus.cpp:4429 ../../src/MaximaCommandMenus.cpp:4435
+#: ../../src/MaximaCommandMenus.cpp:4440
 msgid "\"..\" means \"one directory up\"."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:5053
+#: ../../src/dialogs/ConfigDialogue.cpp:1208
+msgid "\"Copy LaTeX\" adds equation markers"
+msgstr "\"复制为 LaTeX\" 添加公式环境标志"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:446
+msgid ""
+"\"MathML (rendered by the browser)\" is the recommended choice: every current browser renders MathML natively and instantly, and the exported page needs no JavaScript and makes no requests to any external server.\n"
+"\"MathML + MathJaX fall-back for old browsers\" behaves the same on current browsers, but additionally downloads MathJaX from an external server (a CDN) as a fall-back on browsers too old to support MathML. Only choose this if you need to support such browsers and accept the external dependency.\n"
+"Bitmaps tend to need more band width than the other options. They lack support for advanced features like drag-and-drop or accessibility. Also they have problems aligning and scaling with the rest of the text and might use fonts that don't match the rest of the document."
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:930
+msgid "\"Numpad Enter\" always evaluates cells"
+msgstr "按下回车键时，对单元格求值"
+
+#: ../../src/sidebars/SymbolsSidebar.cpp:90
+msgid "\"implies\" symbol"
+msgstr "可推出"
+
+#: ../../src/dialogs/DiffFrame.cpp:306
+#, c-format
+msgid "%d differences"
+msgstr ""
+
+#: ../../src/wxMaxima.cpp:1831
 #, fuzzy, c-format
 msgid "%i cells in evaluation queue"
 msgstr "%i 个单元格位于计算队列"
 
-#: ../../src/Worksheet.cpp:330
+#: ../../src/sidebars/TableOfContents.cpp:570
+#, c-format
+msgid "%li Levels"
+msgstr ""
+
+#: ../../src/worksheet/Worksheet.cpp:423
 #, c-format
 msgid "%s image, %li×%li, %li ppi"
 msgstr ""
 
-#: ../../src/Autocomplete.cpp:319
+#: ../../src/Autocomplete.cpp:405
 #, fuzzy, c-format
 msgid "%s: Can't interpret line: %s"
 msgstr "：不能解释的行：%s"
 
-#: ../../src/wxMaximaFrame.cpp:1655
+#: ../../src/wxMaxima.cpp:2859
+#, c-format
+msgid ""
+"%sCould not write the setting for:%s\n"
+"(Is the client installed?)"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1692
 msgid "&Algebraic Mode"
 msgstr "代数模式(&A)"
 
-#: ../../src/wxMaximaFrame.cpp:1884
+#: ../../src/wxMaximaFrame.cpp:1921
 msgid "&Apropos..."
 msgstr "查找命令(&A)..."
 
-#: ../../src/wxMaximaFrame.cpp:615
+#: ../../src/wxMaximaFrame.cpp:646
 msgid "&Batch File...\tCtrl+B"
 msgstr "批处理文件(&B)...\tCtrl+B"
 
-#: ../../src/wxMaximaFrame.cpp:1278
+#: ../../src/wxMaximaFrame.cpp:1312
 msgid "&Boundary Value Problem..."
 msgstr "边值问题(&B)..."
 
-#: ../../src/wxMaximaFrame.cpp:1950
+#: ../../src/wxMaximaFrame.cpp:1987
 msgid "&Bug Report"
 msgstr "错误报告(&B)"
 
-#: ../../src/wxMaximaFrame.cpp:1505
+#: ../../src/wxMaximaFrame.cpp:1542
 msgid "&Calculus"
 msgstr "微积分(&C)"
 
-#: ../../src/wxMaximaFrame.cpp:1601
+#: ../../src/wxMaximaFrame.cpp:1638
 msgid "&Canonical Form"
 msgstr "标准形(&C)"
 
-#: ../../src/wxMaximaFrame.cpp:1358
+#: ../../src/wxMaximaFrame.cpp:1392
 msgid "&Characteristic Polynomial..."
 msgstr "特征多项式(&C)..."
 
-#: ../../src/wxMaximaFrame.cpp:990
+#: ../../src/wxMaximaFrame.cpp:1024
 msgid "&Clear Memory"
 msgstr "清除内存(&C)"
 
-#: ../../src/wxMaximaFrame.cpp:1583
+#: ../../src/wxMaximaFrame.cpp:1620
 msgid "&Combine Factorials"
 msgstr "合并阶乘(&C)"
 
-#: ../../src/wxMaximaFrame.cpp:1628
+#: ../../src/wxMaximaFrame.cpp:1665
 msgid "&Complex Simplification"
 msgstr "复数化简(&C)"
 
-#: ../../src/wxMaximaFrame.cpp:1502
+#: ../../src/wxMaximaFrame.cpp:1539
 msgid "&Continued Fraction"
 msgstr "连分数(&C)"
 
-#: ../../src/wxMaximaFrame.cpp:638
+#: ../../src/wxMaximaFrame.cpp:675
 msgid "&Copy\tCtrl+C"
 msgstr "复制(&C)\tCtrl+C"
 
-#: ../../src/wxMaximaFrame.cpp:1621
+#: ../../src/wizards/IntegrateWiz.cpp:39
+msgid "&Definite integration"
+msgstr "定积分(&D)"
+
+#: ../../src/wxMaximaFrame.cpp:1658
 msgid "&Demoivre"
 msgstr "棣莫弗公式(&D)"
 
-#: ../../src/wxMaximaFrame.cpp:1362
+#: ../../src/wxMaximaFrame.cpp:1396
 msgid "&Determinant"
 msgstr "行列式(&D)"
 
-#: ../../src/wxMaximaFrame.cpp:1466
+#: ../../src/wxMaximaFrame.cpp:1503
 msgid "&Differentiate..."
 msgstr "微分(&D)..."
 
-#: ../../src/wxMaximaFrame.cpp:689
+#: ../../src/wxMaximaFrame.cpp:726
 msgid "&Edit"
 msgstr "编辑(&E)"
 
-#: ../../src/wxMaximaFrame.cpp:1246
+#: ../../src/wxMaximaFrame.cpp:1280
 msgid "&Eliminate Variable..."
 msgstr "消元(&E)..."
 
-#: ../../src/wxMaximaFrame.cpp:1318
+#: ../../src/wxMaximaFrame.cpp:1352
 msgid "&Enter Matrix..."
 msgstr "输入矩阵(&E)..."
 
-#: ../../src/wxMaximaFrame.cpp:1883
+#: ../../src/wxMaximaFrame.cpp:1920
 msgid "&Example..."
 msgstr "示例(&E)..."
 
-#: ../../src/wxMaximaFrame.cpp:1524
+#: ../../src/wxMaximaFrame.cpp:1561
 msgid "&Expand Expression"
 msgstr "展开表达式(&E)"
 
-#: ../../src/wxMaximaFrame.cpp:1597
+#: ../../src/wxMaximaFrame.cpp:1634
 msgid "&Expand Trigonometric"
 msgstr "展开三角函数(&E)"
 
-#: ../../src/wxMaximaFrame.cpp:1626
+#: ../../src/wxMaximaFrame.cpp:1663
 msgid "&Exponentialize"
 msgstr "指数化(&E)"
 
-#: ../../src/wxMaximaFrame.cpp:618
+#: ../../src/wxMaximaFrame.cpp:651
 msgid "&Export..."
 msgstr "导出(&E)……"
 
-#: ../../src/wxMaximaFrame.cpp:1516
+#: ../../src/wxMaximaFrame.cpp:1553
 msgid "&Factor Expression"
 msgstr "因式分解(&F)"
 
-#: ../../src/wxMaximaFrame.cpp:626
+#: ../../src/wxMaximaFrame.cpp:663
 msgid "&File"
 msgstr "文件(&F)"
 
-#: ../../src/wxMaximaFrame.cpp:1019
+#: ../../src/wxMaximaFrame.cpp:1053
 #, fuzzy
 msgid "&Functions"
 msgstr "函数："
 
-#: ../../src/wxMaximaFrame.cpp:1490
+#: ../../src/wxMaximaFrame.cpp:1527
 msgid "&Greatest Common Divisor..."
 msgstr "最大公因子(&G)..."
 
-#: ../../src/wxMaximaFrame.cpp:1968
+#: ../../src/wxMaximaFrame.cpp:2021
 msgid "&Help"
 msgstr "帮助(&H)"
 
-#: ../../src/wxMaximaFrame.cpp:1453
+#: ../../src/wxMaximaFrame.cpp:1490
 msgid "&Integrate..."
 msgstr "积分(&I)..."
 
-#: ../../src/wxMaximaFrame.cpp:964
+#: ../../src/wxMaximaFrame.cpp:998
 msgid "&Interrupt\tCtrl+G"
 msgstr "中断(&I)\tCtrl+G"
 
-#: ../../src/wxMaximaFrame.cpp:1355
+#: ../../src/wxMaximaFrame.cpp:1389
 msgid "&Invert Matrix"
 msgstr "求逆矩阵(&I)"
 
-#: ../../src/wxMaximaFrame.cpp:1952
+#: ../../src/wxMaximaFrame.cpp:1995
 msgid "&License"
 msgstr "许可证(&L)"
 
-#: ../../src/wxMaximaFrame.cpp:1763
+#: ../../src/wxMaximaFrame.cpp:1800
 msgid "&List"
 msgstr "列表(&L)"
 
-#: ../../src/wxMaximaFrame.cpp:610
+#: ../../src/wxMaximaFrame.cpp:641
 msgid "&Load Package...\tCtrl+L"
 msgstr "加载程序包(&L)...\tCtrl+L"
 
-#: ../../src/wxMaximaFrame.cpp:1232
+#: ../../src/wxMaximaFrame.cpp:1266
 msgid "&Maxima"
 msgstr "Maxima(&M)"
 
-#: ../../src/wxMaximaFrame.cpp:1882
+#: ../../src/wxMaximaFrame.cpp:1919
 msgid "&Maxima help"
 msgstr "Maxima 帮助(&M)"
 
-#: ../../src/wxMaximaFrame.cpp:1660
+#: ../../src/wxMaximaFrame.cpp:1697
 msgid "&Modulus Computation..."
 msgstr "模运算(&M)..."
 
-#: ../../src/main.cpp:435
+#: ../../src/main.cpp:674
 msgid "&New\tCtrl+N"
 msgstr "新建(&N)\tCtrl+N"
 
-#: ../../src/wxMaximaFrame.cpp:1870
+#: ../../src/wxMaximaFrame.cpp:1907
 msgid "&Numeric"
 msgstr "数值(&N)"
 
-#: ../../src/wxMaximaFrame.cpp:1785
+#: ../../src/wxMaximaFrame.cpp:1822
 msgid "&Numeric Output"
 msgstr "数值输出(&N)"
 
-#: ../../src/main.cpp:436
+#: ../../src/wizards/IntegrateWiz.cpp:52
+msgid "&Numerical integration"
+msgstr "数值积分(&N)"
+
+#: ../../src/wizards/SumWiz.cpp:44
+msgid "&Nusum"
+msgstr "使用 Nusum(&N)"
+
+#: ../../src/main.cpp:675
 msgid "&Open\tCtrl+O"
 msgstr "打开(&O)\tCtrl+O"
 
-#: ../../src/wxMaximaFrame.cpp:598
+#: ../../src/wxMaximaFrame.cpp:629
 msgid "&Open...\tCtrl+O"
 msgstr "打开(&O)...\tCtrl+O"
 
-#: ../../src/wxMaximaFrame.cpp:1780
+#: ../../src/wxMaximaFrame.cpp:1817
 msgid "&Plot"
 msgstr "绘图(&P)"
 
-#: ../../src/wxMaximaFrame.cpp:622
+#: ../../src/wizards/SeriesWiz.cpp:45
+msgid "&Power series"
+msgstr "幂级数(&P)"
+
+#: ../../src/wxMaximaFrame.cpp:655
 msgid "&Print...\tCtrl+P"
 msgstr "打印(&P)...\tCtrl+P"
 
-#: ../../src/wxMaximaFrame.cpp:1594
+#: ../../src/wizards/SubstituteWiz.cpp:38
+msgid "&Rational"
+msgstr "有理式(&R)"
+
+#: ../../src/wxMaximaFrame.cpp:1631
 msgid "&Reduce Trigonometric"
 msgstr "合并三角函数(&R)"
 
-#: ../../src/wxMaximaFrame.cpp:974
+#: ../../src/wxMaximaFrame.cpp:1008
 #, fuzzy
 msgid "&Restart Maxima\tCtrl+Alt+R"
 msgstr "重启 Maxima(&R)"
 
-#: ../../src/wxMaximaFrame.cpp:608
+#: ../../src/wxMaximaFrame.cpp:639
 msgid "&Save\tCtrl+S"
 msgstr "保存(&S)\tCtrl+S"
 
-#: ../../src/wxMaximaFrame.cpp:1662
+#: ../../src/wizards/SumWiz.cpp:43 ../../src/wxMaximaFrame.cpp:1699
 msgid "&Simplify"
 msgstr "化简(&S)"
 
-#: ../../src/wxMaximaFrame.cpp:1581
+#: ../../src/wxMaximaFrame.cpp:1618
 msgid "&Simplify Factorials"
 msgstr "化简阶乘(&S)"
 
-#: ../../src/wxMaximaFrame.cpp:1591
+#: ../../src/wxMaximaFrame.cpp:1628
 msgid "&Simplify Trigonometric"
 msgstr "化简三角函数(&S)"
 
-#: ../../src/wxMaximaFrame.cpp:1238
+#: ../../src/wxMaximaFrame.cpp:1272
 msgid "&Solve..."
 msgstr "求解(&S)..."
 
-#: ../../src/wxMaximaFrame.cpp:1035
+#: ../../src/wizards/Plot2dWiz.cpp:42
+msgid "&Special"
+msgstr "特殊(&S)"
+
+#: ../../src/wizards/LimitWiz.cpp:45
+msgid "&Taylor series"
+msgstr "泰勒级数(&T)"
+
+#: ../../src/wxMaximaFrame.cpp:1069
 msgid "&Time Display"
 msgstr "显示运行时间(&T)"
 
-#: ../../src/wxMaximaFrame.cpp:1375
+#: ../../src/wxMaximaFrame.cpp:1409
 msgid "&Transpose Matrix"
 msgstr "转置矩阵(&T)"
 
-#: ../../src/wxMaximaFrame.cpp:1605
+#: ../../src/wxMaximaFrame.cpp:1642
 msgid "&Trigonometric Simplification"
 msgstr "三角函数化简(&T)"
 
-#: ../../src/wxMaximaFrame.cpp:1021
+#: ../../src/wxMaximaFrame.cpp:1055
 #, fuzzy
 msgid "&Variables"
 msgstr "变量"
 
-#: ../../src/wxMaxima.cpp:2443
+#: ../../src/wizards/Plot3dWiz.cpp:79
+msgid "&pm3d"
+msgstr "&pm3d"
+
+#: ../../src/cells/AnimationCell.cpp:475
+msgid "(Animation)"
+msgstr ""
+
+#: ../../src/MaximaProcessManager.cpp:771
 msgid "(Config tells to suppress the output of long cells)"
 msgstr ""
 
-#: ../../src/MathParser.cpp:1288
+#: ../../src/cells/ImgCell.cpp:284
+msgid "(Image)"
+msgstr ""
+
+#: ../../src/MathParser.cpp:1418
 msgid "(Invalid XML from maxima)"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:4221
+#: ../../src/cells/GroupCell.cpp:652
+msgid "(Layout took too long and was suppressed)"
+msgstr ""
+
+#: ../../src/MaximaFileIO.cpp:120
 msgid "(Maybe a permission problem?)"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:9248
+#: ../../src/sidebars/CharButton.cpp:211
+msgid "(Might not be displayed correctly in at least one of the worksheet fonts)"
+msgstr ""
+
+#: ../../src/sidebars/VariablesPane.cpp:254
+msgid "(Not a valid variable name)"
+msgstr "（非可用变量名）"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:183
+msgid "(Use default language)"
+msgstr "（使用默认语言）"
+
+#: ../../src/MaximaCommandMenus.cpp:440
 msgid "(f(x),x,a,b)), Epsilon algorithm"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:9235
+#: ../../src/MaximaCommandMenus.cpp:426
 msgid "(f(x),x,a,b)), Strategy of Aind"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:9258
+#: ../../src/MaximaCommandMenus.cpp:453
 msgid "(f(x),x,a,b), (semi-) infinite interval"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1841
+#: ../../src/wxMaximaFrame.cpp:1878
 msgid "(f(x),x,a,b), Epsilon algorithm"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1843
+#: ../../src/wxMaximaFrame.cpp:1880
 msgid "(f(x),x,a,b), infinite interval"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1839
+#: ../../src/wxMaximaFrame.cpp:1876
 msgid "(f(x),x,a,b), strategy of Aind"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:9361 ../../src/wxMaximaFrame.cpp:1867
+#: ../../src/MaximaCommandMenus.cpp:596 ../../src/wxMaximaFrame.cpp:1904
 msgid "(f(x),x,y) with singularities+discontinuities"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2065
+#: ../../src/wizards/DrawWiz.cpp:274 ../../src/wizards/DrawWiz.cpp:287
+#: ../../src/wizards/DrawWiz.cpp:303 ../../src/wizards/DrawWiz.cpp:320
+#: ../../src/wizards/DrawWiz.cpp:335
+msgid "-"
+msgstr ""
+
+#: ../../src/wizards/IntegrateWiz.cpp:192
+#: ../../src/wizards/IntegrateWiz.cpp:202
+#: ../../src/wizards/IntegrateWiz.cpp:207
+#: ../../src/wizards/IntegrateWiz.cpp:217 ../../src/wizards/LimitWiz.cpp:132
+#: ../../src/wizards/LimitWiz.cpp:142
+msgid "- Infinity"
+msgstr "负无穷"
+
+#: ../../src/MaximaOutputAppender.cpp:116
 #, fuzzy
 msgid "... [suppressed additional lines as the output is longer than allowed in the wxMaxima configuration] "
 msgstr "... [由于输出长度超过设置中允许的长度，因此省略了一些行] "
 
-#: ../../src/Worksheet.cpp:6666
+#: ../../src/worksheet/Worksheet.cpp:4657
 msgid ".wxm clipboard data with unusual header"
 msgstr "带有不寻常文件头的 .wxm 剪切板数据"
 
-#: ../../src/wxMaxima.cpp:8047
-#, fuzzy
-msgid "1×n Matrix b:"
-msgstr "矩阵 #1："
+#: ../../src/sidebars/TableOfContents.cpp:567
+msgid "1 Level"
+msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1312
+#: ../../src/sidebars/SymbolsSidebar.cpp:77
+msgid "1/2"
+msgstr "1/2"
+
+#: ../../src/sidebars/DrawSidebar.cpp:45
+#, fuzzy
+msgid "2D"
+msgstr ""
+"#-#-#-#-#  zh_CN.po (wxMaxima HEAD)  #-#-#-#-#\n"
+"二维绘图\n"
+"#-#-#-#-#  zh_CN.po (wxMaxima-manual)  #-#-#-#-#\n"
+"二维图形"
+
+#: ../../src/wxMaximaFrame.cpp:1346
 #, fuzzy
 msgid "2D Array to Matrix..."
 msgstr "映射至矩阵(&P)..."
 
-#: ../../src/wxMaximaFrame.cpp:743
+#: ../../src/wxMaximaFrame.cpp:780
 msgid "2D equations using ASCII Art"
 msgstr "使用 ASCII 艺术的 2D 方程"
 
-#: ../../src/wxMaximaFrame.cpp:746
+#: ../../src/wxMaximaFrame.cpp:783
 msgid "2D equations using ASCII Art with unicode characters, if available"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:5057
+#: ../../src/dialogs/ConfigDialogue.cpp:786
+msgid "2D if it fits on the page width"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:785
+msgid "2D, whenever possible"
+msgstr ""
+
+#: ../../src/sidebars/DrawSidebar.cpp:49
+#, fuzzy
+msgid "3D"
+msgstr ""
+"#-#-#-#-#  zh_CN.po (wxMaxima HEAD)  #-#-#-#-#\n"
+"三维绘图\n"
+"#-#-#-#-#  zh_CN.po (wxMaxima-manual)  #-#-#-#-#\n"
+"三维图形"
+
+#: ../../src/wxMaxima.cpp:1835
 #, fuzzy, c-format
 msgid "; %i commands left in the current cell"
 msgstr "；当前单元格还剩下 %i 个命令"
 
-#: ../../src/wxMaxima.cpp:10617
+#: ../../src/MaximaEvaluator.cpp:500
 msgid "A \":lisp\" as the first command might fail to send a \"finished\" signal."
 msgstr "以“:lisp”开头的命令可能无法发出“已完成（finished）”信号。"
 
-#: ../../src/wxMaxima.cpp:6585
+#: ../../src/dialogs/TipOfTheDay.cpp:102
+msgid "A 'horizontal cursor' was introduced in wxMaxima 0.8.0. It looks like a horizontal line between cells. It indicates where a new cell will appear if you type or paste text or execute a menu command."
+msgstr "wxMaxima 0.8.0 引入了“水平光标”，其外观是单元格之间的水平线。在键入、粘贴文本或执行菜单命令时，水平光标用于指示新单元格出现的位置。"
+
+#: ../../src/MaximaCommandMenus.cpp:3099
 msgid "A Ctrl-F event"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1973
+#: ../../src/cells/GroupCell.cpp:2178
+msgid "A Maxima input cell with its output"
+msgstr ""
+
+#: ../../src/worksheet/WorksheetContextMenu.cpp:745
 msgid "A Scalar"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:6653
+#: ../../src/cells/TextCell.cpp:239
+msgid ""
+"A command or number wasn't preceded by a \":\", a \"$\", a \";\" or a \",\".\n"
+"Most probable cause: A missing comma between two list items."
+msgstr ""
+
+#: ../../src/wxMaxima.cpp:2642
 #, c-format
 msgid "A find event, %s"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:2012
+#: ../../src/wizards/ListSortWiz.cpp:63
+msgid "A function f(a,b), named"
+msgstr "一个函数 f(a,b) 名"
+
+#: ../../src/worksheet/WorksheetContextMenu.cpp:784
 msgid "A function returning integers"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:2014
+#: ../../src/worksheet/WorksheetContextMenu.cpp:786
 msgid "A function returning positive numbers"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1965
+#: ../../src/wizards/DrawWiz.cpp:164
+msgid "A good example equation would be x^2+y^2=1"
+msgstr ""
+
+#: ../../src/cells/GroupCell.cpp:2193 ../../src/cells/GroupCell.cpp:2196
+msgid "A heading"
+msgstr ""
+
+#: ../../src/worksheet/WorksheetContextMenu.cpp:737
 #, fuzzy
 msgid "A irrational variable"
 msgstr "修改变量"
 
-#: ../../src/Worksheet.cpp:2016
+#: ../../src/worksheet/WorksheetContextMenu.cpp:788
 msgid "A left-associative function"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:2019
+#: ../../src/worksheet/WorksheetContextMenu.cpp:791
 #, fuzzy
 msgid "A linear function"
 msgstr "删除函数"
 
-#: ../../src/wxMaxima.cpp:9590
+#: ../../src/MaximaCommandMenus.cpp:1830
 msgid "A matrix in which each row is a set of variables"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1963
+#: ../../src/dialogs/TipOfTheDay.cpp:84
+#, fuzzy
+msgid "A new document format has been introduced in wxMaxima 0.8.2 that saves not only your input and text commentaries, but also the outputs of your calculations. When saving your document, select 'Whole document (*.wxmx)' format."
+msgstr "wxMaxima 0.8.2 引入了一种新的文档格式，这种格式的文档不仅可以保存用户输入的命令和注释文本，还可以保存计算结果。在保存文档时，选择“整个文档（*.wxmx）”即可使用该格式。"
+
+#: ../../src/cells/GroupCell.cpp:2175
+msgid "A page break"
+msgstr "换页"
+
+#: ../../src/dialogs/TipOfTheDay.cpp:168
+msgid "A plot to be embedded into the work sheet by preceding its name with a \"wx\". \"draw\" can be replaced by \"wxdraw\", plot by \"wxplot\" etc."
+msgstr "通过在 Maxima 绘图命令的名称前面加上“wx”，例如将“draw”替换为“wxdraw”，“plot”替换为“wxplot”等，可以将生成的图片嵌入当前工作簿。"
+
+#: ../../src/worksheet/WorksheetContextMenu.cpp:735
 #, fuzzy
 msgid "A rational variable"
 msgstr "修改变量"
 
-#: ../../src/Worksheet.cpp:2018
+#: ../../src/worksheet/WorksheetContextMenu.cpp:790
 msgid "A right-associative function"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1634
+#: ../../src/dialogs/ConfigDialogue.cpp:436
+msgid "A scale factor for the printout. Helpful for printing big equations on small pdf pages."
+msgstr "打印输出的比例因子。有助于在小的 pdf 页面上打印大的公式。"
+
+#: ../../src/wxMaximaFrame.cpp:1671
 msgid "A search-and-replace for equations"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1636
+#: ../../src/cells/EditorCell.cpp:4522 ../../src/cells/GroupCell.cpp:2184
+msgid "A section heading"
+msgstr ""
+
+#: ../../src/wizards/DrawWiz.cpp:479
+#, fuzzy
+msgid "A static plot"
+msgstr "参数式绘图"
+
+#: ../../src/cells/EditorCell.cpp:4534
+msgid "A sub-sub-sub-subsection heading"
+msgstr ""
+
+#: ../../src/cells/EditorCell.cpp:4531
+msgid "A sub-sub-subsection heading"
+msgstr ""
+
+#: ../../src/cells/EditorCell.cpp:4528 ../../src/cells/GroupCell.cpp:2190
+msgid "A sub-subsection heading"
+msgstr "小小节单元"
+
+#: ../../src/cells/EditorCell.cpp:4525 ../../src/cells/GroupCell.cpp:2187
+msgid "A subsection heading"
+msgstr "小节头文件"
+
+#: ../../src/wxMaximaFrame.cpp:1673
 msgid "A subst with basic maths knowledge"
 msgstr ""
 
-#: ../../src/BTextCtrl.cpp:64
+#: ../../src/sidebars/SymbolsSidebar.cpp:239
+msgid "A symbol from the configuration dialogue"
+msgstr "来自设置对话框中的符号"
+
+#: ../../src/cells/GroupCell.cpp:2181
+msgid "A text cell"
+msgstr ""
+
+#: ../../src/BTextCtrl.cpp:66
 msgid "A text control got the mouse focus"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1442
+#: ../../src/cells/GroupCell.cpp:2199
+msgid "A title"
+msgstr ""
+
+#: ../../src/cells/TextCell.cpp:197
+msgid ""
+"A variable that can be assigned a number to.\n"
+"Often used by solve() and algsys(), if there is an infinite number of results."
+msgstr ""
+
+#: ../../src/cells/GroupCell.cpp:2205
+msgid "A worksheet cell"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1479
 #, fuzzy
 msgid "A&pply function to each Matrix element..."
 msgstr "应用函数至每个列表元素"
 
-#: ../../src/wxMaximaFrame.cpp:1291
+#: ../../src/wxMaximaFrame.cpp:1325
 msgid "A&t Value..."
 msgstr "函数赋值(&A)..."
 
-#: ../../src/Configuration.cpp:85
+#: ../../src/Styles.cpp:114
 msgid "ASCII maths"
 msgstr "ASCII 艺术"
 
-#: ../../src/wxMaximaFrame.cpp:1963
+#: ../../src/dialogs/ConfigDialogue.cpp:1618
+msgid "Abort evaluation on error"
+msgstr "发生错误时中止计算"
+
+#: ../../src/MaximaEvaluator.cpp:214
+#, c-format
+msgid "Aborting due to --exit-on-error (exit code 1). Cell: %s"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:2016
 msgid "About"
 msgstr "关于"
 
-#: ../../src/wxMaximaFrame.cpp:1963 ../../src/wxMaximaFrame.cpp:1965
+#: ../../src/wxMaximaFrame.cpp:2016 ../../src/wxMaximaFrame.cpp:2018
 msgid "About wxMaxima"
 msgstr "关于 wxMaxima"
 
-#: ../../src/wxMaxima.cpp:7837
+#: ../../src/MaximaCommandMenus.cpp:1018
 msgid "Accepts one expression or a list in the format [ode1,ode2,...]"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7841
+#: ../../src/MaximaCommandMenus.cpp:1022
 msgid "Accepts one variable or a list in the format [1,4,...]"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7839
+#: ../../src/MaximaCommandMenus.cpp:1020
 msgid "Accepts one variable or a list in the format [var1,var2,...]"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1371
+#: ../../src/dialogs/ConfigDialogue.cpp:292
+msgid "Accessibility"
+msgstr ""
+
+#: ../../src/sidebars/DrawSidebar.cpp:103
+msgid "Accuracy"
+msgstr "精度"
+
+#: ../../src/wxMaximaFrame.cpp:1405
 msgid "Ad&joint Matrix"
 msgstr "伴随矩阵(&J)"
 
-#: ../../src/wxMaximaFrame.cpp:1657
+#: ../../src/wxMaximaFrame.cpp:1694
 msgid "Add Algebraic E&quality..."
 msgstr "添加代数数(&Q)..."
 
-#: ../../src/wxMaximaFrame.cpp:1015
+#: ../../src/wxMaximaFrame.cpp:1049
 msgid "Add a directory to search path"
 msgstr "添加目录至搜索路径"
 
-#: ../../src/wxMaximaFrame.cpp:1752
+#: ../../src/wxMaximaFrame.cpp:1789
 msgid "Add a new item to the beginning of the list. Useful for creating stacks."
 msgstr "添加新元素至列表开头，可用来生成堆栈（stack）。"
 
-#: ../../src/wxMaxima.cpp:8602
+#: ../../src/sidebars/VariablesPane.cpp:228
+msgid "Add all"
+msgstr "添加所有"
+
+#: ../../src/MaximaCommandMenus.cpp:1621
 msgid "Add an element to the end of a list"
 msgstr "添加一个元素至列表末尾"
 
-#: ../../src/wxMaxima.cpp:8597
+#: ../../src/MaximaCommandMenus.cpp:1616
 msgid "Add an element to the start of a list"
 msgstr "添加一个元素至列表开头"
 
-#: ../../src/wxMaxima.cpp:7625
+#: ../../src/MaximaCommandMenus.cpp:4497
 msgid "Add dir to path:"
 msgstr "添加目录至搜索路径："
 
-#: ../../src/wxMaximaFrame.cpp:1658
+#: ../../src/wxMaximaFrame.cpp:1695
 msgid "Add equality to the rational simplifier"
 msgstr "添加等式以利用其根化简有理式"
 
-#: ../../src/wxMaximaFrame.cpp:1015
+#: ../../src/sidebars/SymbolsSidebar.cpp:204
+msgid "Add more symbols"
+msgstr "添加更多符号"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1262
+msgid "Add the .wxmx file to the HTML export"
+msgstr "为导出的 HTML 文件添加 .wxmx 文件"
+
+#: ../../src/wxMaximaFrame.cpp:1049
 msgid "Add to &Path..."
 msgstr "添加至搜索路径(&P)..."
 
-#: ../../src/Worksheet.cpp:1531 ../../src/Worksheet.cpp:1564
-#: ../../src/Worksheet.cpp:1704
+#: ../../src/sidebars/UnicodeSidebar.cpp:105
+msgid "Add to symbols Sidebar"
+msgstr "添加至符号侧边栏"
+
+#: ../../src/worksheet/WorksheetContextMenu.cpp:304
+#: ../../src/worksheet/WorksheetContextMenu.cpp:337
+#: ../../src/worksheet/WorksheetContextMenu.cpp:477
 msgid "Add to watchlist"
 msgstr "添加至监视列表"
 
-#: ../../src/wxMaximaFrame.cpp:1562
+#: ../../src/sidebars/XmlInspector.cpp:147
+#, c-format
+msgid "Added much text (%li chars) to the XML inspector."
+msgstr "向 XML 检查器添加了大量文本（%li 个字符）。"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1896
+msgid "Additional clipboard formats to put on the clipboard on ordinary copy"
+msgstr "在复制到剪贴板时，附加剪贴板格式"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:393
+msgid "Additional commands to be added to the preamble of LaTeX output for pdftex."
+msgstr "输出 LaTeX 文件时，添加额外的命令到导言区。"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1187
+msgid "Additional lines for the TeX preamble:"
+msgstr "LaTeX 导言区的附加内容："
+
+#: ../../src/dialogs/ConfigDialogue.cpp:389
+msgid "Additional parameters for Maxima (e.g. -l clisp)."
+msgstr "Maxima 的附加参数（例如： -l clisp）。"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1543
+msgid "Additional parameters for Maxima (restart Maxima after changes)"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1318
+msgid "Additional symbols for the \"symbols\" sidebar:"
+msgstr "为符号侧边栏添加额外的符号："
+
+#: ../../src/wxMaximaFrame.cpp:1599
 msgid "Additionally: log(a*b)=log(a)+log(b)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1566
+#: ../../src/wxMaximaFrame.cpp:1603
 msgid "Additionally: log(a/b)=log(a)-log(b), a and b positive integers"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1996
+#: ../../src/worksheet/WorksheetContextMenu.cpp:768
 msgid "Additive function: f(a+b)=f(a)+f(b)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1911
+#: ../../src/wxMaximaFrame.cpp:1948
 msgid "Advanced 2d plotting"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1809
+#: ../../src/wxMaximaFrame.cpp:1846
 msgid "Advanced guess (PSLQ algorithm)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1920
+#: ../../src/wxMaximaFrame.cpp:1957
 msgid "Advanced variable names"
 msgstr "高级变量名"
 
-#: ../../src/ToolBar.cpp:321 ../../src/ToolBar.cpp:589
-msgid "After clicking on animations created with with_slider_draw() or similar this slider allows to change the current frame."
-msgstr "在单击由 with_slider_draw() 等命令创建的动图后，使用此滑块可以更改当前帧。"
+#: ../../src/dialogs/ConfigDialogue.cpp:184
+msgid "Afrikaans"
+msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1028
+#: ../../src/ToolBar.cpp:536 ../../src/ToolBar.cpp:789
+msgid "After clicking on animations created with with_slider_draw() or similar, this slider allows changing the current frame."
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:185
+msgid "Albanian"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1062
 #, fuzzy
 msgid "Aliases"
 msgstr "线条抗锯齿"
 
-#: ../../src/wxMaximaFrame.cpp:1714
+#: ../../src/sidebars/TableOfContents.cpp:572
+msgid "All Levels"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1751
 msgid "All but the 1st n elements"
 msgstr "去掉前 n 个元素"
 
-#: ../../src/wxMaximaFrame.cpp:1716
+#: ../../src/wxMaximaFrame.cpp:1753
 msgid "All but the last n elements"
 msgstr "去掉后 n 个元素"
 
-#: ../../src/main.cpp:594 ../../src/wxMaxima.cpp:6075
+#: ../../src/MaximaCommandMenus.cpp:2198 ../../src/main.cpp:883
 msgid "All openable types (*.wxm, *.wxmx, *.mac, *.out, *.xml)|*.wxm;*.wxmx;*.mac;*.out;*.xml|wxMaxima document (*.wxm, *.wxmx)|*.wxm;*.wxmx|Maxima session (*.mac)|*.mac|Xmaxima session (*.out)|*.out|xml from broken .wxmx (*.xml)|*.xml"
 msgstr "所有可打开的文件类型 (*.wxm, *.wxmx, *.mac, *.out, *.xml)|*.wxm; *.wxmx; *.mac; *.out; *.xml|wxMaxima 文档 (*.wxm, *.wxmx)|*.wxm; *.wxmx|Maxima 会话 (*.mac)|*.mac|Xmaxima 会话 (*.out)|*.out|来自已损坏 .wxmx 文档的 xml 文件 (*.xml)|*.xml"
 
-#: ../../src/wxMaximaFrame.cpp:733
+#: ../../src/dialogs/ConfigDialogue.cpp:750
+msgid "All variable names"
+msgstr "所有变量名"
+
+#: ../../src/wxMaximaFrame.cpp:770
 #, fuzzy
 msgid "All visible sidebars"
 msgstr "所有变量名"
 
-#: ../../src/wxMaximaFrame.cpp:1650
-msgid "Allow to substitute operators"
+#: ../../src/sidebars/HelpBrowser.cpp:48
+msgid "Allow access to an online manual?"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:9040
-msgid "Allows to vary the parameters of a function until it fits experimental data."
+#: ../../src/wxMaximaFrame.cpp:1687
+msgid "Allow substituting operators"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:763
+#: ../../src/wizards/DrawWiz.cpp:722
+msgid "Allows providing separate expressions for calculating"
+msgstr ""
+
+#: ../../src/sidebars/SymbolsSidebar.cpp:182
+msgid "Allows specifying which non-builtin unicode symbols should be displayed in the symbols sidebar along with the built-in symbols."
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:294
+msgid "Allows varying the parameters of a function until it fits experimental data."
+msgstr ""
+
+#: ../../src/dialogs/BinaryNameCtrl.cpp:69
+msgid "All|*"
+msgstr "所有类型|*"
+
+#: ../../src/wxMaximaFrame.cpp:800
 msgid "Always after underscores"
 msgstr "总是在下划线后面"
 
-#: ../../src/wxMaximaFrame.cpp:764
+#: ../../src/wxMaximaFrame.cpp:801
 msgid "Always autosubscript after an underscore"
 msgstr "总是将下划线后面的字符显示为下标"
 
-#: ../../src/wxMaximaFrame.cpp:774
+#: ../../src/wxMaximaFrame.cpp:811
 msgid "Always display this variable with subscript"
 msgstr "总是显示此变量及其下标"
 
-#: ../../src/Worksheet.cpp:1605
+#: ../../src/worksheet/WorksheetContextMenu.cpp:378
 msgid "Always show all digits"
 msgstr "总是显示所有数字"
 
-#: ../../src/wxMaxima.cpp:9241
+#: ../../src/wizards/DrawWiz.cpp:484
+msgid "An animation with multiple frames"
+msgstr ""
+
+#: ../../src/cells/GroupCell.cpp:2202
+msgid "An image cell"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:433
 msgid "An integer between 1..6; Higher numbers work better for oscillating integrands"
 msgstr ""
 
-#: ../../src/MaximaManual.cpp:385
+#: ../../src/cells/TextCell.cpp:202
+msgid "An integration constant."
+msgstr "积分常量"
+
+#: ../../src/MaximaManual.cpp:402
 msgid "Anchors file has no top node."
 msgstr "锚文件没有顶部节点。"
 
-#: ../../src/wxMaximaFrame.cpp:791
+#: ../../src/wxMaximaFrame.cpp:828
 msgid "Angles"
 msgstr "角"
 
-#: ../../src/wxMaximaFrame.cpp:1775
+#: ../../src/worksheet/WorksheetExport.cpp:1122
+#: ../../src/worksheet/WorksheetExport.cpp:1387
+msgid "Animated Diagram"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1812
 msgid "Animation autoplay"
 msgstr "自动播放动图"
 
-#: ../../src/wxMaximaFrame.cpp:1778
+#: ../../src/wxMaximaFrame.cpp:1815
 msgid "Animation framerate..."
 msgstr "动图帧率..."
 
-#: ../../src/Worksheet.cpp:2002
+#: ../../src/dialogs/ConfigDialogue.cpp:1871
+msgid "Announce Maxima's output as MathML"
+msgstr ""
+
+#: ../../src/worksheet/Worksheet.cpp:5467 ../../src/wxMaximaFrame.cpp:1989
+msgid "Anonymize Code for Bug Report"
+msgstr ""
+
+#: ../../src/worksheet/WorksheetContextMenu.cpp:774
 msgid "Antisymmetric function: f(x)=-f(-x)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1739
+#: ../../src/dialogs/ConfigDialogue.cpp:2064
+msgid "Appearance:"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1776
 msgid "Append"
 msgstr "追加"
 
-#: ../../src/wxMaximaFrame.cpp:1735
+#: ../../src/wxMaximaFrame.cpp:1772
 msgid "Append a list"
 msgstr "追加一个列表"
 
-#: ../../src/wxMaximaFrame.cpp:1736
+#: ../../src/wxMaximaFrame.cpp:1773
 msgid "Append a list to an existing list"
 msgstr "向已有列表追加一个列表"
 
-#: ../../src/wxMaxima.cpp:8607
+#: ../../src/MaximaCommandMenus.cpp:1626
 #, fuzzy
 msgid "Append a list to another list"
 msgstr "向已有列表追加一个列表"
 
-#: ../../src/wxMaximaFrame.cpp:1729
+#: ../../src/wxMaximaFrame.cpp:1766
 msgid "Append an element"
 msgstr "追加元素"
 
-#: ../../src/wxMaximaFrame.cpp:1734
+#: ../../src/wxMaximaFrame.cpp:1771
 msgid "Append an element to the beginning an existing list"
 msgstr "向已有列表开头追加一个元素"
 
-#: ../../src/wxMaximaFrame.cpp:1730
+#: ../../src/wxMaximaFrame.cpp:1767
 msgid "Append an element to the end of an existing list"
 msgstr "向已有列表结尾追加一个元素"
 
-#: ../../src/wxMaxima.cpp:8552
+#: ../../src/MaximaCommandMenus.cpp:1565
 msgid "Apply a function to each list element"
 msgstr "应用函数至每个列表元素"
 
-#: ../../src/wxMaximaFrame.cpp:1810
+#: ../../src/wxMaximaFrame.cpp:1847
 #, c-format
 msgid "Approximate by a fraction using log(), sqrt() and %pi, when needed. Only available in maxima > 5.46.0"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1806
+#: ../../src/wxMaximaFrame.cpp:1843
 msgid "Approximate by nice fraction"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8931
+#: ../../src/MaximaCommandMenus.cpp:182
 msgid ""
 "Approximates a expression around a point as a polynom\n"
 "The trailing \"...\" can be removed by using ratdisrep()"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8939
+#: ../../src/MaximaCommandMenus.cpp:190
 msgid "Approximates a expression as a polynom"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:9474
+#: ../../src/MaximaCommandMenus.cpp:2117
 msgid "Apropos"
 msgstr "命令查找"
 
-#: ../../src/wxMaxima.cpp:7317
+#: ../../src/dialogs/ConfigDialogue.cpp:186
+msgid "Arabic"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:4189
 msgid "Are the chars equal, if case is ignored?"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7312
+#: ../../src/MaximaCommandMenus.cpp:4184
 #, fuzzy
 msgid "Are the chars equal?"
 msgstr "大于等于"
 
-#: ../../src/wxMaxima.cpp:7349
+#: ../../src/MaximaCommandMenus.cpp:4221
 msgid "Are these strings equal if case is ignored?"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7344
+#: ../../src/MaximaCommandMenus.cpp:4216
 msgid "Are these strings equal?"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7259
+#: ../../src/MaximaCommandMenus.cpp:4131
 msgid "Arguments:"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8189
+#: ../../src/MaximaCommandMenus.cpp:1379
 #, fuzzy
 msgid "Array"
 msgstr "数组："
 
-#: ../../src/wxMaximaFrame.cpp:1023
+#: ../../src/wxMaximaFrame.cpp:1057
 #, fuzzy
 msgid "Arrays"
 msgstr "数组："
 
-#: ../../src/wxMaxima.cpp:7308 ../../src/wxMaxima.cpp:7354
+#: ../../src/cells/TextCell.cpp:212
+msgid ""
+"As calculating 0.1^12 demonstrates maxima by default doesn't tend to hide what looks like being the small error using floating-point numbers introduces.\n"
+"If this seems to be the case here the error can be avoided by using exact numbers like 1/10, 1*10^-1 or rat(.1).\n"
+"It also can be hidden by setting fpprintprec to an appropriate value. But be aware in this case that even small errors can add up."
+msgstr ""
+
+#: ../../src/wizards/ListSortWiz.cpp:51
+msgid "Ascending by magnitude (numeric only)"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:4180 ../../src/MaximaCommandMenus.cpp:4226
 msgid "Ascii code to char"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1138
+#: ../../src/wxMaximaFrame.cpp:1172
 msgid "Ascii code to char..."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:10063
+#: ../../src/dialogs/ConfigDialogue.cpp:1397
+msgid "Ask to save untitled documents"
+msgstr "询问是否保存未命名文档"
+
+#: ../../src/dialogs/MaximaNotStartingDialog.cpp:36
+msgid "Asking the user for the location of a working maxima binary"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:3552
 msgid "Assignment(s):"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:10064
+#: ../../src/MaximaCommandMenus.cpp:3553
 msgid "Assignments of the format a=10,b=20"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:6851
+#: ../../src/MaximaCommandMenus.cpp:1754
 #, fuzzy
 msgid "Assume a value range for a variable"
 msgstr "提取变量的实际值"
 
-#: ../../src/wxMaxima.cpp:8545
+#: ../../src/MaximaCommandMenus.cpp:1558
 msgid "Attention: Extracting a random list element isn't efficient for long lists.Iterating over lists using makelist() or for loops is way faster."
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1618
+#: ../../src/dialogs/ConfigDialogue.cpp:897
+msgid "Auto-indent new lines"
+msgstr "自动缩进新行"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:893
+#, fuzzy
+msgid "Auto-insert closing parenthesis"
+msgstr "未配对的括号"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1441
+#: ../../src/dialogs/ConfigDialogue.cpp:1472
+#: ../../src/dialogs/MaximaNotStartingDialog.cpp:43
+msgid "Autodetect"
+msgstr "自动检测"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1236
+msgid "Automatic"
+msgstr "自动"
+
+#: ../../src/worksheet/WorksheetContextMenu.cpp:391
 msgid "Automatic labels"
 msgstr "自动设置标签"
 
-#: ../../src/wxMaximaFrame.cpp:952
+#: ../../src/dialogs/ConfigDialogue.cpp:769
+#, c-format
+msgid "Automatic labels (%i1, %o1,...)"
+msgstr "自动设置标签（%i1, %o1, ...）"
+
+#: ../../src/wxMaximaFrame.cpp:986
 msgid "Automatically answer questions"
 msgstr "自动回答"
 
-#: ../../src/wxMaximaFrame.cpp:953
+#: ../../src/wxMaximaFrame.cpp:987
 msgid "Automatically fill in answers known from the last run"
 msgstr "自动填入上一次的运行结果"
 
-#: ../../src/Worksheet.cpp:1464 ../../src/Worksheet.cpp:1838
+#: ../../src/dialogs/ConfigDialogue.cpp:460
+msgid "Automatically insert a closing parenthesis the moment the user enters an opening one."
+msgstr ""
+
+#: ../../src/worksheet/WorksheetContextMenu.cpp:235
+#: ../../src/worksheet/WorksheetContextMenu.cpp:610
 msgid "Automatically send known answers"
 msgstr "自动传递已有答案"
 
-#: ../../src/wxMaxima.cpp:6021
+#: ../../src/MaximaFileIO.cpp:902
 #, c-format
 msgid "Autosaving as temp file %s"
 msgstr "自动保存为临时文件 %s"
 
-#: ../../src/wxMaxima.cpp:6033
+#: ../../src/MaximaFileIO.cpp:914
 #, c-format
 msgid "Autosaving the .wxmx file as %s"
 msgstr "自动保存 .wxmx 文件为 %s"
 
-#: ../../src/wxMaximaFrame.cpp:781
+#: ../../src/wxMaximaFrame.cpp:818
 msgid "Autosubscript"
 msgstr "自动下标"
 
-#: ../../src/wxMaximaFrame.cpp:782
+#: ../../src/wxMaximaFrame.cpp:819
 msgid "Autosubscript chars after an underscore"
 msgstr "自动将下划线后的字符显示为下标"
 
-#: ../../src/wxMaximaFrame.cpp:767
+#: ../../src/wxMaximaFrame.cpp:804
 msgid "Autosubscript numbers and text following single letters"
 msgstr "自动将单个字母后的数字显示为下标"
 
-#: ../../src/wxMaxima.cpp:6529
+#: ../../src/MaximaCommandMenus.cpp:3049
 #, fuzzy
 msgid "Autosubscript this variable"
 msgstr "从不将此变量自动显示为下标"
 
-#: ../../src/MaximaManual.cpp:536
+#: ../../src/dialogs/ConfigDialogue.cpp:734
+msgid "Autowrap long lines:"
+msgstr "对较长的行自动换行："
+
+#: ../../src/sidebars/DrawSidebar.cpp:75
+msgid "Axis"
+msgstr "坐标轴"
+
+#: ../../src/wizards/BC2Wiz.cpp:59
+msgid "BC2"
+msgstr "两个边界条件"
+
+#: ../../src/MaximaManual.cpp:559
 msgid "Background task that compiles the Manual anchors scheduled."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1350
+#: ../../src/sidebars/StatSidebar.cpp:91
+msgid "Barsplot..."
+msgstr "直方图..."
+
+#: ../../src/wxMaximaFrame.cpp:1384
 msgid "Basic matrix operations"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:6210
+#: ../../src/dialogs/ConfigDialogue.cpp:187
+msgid "Basque"
+msgstr ""
+
+#: ../../src/dialogs/BinaryNameCtrl.cpp:67
+msgid "Bat files (*.bat)|*.bat|Exe files (*.exe)|*.exe|All|*"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:2366
 msgid "Batch File"
 msgstr "批处理文件"
 
-#: ../../src/wxMaxima.cpp:5318
+#: ../../src/wxMaxima.cpp:2079
+#, c-format
+msgid "Batch mode: %d image(s) could not be loaded at all."
+msgstr ""
+
+#: ../../src/wxMaxima.cpp:2084
+#, c-format
+msgid "Batch mode: %d image(s) failed to decode/render (--debug)."
+msgstr ""
+
+#: ../../src/MaximaResponseReader.cpp:523
+#, c-format
+msgid "Batch mode: Maxima asked a question with no scripted answer available (\"%s\"). Halting, as documented for --batch."
+msgstr ""
+
+#: ../../src/cells/TextCell.cpp:305
+msgid "Besides a division by 0 the reason for this error message can be a calculation that returns +/-infinity."
+msgstr ""
+
+#: ../../src/dialogs/TipOfTheDay.cpp:141
+msgid "Besides the global undo functionality that is active when the cursor is between cells, wxMaxima has a per-cell undo function that is active if the cursor is inside a cell. Pressing Ctrl+Z inside a cell can therefore been used for a fine-pitch undo that doesn't affect latter changes made in other cells."
+msgstr "当光标处于在单元格之间（即显示为水平光标）时，wxMaxima 将激活全局撤销功能。当光标处于在单元格内部（即显示为竖直光标）时，wxMaxima 将激活单元格撤消功能。因此，可以定位到单元格内，按 Ctrl+Z 键撤销该单元格内部的改动，而不会影响之前在其他单元格中所做的更改。"
+
+#: ../../src/sidebars/GreekSidebar.cpp:179
+msgid "Beta"
+msgstr "Beta"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1898
+msgid "Bitmap"
+msgstr "位图"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1273
+msgid "Bitmap scale for export:"
+msgstr "导出位图的比例："
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1223
+msgid "Bitmaps"
+msgstr "位图"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:2109
+msgid "Bold"
+msgstr "黑体"
+
+#: ../../src/wxMaxima.cpp:2261
 msgid "Both horizontal and vertical cursor active at the same time"
 msgstr "水平光标和竖直光标同时被激活"
 
-#: ../../src/wxMaxima.cpp:8191
+#: ../../src/dialogs/ConfigDialogue.cpp:1999
+msgid "Bottom"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:1381
 msgid "Bottom end"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7817
+#: ../../src/MaximaCommandMenus.cpp:998
 #, fuzzy
 msgid "Boundary value problem"
 msgstr "边值问题(&B)..."
+
+#: ../../src/MaximaCommandMenus.cpp:1780
+msgid "Boxplot"
+msgstr ""
+
+#: ../../src/sidebars/StatSidebar.cpp:97
+msgid "Boxplot..."
+msgstr "箱线图..."
+
+#: ../../src/dialogs/BinaryNameCtrl.cpp:42 ../../src/wizards/CsvWiz.cpp:57
+#: ../../src/wizards/CsvWiz.cpp:131 ../../src/wizards/Plot2dWiz.cpp:114
+#: ../../src/wizards/Plot3dWiz.cpp:109
+msgid "Browse"
+msgstr "浏览"
 
 #: ../../src/wxMathml.cpp:101
 msgid "Bug: After removing the whitespace wxMathml.lisp is shorter than expected!"
 msgstr "Bug: After removing the whitespace wxMathml.lisp is shorter than expected!"
 
-#: ../../src/Autocomplete.cpp:509
+#: ../../src/cells/Cell.cpp:498
+#, c-format
+msgid "Bug: AltCopyTexts not implemented for %s cell"
+msgstr ""
+
+#: ../../src/Autocomplete.cpp:642
 msgid "Bug: Autocompletion requested for unknown type of item."
 msgstr "Bug: Autocompletion requested for unknown type of item."
 
-#: ../../src/Worksheet.cpp:2992
+#: ../../src/TreeUndoManager.h:138
 msgid "Bug: Cell left but not entered."
 msgstr "Bug: Cell left but not entered."
 
-#: ../../src/Worksheet.cpp:6203
+#: ../../src/worksheet/Worksheet.cpp:4193
 msgid "Bug: Cell with negative y position!"
 msgstr "Bug: Cell with negative y position!"
 
-#: ../../src/Worksheet.cpp:7723
+#: ../../src/worksheet/Worksheet.cpp:5905
 msgid "Bug: Encountered a heading I don't know how to move in one sectioning unit"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:7766
+#: ../../src/worksheet/Worksheet.cpp:5952
 msgid "Bug: Encountered a heading I don't know how to move out one sectioning unit"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:3112
+#: ../../src/worksheet/Worksheet.cpp:2244
 msgid "Bug: Got a question but no cell to answer it in"
 msgstr "Bug: Got a question but no cell to answer it in"
 
-#: ../../src/Worksheet.cpp:6378
-msgid "Bug: Got a request to change the contents of the cell above the beginning of the worksheet."
-msgstr "Bug: Got a request to change the contents of the cell above the beginning of the worksheet."
-
-#: ../../src/Worksheet.cpp:6346
+#: ../../src/worksheet/Worksheet.cpp:4293
 msgid "Bug: Got a request to delete the cell above the beginning of the worksheet."
 msgstr "Bug: Got a request to delete the cell above the beginning of the worksheet."
 
-#: ../../src/Worksheet.cpp:6415
+#: ../../src/worksheet/WorksheetDocument.cpp:239
 msgid "Bug: Got a request to first change the contents of a cell and to then undelete it."
 msgstr "Bug: Got a request to first change the contents of a cell and to then undelete it."
 
-#: ../../src/Worksheet.cpp:5578
+#: ../../src/worksheet/WorksheetExport.cpp:1576
 msgid "Bug: HTML output is no valid XML"
 msgstr "Bug: HTML output is no valid XML"
 
-#: ../../src/Configuration.h:615
+#: ../../src/cells/Cell.cpp:289
+msgid "Bug: Math Cell that claims to have no group Cell it belongs to"
+msgstr ""
+
+#: ../../src/Configuration.h:741
 msgid "Bug: Maximum number of digits that is to be displayed is too low!"
 msgstr "Bug: Maximum number of digits that is to be displayed is too low!"
 
-#: ../../src/MathParser.cpp:523
+#: ../../src/MathParser.cpp:575
 msgid "Bug: Missing contents"
 msgstr "Bug: Missing contents"
 
-#: ../../src/Worksheet.cpp:2597 ../../src/Worksheet.cpp:2711
-#: ../../src/Worksheet.cpp:2753 ../../src/Worksheet.cpp:2787
-#: ../../src/Worksheet.cpp:2816 ../../src/Worksheet.cpp:2828
-#: ../../src/Worksheet.cpp:4442 ../../src/Worksheet.cpp:6650
-#: ../../src/Worksheet.cpp:6863
+#: ../../src/cells/GroupCell.cpp:1498
+msgid "Bug: No image counter to write to!"
+msgstr ""
+
+#: ../../src/cells/AnimationCell.cpp:543 ../../src/cells/EditorCell.cpp:2968
+#: ../../src/cells/ImgCell.cpp:353 ../../src/graphical_io/BitmapOut.cpp:161
+#: ../../src/graphical_io/OutCommon.cpp:264
+#: ../../src/worksheet/Worksheet.cpp:1764
+#: ../../src/worksheet/Worksheet.cpp:1901
+#: ../../src/worksheet/Worksheet.cpp:1943
+#: ../../src/worksheet/Worksheet.cpp:1977
+#: ../../src/worksheet/Worksheet.cpp:2006
+#: ../../src/worksheet/Worksheet.cpp:2018
+#: ../../src/worksheet/Worksheet.cpp:3512
+#: ../../src/worksheet/Worksheet.cpp:4641
+#: ../../src/worksheet/Worksheet.cpp:4866
 msgid "Bug: The clipboard is already opened"
 msgstr "Bug: The clipboard is already opened"
 
-#: ../../src/Worksheet.cpp:7763
+#: ../../src/cells/EditorCell.cpp:3051
+msgid "Bug: The clipboard isn't open on pasting into an editor cell"
+msgstr ""
+
+#: ../../src/cells/GroupCell.cpp:2288
+msgid "Bug: The predecessor to a GroupCell is not a GroupCell."
+msgstr ""
+
+#: ../../src/cells/GroupCell.cpp:2286
+msgid "Bug: The successor to a GroupCell is not a GroupCell."
+msgstr ""
+
+#: ../../src/cells/GroupCell.cpp:340
+msgid "Bug: Trying to append NULL to a group cell."
+msgstr ""
+
+#: ../../src/worksheet/Worksheet.cpp:5949
 msgid "Bug: Trying to move a title out by one sectioning unit"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:6934
+#: ../../src/worksheet/Worksheet.cpp:4925
 msgid "Bug: Trying to move the horizontally-drawn cursor to a place inside a GroupCell."
 msgstr "Bug: Trying to move the horizontally-drawn cursor to a place inside a GroupCell."
 
-#: ../../src/Worksheet.h:247 ../../src/Worksheet.h:252
+#: ../../src/TreeUndoAction.h:52 ../../src/TreeUndoAction.h:57
 msgid "Bug: Trying to record a cell contents change for undo without a cell."
 msgstr "Bug: Trying to record a cell contents change for undo without a cell."
 
-#: ../../src/Worksheet.cpp:6417
+#: ../../src/TreeUndoAction.h:73
+msgid "Bug: Trying to record a fold/unfold for undo without a cell."
+msgstr ""
+
+#: ../../src/worksheet/WorksheetDocument.cpp:241
 msgid "Bug: Undo action with both cell contents change and cell addition."
 msgstr "Bug: Undo action with both cell contents change and cell addition."
 
-#: ../../src/Worksheet.cpp:6383
-msgid "Bug: Undo request for cell outside worksheet."
-msgstr "Bug: Undo request for cell outside worksheet."
+#: ../../src/cells/EditorCell.cpp:4541
+msgid "Bug: Unknown type of text"
+msgstr "错误：未知文本类型"
 
-#: ../../src/wxMaximaFrame.cpp:1948
+#: ../../src/cells/EditorCell.cpp:3981 ../../src/cells/TextCell.cpp:479
+msgid "Bug: dc == NULL"
+msgstr ""
+
+#: ../../src/cells/EditorCell.cpp:2637
+msgid "Bug: x position of cell is unknown!"
+msgstr ""
+
+#: ../../src/cells/EditorCell.cpp:2638
+msgid "Bug: y position of cell is unknown!"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1985
 msgid "Build &Info"
 msgstr "编译信息(&I)"
 
-#: ../../src/wxMaxima.cpp:7275
+#: ../../src/dialogs/AboutDialog.cpp:45
+#, fuzzy, c-format
+msgid "Build from Git version: %s\n"
+msgstr "Maxima 版本：%s"
+
+#: ../../src/dialogs/TipOfTheDay.cpp:54
+msgid "By default, Shift-Enter is used to evaluate commands, while Enter is used for multiline input. This behaviour can be changed in 'Edit->Configure' dialog by checking 'Enter evaluates cells'. This switches the roles of these two key commands."
+msgstr "在默认情况下，使用 Shift+Enter 键执行命令，而使用 Enter 键输入多行命令。可以在“编辑->设置”对话框中更改此行为。选中“按下 Enter 键执行命令”，将切换这两种键位的功能。"
+
+#: ../../src/MaximaCommandMenus.cpp:4147
 msgid "Byte:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1458
+#: ../../src/wxMaximaFrame.cpp:1495
 #, fuzzy
 msgid "C&hange Variable in Integrate..."
 msgstr "修改变量(&H)..."
 
-#: ../../src/wxMaximaFrame.cpp:687
+#: ../../src/wxMaximaFrame.cpp:724
 msgid "C&onfigure"
 msgstr "设置(&O)"
 
-#: ../../src/wxMaximaFrame.cpp:1482
+#: ../../src/wizards/CsvWiz.cpp:105
+msgid "CSV export"
+msgstr ""
+
+#: ../../src/wizards/CsvWiz.cpp:34
+msgid "CSV import"
+msgstr ""
+
+#: ../../src/cells/FontVariantCache.cpp:96
+#, c-format
+msgid "Caching font variant: %s"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1519
 msgid "Calculate &Product..."
 msgstr "计算乘积(&P)..."
 
-#: ../../src/wxMaxima.cpp:8057
+#: ../../src/MaximaCommandMenus.cpp:1243
 msgid "Calculate Singular Value Decomposition of a matrix numerically"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8050
+#: ../../src/MaximaCommandMenus.cpp:1236
 msgid "Calculate Singular Value Decomposition, left and right singular vectors numerically"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1480
+#: ../../src/wxMaximaFrame.cpp:1517
 msgid "Calculate Su&m..."
 msgstr "计算和(&M)..."
 
-#: ../../src/wxMaximaFrame.cpp:1795
+#: ../../src/wxMaximaFrame.cpp:1832
 msgid "Calculate bigfloat value of the last result"
 msgstr "将计算结果以大浮点数（bigfloat）表示"
 
-#: ../../src/wxMaximaFrame.cpp:1792
+#: ../../src/wxMaximaFrame.cpp:1829
 msgid "Calculate float value of the last result"
 msgstr "将计算结果以浮点数（float）表示"
 
-#: ../../src/wxMaxima.cpp:9550
+#: ../../src/MaximaCommandMenus.cpp:1788
 #, fuzzy
 msgid "Calculate mean value"
 msgstr "模运算："
 
-#: ../../src/wxMaxima.cpp:9554
+#: ../../src/MaximaCommandMenus.cpp:1792
 #, fuzzy
 msgid "Calculate median value"
 msgstr "模运算："
 
-#: ../../src/wxMaxima.cpp:8871
+#: ../../src/MaximaCommandMenus.cpp:878
 msgid "Calculate modulus:"
 msgstr "模运算："
 
-#: ../../src/wxMaximaFrame.cpp:1798
+#: ../../src/wxMaximaFrame.cpp:1835
 msgid "Calculate numeric value of the last result"
 msgstr "将计算结果以数值表示"
 
-#: ../../src/wxMaximaFrame.cpp:1483
+#: ../../src/wxMaximaFrame.cpp:1520
 msgid "Calculate products"
 msgstr "计算乘积"
 
-#: ../../src/wxMaxima.cpp:9562
+#: ../../src/MaximaCommandMenus.cpp:1800
 msgid "Calculate standard deviation"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1480
+#: ../../src/wxMaximaFrame.cpp:1517
 msgid "Calculate sums"
 msgstr "计算和"
 
-#: ../../src/wxMaxima.cpp:8025 ../../src/wxMaxima.cpp:8035
+#: ../../src/MaximaCommandMenus.cpp:1209 ../../src/MaximaCommandMenus.cpp:1219
 msgid "Calculate the eigenvalues and eigenvectors numerically"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8020 ../../src/wxMaxima.cpp:8030
+#: ../../src/MaximaCommandMenus.cpp:1204 ../../src/MaximaCommandMenus.cpp:1214
 #, fuzzy
 msgid "Calculate the eigenvalues of a matrix numerically"
 msgstr "计算逆矩阵"
 
-#: ../../src/wxMaxima.cpp:8078 ../../src/wxMaxima.cpp:8099
+#: ../../src/MaximaCommandMenus.cpp:1264 ../../src/MaximaCommandMenus.cpp:1287
 msgid "Calculate the root of the sum of squares of matrix entries"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:9558
-#, fuzzy
-msgid "Calculate variation"
-msgstr "计算乘积"
+#: ../../src/MaximaCommandMenus.cpp:1796
+msgid "Calculate variance"
+msgstr ""
 
-#: ../../src/wxMaxima.cpp:8949
+#: ../../src/MaximaCommandMenus.cpp:203
 msgid "Calculates the fourier coefficients for the expression from -p to p"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1968
+#: ../../src/worksheet/WorksheetContextMenu.cpp:740
 msgid "Calls assume() in order to tell maxima about the variable's range"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:2031
+#: ../../src/worksheet/WorksheetContextMenu.cpp:803
 msgid "Can be specified as flag in ev(exp, flag)"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:11125
+#: ../../src/wxMaxima.cpp:3438
 msgid "Can not connect to the web server."
 msgstr "无法连接到网页服务器。"
 
-#: ../../src/wxMaxima.cpp:11166
+#: ../../src/wxMaxima.cpp:3384 ../../src/wxMaxima.cpp:3420
+#: ../../src/wxMaxima.cpp:3472
 msgid "Can not download version info."
 msgstr "无法下载版本信息。"
 
-#: ../../src/wxMaxima.cpp:3016 ../../src/wxMaxima.cpp:4836
+#: ../../src/MaximaProcessManager.cpp:577 ../../src/wxMaxima.cpp:1581
 msgid "Can not start Maxima. The most probable cause is that Maxima isn't installed (it can be downloaded from https://maxima.sourceforge.io) or in wxMaxima's config dialogue the setting for Maxima's location is wrong."
 msgstr "无法启动 Maxima。最可能的原因是没有安装 Maxima（可以从http://maxima.sourceforge.io 下载）或者在 wxMaxima 的设置对话框中，Maxima 的位置设置错误。"
 
-#: ../../src/wxMaxima.cpp:11203
+#: ../../src/dialogs/MaxSizeChooser.cpp:46
+#: ../../src/dialogs/MaxSizeChooser.cpp:48
+#: ../../src/dialogs/MaximaNotStartingDialog.cpp:71
+#: ../../src/dialogs/MaximaNotStartingDialog.cpp:73
+#: ../../src/dialogs/ResolutionChooser.cpp:41
+#: ../../src/dialogs/ResolutionChooser.cpp:43
+#: ../../src/wizards/ActualValuesStorageWiz.cpp:61
+#: ../../src/wizards/ActualValuesStorageWiz.cpp:63
+#: ../../src/wizards/BC2Wiz.cpp:48 ../../src/wizards/BC2Wiz.cpp:50
+#: ../../src/wizards/CsvWiz.cpp:65 ../../src/wizards/CsvWiz.cpp:139
+#: ../../src/wizards/DrawWiz.cpp:111 ../../src/wizards/DrawWiz.cpp:222
+#: ../../src/wizards/DrawWiz.cpp:354 ../../src/wizards/DrawWiz.cpp:509
+#: ../../src/wizards/DrawWiz.cpp:568 ../../src/wizards/DrawWiz.cpp:665
+#: ../../src/wizards/DrawWiz.cpp:773 ../../src/wizards/DrawWiz.cpp:849
+#: ../../src/wizards/DrawWiz.cpp:987 ../../src/wizards/Gen1Wiz.cpp:44
+#: ../../src/wizards/Gen1Wiz.cpp:46 ../../src/wizards/Gen2Wiz.cpp:47
+#: ../../src/wizards/Gen2Wiz.cpp:49 ../../src/wizards/Gen3Wiz.cpp:55
+#: ../../src/wizards/Gen3Wiz.cpp:57 ../../src/wizards/Gen4Wiz.cpp:62
+#: ../../src/wizards/Gen4Wiz.cpp:64 ../../src/wizards/Gen5Wiz.cpp:70
+#: ../../src/wizards/Gen5Wiz.cpp:72 ../../src/wizards/GenWizPanel.cpp:111
+#: ../../src/wizards/GenWizPanel.cpp:113 ../../src/wizards/IntegrateWiz.cpp:62
+#: ../../src/wizards/IntegrateWiz.cpp:64 ../../src/wizards/LimitWiz.cpp:50
+#: ../../src/wizards/LimitWiz.cpp:52 ../../src/wizards/ListSortWiz.cpp:77
+#: ../../src/wizards/ListSortWiz.cpp:79 ../../src/wizards/MatWiz.cpp:40
+#: ../../src/wizards/MatWiz.cpp:42 ../../src/wizards/MatWiz.cpp:169
+#: ../../src/wizards/MatWiz.cpp:171 ../../src/wizards/Plot2dWiz.cpp:95
+#: ../../src/wizards/Plot2dWiz.cpp:97 ../../src/wizards/Plot2dWiz.cpp:512
+#: ../../src/wizards/Plot2dWiz.cpp:514 ../../src/wizards/Plot2dWiz.cpp:608
+#: ../../src/wizards/Plot2dWiz.cpp:610 ../../src/wizards/Plot3dWiz.cpp:90
+#: ../../src/wizards/Plot3dWiz.cpp:92 ../../src/wizards/PlotFormatWiz.cpp:48
+#: ../../src/wizards/PlotFormatWiz.cpp:50 ../../src/wizards/SeriesWiz.cpp:50
+#: ../../src/wizards/SeriesWiz.cpp:52 ../../src/wizards/SubstituteWiz.cpp:42
+#: ../../src/wizards/SubstituteWiz.cpp:44 ../../src/wizards/SumWiz.cpp:48
+#: ../../src/wizards/SumWiz.cpp:50 ../../src/wizards/SystemWiz.cpp:39
+#: ../../src/wizards/SystemWiz.cpp:41 ../../src/wxMaxima.cpp:3509
 msgid "Cancel"
 msgstr "取消"
 
-#: ../../src/wxMaxima.cpp:3292
+#: ../../src/MaximaResponseReader.cpp:344
 msgid "Cannot authenticate Maxima!"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2677
+#: ../../src/wxMaxima.cpp:1283
+#, c-format
+msgid "Cannot cache the list of known symbols to %s"
+msgstr ""
+
+#: ../../src/cells/FontVariantCache.cpp:85
+#, c-format
+msgid "Cannot create a font based on %s. Falling back to a default font."
+msgstr ""
+
+#: ../../src/MaximaProcessManager.cpp:370
 msgid "Cannot find a maxima binary and no binary chosen in the config dialogue."
 msgstr "无法找到 Maxima 程序，且设置对话框中未设置相应的程序。"
 
-#: ../../src/Autocomplete.cpp:583
+#: ../../src/Autocomplete.cpp:719
 #, fuzzy, c-format
 msgid "Cannot interpret template %s"
 msgstr "：不能解释的行：%s"
 
-#: ../../src/wxMaxima.cpp:3082
+#: ../../src/MaximaResponseReader.cpp:221
 #, c-format
 msgid "Cannot interpret the numeric value of pid %s"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:11066 ../../src/wxMaxima.cpp:11073
-#: ../../src/wxMaxima.cpp:11080
+#: ../../src/wxMaxima.cpp:3347 ../../src/wxMaxima.cpp:3354
+#: ../../src/wxMaxima.cpp:3361
 #, c-format
 msgid "Cannot interpret version number component %s"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2530
+#: ../../src/cells/EditorCell.cpp:2991
+msgid "Cannot put the copied text on the clipboard"
+msgstr ""
+
+#: ../../src/cells/EditorCell.cpp:2984
+msgid "Cannot put the copied text on the clipboard (1st try)"
+msgstr ""
+
+#: ../../src/cells/EditorCell.cpp:2988
+msgid "Cannot put the copied text on the clipboard (2nd try)"
+msgstr ""
+
+#: ../../src/graphical_io/OutCommon.cpp:98
+#, c-format
+msgid "Cannot remove the file %s"
+msgstr "无法移除文件 %s"
+
+#: ../../src/sidebars/History.cpp:258
+#, c-format
+msgid "Cannot save the command history to %s"
+msgstr ""
+
+#: ../../src/MaximaManual.cpp:386
+#, c-format
+msgid "Cannot save the list of subjects manual contains to the file %s."
+msgstr ""
+
+#: ../../src/MaximaProcessManager.cpp:191
 msgid "Cannot set the communication address to localhost."
 msgstr "无法将通信地址设置为本地主机。"
 
-#: ../../src/wxMaxima.cpp:2532
+#: ../../src/MaximaProcessManager.cpp:193
 #, fuzzy, c-format
 msgid "Cannot set the communication port to %i."
 msgstr "无法将通信端口设置为 %i。"
 
-#: ../../src/wxMaxima.cpp:3656 ../../src/wxMaxima.cpp:6359
+#: ../../src/MaximaCommandMenus.cpp:2795 ../../src/MaximaResponseReader.cpp:880
 msgid "Cannot start gnuplot"
 msgstr "无法启动 gnuplot"
 
-#: ../../src/StatusBar.cpp:216 ../../src/wxMaxima.cpp:2662
+#: ../../src/MaximaCommandMenus.cpp:2844
+msgid "Cannot start the headless gnuplot warnings check"
+msgstr ""
+
+#: ../../src/MaximaProcessManager.cpp:341 ../../src/StatusBar.cpp:254
 msgid "Cannot start the maxima binary"
 msgstr "无法启动 Maxima 程序"
 
-#: ../../src/wxMaxima.cpp:9268
+#: ../../src/sidebars/MathSidebar.cpp:62
+msgid "Canonical (tr)"
+msgstr "标准形式（三角）"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:188
+msgid "Catalan"
+msgstr "加泰罗尼亚语"
+
+#: ../../src/MaximaCommandMenus.cpp:466
 msgid "Cauchy principal value of f(x)/(x-c), finite interval"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1845
+#: ../../src/wxMaximaFrame.cpp:1882
 msgid "Cauchy principal value, finite interval"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:955
+#: ../../src/wxMaximaFrame.cpp:989
 msgid "Ce&ll"
 msgstr "单元格(&L)"
 
-#: ../../src/Configuration.cpp:96
+#: ../../src/Styles.cpp:125
 #, fuzzy
 msgid "Cell bracket fill, Active"
 msgstr "单元格括号"
 
-#: ../../src/Configuration.cpp:95
+#: ../../src/Styles.cpp:124
 #, fuzzy
 msgid "Cell bracket fill, Inactive"
 msgstr "单元格括号"
 
-#: ../../src/wxMaxima.cpp:10395
+#: ../../src/wxMaxima.cpp:3082
 msgid "Cell ends in a backslash"
 msgstr "单元格以反斜线（\\）结尾"
 
-#: ../../src/wxMaximaFrame.cpp:1038
+#: ../../src/MaximaCommandMenus.cpp:2262
+#, c-format
+msgid "Cell with UUID %s not found!"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1072
 msgid "Change &2d Display"
 msgstr "修改 2D 公式显示方式(&2)"
 
-#: ../../src/wxMaxima.cpp:10146
+#: ../../src/MaximaCommandMenus.cpp:3641
 #, fuzzy
 msgid "Change Image"
 msgstr "修改变量"
 
-#: ../../src/Worksheet.cpp:1324
+#: ../../src/worksheet/WorksheetContextMenu.cpp:86
 #, fuzzy
 msgid "Change Image..."
 msgstr "保存图片..."
 
-#: ../../src/wxMaximaFrame.cpp:1954
+#: ../../src/wxMaximaFrame.cpp:1997
 #, fuzzy
 msgid "Change Log"
 msgstr "修改变量"
 
-#: ../../src/wxMaxima.cpp:7555
+#: ../../src/MaximaCommandMenus.cpp:4427
 msgid "Change directory"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1202
+#: ../../src/wxMaximaFrame.cpp:1236
 #, fuzzy
 msgid "Change directory..."
 msgstr "保存图片..."
 
-#: ../../src/wxMaximaFrame.cpp:1039
+#: ../../src/dialogs/ConfigDialogue.cpp:859
+msgid "Change names of greek letters to greek letters"
+msgstr "修改希腊字母的名称为希腊字母"
+
+#: ../../src/wxMaximaFrame.cpp:1073
 msgid "Change the 2d display algorithm used to display math output"
 msgstr "修改用于数学式的 2D 显示算法"
 
-#: ../../src/wxMaxima.cpp:8885
+#: ../../src/dialogs/ConfigDialogue.cpp:489
+msgid "Change the text \"alpha\" and \"beta\" to the corresponding greek letter?"
+msgstr "修改文本“alpha”和“beta”为相应的希腊字母？"
+
+#: ../../src/MaximaCommandMenus.cpp:136
 msgid "Change variable"
 msgstr "修改变量"
 
-#: ../../src/wxMaxima.cpp:8905
+#: ../../src/MaximaCommandMenus.cpp:156
 #, fuzzy
 msgid "Change variable and evaluate"
 msgstr "修改积分或求和中的变量"
 
-#: ../../src/wxMaximaFrame.cpp:1459
+#: ../../src/wxMaximaFrame.cpp:1496
 msgid "Change variable in integral or sum"
 msgstr "修改积分或求和中的变量"
 
-#: ../../src/wxMaximaFrame.cpp:1463
+#: ../../src/wxMaximaFrame.cpp:1500
 #, fuzzy
 msgid "Change variable in integral or sum and evaluate the result"
 msgstr "修改积分或求和中的变量"
 
-#: ../../src/wxMaximaFrame.cpp:1026
+#: ../../src/dialogs/ChangeLogDialog.cpp:37
+#, fuzzy
+msgid "ChangeLog"
+msgstr "修改变量"
+
+#: ../../src/wxMaximaFrame.cpp:1060
 #, fuzzy
 msgid "Changed option variables"
 msgstr "修改变量"
 
-#: ../../src/wxMaxima.cpp:10170
+#: ../../src/MaximaCommandMenus.cpp:3699
 #, c-format
 msgid "Changing image originally loaded from file %s to %s."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7313 ../../src/wxMaxima.cpp:7318
-#: ../../src/wxMaxima.cpp:7323 ../../src/wxMaxima.cpp:7329
-#: ../../src/wxMaxima.cpp:7334 ../../src/wxMaxima.cpp:7340
+#: ../../src/MaximaCommandMenus.cpp:4185 ../../src/MaximaCommandMenus.cpp:4190
+#: ../../src/MaximaCommandMenus.cpp:4195 ../../src/MaximaCommandMenus.cpp:4201
+#: ../../src/MaximaCommandMenus.cpp:4206 ../../src/MaximaCommandMenus.cpp:4212
 msgid "Char #1:"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7314 ../../src/wxMaxima.cpp:7319
-#: ../../src/wxMaxima.cpp:7324 ../../src/wxMaxima.cpp:7329
-#: ../../src/wxMaxima.cpp:7335 ../../src/wxMaxima.cpp:7340
+#: ../../src/MaximaCommandMenus.cpp:4186 ../../src/MaximaCommandMenus.cpp:4191
+#: ../../src/MaximaCommandMenus.cpp:4196 ../../src/MaximaCommandMenus.cpp:4201
+#: ../../src/MaximaCommandMenus.cpp:4207 ../../src/MaximaCommandMenus.cpp:4212
 #, fuzzy
 msgid "Char #2:"
 msgstr "矩阵 #2："
 
-#: ../../src/wxMaximaFrame.cpp:1140
+#: ../../src/wxMaximaFrame.cpp:1174
 msgid "Char to Unicode code point..."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7358 ../../src/wxMaxima.cpp:7362
+#: ../../src/MaximaCommandMenus.cpp:4230 ../../src/MaximaCommandMenus.cpp:4234
 msgid "Char to unicode code point"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7285 ../../src/wxMaxima.cpp:7289
-#: ../../src/wxMaxima.cpp:7293 ../../src/wxMaxima.cpp:7297
-#: ../../src/wxMaxima.cpp:7301 ../../src/wxMaxima.cpp:7305
-#: ../../src/wxMaxima.cpp:7359 ../../src/wxMaxima.cpp:7363
-#: ../../src/wxMaxima.cpp:7435
+#: ../../src/MaximaCommandMenus.cpp:4157 ../../src/MaximaCommandMenus.cpp:4161
+#: ../../src/MaximaCommandMenus.cpp:4165 ../../src/MaximaCommandMenus.cpp:4169
+#: ../../src/MaximaCommandMenus.cpp:4173 ../../src/MaximaCommandMenus.cpp:4177
+#: ../../src/MaximaCommandMenus.cpp:4231 ../../src/MaximaCommandMenus.cpp:4235
+#: ../../src/MaximaCommandMenus.cpp:4307
 msgid "Char:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1131
+#: ../../src/wxMaximaFrame.cpp:1165
 msgid "Character Tests"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8181
+#: ../../src/MaximaCommandMenus.cpp:1369
 #, fuzzy
 msgid "Characteristic polynom"
 msgstr "特征多项式(&C)..."
 
-#: ../../src/wxMaxima.cpp:7280
+#: ../../src/MaximaCommandMenus.cpp:4152
 msgid "Chars are strings that are one character long"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1957
+#: ../../src/wxMaximaFrame.cpp:2000
 msgid "Check for Updates"
 msgstr "检查更新"
 
-#: ../../src/wxMaximaFrame.cpp:1958
+#: ../../src/wxMaximaFrame.cpp:2001
 msgid "Check if a newer version of wxMaxima is available."
 msgstr "检查是否存在新版本的 wxMaxima。"
 
-#: ../../src/wxMaximaFrame.cpp:800
+#: ../../src/sidebars/GreekSidebar.cpp:199
+msgid "Chi"
+msgstr "Chi"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:189
+msgid "Chinese (Simplified)"
+msgstr "简体中文"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:190
+msgid "Chinese (traditional)"
+msgstr "繁体中文"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1554
+msgid "Choose a Lisp Maxima was compiled with"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1560
+msgid "Choose between installed Maxima versions"
+msgstr ""
+
+#: ../../src/sidebars/HelpBrowser.cpp:204
+msgid "Choose between the following help topics:"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:2100
+msgid "Choose font"
+msgstr "选择字体"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:793
+msgid ""
+"Choose how mathematical output is formatted:\n"
+"\"2D, whenever possible\" keeps all expressions in two-dimensional form (fractions stacked, matrices drawn as boxes), even if they overflow the page width.\n"
+"\"2D if it fits on the page width\" (default) switches wide objects to linear notation.\n"
+"\"Prefer 1D\" always uses linear notation."
+msgstr ""
+
+#: ../../src/wizards/PlotFormatWiz.cpp:31
+msgid "Choose new plot format:"
+msgstr "选择新的绘图格式："
+
+#: ../../src/dialogs/ConfigDialogue.cpp:2432
+#, c-format
+msgid "Choose the %s Font"
+msgstr "选择 %s 字体"
+
+#: ../../src/wxMaximaFrame.cpp:837
 msgid "Choose the parenthesis type for Matrices"
 msgstr "选择矩阵括号的样式"
 
-#: ../../src/wxMaxima.cpp:9530 ../../src/wxMaxima.cpp:9535
+#: ../../src/MaximaCommandMenus.cpp:1768 ../../src/MaximaCommandMenus.cpp:1773
 msgid "Classes:"
 msgstr "类型："
 
-#: ../../src/wxMaximaFrame.cpp:1378
+#: ../../src/wxMaximaFrame.cpp:1412
 msgid "Classic matrix operations"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:998
+#: ../../src/wxMaximaFrame.cpp:1032
 #, fuzzy
 msgid "Clear all aliases"
 msgstr "删除历史记录"
 
-#: ../../src/wxMaximaFrame.cpp:995
+#: ../../src/wxMaximaFrame.cpp:1029
 #, fuzzy
 msgid "Clear all arrays"
 msgstr "删除历史记录"
 
-#: ../../src/wxMaximaFrame.cpp:992
+#: ../../src/wxMaximaFrame.cpp:1026
 #, fuzzy
 msgid "Clear all dependencies"
 msgstr "删除历史记录"
 
-#: ../../src/wxMaximaFrame.cpp:994
+#: ../../src/wxMaximaFrame.cpp:1028
 #, fuzzy
 msgid "Clear all functions"
 msgstr "删除函数"
 
-#: ../../src/wxMaximaFrame.cpp:1001
+#: ../../src/wxMaximaFrame.cpp:1035
 #, fuzzy
 msgid "Clear all gradefs"
 msgstr "删除历史记录"
 
-#: ../../src/wxMaximaFrame.cpp:1000
+#: ../../src/sidebars/History.cpp:116
+msgid "Clear all history"
+msgstr "删除历史记录"
+
+#: ../../src/wxMaximaFrame.cpp:1034
 #, fuzzy
 msgid "Clear all labels"
 msgstr "删除历史记录"
 
-#: ../../src/wxMaximaFrame.cpp:1004
+#: ../../src/wxMaximaFrame.cpp:1038
 #, fuzzy
 msgid "Clear all let rule packages"
 msgstr "用户定义的 let 规则程序包列表"
 
-#: ../../src/wxMaximaFrame.cpp:1003
+#: ../../src/wxMaximaFrame.cpp:1037
 #, fuzzy
 msgid "Clear all macros"
 msgstr "删除历史记录"
 
-#: ../../src/wxMaximaFrame.cpp:1002
+#: ../../src/wxMaximaFrame.cpp:1036
 #, fuzzy
 msgid "Clear all props"
 msgstr "删除历史记录"
 
-#: ../../src/wxMaximaFrame.cpp:997
+#: ../../src/wxMaximaFrame.cpp:1031
 #, fuzzy
 msgid "Clear all rules"
 msgstr "删除历史记录"
 
-#: ../../src/wxMaximaFrame.cpp:999
+#: ../../src/wxMaximaFrame.cpp:1033
 #, fuzzy
 msgid "Clear all structures"
 msgstr "删除历史记录"
 
-#: ../../src/wxMaximaFrame.cpp:993
+#: ../../src/wxMaximaFrame.cpp:1027
 #, fuzzy
 msgid "Clear all variables"
 msgstr "删除变量"
 
-#: ../../src/wxMaximaFrame.cpp:606
+#: ../../src/sidebars/History.cpp:115
+msgid "Clear the selection"
+msgstr "删除所选单元格"
+
+#: ../../src/cells/FontVariantCache.cpp:44
+#, c-format
+msgid "Cleared font cache for font %s"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1926
+msgid "Clipboard format parameters"
+msgstr "剪贴板格式参数"
+
+#: ../../src/wxMaximaFrame.cpp:637
 msgid "Close\tCtrl+W"
 msgstr "关闭\tCtrl+W"
 
-#: ../../src/wxMaxima.cpp:7235
+#: ../../src/MaximaCommandMenus.cpp:4107
 msgid "Close Stream"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:606
+#: ../../src/wxMaximaFrame.cpp:637
 msgid "Close window"
 msgstr "关闭窗口"
 
-#: ../../src/wxMaximaFrame.cpp:1105
+#: ../../src/wxMaximaFrame.cpp:1139
 #, fuzzy
 msgid "Close..."
 msgstr "求解..."
 
-#: ../../src/WXMXformat.cpp:301
+#: ../../src/WXMXformat.cpp:303
 msgid "Closed the zip archive"
 msgstr ""
 
-#: ../../src/Configuration.cpp:77
+#: ../../src/Styles.cpp:106
 #, fuzzy
 msgid "Code Default (Maxima input)"
 msgstr "Maxima 输入"
 
-#: ../../src/Configuration.cpp:103
+#: ../../src/Styles.cpp:133
 msgid "Code highlighting: Comments"
 msgstr "代码高亮：注释"
 
-#: ../../src/Configuration.cpp:108
+#: ../../src/Styles.cpp:138
 #, fuzzy
 msgid "Code highlighting: End of line markers"
 msgstr "代码高亮：行结束"
 
-#: ../../src/Configuration.cpp:102
+#: ../../src/Styles.cpp:132
 msgid "Code highlighting: Functions"
 msgstr "代码高亮：函数"
 
-#: ../../src/Configuration.cpp:107
+#: ../../src/Styles.cpp:137
 msgid "Code highlighting: Lisp"
 msgstr "代码高亮：Lisp"
 
-#: ../../src/Configuration.cpp:104
+#: ../../src/Styles.cpp:134
 msgid "Code highlighting: Numbers"
 msgstr "代码高亮：数字"
 
-#: ../../src/Configuration.cpp:106
+#: ../../src/Styles.cpp:136
 msgid "Code highlighting: Operators"
 msgstr "代码高亮：运算符"
 
-#: ../../src/Configuration.cpp:105
+#: ../../src/Styles.cpp:135
 msgid "Code highlighting: Strings"
 msgstr "代码高亮：字符串"
 
-#: ../../src/Configuration.cpp:101
+#: ../../src/Styles.cpp:131
 msgid "Code highlighting: Variables"
 msgstr "代码高亮：变量"
 
-#: ../../src/wxMaxima.cpp:7309 ../../src/wxMaxima.cpp:7355
+#: ../../src/MaximaCommandMenus.cpp:4181 ../../src/MaximaCommandMenus.cpp:4227
 #, fuzzy
 msgid "Code number:"
 msgstr "行号"
 
-#: ../../src/wxMaxima.cpp:7367 ../../src/wxMaxima.cpp:7373
+#: ../../src/MaximaCommandMenus.cpp:4239 ../../src/MaximaCommandMenus.cpp:4245
 #, fuzzy
 msgid "Codepoint number:"
 msgstr "行号"
 
-#: ../../src/wxMaxima.cpp:9590
+#: ../../src/MaximaCommandMenus.cpp:1830
 msgid "Col. names:"
 msgstr "列名称："
 
-#: ../../src/Configuration.cpp:100
+#: ../../src/Styles.cpp:130
 #, fuzzy
 msgid "Color of Outdated cells"
 msgstr "单元格已过期"
 
-#: ../../src/Configuration.cpp:99
+#: ../../src/Styles.cpp:128
 #, fuzzy
 msgid "Color of text equal to selection"
 msgstr "与选择内容相同的文本"
 
-#: ../../src/wxMaxima.cpp:7962
+#: ../../src/MaximaCommandMenus.cpp:1142 ../../src/MaximaCommandMenus.cpp:1152
 #, fuzzy
 msgid "Column number:"
 msgstr "行号"
 
-#: ../../src/wxMaxima.cpp:7978
+#: ../../src/MaximaCommandMenus.cpp:1157
 #, fuzzy
 msgid "Column numbers:"
 msgstr "列："
 
-#: ../../src/wxMaxima.cpp:8202
+#: ../../src/MaximaCommandMenus.cpp:1392
 #, fuzzy
 msgid "Columns"
 msgstr "列："
 
-#: ../../src/wxMaximaFrame.cpp:1584
+#: ../../src/wizards/MatWiz.cpp:155
+msgid "Columns:"
+msgstr "列："
+
+#: ../../src/wxMaximaFrame.cpp:1621
 msgid "Combine factorials in an expression"
 msgstr "合并表达式中的阶乘"
 
-#: ../../src/wxMaxima.cpp:10454
+#: ../../src/wizards/CsvWiz.cpp:41 ../../src/wizards/CsvWiz.cpp:112
+msgid "Comma"
+msgstr ""
+
+#: ../../src/wxMaxima.cpp:3141
 msgid "Comma directly followed by a closing parenthesis"
 msgstr "右括号后紧接逗号"
 
-#: ../../src/wxMaxima.cpp:7259
+#: ../../src/wizards/Plot2dWiz.cpp:626
+msgid "Comma separated x coordinates"
+msgstr "x坐标，以逗号分割"
+
+#: ../../src/wizards/Plot2dWiz.cpp:627
+msgid "Comma separated y coordinates"
+msgstr "y 坐标，以逗号分割"
+
+#: ../../src/MaximaCommandMenus.cpp:4131
 #, fuzzy
 msgid "Comma-separated arguments"
 msgstr "以逗号分隔的元素"
 
-#: ../../src/wxMaxima.cpp:7057 ../../src/wxMaxima.cpp:7066
+#: ../../src/MaximaCommandMenus.cpp:3929 ../../src/MaximaCommandMenus.cpp:3938
 #, fuzzy
 msgid "Comma-separated commands"
 msgstr "以逗号分隔的元素"
 
-#: ../../src/wxMaxima.cpp:8458
+#: ../../src/MaximaCommandMenus.cpp:1461
 msgid "Comma-separated elements"
 msgstr "以逗号分隔的元素"
 
-#: ../../src/wxMaxima.cpp:7752 ../../src/wxMaxima.cpp:7766
-#: ../../src/wxMaxima.cpp:10031
+#: ../../src/MaximaCommandMenus.cpp:933 ../../src/MaximaCommandMenus.cpp:947
+#: ../../src/MaximaCommandMenus.cpp:3520
 msgid "Comma-separated equations"
 msgstr "以逗号分隔的式子"
 
-#: ../../src/wxMaxima.cpp:8727 ../../src/wxMaxima.cpp:8735
-#: ../../src/wxMaxima.cpp:8743 ../../src/wxMaxima.cpp:8751
-#: ../../src/wxMaxima.cpp:8760 ../../src/wxMaxima.cpp:8768
+#: ../../src/MaximaCommandMenus.cpp:722 ../../src/MaximaCommandMenus.cpp:732
+#: ../../src/MaximaCommandMenus.cpp:741 ../../src/MaximaCommandMenus.cpp:752
+#: ../../src/MaximaCommandMenus.cpp:764
 #, fuzzy
 msgid "Comma-separated expressions"
 msgstr "以逗号分隔的式子"
 
-#: ../../src/wxMaxima.cpp:7215
+#: ../../src/MaximaCommandMenus.cpp:4087
 #, fuzzy
 msgid "Comma-separated expressions that shall be converted to a string"
 msgstr "以逗号分隔的式子"
 
-#: ../../src/wxMaxima.cpp:7100 ../../src/wxMaxima.cpp:7114
+#: ../../src/MaximaCommandMenus.cpp:3972 ../../src/MaximaCommandMenus.cpp:3986
 #, fuzzy
 msgid "Comma-separated expressions."
 msgstr "以逗号分隔的式子"
 
-#: ../../src/wxMaxima.cpp:7073 ../../src/wxMaxima.cpp:7168
+#: ../../src/MaximaCommandMenus.cpp:3945 ../../src/MaximaCommandMenus.cpp:4040
 #, fuzzy
 msgid "Comma-separated function names"
 msgstr "以逗号分隔的式子"
 
-#: ../../src/wxMaxima.cpp:7086
+#: ../../src/MaximaCommandMenus.cpp:3958
 #, fuzzy
 msgid "Comma-separated function names."
 msgstr "以逗号分隔的式子"
 
-#: ../../src/wxMaxima.cpp:8560 ../../src/wxMaxima.cpp:8567
-#: ../../src/wxMaxima.cpp:8573 ../../src/wxMaxima.cpp:8580
+#: ../../src/MaximaCommandMenus.cpp:1576 ../../src/MaximaCommandMenus.cpp:1585
+#: ../../src/MaximaCommandMenus.cpp:1591 ../../src/MaximaCommandMenus.cpp:1598
 msgid "Comma-separated list entry in the format val1=1,val2=2"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7205
+#: ../../src/MaximaCommandMenus.cpp:4077
 msgid "Comma-separated names of the elements that shall be written"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7099
+#: ../../src/MaximaCommandMenus.cpp:3971
 msgid "Comma-separated names the parameters will be referenced by later."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7488 ../../src/wxMaxima.cpp:7493
+#: ../../src/MaximaCommandMenus.cpp:4360 ../../src/MaximaCommandMenus.cpp:4365
 #, fuzzy
 msgid "Comma-separated numbers from 0 to 255"
 msgstr "要删除的行，用逗号分隔："
 
-#: ../../src/wxMaxima.cpp:8770
-msgid "Comma-separated numbers of the terms to substitute in"
-msgstr ""
-
-#: ../../src/wxMaxima.cpp:7137 ../../src/wxMaxima.cpp:7150
+#: ../../src/MaximaCommandMenus.cpp:4009 ../../src/MaximaCommandMenus.cpp:4022
 msgid "Comma-separated parameter names. A parameter in square brackets [] will be filled with the list of any additional arguments the function gets."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7054
+#: ../../src/MaximaCommandMenus.cpp:776
+msgid "Comma-separated part numbers selecting the subexpression to replace (as in part())"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:3926
 msgid "Comma-separated variable names, can be initialized by the \":\" operator."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7753 ../../src/wxMaxima.cpp:7767
-#: ../../src/wxMaxima.cpp:8719 ../../src/wxMaxima.cpp:8785
-#: ../../src/wxMaxima.cpp:10032
+#: ../../src/MaximaCommandMenus.cpp:711 ../../src/MaximaCommandMenus.cpp:792
+#: ../../src/MaximaCommandMenus.cpp:934 ../../src/MaximaCommandMenus.cpp:948
+#: ../../src/MaximaCommandMenus.cpp:3521
 msgid "Comma-separated variables"
 msgstr "以逗号分隔的变量"
 
-#: ../../src/wxMaxima.cpp:9469
+#: ../../src/wizards/GenWizPanel.cpp:226
+msgid "Command"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:2112
 msgid "Command:"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1692
+#: ../../src/dialogs/ConfigDialogue.cpp:1145
+msgid "Commands that are executed at every start of maxima."
+msgstr "每次启动 Maxima 时执行的命令。"
+
+#: ../../src/cells/EditorCell.cpp:4538
+msgid "Comment (ordinary worksheet text that isn't fed to maxima)"
+msgstr ""
+
+#: ../../src/worksheet/WorksheetContextMenu.cpp:465
 msgid "Comment Selection"
 msgstr "注释掉所选内容"
 
-#: ../../src/wxMaximaFrame.cpp:681
+#: ../../src/wxMaximaFrame.cpp:718
 msgid "Comment out the currently selected text"
 msgstr "注释掉当前所选内容"
 
-#: ../../src/wxMaximaFrame.cpp:680
+#: ../../src/wxMaximaFrame.cpp:717
 msgid "Comment selection\tCtrl+/"
 msgstr "注释掉所选内容\tCtrl+/"
 
-#: ../../src/Worksheet.cpp:2004
+#: ../../src/worksheet/WorksheetContextMenu.cpp:776
 msgid "Commutative function"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1396
+#: ../../src/wxMaximaFrame.cpp:649
+msgid "Compare files..."
+msgstr ""
+
+#: ../../src/main.cpp:723
+msgid "Comparing worksheets (the --diff option or the wxmxdiff command) needs 2 or 3 files to compare."
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1430
 msgid "Compile a QR decomposition using dgeqrf"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7162
+#: ../../src/MaximaCommandMenus.cpp:4034
 #, fuzzy
 msgid "Compile a function"
 msgstr "删除函数"
 
-#: ../../src/wxMaximaFrame.cpp:1188
+#: ../../src/wxMaximaFrame.cpp:1222
 #, fuzzy
 msgid "Compile a regular expression"
 msgstr "删除函数"
 
-#: ../../src/wxMaximaFrame.cpp:1385
+#: ../../src/wxMaximaFrame.cpp:1419
 msgid "Compile eigenvalues using dgeev"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1388
+#: ../../src/wxMaximaFrame.cpp:1422
 msgid "Compile eigenvalues using zgeev"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1391
+#: ../../src/wxMaximaFrame.cpp:1425
 msgid "Compile eigenvalues+eigenvectors using dgeev"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1394
+#: ../../src/wxMaximaFrame.cpp:1428
 msgid "Compile eigenvalues+eigenvectors using zgeev"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1076
+#: ../../src/wxMaximaFrame.cpp:1110
 #, fuzzy
 msgid "Compile function..."
 msgstr "删除函数(&U)..."
 
-#: ../../src/wxMaxima.cpp:7511
+#: ../../src/MaximaCommandMenus.cpp:4383
 #, fuzzy
 msgid "Compile regex"
 msgstr "自动补全"
@@ -1493,1735 +2413,2354 @@ msgstr "自动补全"
 msgid "Compiler-Bug? wxMathml.lisp is shorter than expected!"
 msgstr "编译器有错误（bug）？wxMathml.lisp 文件比预期的要小！"
 
-#: ../../src/wxMaxima.cpp:2234
+#: ../../src/MaximaOutputAppender.cpp:286
 #, c-format
 msgid "Compiling %s"
 msgstr "编译 %s 中"
 
-#: ../../src/wxMaxima.cpp:7163
+#: ../../src/MaximaCommandMenus.cpp:4035
 msgid "Compiling a function can generate a considerable speed boost if the types of the function parameters are made known to the function before it is compiled. Else the generated code has to be hideously generic."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:892
+#: ../../src/wxMaximaFrame.cpp:926
 msgid "Complete Word\tCtrl+Space"
 msgstr "自动补全\tCtrl+K"
 
-#: ../../src/wxMaximaFrame.cpp:893
+#: ../../src/wxMaximaFrame.cpp:927
 msgid "Complete word"
 msgstr "自动补全"
 
-#: ../../src/ToolBar.cpp:230
+#: ../../src/ToolBar.cpp:412 ../../src/ToolBar.cpp:418
 msgid "Completely stop maxima and restart it"
 msgstr "彻底停止 Maxima 运行，并重启"
 
-#: ../../src/wxMaximaFrame.cpp:1503
+#: ../../src/cells/TextCell.cpp:192
+msgid "Complex infinity."
+msgstr "负无穷"
+
+#: ../../src/graphical_io/Printout.cpp:184
+msgid "Composing a list of the line starts we can use as page starts"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1540
 msgid "Compute continued fraction of a value"
 msgstr "计算数值的连分数表示"
 
-#: ../../src/wxMaximaFrame.cpp:1372
+#: ../../src/wxMaximaFrame.cpp:1406
 msgid "Compute the adjoint matrix"
 msgstr "计算伴随矩阵"
 
-#: ../../src/wxMaximaFrame.cpp:1359
+#: ../../src/wxMaximaFrame.cpp:1393
 msgid "Compute the characteristic polynomial of a matrix"
 msgstr "计算矩阵的特征多项式"
 
-#: ../../src/wxMaximaFrame.cpp:1363
+#: ../../src/wxMaximaFrame.cpp:1397
 msgid "Compute the determinant of a matrix"
 msgstr "计算矩阵的行列式"
 
-#: ../../src/wxMaximaFrame.cpp:1491
+#: ../../src/wxMaximaFrame.cpp:1528
 msgid "Compute the greatest common divisor"
 msgstr "计算最大公因子"
 
-#: ../../src/wxMaximaFrame.cpp:1356
+#: ../../src/wxMaximaFrame.cpp:1390
 msgid "Compute the inverse of a matrix"
 msgstr "计算逆矩阵"
 
-#: ../../src/wxMaximaFrame.cpp:1494
+#: ../../src/wxMaximaFrame.cpp:1531
 msgid "Compute the least common multiple (do load(functs) before using)"
 msgstr "计算最小公倍式（在使用前应先执行 load(functs)）"
 
-#: ../../src/wxMaximaFrame.cpp:1374
+#: ../../src/wxMaximaFrame.cpp:1408
 msgid "Compute the rank of a matrix"
 msgstr "计算矩阵的秩"
 
-#: ../../src/wxMaxima.cpp:9629
+#: ../../src/MaximaCommandMenus.cpp:1869
 msgid "Condition:"
 msgstr "条件："
 
-#: ../../src/ToolBar.cpp:200 ../../src/wxMaximaFrame.cpp:685
-#: ../../src/wxMaximaFrame.cpp:687
+#: ../../src/dialogs/ConfigDialogue.cpp:2479
+#: ../../src/dialogs/ConfigDialogue.cpp:2489
+#: ../../src/dialogs/ConfigDialogue.cpp:2641
+#: ../../src/dialogs/ConfigDialogue.cpp:2647
+msgid "Config file (*.ini)|*.ini"
+msgstr "设置文件 (*.ini)|*.ini"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:2539
+#, c-format
+msgid "Config item \"%s\" was of an unknown type"
+msgstr "设置项“%s”为未知类型"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:2607
+msgid "Configuration warning"
+msgstr "设置警告"
+
+#: ../../src/ToolBar.cpp:367 ../../src/ToolBar.cpp:369
+#: ../../src/wxMaximaFrame.cpp:722 ../../src/wxMaximaFrame.cpp:724
 msgid "Configure wxMaxima"
 msgstr "设置 wxMaxima"
 
-#: ../../src/wxMaxima.cpp:2504
+#: ../../src/wizards/DrawWiz.cpp:829
+msgid "Connect the dots"
+msgstr ""
+
+#: ../../src/MaximaProcessManager.cpp:165
 msgid "Connection attempt, but connection failed."
 msgstr "试图连接，但未成功。"
 
-#: ../../src/wxMaxima.cpp:2459
+#: ../../src/MaximaProcessManager.cpp:792
 msgid "Connection to Maxima lost."
 msgstr "失去与 Maxima 的连接。"
 
-#: ../../src/wxMaxima.cpp:7921
+#: ../../src/wizards/IntegrateWiz.cpp:193
+#: ../../src/wizards/IntegrateWiz.cpp:208 ../../src/wizards/LimitWiz.cpp:133
+#: ../../src/wizards/SeriesWiz.cpp:105
+msgid "Constant"
+msgstr "常量"
+
+#: ../../src/MaximaCommandMenus.cpp:1102
 #, fuzzy
 msgid "Construct a fraction"
 msgstr "连分数(&C)"
 
-#: ../../src/wxMaximaFrame.cpp:1305
+#: ../../src/wxMaximaFrame.cpp:1339
 #, fuzzy
 msgid "Construct fraction..."
 msgstr "连分数(&C)"
 
-#: ../../src/wxMaxima.cpp:7158
+#: ../../src/sidebars/VariablesPane.cpp:58
+msgid "Contents"
+msgstr "内容"
+
+#: ../../src/MaximaCommandMenus.cpp:4030
 #, fuzzy
 msgid "Contents:"
 msgstr "内容"
 
-#: ../../src/wxMaximaFrame.cpp:1877
+#: ../../src/wxMaximaFrame.cpp:1914
 msgid "Context-sensitive &Help\tCtrl+?"
 msgstr "上下文相关的帮助(&H)\tCtrl+?"
 
-#: ../../src/wxMaximaFrame.cpp:1879
+#: ../../src/wxMaximaFrame.cpp:1916
 msgid "Context-sensitive &Help\tF1"
 msgstr "上下文相关的帮助(&H)\tF1"
 
-#: ../../src/wxMaximaFrame.cpp:1542
+#: ../../src/sidebars/DrawSidebar.cpp:80
+msgid "Contour"
+msgstr "等高线"
+
+#: ../../src/sidebars/DrawSidebar.cpp:101
+msgid "Contour lines for 3d plots"
+msgstr "三维图形的等高线"
+
+#: ../../src/wizards/DrawWiz.cpp:648
+msgid "Contour lines on surface and Bottom"
+msgstr ""
+
+#: ../../src/wizards/DrawWiz.cpp:644
+msgid "Contour lines on the Bottom"
+msgstr ""
+
+#: ../../src/wizards/DrawWiz.cpp:641
+msgid "Contour lines on the Surface"
+msgstr ""
+
+#: ../../src/wizards/DrawWiz.cpp:629
+msgid "Contour lines settings for the following 3d plots"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1579
 msgid "Contract Logarithms"
 msgstr "合并对数式"
 
-#: ../../src/wxMaximaFrame.cpp:1161
+#: ../../src/wxMaximaFrame.cpp:1195
 #, fuzzy
 msgid "Conversions"
 msgstr "转换为直角坐标形式(&R)"
 
-#: ../../src/wxMaximaFrame.cpp:1229
+#: ../../src/wxMaximaFrame.cpp:1263
 #, fuzzy
 msgid "Convert"
 msgstr "转换为直角坐标形式(&R)"
 
-#: ../../src/wxMaximaFrame.cpp:1230
+#: ../../src/wxMaximaFrame.cpp:1264
 #, fuzzy
 msgid "Convert + Write to file"
 msgstr "将一行转换为列表"
 
-#: ../../src/wxMaximaFrame.cpp:1434
+#: ../../src/wxMaximaFrame.cpp:1471
 #, fuzzy
 msgid "Convert Column to list..."
 msgstr "将一列转换为列表"
 
-#: ../../src/wxMaximaFrame.cpp:1430
+#: ../../src/wxMaximaFrame.cpp:1467
 #, fuzzy
 msgid "Convert Row to list..."
 msgstr "将一行转换为列表"
 
-#: ../../src/wxMaximaFrame.cpp:1044
+#: ../../src/wxMaximaFrame.cpp:1078
 #, fuzzy
 msgid "Convert a command to maxima code"
 msgstr "发送命令至 Maxima"
 
-#: ../../src/wxMaximaFrame.cpp:1321
+#: ../../src/wxMaximaFrame.cpp:1355
 msgid "Convert a list of lists to a matrix"
 msgstr "将列表的列表转换为矩阵"
 
-#: ../../src/wxMaximaFrame.cpp:1574
+#: ../../src/wxMaximaFrame.cpp:1611
 msgid "Convert binomials, beta and gamma function to factorials"
 msgstr "将二项式、Beta 函数及 Gamma 函数转换为阶乘形式"
 
-#: ../../src/wxMaximaFrame.cpp:1578
+#: ../../src/wxMaximaFrame.cpp:1615
 msgid "Convert binomials, factorials and beta function to gamma function"
 msgstr "将二项式、阶乘及 Beta 函数转换为 Gamma 函数"
 
-#: ../../src/wxMaximaFrame.cpp:1613
+#: ../../src/wxMaximaFrame.cpp:1650
 msgid "Convert complex expression to polar form"
 msgstr "将复数表达式转换为极坐标形式"
 
-#: ../../src/wxMaximaFrame.cpp:1610
+#: ../../src/wxMaximaFrame.cpp:1647
 msgid "Convert complex expression to rect form"
 msgstr "将复数表达式转换为直角坐标形式"
 
-#: ../../src/wxMaximaFrame.cpp:1622
+#: ../../src/wxMaximaFrame.cpp:1659
 msgid "Convert exponential function of imaginary argument to trigonometric form"
 msgstr "将虚数变量指数函数转换为三角函数形式"
 
-#: ../../src/wxMaxima.cpp:7411
+#: ../../src/MaximaCommandMenus.cpp:4283
 #, fuzzy
 msgid "Convert string to lowercase"
 msgstr "转换为阶乘(&F)"
 
-#: ../../src/wxMaxima.cpp:7543
+#: ../../src/MaximaCommandMenus.cpp:4415
 #, fuzzy
 msgid "Convert string to matching regex"
 msgstr "显示五级标题"
 
-#: ../../src/wxMaximaFrame.cpp:1543
+#: ../../src/wxMaximaFrame.cpp:1580
 msgid "Convert sum of logarithms to logarithm of product"
 msgstr "将对数的和转换为乘积的对数"
 
-#: ../../src/wxMaximaFrame.cpp:1573
+#: ../../src/wxMaximaFrame.cpp:1610
 msgid "Convert to &Factorials"
 msgstr "转换为阶乘(&F)"
 
-#: ../../src/wxMaximaFrame.cpp:1577
+#: ../../src/wxMaximaFrame.cpp:1614
 msgid "Convert to &Gamma"
 msgstr "转换为 Gamma 函数(&G)"
 
-#: ../../src/wxMaximaFrame.cpp:1612
+#: ../../src/wxMaximaFrame.cpp:1649
 msgid "Convert to &Polarform"
 msgstr "转换为极坐标形式(&P)"
 
-#: ../../src/wxMaximaFrame.cpp:1609
+#: ../../src/wxMaximaFrame.cpp:1646
 msgid "Convert to &Rectform"
 msgstr "转换为直角坐标形式(&R)"
 
-#: ../../src/wxMaximaFrame.cpp:1166
+#: ../../src/sidebars/TableOfContents.cpp:522
+#: ../../src/sidebars/TableOfContents.cpp:543
+#, fuzzy
+msgid "Convert to Heading 5"
+msgstr "显示五级标题"
+
+#: ../../src/sidebars/TableOfContents.cpp:519
+#, fuzzy
+msgid "Convert to Heading 6"
+msgstr "显示六级标题"
+
+#: ../../src/sidebars/TableOfContents.cpp:531
+#: ../../src/sidebars/TableOfContents.cpp:552
+#, fuzzy
+msgid "Convert to Section"
+msgstr "转换为直角坐标形式(&R)"
+
+#: ../../src/sidebars/TableOfContents.cpp:525
+#: ../../src/sidebars/TableOfContents.cpp:546
+#, fuzzy
+msgid "Convert to Sub-Subsection"
+msgstr "插入小小节单元格"
+
+#: ../../src/sidebars/TableOfContents.cpp:528
+#: ../../src/sidebars/TableOfContents.cpp:549
+#, fuzzy
+msgid "Convert to Subsection"
+msgstr "转换为直角坐标形式(&R)"
+
+#: ../../src/sidebars/TableOfContents.cpp:555
+#, fuzzy
+msgid "Convert to Title"
+msgstr "将一行转换为列表"
+
+#: ../../src/wxMaximaFrame.cpp:1200
 #, fuzzy
 msgid "Convert to downcase..."
 msgstr "将一行转换为列表"
 
-#: ../../src/wxMaxima.cpp:7016
+#: ../../src/MaximaCommandMenus.cpp:3888
 #, fuzzy
 msgid "Convert to programming language"
 msgstr "显示五级标题"
 
-#: ../../src/wxMaxima.cpp:7022
+#: ../../src/MaximaCommandMenus.cpp:3894
 #, fuzzy
 msgid "Convert to programming language file"
 msgstr "未设置语言 %i"
 
-#: ../../src/wxMaximaFrame.cpp:1602
+#: ../../src/wxMaximaFrame.cpp:1639
 msgid "Convert trigonometric expression to canonical quasilinear form"
 msgstr "将三角函数表达式转换为标准拟线性形式"
 
-#: ../../src/wxMaximaFrame.cpp:1627
+#: ../../src/wxMaximaFrame.cpp:1664
 msgid "Convert trigonometric functions to exponential form"
 msgstr "将三角函数转换为指数形式"
 
-#: ../../src/wxMaximaFrame.cpp:1762
+#: ../../src/sidebars/PerformanceSidebar.cpp:46
+msgid "Converted to 2D:"
+msgstr ""
+
+#: ../../src/sidebars/PerformanceSidebar.cpp:45
+msgid "Converted to linear:"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1799
 msgid "Converts a matrix to a list of lists"
 msgstr "将矩阵转换为列表的列表"
 
-#: ../../src/wxMaximaFrame.cpp:1760
+#: ../../src/wxMaximaFrame.cpp:1797
 msgid "Converts a nested list like [[1,2],[3,4]] to a matrix"
 msgstr "将嵌套式列表（如 [[1,2],[3,4]] ）转换为矩阵"
 
-#: ../../src/ToolBar.cpp:209 ../../src/Worksheet.cpp:1290
-#: ../../src/Worksheet.cpp:1359 ../../src/Worksheet.cpp:1498
-#: ../../src/Worksheet.cpp:1684
+#: ../../src/ToolBar.cpp:380 ../../src/ToolBar.cpp:384
+#: ../../src/dialogs/ConfigDialogue.cpp:285
+#: ../../src/worksheet/WorksheetContextMenu.cpp:48
+#: ../../src/worksheet/WorksheetContextMenu.cpp:122
+#: ../../src/worksheet/WorksheetContextMenu.cpp:269
+#: ../../src/worksheet/WorksheetContextMenu.cpp:457
 msgid "Copy"
 msgstr "复制"
 
-#: ../../src/Worksheet.cpp:1296 ../../src/Worksheet.cpp:1375
-#: ../../src/Worksheet.cpp:1514
+#: ../../src/worksheet/WorksheetContextMenu.cpp:58
+#: ../../src/worksheet/WorksheetContextMenu.cpp:140
+#: ../../src/worksheet/WorksheetContextMenu.cpp:287
 msgid "Copy Animation"
 msgstr "复制动图"
 
-#: ../../src/wxMaximaFrame.cpp:887
+#: ../../src/wxMaximaFrame.cpp:921
 msgid "Copy Previous Input\tCtrl+I"
 msgstr "复制前一次输入\tCtrl+I"
 
-#: ../../src/wxMaximaFrame.cpp:890
+#: ../../src/wxMaximaFrame.cpp:924
 msgid "Copy Previous Output\tCtrl+U"
 msgstr "复制前一次输出\tCtrl+U"
 
-#: ../../src/wxMaxima.cpp:7992
+#: ../../src/MaximaCommandMenus.cpp:1176
 #, fuzzy
 msgid "Copy a matrix"
 msgstr "复制为图片"
 
-#: ../../src/Worksheet.cpp:1380 ../../src/Worksheet.cpp:1519
-#: ../../src/wxMaximaFrame.cpp:663
+#: ../../src/worksheet/WorksheetContextMenu.cpp:145
+#: ../../src/worksheet/WorksheetContextMenu.cpp:292
+#: ../../src/wxMaximaFrame.cpp:700
 msgid "Copy as EMF"
 msgstr "复制为 EMF"
 
-#: ../../src/Worksheet.cpp:1370 ../../src/Worksheet.cpp:1509
-#: ../../src/wxMaximaFrame.cpp:652
+#: ../../src/worksheet/WorksheetContextMenu.cpp:135
+#: ../../src/worksheet/WorksheetContextMenu.cpp:282
+#: ../../src/wxMaximaFrame.cpp:689
 msgid "Copy as Image"
 msgstr "复制为图片"
 
-#: ../../src/Worksheet.cpp:1362 ../../src/Worksheet.cpp:1501
-#: ../../src/wxMaximaFrame.cpp:645
+#: ../../src/worksheet/WorksheetContextMenu.cpp:126
+#: ../../src/worksheet/WorksheetContextMenu.cpp:273
+#: ../../src/wxMaximaFrame.cpp:682
 msgid "Copy as LaTeX"
 msgstr "复制为 LaTeX"
 
-#: ../../src/wxMaximaFrame.cpp:648
+#: ../../src/wxMaximaFrame.cpp:685
 msgid "Copy as MathML"
 msgstr "复制为 MathML"
 
-#: ../../src/Worksheet.cpp:1368 ../../src/Worksheet.cpp:1506
+#: ../../src/worksheet/WorksheetContextMenu.cpp:133
+#: ../../src/worksheet/WorksheetContextMenu.cpp:279
 msgid "Copy as MathML (e.g. to word processor)"
 msgstr "复制为 MathML（给文字处理软件）"
 
-#: ../../src/Worksheet.cpp:1383 ../../src/Worksheet.cpp:1522
-#: ../../src/wxMaximaFrame.cpp:658
+#: ../../src/worksheet/WorksheetContextMenu.cpp:148
+#: ../../src/worksheet/WorksheetContextMenu.cpp:295
+#: ../../src/wxMaximaFrame.cpp:695
 msgid "Copy as RTF"
 msgstr "复制为 RTF"
 
-#: ../../src/Worksheet.cpp:1377 ../../src/Worksheet.cpp:1516
-#: ../../src/wxMaximaFrame.cpp:655
+#: ../../src/worksheet/WorksheetContextMenu.cpp:142
+#: ../../src/worksheet/WorksheetContextMenu.cpp:289
+#: ../../src/wxMaximaFrame.cpp:692
 msgid "Copy as SVG"
 msgstr "复制为 SVG"
 
-#: ../../src/wxMaximaFrame.cpp:640
+#: ../../src/wxMaximaFrame.cpp:677
 msgid "Copy as Text\tCtrl+Shift+C"
 msgstr "复制为文本\tCtrl+Shift+C"
 
-#: ../../src/Worksheet.cpp:1364 ../../src/Worksheet.cpp:1503
+#: ../../src/worksheet/WorksheetContextMenu.cpp:128
+#: ../../src/worksheet/WorksheetContextMenu.cpp:275
 msgid "Copy as plain text"
 msgstr "复制为纯文本"
 
-#: ../../src/wxMaxima.cpp:7576
+#: ../../src/MaximaCommandMenus.cpp:4448
 #, fuzzy
 msgid "Copy file"
 msgstr "复制"
 
-#: ../../src/wxMaximaFrame.cpp:1214
+#: ../../src/wxMaximaFrame.cpp:1248
 #, fuzzy
 msgid "Copy file..."
 msgstr "求解..."
 
-#: ../../src/Worksheet.cpp:1360 ../../src/Worksheet.cpp:1499
-#: ../../src/wxMaximaFrame.cpp:643
+#: ../../src/worksheet/WorksheetContextMenu.cpp:124
+#: ../../src/worksheet/WorksheetContextMenu.cpp:271
+#: ../../src/wxMaximaFrame.cpp:680
 msgid "Copy for Octave/Matlab"
 msgstr "复制给 Octave/Matlab"
 
-#: ../../src/ToolBar.cpp:209 ../../src/wxMaximaFrame.cpp:638
+#: ../../src/worksheet/WorksheetContextMenu.cpp:49
+#: ../../src/worksheet/WorksheetContextMenu.cpp:105
+#: ../../src/worksheet/WorksheetContextMenu.cpp:123
+#: ../../src/worksheet/WorksheetContextMenu.cpp:270
+msgid "Copy position (UUID)"
+msgstr ""
+
+#: ../../src/ToolBar.cpp:380 ../../src/ToolBar.cpp:384
+#: ../../src/wxMaximaFrame.cpp:675
 msgid "Copy selection"
 msgstr "复制所选区域"
 
-#: ../../src/wxMaximaFrame.cpp:664
+#: ../../src/wxMaximaFrame.cpp:701
 msgid "Copy selection from document as an Enhanced Metafile"
 msgstr "复制文档中所选区域为增强图元文件（Enhanced Metafile）"
 
-#: ../../src/wxMaximaFrame.cpp:656
+#: ../../src/wxMaximaFrame.cpp:693
 msgid "Copy selection from document as an SVG image"
 msgstr "复制文档中所选区域为 SVG 图片"
 
-#: ../../src/wxMaximaFrame.cpp:653
+#: ../../src/wxMaximaFrame.cpp:690
 msgid "Copy selection from document as an image"
 msgstr "复制文档中所选区域为图片"
 
-#: ../../src/wxMaximaFrame.cpp:659
+#: ../../src/wxMaximaFrame.cpp:696
 msgid "Copy selection from document as rtf that a word processor might understand"
 msgstr "复制文档中所选区域为 rtf 格式（供文字处理程序使用）"
 
-#: ../../src/wxMaximaFrame.cpp:641
+#: ../../src/wxMaximaFrame.cpp:678
 msgid "Copy selection from document as text"
 msgstr "复制文档中所选区域为纯文本"
 
-#: ../../src/wxMaximaFrame.cpp:646
+#: ../../src/wxMaximaFrame.cpp:683
 msgid "Copy selection from document in LaTeX format"
 msgstr "复制文档中所选区域为 LaTeX 格式"
 
-#: ../../src/wxMaximaFrame.cpp:644
+#: ../../src/wxMaximaFrame.cpp:681
 msgid "Copy selection from document in Matlab format"
 msgstr "复制文档中所选区域为 Matlab 格式"
 
-#: ../../src/wxMaximaFrame.cpp:649
+#: ../../src/wxMaximaFrame.cpp:686
 msgid "Copy selection from document in a MathML format many word processors can display as 2d equation"
 msgstr "复制文档中所选区域为 MathML 格式（一些文字处理程序可以将其显示为 2D 公式）"
 
-#: ../../src/wxMaxima.cpp:7403
+#: ../../src/MaximaCommandMenus.cpp:4275
 #, fuzzy
 msgid "Copy string"
 msgstr "复制所选区域"
 
-#: ../../src/wxMaximaFrame.cpp:1165
+#: ../../src/wxMaximaFrame.cpp:1199
 #, fuzzy
 msgid "Copy string..."
 msgstr "未封闭的字符串。"
 
-#: ../../src/ToolBar.cpp:623
+#: ../../src/ToolBar.cpp:823
 msgid "Copy, Cut and Paste button"
 msgstr "复制，剪切和粘贴按钮"
 
-#: ../../src/WXMXformat.cpp:295
+#: ../../src/dialogs/ConfigDialogue.cpp:2523
+#, c-format
+msgid "Copying config bool \"%s\""
+msgstr "正在复制设置布尔变量“%s”"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:2533
+#, c-format
+msgid "Copying config float \"%s\""
+msgstr "正在复制设置浮点数变量“%s”"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:2528
+#, c-format
+msgid "Copying config int \"%s\""
+msgstr "正在复制设置整数变量“%s”"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:2518
+#, c-format
+msgid "Copying config string \"%s\""
+msgstr "正在复制设置字符串变量“%s”"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:191
+msgid "Corsican"
+msgstr ""
+
+#: ../../src/WXMXformat.cpp:297
 msgid "Could not create the backup file during saving => aborting."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3294 ../../src/wxMaxima.cpp:3306
+#: ../../src/MaximaResponseReader.cpp:359
 msgid "Could not make sure that we talk to the maxima we started => discarding all data it sends."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2783
+#: ../../src/MaximaProcessManager.cpp:893
 msgid "Could not map view of the file needed in order to send an interrupt signal to maxima."
 msgstr "无法使用 MapViewOfFile 功能以发送中断信号到 Maxima。"
 
-#: ../../src/wxMaxima.cpp:2763 ../../src/wxMaxima.cpp:2805
+#: ../../src/Image.cpp:1000
+msgid "Could not parse the SVG image data."
+msgstr ""
+
+#: ../../src/MaximaProcessManager.cpp:873
+#: ../../src/MaximaProcessManager.cpp:916
 msgid "Could not send an interrupt signal to maxima."
 msgstr "无法发送中断信号到 Maxima。"
 
-#: ../../src/WXMXformat.cpp:287
+#: ../../src/WXMXformat.cpp:289
 msgid "Could not write the file's contents during saving => aborting."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1325
+#: ../../src/wxMaximaFrame.cpp:1359
 #, fuzzy
 msgid "Create Matrix"
 msgstr "创建矩阵"
 
-#: ../../src/wxMaximaFrame.cpp:1688
+#: ../../src/wxMaximaFrame.cpp:1725
 msgid "Create a list"
 msgstr "创建列表"
 
-#: ../../src/wxMaxima.cpp:8487
+#: ../../src/MaximaCommandMenus.cpp:1491
 msgid "Create a list as a storage for the values of variables"
 msgstr "创建列表以储存一些变量的数值"
 
-#: ../../src/wxMaxima.cpp:8463 ../../src/wxMaxima.cpp:8476
+#: ../../src/MaximaCommandMenus.cpp:1479
+msgid "Create a list from a list"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:1466
 msgid "Create a list from a rule"
 msgstr "从表达式创建列表"
 
-#: ../../src/wxMaximaFrame.cpp:1670
+#: ../../src/wxMaximaFrame.cpp:1707
 msgid "Create a list from comma-separated elements"
 msgstr "从以逗号分隔的元素创建列表"
 
-#: ../../src/wxMaximaFrame.cpp:888
+#: ../../src/wxMaximaFrame.cpp:922
 msgid "Create a new cell with previous input"
 msgstr "使用前一次输入新建单元格"
 
-#: ../../src/wxMaximaFrame.cpp:891
+#: ../../src/wxMaximaFrame.cpp:925
 msgid "Create a new cell with previous output"
 msgstr "使用前一次输出新建单元"
 
-#: ../../src/wxMaximaFrame.cpp:1348
+#: ../../src/wxMaximaFrame.cpp:1382
 msgid "Create copy, not clone..."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7561
+#: ../../src/MaximaCommandMenus.cpp:4433
 #, fuzzy
 msgid "Create directory"
 msgstr "创建列表"
 
-#: ../../src/wxMaximaFrame.cpp:1203
+#: ../../src/wxMaximaFrame.cpp:1237
 #, fuzzy
 msgid "Create directory..."
 msgstr "创建列表"
 
-#: ../../src/wxMaxima.cpp:7419
+#: ../../src/MaximaCommandMenus.cpp:4291
 #, fuzzy
 msgid "Create empty string"
 msgstr "创建矩阵"
 
-#: ../../src/wxMaximaFrame.cpp:1168
+#: ../../src/wxMaximaFrame.cpp:1202
 #, fuzzy
 msgid "Create empty string..."
 msgstr "创建列表"
 
-#: ../../src/wxMaximaFrame.cpp:1687
+#: ../../src/wxMaximaFrame.cpp:1724
 msgid "Create list"
 msgstr "创建列表"
 
-#: ../../src/wxMaxima.cpp:8457
+#: ../../src/MaximaCommandMenus.cpp:1460
 msgid "Create list from comma-separated elements"
 msgstr "从以逗号分隔的元素创建列表"
 
-#: ../../src/wxMaximaFrame.cpp:1082
+#: ../../src/dialogs/ConfigDialogue.cpp:1389
+msgid "Create scalable plots."
+msgstr "创建可缩放图形"
+
+#: ../../src/wxMaximaFrame.cpp:1116
 #, fuzzy
 msgid "Create struct..."
 msgstr "创建列表"
 
-#: ../../src/WXMXformat.cpp:80
+#: ../../src/WXMXformat.cpp:81
 msgid "Created a .zip archive (the .wxmx file technically is a .zip file)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1349
+#: ../../src/wxMaximaFrame.cpp:1383
 msgid "Creates an independent matrix with the same contents"
 msgstr ""
 
-#: ../../src/Configuration.cpp:97
+#: ../../src/dialogs/ConfigDialogue.cpp:192
+msgid "Croatian"
+msgstr ""
+
+#: ../../src/wizards/CsvWiz.cpp:93 ../../src/wizards/CsvWiz.cpp:167
+msgid "Csv files (*.csv)|*.csv|Text files (*.txt)|*.txt|All|*"
+msgstr ""
+
+#: ../../src/worksheet/Worksheet.cpp:6125
+msgid "Cursor"
+msgstr "光标"
+
+#: ../../src/Styles.cpp:126
 #, fuzzy
 msgid "Cursor color"
 msgstr "光标"
 
-#: ../../src/ToolBar.cpp:208 ../../src/Worksheet.cpp:1683
+#: ../../src/ToolBar.cpp:379 ../../src/ToolBar.cpp:383
+#: ../../src/worksheet/WorksheetContextMenu.cpp:456
 msgid "Cut"
 msgstr "剪切"
 
-#: ../../src/wxMaximaFrame.cpp:636
+#: ../../src/wxMaximaFrame.cpp:673
 msgid "Cut\tCtrl+X"
 msgstr "剪切\tCtrl+X"
 
-#: ../../src/ToolBar.cpp:208 ../../src/wxMaximaFrame.cpp:636
+#: ../../src/ToolBar.cpp:379 ../../src/ToolBar.cpp:383
+#: ../../src/wxMaximaFrame.cpp:673
 msgid "Cut selection"
 msgstr "剪切所选区域"
 
-#: ../../src/wxMaxima.cpp:9589 ../../src/wxMaxima.cpp:9629
+#: ../../src/dialogs/ConfigDialogue.cpp:193
+msgid "Czech"
+msgstr "捷克语"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:194
+msgid "Danish"
+msgstr "丹麦语"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:2069
+msgid "Dark"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:1829 ../../src/MaximaCommandMenus.cpp:1869
 msgid "Data Matrix:"
 msgstr "数据矩阵："
 
-#: ../../src/wxMaxima.cpp:9599
+#: ../../src/MaximaCommandMenus.cpp:1839
 msgid "Data file (*.csv, *.tab, *.txt)|*.csv;*.tab;*.txt"
 msgstr "数据文件 (*.csv, *.tab, *.txt)|*.csv;*.tab;*.txt"
 
-#: ../../src/wxMaxima.cpp:9529 ../../src/wxMaxima.cpp:9534
-#: ../../src/wxMaxima.cpp:9539 ../../src/wxMaxima.cpp:9543
-#: ../../src/wxMaxima.cpp:9547 ../../src/wxMaxima.cpp:9551
-#: ../../src/wxMaxima.cpp:9555 ../../src/wxMaxima.cpp:9559
-#: ../../src/wxMaxima.cpp:9563 ../../src/wxMaxima.cpp:9577
-#: ../../src/wxMaxima.cpp:9582 ../../src/wxMaxima.cpp:10030
+#: ../../src/wizards/DrawWiz.cpp:810
+msgid "Data format"
+msgstr "数据格式"
+
+#: ../../src/MaximaCommandMenus.cpp:1767 ../../src/MaximaCommandMenus.cpp:1772
+#: ../../src/MaximaCommandMenus.cpp:1777 ../../src/MaximaCommandMenus.cpp:1781
+#: ../../src/MaximaCommandMenus.cpp:1785 ../../src/MaximaCommandMenus.cpp:1789
+#: ../../src/MaximaCommandMenus.cpp:1793 ../../src/MaximaCommandMenus.cpp:1797
+#: ../../src/MaximaCommandMenus.cpp:1801 ../../src/MaximaCommandMenus.cpp:1815
+#: ../../src/MaximaCommandMenus.cpp:1822 ../../src/MaximaCommandMenus.cpp:3519
 msgid "Data:"
 msgstr "数据："
 
-#: ../../src/wxMaximaFrame.cpp:1057
+#: ../../src/wxMaximaFrame.cpp:1091
 msgid "Debugger trigger"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:779
+#: ../../src/wxMaximaFrame.cpp:816
 msgid "Declare Text to always be displayed as subscript"
 msgstr "声明总显示为下标的文本"
 
-#: ../../src/wxMaxima.cpp:7069
+#: ../../src/MaximaCommandMenus.cpp:3941
 msgid "Declare a function local to a Program"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:6539
+#: ../../src/MaximaCommandMenus.cpp:3059
 msgid "Declare a text snippet to always be displayed as subscript"
 msgstr "声明一个文本片段，使其总显示为下标"
 
-#: ../../src/Worksheet.cpp:2044
+#: ../../src/worksheet/WorksheetContextMenu.cpp:816
 #, c-format
 msgid "Declare facts about %s"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8800
+#: ../../src/MaximaCommandMenus.cpp:807
 #, fuzzy
 msgid "Declare main variable:"
 msgstr "删除变量"
 
-#: ../../src/wxMaxima.cpp:7171
+#: ../../src/MaximaCommandMenus.cpp:4043
 msgid "Declare the type of a function parameter"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:2038
+#: ../../src/worksheet/WorksheetContextMenu.cpp:810
 msgid "Declare these chars as ordinary letters"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1500 ../../src/wxMaximaFrame.cpp:1536
+#: ../../src/wxMaximaFrame.cpp:1537 ../../src/wxMaximaFrame.cpp:1573
 msgid "Decompose rational function to partial fractions"
 msgstr "分解有理函数为部分分式"
 
-#: ../../src/Worksheet.cpp:2010
+#: ../../src/worksheet/WorksheetContextMenu.cpp:782
 #, fuzzy
 msgid "Decreasing function f(x)<x"
 msgstr "删除函数："
 
-#: ../../src/wxMaxima.cpp:7134
+#: ../../src/dialogs/ConfigDialogue.cpp:1336
+msgid "Default animation framerate:"
+msgstr "默认动画帧率："
+
+#: ../../src/dialogs/ConfigDialogue.cpp:717
+msgid "Default plot size for new maxima sessions:"
+msgstr "新 Maxima 会话的默认绘图大小"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1534
+msgid "Default port for communication with wxMaxima:"
+msgstr "与 wxMaxima 通信的默认端口："
+
+#: ../../src/MaximaCommandMenus.cpp:4006
 #, fuzzy
 msgid "Define a function"
 msgstr "删除函数"
 
-#: ../../src/wxMaxima.cpp:7147
+#: ../../src/MaximaCommandMenus.cpp:4019
 msgid "Define a macro"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7189
+#: ../../src/MaximaCommandMenus.cpp:4061
 msgid "Define a structure"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7183
+#: ../../src/MaximaCommandMenus.cpp:4055
 msgid "Define a structure type"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7156
+#: ../../src/MaximaCommandMenus.cpp:4028
 #, fuzzy
 msgid "Define a variable"
 msgstr "删除变量"
 
-#: ../../src/wxMaximaFrame.cpp:1072
+#: ../../src/wxMaximaFrame.cpp:1106
 #, fuzzy
 msgid "Define function..."
 msgstr "删除函数(&U)..."
 
-#: ../../src/wxMaximaFrame.cpp:1079
+#: ../../src/wxMaximaFrame.cpp:1113
 msgid "Define macro..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1077
+#: ../../src/wxMaximaFrame.cpp:1111
 msgid "Define parameter type..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1081
+#: ../../src/wxMaximaFrame.cpp:1115
 msgid "Define struct..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1080
+#: ../../src/dialogs/ConfigDialogue.cpp:404
+msgid "Define the default speed (in frames per second) animations are played back with."
+msgstr "定义动图回放的默认速度（帧率）。"
+
+#: ../../src/wxMaximaFrame.cpp:1114
 #, fuzzy
 msgid "Define variable..."
 msgstr "删除变量"
 
-#: ../../src/wxMaximaFrame.cpp:1776
+#: ../../src/wxMaximaFrame.cpp:1813
 msgid "Defines if an animation is automatically started or only by clicking on it."
 msgstr "定义动图是自动播放，还是只在点击后播放。"
 
-#: ../../src/wxMaxima.cpp:8935
+#: ../../src/MaximaCommandMenus.cpp:186
 msgid "Degree:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:985
+#: ../../src/wxMaximaFrame.cpp:1019
 msgid "Delete F&unction..."
 msgstr "删除函数(&U)..."
 
-#: ../../src/Worksheet.cpp:1386 ../../src/Worksheet.cpp:1525
+#: ../../src/worksheet/WorksheetContextMenu.cpp:157
+#: ../../src/worksheet/WorksheetContextMenu.cpp:298
 msgid "Delete Selection"
 msgstr "删除所选区域"
 
-#: ../../src/wxMaximaFrame.cpp:987
+#: ../../src/wxMaximaFrame.cpp:1021
 msgid "Delete V&ariable..."
 msgstr "删除变量(&A)..."
 
-#: ../../src/wxMaximaFrame.cpp:986
+#: ../../src/wxMaximaFrame.cpp:1020
 msgid "Delete a function"
 msgstr "删除函数"
 
-#: ../../src/wxMaximaFrame.cpp:988
+#: ../../src/wxMaximaFrame.cpp:1022
 msgid "Delete a variable"
 msgstr "删除变量"
 
-#: ../../src/wxMaximaFrame.cpp:982
+#: ../../src/wxMaximaFrame.cpp:1016
 msgid "Delete all objects with a given name"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:991
+#: ../../src/wxMaximaFrame.cpp:1025
 msgid "Delete all values from memory"
 msgstr "删除内存中所有值"
 
-#: ../../src/wxMaxima.cpp:7588
+#: ../../src/MaximaCommandMenus.cpp:4460
 #, fuzzy
 msgid "Delete file"
 msgstr "删除变量"
 
-#: ../../src/wxMaximaFrame.cpp:1216
+#: ../../src/wxMaximaFrame.cpp:1250
 #, fuzzy
 msgid "Delete file..."
 msgstr "删除变量(&A)..."
 
-#: ../../src/wxMaxima.cpp:7683
+#: ../../src/MaximaCommandMenus.cpp:4555
 #, fuzzy
 msgid "Delete function(s)"
 msgstr "删除函数："
 
-#: ../../src/wxMaxima.cpp:7679
+#: ../../src/MaximaCommandMenus.cpp:4551
 #, fuzzy
 msgid "Delete named object(s)"
 msgstr "删除函数："
 
-#: ../../src/wxMaximaFrame.cpp:981
+#: ../../src/wxMaximaFrame.cpp:1015
 #, fuzzy
 msgid "Delete named object..."
 msgstr "删除函数(&U)..."
 
-#: ../../src/wxMaxima.cpp:7674
+#: ../../src/MaximaCommandMenus.cpp:4546
 #, fuzzy
 msgid "Delete variable(s)"
 msgstr "删除变量："
 
-#: ../../src/wxMaxima.cpp:7430
+#: ../../src/MaximaCommandMenus.cpp:4302
 #, fuzzy
 msgid "Delimiter:"
 msgstr "消元"
 
-#: ../../src/Worksheet.cpp:1347 ../../src/Worksheet.cpp:1785
+#: ../../src/sidebars/GreekSidebar.cpp:181
+msgid "Delta"
+msgstr "Delta"
+
+#: ../../src/worksheet/WorksheetContextMenu.cpp:110
+#: ../../src/worksheet/WorksheetContextMenu.cpp:558
 #, fuzzy, c-format
 msgid "Demo for \"%s\""
 msgstr "关于“%s”的帮助"
 
-#: ../../src/wxMaximaFrame.cpp:1930
+#: ../../src/wxMaximaFrame.cpp:1967
 msgid "Demos"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8927
+#: ../../src/MaximaCommandMenus.cpp:178
 msgid "Denom. deg:"
 msgstr "分母次数："
 
-#: ../../src/wxMaxima.cpp:7923
+#: ../../src/MaximaCommandMenus.cpp:1104
 msgid "Denominator:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1030
+#: ../../src/wxMaximaFrame.cpp:1064
 msgid "Dependencies"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7813
+#: ../../src/wizards/SeriesWiz.cpp:42
+msgid "Depth:"
+msgstr "深度："
+
+#: ../../src/MaximaCommandMenus.cpp:994
 msgid "Derivate of y at that point:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1497
+#: ../../src/wizards/ListSortWiz.cpp:56
+msgid "Descending by magnitude (numeric only)"
+msgstr ""
+
+#: ../../src/wizards/GenWizPanel.cpp:255
+msgid "Description"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:435 ../../src/MaximaCommandMenus.cpp:448
+#: ../../src/MaximaCommandMenus.cpp:461 ../../src/MaximaCommandMenus.cpp:475
+#: ../../src/MaximaCommandMenus.cpp:486 ../../src/MaximaCommandMenus.cpp:499
+#: ../../src/MaximaCommandMenus.cpp:514 ../../src/MaximaCommandMenus.cpp:528
+#: ../../src/MaximaCommandMenus.cpp:546 ../../src/MaximaCommandMenus.cpp:561
+#: ../../src/MaximaCommandMenus.cpp:576 ../../src/MaximaCommandMenus.cpp:591
+#: ../../src/MaximaCommandMenus.cpp:605
+msgid "Desired absolute error of approximation."
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:434 ../../src/MaximaCommandMenus.cpp:447
+#: ../../src/MaximaCommandMenus.cpp:460 ../../src/MaximaCommandMenus.cpp:474
+#: ../../src/MaximaCommandMenus.cpp:513 ../../src/MaximaCommandMenus.cpp:527
+#: ../../src/MaximaCommandMenus.cpp:545 ../../src/MaximaCommandMenus.cpp:560
+#: ../../src/MaximaCommandMenus.cpp:575 ../../src/MaximaCommandMenus.cpp:590
+#: ../../src/MaximaCommandMenus.cpp:604
+msgid "Desired relative error of approximation."
+msgstr ""
+
+#: ../../src/sidebars/StatSidebar.cpp:61
+msgid "Deviation..."
+msgstr "偏差..."
+
+#: ../../src/wxMaximaFrame.cpp:1534
 msgid "Di&vide Polynomials..."
 msgstr "多项式相除(&V)..."
 
-#: ../../src/MaximaManual.cpp:517
+#: ../../src/worksheet/WorksheetExport.cpp:1400
+msgid "Diagram"
+msgstr ""
+
+#: ../../src/sidebars/DrawSidebar.cpp:71
+msgid "Diagram title"
+msgstr "图表标题"
+
+#: ../../src/sidebars/HelpBrowser.cpp:51
+msgid "Didn't find an installed offline manual."
+msgstr ""
+
+#: ../../src/MaximaManual.cpp:534
 msgid "Didn't find the maxima HTML manual."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:4907
+#: ../../src/wxMaxima.cpp:1685
 msgid "Didn't get a help browser launch program command line, but can request the system's default help browser."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:9010 ../../src/wxMaxima.cpp:10055
+#: ../../src/Styles.cpp:129
+msgid "Diff viewer: changed text"
+msgstr ""
+
+#: ../../src/sidebars/MathSidebar.cpp:80
+msgid "Diff..."
+msgstr "求导..."
+
+#: ../../src/dialogs/DiffFrame.cpp:308
+#, c-format
+msgid "Difference %d / %d"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:264 ../../src/MaximaCommandMenus.cpp:3544
 msgid "Differentiate"
 msgstr "求导"
 
-#: ../../src/wxMaximaFrame.cpp:1467
+#: ../../src/wxMaximaFrame.cpp:1504
 msgid "Differentiate expression"
 msgstr "对表达式求导"
 
-#: ../../src/Worksheet.cpp:1590
+#: ../../src/worksheet/WorksheetContextMenu.cpp:363
 msgid "Differentiate..."
 msgstr "求导..."
 
-#: ../../src/wxMaxima.cpp:9010
+#: ../../src/MaximaCommandMenus.cpp:264
 #, fuzzy
 msgid "Differentiates an expression n times"
 msgstr "对表达式求导"
 
-#: ../../src/wxMaxima.cpp:10055
+#: ../../src/MaximaCommandMenus.cpp:3544
 #, fuzzy
 msgid "Differentiates the expression n times"
 msgstr "对表达式求导"
 
-#: ../../src/wxMaximaFrame.cpp:1212
+#: ../../src/wizards/LimitWiz.cpp:41
+msgid "Direction:"
+msgstr "方向："
+
+#: ../../src/wxMaximaFrame.cpp:1246
 #, fuzzy
 msgid "Directory operations"
 msgstr "方向："
 
-#: ../../src/wxMaximaFrame.cpp:1041
+#: ../../src/main.cpp:315
+msgid "Disabled the console's QuickEdit mode for this batch run so a click into the console cannot suspend wxMaxima."
+msgstr ""
+
+#: ../../src/wizards/Plot2dWiz.cpp:418 ../../src/wizards/Plot2dWiz.cpp:619
+msgid "Discrete plot"
+msgstr "离散绘图"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:699
+msgid "Display"
+msgstr "显示"
+
+#: ../../src/wxMaximaFrame.cpp:1075
 msgid "Display Te&X Form"
 msgstr "以 TeX 格式显示(&X)"
 
-#: ../../src/wxMaxima.cpp:6972
+#: ../../src/MaximaCommandMenus.cpp:3844
 msgid "Display algorithm"
 msgstr "显示算法"
 
-#: ../../src/wxMaximaFrame.cpp:751
+#: ../../src/dialogs/ConfigDialogue.cpp:827
+msgid "Display all and allow linebreaks in long numbers"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:820
+#, fuzzy
+msgid "Display all digits"
+msgstr "显示算法"
+
+#: ../../src/wxMaximaFrame.cpp:788
 msgid "Display an expression as maxima's internal lisp representation"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:754
+#: ../../src/wxMaximaFrame.cpp:791
 msgid "Display an expression as wxMaxima's internal XML representation"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:758
+#: ../../src/wxMaximaFrame.cpp:795
 msgid "Display equations"
 msgstr "显示方程"
 
-#: ../../src/wxMaxima.cpp:6508
+#: ../../src/MaximaCommandMenus.cpp:3028
 msgid "Display expression in maxima's internal representation"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:6514
+#: ../../src/MaximaCommandMenus.cpp:3034
 msgid "Display expression in wxMaxima's internal representation"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1042
+#: ../../src/wxMaximaFrame.cpp:1076
 msgid "Display last result in TeX form"
 msgstr "以 TeX 格式显示最后一次结果"
 
-#: ../../src/ToolBar.cpp:360
+#: ../../src/dialogs/ConfigDialogue.cpp:804
+#, fuzzy
+msgid "Display of long numbers"
+msgstr "显示三维图形"
+
+#: ../../src/ToolBar.cpp:580
 #, fuzzy, c-format
 msgid "Display resolution according to wxWidgets: %li x %li ppi"
 msgstr "根据 wxWidgets 的信息显示分辨率：%i x %i ppi"
 
-#: ../../src/wxMaximaFrame.cpp:802
+#: ../../src/wxMaximaFrame.cpp:839
 msgid "Display string quotation marks"
 msgstr "显示字符串引号"
 
-#: ../../src/wxMaximaFrame.cpp:1036
+#: ../../src/wxMaximaFrame.cpp:1070
 msgid "Display time used for evaluation"
 msgstr "显示计算时间"
 
-#: ../../src/wxMaxima.cpp:9206
+#: ../../src/MaximaCommandMenus.cpp:397
 msgid "Displayed Precision"
 msgstr "显示的精度"
 
-#: ../../src/wxMaximaFrame.cpp:1913
+#: ../../src/wxMaximaFrame.cpp:1950
 msgid "Displaying 3d curves"
 msgstr "显示三维图形"
 
-#: ../../src/wxMaximaFrame.cpp:1462
+#: ../../src/wxMaximaFrame.cpp:1499
 #, fuzzy
 msgid "Dito, and evaluate the result..."
 msgstr "计算剩下的"
 
-#: ../../src/wxMaximaFrame.cpp:1445
+#: ../../src/wxMaximaFrame.cpp:1482
 msgid "Dito, but affect all clones of the Matrix..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1255
+#: ../../src/wxMaximaFrame.cpp:1289
 msgid "Dito, but as fraction (real only)..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1532
+#: ../../src/wxMaximaFrame.cpp:1569
 msgid "Dito, including denominator"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1715 ../../src/wxMaximaFrame.cpp:944
+#: ../../src/worksheet/WorksheetContextMenu.cpp:488
+#: ../../src/wxMaximaFrame.cpp:978
 msgid "Divide Cell"
 msgstr "分割单元格"
 
-#: ../../src/wxMaximaFrame.cpp:1498
+#: ../../src/wxMaximaFrame.cpp:1535
 msgid "Divide numbers or polynomials"
 msgstr "将数字或多项式相除"
 
-#: ../../src/wxMaxima.cpp:8578
+#: ../../src/cells/TextCell.cpp:297
+msgid "Division by 0."
+msgstr "除以 0 。"
+
+#: ../../src/MaximaCommandMenus.cpp:1596
 msgid "Do for each list element"
 msgstr "对每个列表元素进行操作"
 
-#: ../../src/wxMaxima.cpp:11197
+#: ../../src/wxMaxima.cpp:3503
 #, c-format
 msgid "Do you want to save the changes you made in the document \"%s\"?"
 msgstr "是否保存文档“%s”中的更改？"
 
-#: ../../src/wxMaximaFrame.cpp:724
+#: ../../src/wxMaximaFrame.cpp:761
 msgid "Dock all Sidebars"
 msgstr "停靠所有侧边栏"
 
-#: ../../src/Configuration.cpp:94
+#: ../../src/Styles.cpp:123
 msgid "Document background"
 msgstr "文档背景"
 
-#: ../../src/wxMaxima.cpp:4611
+#: ../../src/MaximaFileIO.cpp:534
 msgid "Document was saved using a newer version of wxMaxima so it may not load correctly. Please update your wxMaxima."
 msgstr "文档是用新版本 wxMaxima 保存的，可能没有正确地载入。请更新 wxMaxima。"
 
-#: ../../src/wxMaxima.cpp:4603
+#: ../../src/MaximaFileIO.cpp:526
 msgid "Document was saved using a newer version of wxMaxima. Please update your wxMaxima."
 msgstr "文本是用新版本 wxMaxima 保存的，请更新 wxMaxima。"
 
-#: ../../src/wxMaximaFrame.cpp:770
+#: ../../src/dialogs/ConfigDialogue.cpp:1170
+msgid "Documentclass for TeX export:"
+msgstr "导出 Tex 时所用的文档类型（documentclass）："
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1178
+msgid "Documentclass options:"
+msgstr "文档类型（documentclass）选项："
+
+#: ../../src/wxMaximaFrame.cpp:807
 msgid "Don't autosubscript after an underscore"
 msgstr "不将下划线后的文本自动显示为下标"
 
-#: ../../src/wxMaximaFrame.cpp:1086
+#: ../../src/wxMaximaFrame.cpp:1120
 #, fuzzy
 msgid "Don't evaluate Expression..."
 msgstr "对表达式求积分"
 
-#: ../../src/wxMaxima.cpp:7117
+#: ../../src/MaximaCommandMenus.cpp:3989
 #, fuzzy
 msgid "Don't evaluate one command"
 msgstr "显示此命令的示例："
 
-#: ../../src/wxMaxima.cpp:7129
+#: ../../src/MaximaCommandMenus.cpp:4001
 #, fuzzy
 msgid "Don't evaluate one whole expression"
 msgstr "求复数表达式的实部"
 
-#: ../../src/Worksheet.cpp:1931 ../../src/Worksheet.cpp:2064
+#: ../../src/worksheet/WorksheetContextMenu.cpp:703
+#: ../../src/worksheet/WorksheetContextMenu.cpp:836
 msgid "Don't mark cells that contain tooltips in yellow"
 msgstr "不将含提示的单元格标记为黄色"
 
-#: ../../src/Worksheet.cpp:1938 ../../src/Worksheet.cpp:2070
+#: ../../src/worksheet/WorksheetContextMenu.cpp:710
+#: ../../src/worksheet/WorksheetContextMenu.cpp:842
 msgid "Don't mark this message text in yellow"
 msgstr "不将此消息文本标记为黄色"
 
-#: ../../src/wxMaxima.cpp:11203
+#: ../../src/wxMaxima.cpp:3509
 msgid "Don't save"
 msgstr "不保存"
 
-#: ../../src/Worksheet.cpp:1620
+#: ../../src/worksheet/WorksheetContextMenu.cpp:393
 msgid "Don't show labels"
 msgstr "不显示标签"
 
-#: ../../src/Worksheet.cpp:1979
+#: ../../src/worksheet/WorksheetContextMenu.cpp:751
 msgid "Don't use if unassigned"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:797
+#: ../../src/wxMaximaFrame.cpp:834
 msgid "Don't use parenthesis for matrices"
 msgstr "不显示矩阵的括号"
 
-#: ../../src/wxMaxima.cpp:8525
+#: ../../src/dialogs/DiffFrame.cpp:428 ../../src/dialogs/FindReplacePane.cpp:83
+msgid "Down"
+msgstr "下"
+
+#: ../../src/sidebars/SymbolsSidebar.cpp:185
+msgid "Drag-and-drop unicode symbols here"
+msgstr "拖动 unicode 符号到此处"
+
+#: ../../src/wizards/DrawWiz.cpp:155
+msgid "Draw all points where an equation is true."
+msgstr ""
+
+#: ../../src/wizards/DrawWiz.cpp:802
+msgid "Draw points"
+msgstr "画点"
+
+#: ../../src/MaximaCommandMenus.cpp:1536
 #, fuzzy
 msgid "Drop the first n list elements"
 msgstr "对每个列表元素进行操作"
 
-#: ../../src/wxMaxima.cpp:8531 ../../src/wxMaxima.cpp:8537
+#: ../../src/MaximaCommandMenus.cpp:1542
 #, fuzzy
 msgid "Drop the last n list elements"
 msgstr "去掉后 n 个元素"
 
-#: ../../src/wxMaximaFrame.cpp:1306
+#: ../../src/dialogs/ConfigDialogue.cpp:195
+msgid "Dutch"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1340
 msgid "E&quations"
 msgstr "方程(&Q)"
 
-#: ../../src/wxMaximaFrame.cpp:625
+#: ../../src/wxMaximaFrame.cpp:658
 msgid "E&xit\tCtrl+Q"
 msgstr "退出(&X)\tCtrl+Q"
 
-#: ../../src/wxMaximaFrame.cpp:1368
+#: ../../src/wxMaximaFrame.cpp:1402
 msgid "Eige&nvectors"
 msgstr "特征向量(&N)"
 
-#: ../../src/wxMaximaFrame.cpp:1365
+#: ../../src/wxMaximaFrame.cpp:1399
 msgid "Eigen&values"
 msgstr "特征值(&V)"
 
-#: ../../src/wxMaximaFrame.cpp:1387
+#: ../../src/wxMaximaFrame.cpp:1421
 #, fuzzy
 msgid "Eigenvalues (complex)"
 msgstr "特征值(&V)"
 
-#: ../../src/wxMaximaFrame.cpp:1384
+#: ../../src/wxMaximaFrame.cpp:1418
 #, fuzzy
 msgid "Eigenvalues (real)"
 msgstr "特征值(&V)"
 
-#: ../../src/wxMaximaFrame.cpp:1393
+#: ../../src/wxMaximaFrame.cpp:1427
 msgid "Eigenvalues, left+right eigenvectors (complex)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1390
+#: ../../src/wxMaximaFrame.cpp:1424
 msgid "Eigenvalues, left+right eigenvectors (real)"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8584
+#: ../../src/MaximaCommandMenus.cpp:1602
 msgid "Either a single expression or a comma-separated list of expressions between parenthesis. In the latter case the result of the last expression in the parenthesis is used."
 msgstr "输入一个表达式，或用逗号分隔的多个表达式组成的列表。如果是后者，只使用列表中的最后一个表达式。"
 
-#: ../../src/wxMaxima.cpp:8593
+#: ../../src/cells/TextCell.cpp:176
+msgid ""
+"Either negative or zero.\n"
+"A possible result of sign()."
+msgstr ""
+
+#: ../../src/cells/TextCell.cpp:172
+msgid ""
+"Either positive or zero.\n"
+"A possible result of sign()."
+msgstr ""
+
+#: ../../src/cells/TextCell.cpp:168
+msgid ""
+"Either positive, negative or zero.\n"
+"Normally the result of sign() if the sign cannot be determined."
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:1612
 msgid "Element"
 msgstr "元素"
 
-#: ../../src/wxMaxima.cpp:8549
+#: ../../src/MaximaCommandMenus.cpp:1562
 #, fuzzy
 msgid "Element number"
 msgstr "项数 n"
 
-#: ../../src/wxMaxima.cpp:8005
+#: ../../src/MaximaCommandMenus.cpp:1189
 msgid "Element-by-element Product of matrices of the same size (Hadamard product)"
 msgstr "相同大小的矩阵逐个对应元素相乘（Hadamard 积）"
 
-#: ../../src/wxMaxima.cpp:8012
+#: ../../src/MaximaCommandMenus.cpp:1196
 #, fuzzy
 msgid "Element-by-element exponentiation of two matrices"
 msgstr "逐个对应元素相乘"
 
-#: ../../src/wxMaximaFrame.cpp:1342
+#: ../../src/wxMaximaFrame.cpp:1376
 msgid "Element-by-element multiplication"
 msgstr "逐个对应元素相乘"
 
-#: ../../src/wxMaxima.cpp:8510
+#: ../../src/MaximaCommandMenus.cpp:1516
 msgid "Element:"
 msgstr "元素："
 
-#: ../../src/wxMaxima.cpp:7204
+#: ../../src/MaximaCommandMenus.cpp:4076
 #, fuzzy
 msgid "Elements:"
 msgstr "元素："
 
-#: ../../src/wxMaxima.cpp:7847
+#: ../../src/MaximaCommandMenus.cpp:1028
 #, fuzzy
 msgid "Eliminate a variable"
 msgstr "消元(&E)..."
 
-#: ../../src/wxMaximaFrame.cpp:1247
+#: ../../src/wxMaximaFrame.cpp:1281
 msgid "Eliminate a variable from a system of equations"
 msgstr "消去方程组中一个变量"
 
-#: ../../src/wxMaxima.cpp:10651
+#: ../../src/MaximaEvaluator.cpp:536
 msgid "Empty command => re-triggering evaluation"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:9225
+#: ../../src/MaximaCommandMenus.cpp:416
 msgid "Enable:"
 msgstr "启用："
 
-#: ../../src/MathParser.cpp:99
+#: ../../src/MathParser.cpp:94
 #, c-format
 msgid "Encountered an unknown XML tag: <%s>"
 msgstr "遇到未知的 XML 标签：<%s>"
 
-#: ../../src/wxMaxima.cpp:2476
+#: ../../src/MaximaProcessManager.cpp:137
 msgid "Encountered an unknown socket event."
 msgstr "遇到未知的套接字（socket）事件。"
 
-#: ../../src/wxMaxima.cpp:7843
+#: ../../src/sidebars/SymbolsSidebar.cpp:129
+msgid "End of proof"
+msgstr "证毕"
+
+#: ../../src/MaximaCommandMenus.cpp:1024
 #, fuzzy
 msgid "End of t:"
 msgstr "证毕"
 
-#: ../../src/wxMaxima.cpp:4097
+#: ../../src/wizards/DrawWiz.cpp:71 ../../src/wizards/DrawWiz.cpp:176
+msgid "End of the x value"
+msgstr ""
+
+#: ../../src/wizards/DrawWiz.cpp:88 ../../src/wizards/DrawWiz.cpp:191
+msgid "End of the y value"
+msgstr ""
+
+#: ../../src/wizards/DrawWiz.cpp:208
+msgid "End of the z value"
+msgstr ""
+
+#: ../../src/wizards/DrawWiz.cpp:760
+msgid "End value of the parameter"
+msgstr ""
+
+#: ../../src/MaximaResponseReader.cpp:432
+#: ../../src/MaximaResponseReader.cpp:586
 msgid "Ended lisp mode after receiving a maxima prompt!"
 msgstr "收到 Maxima 的请求后终止了 Lisp 模式！"
 
-#: ../../src/wxMaximaFrame.cpp:1828
+#: ../../src/wxMaximaFrame.cpp:1865
 msgid "Engineering format (12.1e6 etc.)"
 msgstr "工程格式（如 12.1e6）"
 
-#: ../../src/wxMaximaFrame.cpp:1319
+#: ../../src/dialogs/ConfigDialogue.cpp:196
+msgid "English"
+msgstr "英语"
+
+#: ../../src/wizards/DrawWiz.cpp:552
+msgid "Enhanced 3D settings:"
+msgstr "增强三维设置："
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1919
+msgid "Enhanced meta file (emf)"
+msgstr "增强图元文件（emf）"
+
+#: ../../src/sidebars/StatSidebar.cpp:106
+msgid "Enter Matrix..."
+msgstr "输入矩阵..."
+
+#: ../../src/MaximaCommandMenus.cpp:2255
+msgid "Enter UUID to jump to:"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1353
 msgid "Enter a matrix"
 msgstr "输入一个矩阵"
 
-#: ../../src/wxMaxima.cpp:8866
+#: ../../src/dialogs/ConfigDialogue.cpp:925
+msgid "Enter adds newlines, Ctrl+Enter evaluates cells"
+msgstr "按下 Enter 键新增一行，按下 Ctrl+Enter 键对单元格求值"
+
+#: ../../src/MaximaCommandMenus.cpp:873
 msgid "Enter an equation for rational simplification:"
 msgstr "输入整系数多项式，以将其根（代数数）用于有理式化简："
 
-#: ../../src/wxMaxima.cpp:8169
+#: ../../src/wizards/SystemWiz.cpp:50
+msgid "Enter comma separated list of variables."
+msgstr "输入变量列表，以逗号分割。"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:921
+msgid "Enter evaluates cells, Ctrl+Enter adds newlines"
+msgstr "按下 Enter 键对单元格求值，按下 Ctrl+Enter 键新增一行"
+
+#: ../../src/MaximaCommandMenus.cpp:1357
 msgid "Enter matrix"
 msgstr "输入矩阵"
 
-#: ../../src/wxMaxima.cpp:9095
+#: ../../src/MaximaCommandMenus.cpp:100
 msgid "Enter new animation frame rate [Hz, integer]:"
 msgstr "输入新的动图帧率（整数，单位：Hz）："
 
-#: ../../src/wxMaxima.cpp:9201
+#: ../../src/MaximaCommandMenus.cpp:392
 msgid "Enter new precision for bigfloats:"
 msgstr "为大浮点数设置新的精度："
 
-#: ../../src/wxMaxima.cpp:7922
+#: ../../src/dialogs/ConfigDialogue.cpp:388
+msgid "Enter the path to the Maxima executable."
+msgstr "输入 Maxima 程序（可执行文件）的路径。"
+
+#: ../../src/MaximaCommandMenus.cpp:1103
 #, fuzzy
 msgid "Enumerator:"
 msgstr "迭代变量："
 
-#: ../../src/wxMaximaFrame.cpp:1220
+#: ../../src/wxMaximaFrame.cpp:1254
 #, fuzzy
 msgid "Environment variables"
 msgstr "Maxima 的环境变量（附加参数）"
 
-#: ../../src/wxMaxima.cpp:9045
+#: ../../src/dialogs/ConfigDialogue.cpp:1605
+msgid "Environment variables for maxima"
+msgstr "Maxima 的环境变量（附加参数）"
+
+#: ../../src/sidebars/GreekSidebar.cpp:182
+msgid "Epsilon"
+msgstr "Epsilon"
+
+#: ../../src/MaximaCommandMenus.cpp:299
 msgid "Epsilon:"
 msgstr "Epsilon（误差）："
 
-#: ../../src/wxMaximaFrame.cpp:1124 ../../src/wxMaximaFrame.cpp:1135
+#: ../../src/wxMaximaFrame.cpp:1158 ../../src/wxMaximaFrame.cpp:1169
 msgid "Equal, ignoring case?..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1133
+#: ../../src/wxMaximaFrame.cpp:1167
 msgid "Equal?..."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8561
+#: ../../src/MaximaCommandMenus.cpp:1577 ../../src/wizards/DrawWiz.cpp:161
 msgid "Equation"
 msgstr "方程"
 
-#: ../../src/wxMaxima.cpp:7751 ../../src/wxMaxima.cpp:7765
+#: ../../src/wizards/SystemWiz.cpp:67
+#, c-format
+msgid "Equation %ld:"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:932 ../../src/MaximaCommandMenus.cpp:946
 #, fuzzy
 msgid "Equation(s)"
 msgstr "方程（组）："
 
-#: ../../src/wxMaxima.cpp:7848 ../../src/wxMaxima.cpp:7900
+#: ../../src/MaximaCommandMenus.cpp:1029 ../../src/MaximaCommandMenus.cpp:1081
 msgid "Equation(s):"
 msgstr "方程（组）："
 
-#: ../../src/wxMaxima.cpp:7776 ../../src/wxMaxima.cpp:7788
-#: ../../src/wxMaxima.cpp:8899 ../../src/wxMaxima.cpp:8919
-#: ../../src/wxMaxima.cpp:9592 ../../src/wxMaxima.cpp:10039
+#: ../../src/MaximaCommandMenus.cpp:150 ../../src/MaximaCommandMenus.cpp:170
+#: ../../src/MaximaCommandMenus.cpp:957 ../../src/MaximaCommandMenus.cpp:969
+#: ../../src/MaximaCommandMenus.cpp:1832 ../../src/MaximaCommandMenus.cpp:3528
 msgid "Equation:"
 msgstr "方程："
 
-#: ../../src/WXMXformat.cpp:258 ../../src/WXMXformat.cpp:288
-#: ../../src/WXMXformat.cpp:296 ../../src/WXMXformat.cpp:311
-#: ../../src/WXMXformat.cpp:332 ../../src/WXMXformat.cpp:362
-#: ../../src/wxMaxima.cpp:3020 ../../src/wxMaxima.cpp:4163
-#: ../../src/wxMaxima.cpp:4222 ../../src/wxMaxima.cpp:4231
-#: ../../src/wxMaxima.cpp:4491 ../../src/wxMaxima.cpp:4502
-#: ../../src/wxMaxima.cpp:4605 ../../src/wxMaxima.cpp:4634
-#: ../../src/wxMaxima.cpp:4645 ../../src/wxMaxima.cpp:11125
-#: ../../src/wxMaxima.cpp:11166
+#: ../../src/dialogs/TipOfTheDay.cpp:196
+msgid "Equations have several advantages over functions. For example they can be manipulated with factor(), expand() and similar functions. They can easily be introduced one into another. Also they are always printed out as 2D maths."
+msgstr "相比函数而言，方程有一些优点。例如，factor()，expand() 等命令可以对直接方程使用；方程很容易互相代入，也总是以 2D 式子的形式输出。"
+
+#: ../../src/MaximaFileIO.cpp:64 ../../src/MaximaFileIO.cpp:121
+#: ../../src/MaximaFileIO.cpp:130 ../../src/MaximaFileIO.cpp:399
+#: ../../src/MaximaFileIO.cpp:410 ../../src/MaximaFileIO.cpp:528
+#: ../../src/MaximaFileIO.cpp:557 ../../src/MaximaFileIO.cpp:568
+#: ../../src/MaximaProcessManager.cpp:581 ../../src/WXMXformat.cpp:260
+#: ../../src/WXMXformat.cpp:290 ../../src/WXMXformat.cpp:298
+#: ../../src/WXMXformat.cpp:313 ../../src/WXMXformat.cpp:334
+#: ../../src/WXMXformat.cpp:364 ../../src/dialogs/BinaryNameCtrl.cpp:78
+#: ../../src/main.cpp:725 ../../src/wxMaxima.cpp:3384
+#: ../../src/wxMaxima.cpp:3420 ../../src/wxMaxima.cpp:3438
+#: ../../src/wxMaxima.cpp:3472
 msgid "Error"
 msgstr "错误"
 
-#: ../../src/wxMaxima.cpp:2456
+#: ../../src/MaximaProcessManager.cpp:789
 msgid "Error writing to Maxima"
 msgstr "向 Maxima 写入时发生错误"
 
-#: ../../src/wxMaxima.cpp:6164 ../../src/wxMaxima.cpp:6176
-#: ../../src/wxMaxima.cpp:6187 ../../src/wxMaxima.cpp:7858
-#: ../../src/wxMaxima.cpp:7880 ../../src/wxMaxima.cpp:8163
+#: ../../src/MaximaCommandMenus.cpp:1039 ../../src/MaximaCommandMenus.cpp:1061
+#: ../../src/MaximaCommandMenus.cpp:1351 ../../src/MaximaCommandMenus.cpp:2320
+#: ../../src/MaximaCommandMenus.cpp:2332 ../../src/MaximaCommandMenus.cpp:2343
+#: ../../src/MaximaFileIO.cpp:873 ../../src/sidebars/History.cpp:228
 msgid "Error!"
 msgstr "错误！"
 
-#: ../../src/Image.cpp:696
+#: ../../src/Image.cpp:779
 #, c-format
 msgid "Error: Cannot render %s."
 msgstr "错误：无法生成 %s 。"
 
-#: ../../src/Image.cpp:699
+#: ../../src/Image.cpp:782
 #, fuzzy, c-format
 msgid ""
 "Error: Cannot render %s:\n"
 "%s"
 msgstr "错误：无法生成 %s 。"
 
-#: ../../src/Image.cpp:704
+#: ../../src/Image.cpp:787
 msgid "Error: Cannot render the image."
 msgstr "错误：无法生成图片。"
 
-#: ../../src/Image.cpp:706
+#: ../../src/Image.cpp:789
 #, fuzzy, c-format
 msgid ""
 "Error: Cannot render the image:\n"
 "%s"
 msgstr "错误：无法生成图片。"
 
-#: ../../src/wxMaxima.cpp:7544
+#: ../../src/MaximaCommandMenus.cpp:4416
 msgid "Escapes all special characters in a string. The result is a regex that matches this string exactly."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1652
+#: ../../src/sidebars/GreekSidebar.cpp:184
+msgid "Eta"
+msgstr "Eta"
+
+#: ../../src/sidebars/TableOfContents.cpp:513
+msgid "Evaluate"
+msgstr "计算"
+
+#: ../../src/wxMaximaFrame.cpp:1689
 #, fuzzy
 msgid "Evaluate &Noun Forms..."
 msgstr "对名词形式求值(&N)"
 
-#: ../../src/wxMaximaFrame.cpp:856
+#: ../../src/wxMaximaFrame.cpp:890
 msgid "Evaluate All Cells\tCtrl+Shift+R"
 msgstr "对所有单元格求值\tCtrl+Shift+R"
 
-#: ../../src/wxMaximaFrame.cpp:851
+#: ../../src/wxMaximaFrame.cpp:885
 msgid "Evaluate All Visible Cells\tCtrl+R"
 msgstr "对所有可见单元格求值\tCtrl+R"
 
-#: ../../src/Worksheet.cpp:1395
+#: ../../src/worksheet/WorksheetContextMenu.cpp:166
 #, fuzzy
 msgid "Evaluate Cell"
 msgstr "对单元格求值"
 
-#: ../../src/Worksheet.cpp:1398 ../../src/wxMaximaFrame.cpp:844
+#: ../../src/worksheet/WorksheetContextMenu.cpp:169
+#: ../../src/wxMaximaFrame.cpp:878
 msgid "Evaluate Cell(s)"
 msgstr "对单元格求值"
 
-#: ../../src/Worksheet.cpp:1391 ../../src/Worksheet.cpp:1674
+#: ../../src/worksheet/WorksheetContextMenu.cpp:162
+#: ../../src/worksheet/WorksheetContextMenu.cpp:447
 msgid "Evaluate Cells Above"
 msgstr "对上方单元格求值"
 
-#: ../../src/wxMaximaFrame.cpp:866
+#: ../../src/wxMaximaFrame.cpp:900
 msgid "Evaluate Cells Above\tCtrl+Shift+P"
 msgstr "对上方单元格求值\tCtrl+Shift+P"
 
-#: ../../src/Worksheet.cpp:1402 ../../src/Worksheet.cpp:1676
-#: ../../src/wxMaximaFrame.cpp:876
+#: ../../src/worksheet/WorksheetContextMenu.cpp:173
+#: ../../src/worksheet/WorksheetContextMenu.cpp:449
+#: ../../src/wxMaximaFrame.cpp:910
 msgid "Evaluate Cells Below"
 msgstr "对下方单元格求值"
 
-#: ../../src/Worksheet.cpp:1451 ../../src/Worksheet.cpp:1756
-#: ../../src/Worksheet.cpp:1890
+#: ../../src/worksheet/WorksheetContextMenu.cpp:222
+#: ../../src/worksheet/WorksheetContextMenu.cpp:529
+#: ../../src/worksheet/WorksheetContextMenu.cpp:662
 msgid "Evaluate Heading 5\tShift+Ctrl+Enter"
 msgstr "对五级标题下的单元格求值\tShift+Ctrl+Enter"
 
-#: ../../src/Worksheet.cpp:1457 ../../src/Worksheet.cpp:1761
-#: ../../src/Worksheet.cpp:1901
+#: ../../src/worksheet/WorksheetContextMenu.cpp:228
+#: ../../src/worksheet/WorksheetContextMenu.cpp:534
+#: ../../src/worksheet/WorksheetContextMenu.cpp:673
 msgid "Evaluate Heading 6\tShift+Ctrl+Enter"
 msgstr "对六级标题下的单元格求值\tShift+Ctrl+Enter"
 
-#: ../../src/wxMaxima.cpp:8626
+#: ../../src/MaximaCommandMenus.cpp:618
 #, fuzzy
 msgid "Evaluate Nouns"
 msgstr "对名词形式求值(&N)"
 
-#: ../../src/Worksheet.cpp:1425 ../../src/Worksheet.cpp:1736
+#: ../../src/worksheet/WorksheetContextMenu.cpp:196
+#: ../../src/worksheet/WorksheetContextMenu.cpp:509
 msgid "Evaluate Part\tShift+Ctrl+Enter"
 msgstr "对本部分（part）单元格求值\tShift+Ctrl+Enter"
 
-#: ../../src/Worksheet.cpp:1431 ../../src/Worksheet.cpp:1741
+#: ../../src/worksheet/WorksheetContextMenu.cpp:202
+#: ../../src/worksheet/WorksheetContextMenu.cpp:514
 msgid "Evaluate Section\tShift+Ctrl+Enter"
 msgstr "对本节单元格求值\tShift+Ctrl+Enter"
 
-#: ../../src/Worksheet.cpp:1445 ../../src/Worksheet.cpp:1751
-#: ../../src/Worksheet.cpp:1879
+#: ../../src/worksheet/WorksheetContextMenu.cpp:216
+#: ../../src/worksheet/WorksheetContextMenu.cpp:524
+#: ../../src/worksheet/WorksheetContextMenu.cpp:651
 msgid "Evaluate Sub-Subsection\tShift+Ctrl+Enter"
 msgstr "对本小小节单元格求值\tShift+Ctrl+Enter"
 
-#: ../../src/Worksheet.cpp:1438 ../../src/Worksheet.cpp:1746
-#: ../../src/Worksheet.cpp:1868
+#: ../../src/worksheet/WorksheetContextMenu.cpp:209
+#: ../../src/worksheet/WorksheetContextMenu.cpp:519
+#: ../../src/worksheet/WorksheetContextMenu.cpp:640
 msgid "Evaluate Subsection\tShift+Ctrl+Enter"
 msgstr "对本小节单元格求值\tShift+Ctrl+Enter"
 
-#: ../../src/wxMaximaFrame.cpp:845
+#: ../../src/wxMaximaFrame.cpp:879
 msgid "Evaluate active or selected cell(s)"
 msgstr "对活动单元格或所选单元格求值"
 
-#: ../../src/ToolBar.cpp:251
+#: ../../src/ToolBar.cpp:445 ../../src/ToolBar.cpp:457
 msgid "Evaluate all"
 msgstr "对所有单元格求值"
 
-#: ../../src/wxMaximaFrame.cpp:857
+#: ../../src/wxMaximaFrame.cpp:891
 msgid "Evaluate all cells in the document"
 msgstr "对文档中所有单元格求值"
 
-#: ../../src/wxMaximaFrame.cpp:1653
+#: ../../src/wxMaximaFrame.cpp:1690
 msgid "Evaluate all noun forms in expression"
 msgstr "对表达式中所有名词形式（noun forms）求值"
 
-#: ../../src/wxMaximaFrame.cpp:852
+#: ../../src/wxMaximaFrame.cpp:886
 msgid "Evaluate all visible cells in the document"
 msgstr "对文档中所有可见单元格求值"
 
-#: ../../src/ToolBar.cpp:248
+#: ../../src/ToolBar.cpp:442 ../../src/ToolBar.cpp:454
 msgid "Evaluate current cell"
 msgstr "对本单元格求值"
 
-#: ../../src/wxMaxima.cpp:7395
+#: ../../src/MaximaCommandMenus.cpp:4267
 #, fuzzy
 msgid "Evaluate string"
 msgstr "计算到此处"
 
-#: ../../src/wxMaximaFrame.cpp:1151
+#: ../../src/wxMaximaFrame.cpp:1185
 #, fuzzy
 msgid "Evaluate string..."
 msgstr "计算到此处"
 
-#: ../../src/ToolBar.cpp:256
+#: ../../src/ToolBar.cpp:449 ../../src/ToolBar.cpp:461
 msgid "Evaluate the file from its beginning to the cell above the cursor"
 msgstr "对从文档开始至光标正上方的单元格求值"
 
-#: ../../src/ToolBar.cpp:259
+#: ../../src/ToolBar.cpp:452 ../../src/ToolBar.cpp:464
 msgid "Evaluate the file from the cursor to its end"
 msgstr "对从光标正下方至文档末尾的单元格求值"
 
-#: ../../src/ToolBar.cpp:258
+#: ../../src/ToolBar.cpp:451 ../../src/ToolBar.cpp:463
 msgid "Evaluate the rest"
 msgstr "计算剩下的"
 
-#: ../../src/ToolBar.cpp:255
+#: ../../src/ToolBar.cpp:448 ../../src/ToolBar.cpp:460
 msgid "Evaluate to point"
 msgstr "计算到此处"
 
-#: ../../src/wxMaxima.cpp:10518
+#: ../../src/MaximaEvaluator.cpp:351
 msgid "Evaluation ended, since evaluation queue is empty."
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1957
+#: ../../src/worksheet/WorksheetContextMenu.cpp:729
 #, fuzzy
 msgid "Even number"
 msgstr "项数 n"
 
-#: ../../src/wxMaximaFrame.cpp:1703
+#: ../../src/dialogs/ConfigDialogue.cpp:2659
+msgid "Example text"
+msgstr "示例文本"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1547
+msgid "Examples:"
+msgstr "示例："
+
+#: ../../src/wxMaximaFrame.cpp:1740
 msgid "Execute a command for each element of the list"
 msgstr "对列表中每个元素执行同一命令"
 
-#: ../../src/main.cpp:438
+#: ../../src/main.cpp:677
 msgid "Exit"
 msgstr "退出"
 
-#: ../../src/wxMaximaFrame.cpp:625
-msgid "Exit wxMaxima"
-msgstr "退出 wxMaxima"
+#: ../../src/sidebars/MathSidebar.cpp:53
+msgid "Expand"
+msgstr "展开"
 
-#: ../../src/Worksheet.cpp:1583
+#: ../../src/sidebars/MathSidebar.cpp:68
+msgid "Expand (tr)"
+msgstr "展开（三角）"
+
+#: ../../src/worksheet/WorksheetContextMenu.cpp:356
 msgid "Expand Expression"
 msgstr "展开表达式"
 
-#: ../../src/wxMaximaFrame.cpp:1525
+#: ../../src/wxMaximaFrame.cpp:1562
 msgid "Expand an expression"
 msgstr "展开一个表达式"
 
-#: ../../src/wxMaximaFrame.cpp:1531
+#: ../../src/wxMaximaFrame.cpp:1568
 #, fuzzy
 msgid "Expand for given variables"
 msgstr "修改变量"
 
-#: ../../src/wxMaxima.cpp:8781
+#: ../../src/MaximaCommandMenus.cpp:788
 msgid "Expand for variable(s) including denominator:"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8716
+#: ../../src/MaximaCommandMenus.cpp:708
 #, fuzzy
 msgid "Expand for variable(s):"
 msgstr "指标变量："
 
-#: ../../src/wxMaximaFrame.cpp:1545
+#: ../../src/wxMaximaFrame.cpp:1582
 #, fuzzy
 msgid "Expand log in previous expression"
 msgstr "展开一个表达式"
 
-#: ../../src/wxMaximaFrame.cpp:1598
+#: ../../src/wxMaximaFrame.cpp:1635
 msgid "Expand trigonometric expression"
 msgstr "展开三角表达式"
 
-#: ../../src/wxMaximaFrame.cpp:1788
+#: ../../src/wxMaximaFrame.cpp:1825
 msgid "Expect numbers harder to be complex"
 msgstr "将数值理解为复数"
 
-#: ../../src/wxMaximaFrame.cpp:1789
+#: ../../src/wxMaximaFrame.cpp:1826
 msgid "Expect variables to contain complex numbers"
 msgstr "认为变量的值含复数"
 
-#: ../../src/wxMaxima.cpp:6121
+#: ../../src/MaximaCommandMenus.cpp:2277
+#: ../../src/dialogs/ConfigDialogue.cpp:283
 msgid "Export"
 msgstr "导出"
 
-#: ../../src/wxMaximaFrame.cpp:1705
+#: ../../src/sidebars/History.cpp:152
+msgid "Export As"
+msgstr "导出为"
+
+#: ../../src/wxMaximaFrame.cpp:1742
 #, fuzzy
 msgid "Export List to csv file..."
 msgstr "将列表导出为 csv 文件"
 
-#: ../../src/wxMaximaFrame.cpp:1706
+#: ../../src/wxMaximaFrame.cpp:1743
 msgid "Export a list to a csv file"
 msgstr "将一个列表导出为 csv 文件"
 
-#: ../../src/wxMaximaFrame.cpp:1332
+#: ../../src/wxMaximaFrame.cpp:1366
 msgid "Export a matrix to a csv file"
 msgstr "将一个矩阵导出为 csv 文件"
 
-#: ../../src/wxMaximaFrame.cpp:619
+#: ../../src/sidebars/History.cpp:102
+msgid "Export all history to a .mac file"
+msgstr "将所有历史记录导出为 .mac 文件"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1016
+msgid "Export all settings"
+msgstr "导出所有设置"
+
+#: ../../src/sidebars/History.cpp:105
+msgid "Export commands from the current maxima session to a .mac file"
+msgstr "将本次 Maxima 会话的所有命令导出为 .mac 文件"
+
+#: ../../src/wxMaximaFrame.cpp:652
 msgid "Export document to a HTML or LaTeX file"
 msgstr "将文档导出为 HTML 文件或 LaTeX 文件"
 
-#: ../../src/wxMaximaFrame.cpp:579
+#: ../../src/dialogs/ConfigDialogue.cpp:1218
+msgid "Export equations to HTML as:"
+msgstr "将式子导出到 HTML 为："
+
+#: ../../src/wxMaximaFrame.cpp:600
 msgid "Export failed."
 msgstr "导出失败。"
 
-#: ../../src/wxMaximaFrame.cpp:567
+#: ../../src/worksheet/WorksheetContextMenu.cpp:154
+msgid "Export output as PNG to a folder..."
+msgstr ""
+
+#: ../../src/worksheet/WorksheetContextMenu.cpp:151
+msgid "Export output as SVG to a folder..."
+msgstr ""
+
+#: ../../src/sidebars/History.cpp:108
+msgid "Export selected commands to a .mac file"
+msgstr "将选中的命令导出为 .mac 文件"
+
+#: ../../src/wxMaximaFrame.cpp:588
 msgid "Export successful."
 msgstr "导出成功。"
 
-#: ../../src/wxMaxima.cpp:6187
+#: ../../src/MaximaCommandMenus.cpp:3468
+msgid "Export the selected output(s) to this folder"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1022
+msgid "Export the style settings"
+msgstr "导出样式设置"
+
+#: ../../src/sidebars/History.cpp:111
+msgid "Export visible commands to a .mac file"
+msgstr "将可见的命令导出为 .mac 文件"
+
+#: ../../src/MaximaCommandMenus.cpp:3477
+#, c-format
+msgid "Exported %d output image(s) to %s"
+msgstr ""
+
+#: ../../src/wxMaxima.cpp:2200 ../../src/wxMaxima.cpp:2242
+#, c-format
+msgid "Exported the worksheet to %s"
+msgstr ""
+
+#: ../../src/sidebars/History.cpp:228
+msgid "Exporting to .mac file failed!"
+msgstr "导出到 .mac 文件失败！"
+
+#: ../../src/MaximaCommandMenus.cpp:2343
 msgid "Exporting to HTML failed!"
 msgstr "导出为 HTML 失败！"
 
-#: ../../src/wxMaxima.cpp:6164
+#: ../../src/MaximaCommandMenus.cpp:2320
 msgid "Exporting to TeX failed!"
 msgstr "导出为 TeX 失败！"
 
-#: ../../src/wxMaxima.cpp:6175
+#: ../../src/MaximaCommandMenus.cpp:2331
 msgid "Exporting to maxima batch file failed!"
 msgstr "导出为 Maxima 批处理（.mac）文件失败！"
 
-#: ../../src/wxMaximaFrame.cpp:561
+#: ../../src/wxMaximaFrame.cpp:582
 msgid "Exporting..."
 msgstr "正在导出"
 
-#: ../../src/wxMaxima.cpp:6510 ../../src/wxMaxima.cpp:6516
-#: ../../src/wxMaxima.cpp:8218 ../../src/wxMaxima.cpp:8633
-#: ../../src/wxMaxima.cpp:8638 ../../src/wxMaxima.cpp:8658
-#: ../../src/wxMaxima.cpp:10065
+#: ../../src/MaximaCommandMenus.cpp:1480
+msgid "Expr:"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:625 ../../src/MaximaCommandMenus.cpp:630
+#: ../../src/MaximaCommandMenus.cpp:650 ../../src/MaximaCommandMenus.cpp:1408
+#: ../../src/MaximaCommandMenus.cpp:3030 ../../src/MaximaCommandMenus.cpp:3036
+#: ../../src/MaximaCommandMenus.cpp:3554 ../../src/sidebars/DrawSidebar.cpp:54
+#: ../../src/wizards/Plot3dWiz.cpp:32
 msgid "Expression"
 msgstr "表达式"
 
-#: ../../src/wxMaxima.cpp:7019 ../../src/wxMaxima.cpp:7025
+#: ../../src/MaximaCommandMenus.cpp:3891 ../../src/MaximaCommandMenus.cpp:3897
 #, fuzzy
 msgid "Expression or a list of comma-separated expressions"
 msgstr "从以逗号分隔的元素创建列表"
 
-#: ../../src/wxMaximaFrame.cpp:1088
+#: ../../src/wizards/DrawWiz.cpp:733
+msgid "Expression that calculates the x value"
+msgstr ""
+
+#: ../../src/wizards/DrawWiz.cpp:738
+msgid "Expression that calculates the y value"
+msgstr ""
+
+#: ../../src/wizards/DrawWiz.cpp:744
+msgid "Expression that calculates the z value"
+msgstr ""
+
+#: ../../src/wizards/DrawWiz.cpp:56
+msgid "Expression to plot"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1122
 #, fuzzy
 msgid "Expression to string..."
 msgstr "正在导出"
 
-#: ../../src/wxMaxima.cpp:7113
+#: ../../src/MaximaCommandMenus.cpp:3985
 msgid "Expression whose output is to be used as maxima's input."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7214
+#: ../../src/MaximaCommandMenus.cpp:4086 ../../src/wizards/Plot2dWiz.cpp:39
 msgid "Expression(s):"
 msgstr "表达式："
 
-#: ../../src/wxMaxima.cpp:8933 ../../src/wxMaxima.cpp:8941
-#: ../../src/wxMaxima.cpp:8952 ../../src/wxMaxima.cpp:8976
-#: ../../src/wxMaxima.cpp:8981 ../../src/wxMaxima.cpp:8998
-#: ../../src/wxMaxima.cpp:9004 ../../src/wxMaxima.cpp:9011
-#: ../../src/wxMaxima.cpp:9043 ../../src/wxMaxima.cpp:9062
-#: ../../src/wxMaxima.cpp:10056
+#: ../../src/MaximaCommandMenus.cpp:184 ../../src/MaximaCommandMenus.cpp:195
+#: ../../src/MaximaCommandMenus.cpp:206 ../../src/MaximaCommandMenus.cpp:230
+#: ../../src/MaximaCommandMenus.cpp:235 ../../src/MaximaCommandMenus.cpp:252
+#: ../../src/MaximaCommandMenus.cpp:258 ../../src/MaximaCommandMenus.cpp:265
+#: ../../src/MaximaCommandMenus.cpp:297 ../../src/MaximaCommandMenus.cpp:316
+#: ../../src/MaximaCommandMenus.cpp:3545 ../../src/wizards/IntegrateWiz.cpp:33
+#: ../../src/wizards/LimitWiz.cpp:29 ../../src/wizards/SeriesWiz.cpp:30
+#: ../../src/wizards/SubstituteWiz.cpp:29 ../../src/wizards/SumWiz.cpp:31
 msgid "Expression:"
 msgstr "表达式："
 
-#: ../../src/wxMaximaFrame.cpp:1423
+#: ../../src/wxMaximaFrame.cpp:1457
 #, fuzzy
 msgid "Extract Column..."
 msgstr "提取列"
 
-#: ../../src/wxMaximaFrame.cpp:1726
+#: ../../src/wxMaximaFrame.cpp:1763
 msgid "Extract Elements"
 msgstr "提取元素"
 
-#: ../../src/wxMaximaFrame.cpp:1421
+#: ../../src/wxMaximaFrame.cpp:1455
 #, fuzzy
 msgid "Extract Row..."
 msgstr "提取行"
 
-#: ../../src/wxMaximaFrame.cpp:1424
+#: ../../src/wxMaximaFrame.cpp:1458
 msgid "Extract a column from the matrix"
 msgstr "提取矩阵的一列"
 
-#: ../../src/wxMaximaFrame.cpp:1435
+#: ../../src/wxMaximaFrame.cpp:1472
 msgid "Extract a column from the matrix and convert it to a list"
 msgstr "提取矩阵的一列并转化为列表"
 
-#: ../../src/wxMaxima.cpp:7960
+#: ../../src/MaximaCommandMenus.cpp:1140
 #, fuzzy
 msgid "Extract a matrix column"
 msgstr "提取矩阵的一行"
 
-#: ../../src/wxMaxima.cpp:7970
+#: ../../src/MaximaCommandMenus.cpp:1150
 #, fuzzy
 msgid "Extract a matrix column as a list"
 msgstr "提取矩阵的一行"
 
-#: ../../src/wxMaximaFrame.cpp:1313
+#: ../../src/wxMaximaFrame.cpp:1347
 #, fuzzy
 msgid "Extract a matrix from a 2-dimensional array"
 msgstr "从二维数组创建一个矩阵"
 
-#: ../../src/wxMaxima.cpp:7955
+#: ../../src/MaximaCommandMenus.cpp:1135
 msgid "Extract a matrix row"
 msgstr "提取矩阵的一行"
 
-#: ../../src/wxMaxima.cpp:7965
+#: ../../src/MaximaCommandMenus.cpp:1145
 #, fuzzy
 msgid "Extract a matrix row as a list"
 msgstr "提取矩阵的一行"
 
-#: ../../src/wxMaximaFrame.cpp:1422
+#: ../../src/wxMaximaFrame.cpp:1456
 msgid "Extract a row from the matrix"
 msgstr "提取矩阵的一行"
 
-#: ../../src/wxMaximaFrame.cpp:1431
+#: ../../src/wxMaximaFrame.cpp:1468
 msgid "Extract a row from the matrix and convert it to a list"
 msgstr "提取矩阵的一行并转化为列表"
 
-#: ../../src/wxMaxima.cpp:8564
+#: ../../src/MaximaCommandMenus.cpp:1580
 msgid "Extract a variable's value from a list of variable values"
 msgstr "提取变量值列表中的一个值"
 
-#: ../../src/wxMaximaFrame.cpp:1723
+#: ../../src/wxMaximaFrame.cpp:1760
 msgid "Extract an actual value for a variable"
 msgstr "提取变量的实际值"
 
-#: ../../src/wxMaximaFrame.cpp:1163
+#: ../../src/wxMaximaFrame.cpp:1197
 #, fuzzy
 msgid "Extract char..."
 msgstr "提取行"
 
-#: ../../src/wxMaximaFrame.cpp:1207
+#: ../../src/wxMaximaFrame.cpp:1241
 #, fuzzy
 msgid "Extract dir from path..."
 msgstr "提取矩阵的一行"
 
-#: ../../src/wxMaxima.cpp:7605
+#: ../../src/MaximaCommandMenus.cpp:4477
 #, fuzzy
 msgid "Extract directory part"
 msgstr "提取函数的参数"
 
-#: ../../src/wxMaxima.cpp:7617
+#: ../../src/MaximaCommandMenus.cpp:4489
 #, fuzzy
 msgid "Extract file type extension"
 msgstr "提取列表的元素"
 
-#: ../../src/wxMaximaFrame.cpp:1209
+#: ../../src/wxMaximaFrame.cpp:1243
 msgid "Extract filename from path..."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7611
+#: ../../src/MaximaCommandMenus.cpp:4483
 #, fuzzy
 msgid "Extract filename part"
 msgstr "提取元素"
 
-#: ../../src/wxMaximaFrame.cpp:1211
+#: ../../src/wxMaximaFrame.cpp:1245
 msgid "Extract filetype from path..."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8445
+#: ../../src/MaximaCommandMenus.cpp:1442
 msgid "Extract function arguments"
 msgstr "提取函数的参数"
 
-#: ../../src/wxMaximaFrame.cpp:1727
+#: ../../src/wxMaximaFrame.cpp:1764
 msgid "Extract list Elements"
 msgstr "提取列表的元素"
 
-#: ../../src/wxMaxima.cpp:8187
+#: ../../src/MaximaCommandMenus.cpp:1375
 #, fuzzy
 msgid "Extract matrix from 2D array"
 msgstr "提取矩阵的一行"
 
-#: ../../src/wxMaximaFrame.cpp:1686
+#: ../../src/wxMaximaFrame.cpp:1723
 msgid "Extract the argument list from a function call"
 msgstr "提取函数调用中的参数列表"
 
-#: ../../src/wxMaxima.cpp:8538
+#: ../../src/MaximaCommandMenus.cpp:1551
 msgid "Extract the last n elements from a list"
 msgstr "提取列表中的后 n 个元素"
 
-#: ../../src/wxMaxima.cpp:7376
+#: ../../src/MaximaCommandMenus.cpp:1550
+msgid "Extract the last n list elements"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:4248
 #, fuzzy
 msgid "Extract the nth char of a string"
 msgstr "提取列表的元素"
 
-#: ../../src/wxMaxima.cpp:8544
+#: ../../src/MaximaCommandMenus.cpp:1557
 #, fuzzy
 msgid "Extract the nth list elements"
 msgstr "提取列表的元素"
 
-#: ../../src/wxMaximaFrame.cpp:1724
+#: ../../src/wxMaximaFrame.cpp:1761
 msgid "Extract the value for one variable assigned in a list"
 msgstr "提取列表中一个变量的值"
 
-#: ../../src/wxMaximaFrame.cpp:1439
+#: ../../src/wxMaximaFrame.cpp:1476
 msgid "Extract, append or delete rows or columns"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8188
+#: ../../src/MaximaCommandMenus.cpp:1376
 #, fuzzy
 msgid "Extracts a rectangle from a 2D array and converts it to a matrix"
 msgstr "提取矩阵的一行并转化为列表"
 
-#: ../../src/wxMaximaFrame.cpp:1521
+#: ../../src/sidebars/MathSidebar.cpp:50
+msgid "Factor"
+msgstr "因式分解"
+
+#: ../../src/wxMaximaFrame.cpp:1558
 msgid "Factor Complex"
 msgstr "因式分解（复系数）"
 
-#: ../../src/Worksheet.cpp:1581
+#: ../../src/worksheet/WorksheetContextMenu.cpp:354
 msgid "Factor Expression"
 msgstr "因式分解表达式"
 
-#: ../../src/wxMaximaFrame.cpp:1519
+#: ../../src/wxMaximaFrame.cpp:1556
 #, fuzzy
 msgid "Factor Expression including subexpressions"
 msgstr "因式分解一个表达式，使其系数为复数（Gauss 数）"
 
-#: ../../src/wxMaximaFrame.cpp:1517 ../../src/wxMaximaFrame.cpp:1520
+#: ../../src/wxMaximaFrame.cpp:1554 ../../src/wxMaximaFrame.cpp:1557
 msgid "Factor an expression"
 msgstr "因式分解一个表达式"
 
-#: ../../src/wxMaximaFrame.cpp:1522
+#: ../../src/wxMaximaFrame.cpp:1559
 msgid "Factor an expression in Gaussian numbers"
 msgstr "因式分解一个表达式，使其系数为复数（Gauss 数）"
 
-#: ../../src/wxMaximaFrame.cpp:1587
+#: ../../src/wxMaximaFrame.cpp:1624
 msgid "Factorials and &Gamma"
 msgstr "阶乘和 Gamma 函数(&G)"
 
-#: ../../src/Image.cpp:137
+#: ../../src/Image.cpp:173
 #, fuzzy, c-format
 msgid "Failed to delete gnuplot data file %s"
 msgstr "尝试删除 gnuplot 文件 %s"
 
-#: ../../src/Image.cpp:121 ../../src/Image.cpp:128
+#: ../../src/Image.cpp:157 ../../src/Image.cpp:164
 #, fuzzy, c-format
 msgid "Failed to delete gnuplot file %s"
 msgstr "尝试删除 gnuplot 文件 %s"
 
-#: ../../src/wxMaxima.cpp:2667
+#: ../../src/MaximaProcessManager.cpp:352
 #, fuzzy
 msgid "Failed to start Maxima"
 msgstr "重启 Maxima"
 
-#: ../../src/wxMaximaFrame.cpp:1418
+#: ../../src/MaximaProcessManager.cpp:628
+msgid "Failed to write to Maxima's stdin (LDB)."
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1452
 msgid "Fast fortran routines that perform numerical tasks"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1922
+#: ../../src/wxMaximaFrame.cpp:1959
 msgid "Fast list access"
 msgstr "快速访问列表"
 
-#: ../../src/wxMaxima.cpp:2553
+#: ../../src/MaximaProcessManager.cpp:218
 msgid "Fatal error"
 msgstr "严重错误"
 
-#: ../../src/wxMaxima.cpp:7191
+#: ../../src/wizards/CsvWiz.cpp:38 ../../src/wizards/CsvWiz.cpp:109
+msgid "Field Separator"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:4063
 #, fuzzy
 msgid "Field contents:"
 msgstr "隐藏内容"
 
-#: ../../src/wxMaxima.cpp:7198
+#: ../../src/MaximaCommandMenus.cpp:4070
 #, fuzzy
 msgid "Field name:"
 msgstr "变量名"
 
-#: ../../src/wxMaxima.cpp:7185
+#: ../../src/MaximaCommandMenus.cpp:4057
 msgid "Fields:"
 msgstr ""
 
-#: ../../src/main.cpp:439
+#: ../../src/cells/GroupCell.cpp:2115
+#, c-format
+msgid "Figure %d:"
+msgstr "图 %d："
+
+#: ../../src/main.cpp:678
 msgid "File"
 msgstr "文件"
 
-#: ../../src/wxMaximaFrame.cpp:1333
+#: ../../src/wxMaximaFrame.cpp:1367
 #, fuzzy
 msgid "File I/O"
 msgstr "文件"
 
-#: ../../src/wxMaxima.cpp:4165 ../../src/wxMaxima.cpp:4224
-#: ../../src/wxMaxima.cpp:4493 ../../src/wxMaxima.cpp:4504
-#: ../../src/wxMaxima.cpp:4606 ../../src/wxMaxima.cpp:4636
-#: ../../src/wxMaxima.cpp:4647 ../../src/wxMaxima.cpp:5641
+#: ../../src/MaximaFileIO.cpp:66 ../../src/MaximaFileIO.cpp:123
+#: ../../src/MaximaFileIO.cpp:401 ../../src/MaximaFileIO.cpp:412
+#: ../../src/MaximaFileIO.cpp:529 ../../src/MaximaFileIO.cpp:559
+#: ../../src/MaximaFileIO.cpp:570 ../../src/MaximaFileIO.cpp:732
 msgid "File could not be opened"
 msgstr "文件无法打开"
 
-#: ../../src/wxMaxima.cpp:7241 ../../src/wxMaxima.cpp:7246
-#: ../../src/wxMaxima.cpp:7251
+#: ../../src/MaximaCommandMenus.cpp:4113 ../../src/MaximaCommandMenus.cpp:4118
+#: ../../src/MaximaCommandMenus.cpp:4123
 #, fuzzy
 msgid "File name:"
 msgstr "变量名"
 
-#: ../../src/wxMaxima.cpp:10225 ../../src/wxMaxima.cpp:10268
+#: ../../src/wxMaxima.cpp:2995 ../../src/wxMaxima.cpp:3038
 msgid "File not found"
 msgstr "文件无法找到"
 
-#: ../../src/wxMaxima.cpp:5631
+#: ../../src/MaximaFileIO.cpp:730
 msgid "File opened"
 msgstr "文件已打开"
 
-#: ../../src/wxMaximaFrame.cpp:1217
+#: ../../src/wxMaximaFrame.cpp:1251
 #, fuzzy
 msgid "File operations"
 msgstr "文件已打开"
 
-#: ../../src/wxMaxima.cpp:10224 ../../src/wxMaxima.cpp:10267
+#: ../../src/wxMaxima.cpp:2994 ../../src/wxMaxima.cpp:3037
 msgid "File you tried to open does not exist."
 msgstr "要打开的文件不存在。"
 
-#: ../../src/wxMaximaFrame.cpp:1221
+#: ../../src/wxMaximaFrame.cpp:1255
 #, fuzzy
 msgid "File/directory functions"
 msgstr "方向："
 
-#: ../../src/wxMaxima.cpp:7027
+#: ../../src/wizards/CsvWiz.cpp:54 ../../src/wizards/CsvWiz.cpp:128
+msgid "Filename"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:3899
 #, fuzzy
 msgid "Filename or a list of comma-separated file names"
 msgstr "从以逗号分隔的元素创建列表"
 
-#: ../../src/ToolBar.cpp:222
+#: ../../src/sidebars/DrawSidebar.cpp:93
+msgid "Fill color"
+msgstr "填充色"
+
+#: ../../src/ToolBar.cpp:401 ../../src/ToolBar.cpp:403
 msgid "Find"
 msgstr "查找"
 
-#: ../../src/wxMaximaFrame.cpp:670
+#: ../../src/wxMaximaFrame.cpp:707
 msgid "Find\tCtrl+F"
 msgstr "查找\tCtrl+F"
 
-#: ../../src/wxMaximaFrame.cpp:1468
+#: ../../src/wxMaximaFrame.cpp:1505
 msgid "Find &Limit..."
 msgstr "求极限(&L)..."
 
-#: ../../src/wxMaximaFrame.cpp:1470
+#: ../../src/wxMaximaFrame.cpp:1507
 msgid "Find Minimum..."
 msgstr "求最小值..."
 
-#: ../../src/Worksheet.cpp:1576
+#: ../../src/worksheet/WorksheetContextMenu.cpp:349
 msgid "Find Root..."
 msgstr "求根..."
 
-#: ../../src/wxMaximaFrame.cpp:1471
+#: ../../src/wxMaximaFrame.cpp:1508
 msgid "Find a (unconstrained) minimum of an expression"
 msgstr "求表达式的（无约束）最小值"
 
-#: ../../src/wxMaximaFrame.cpp:1804
+#: ../../src/wxMaximaFrame.cpp:1841
 msgid "Find a fraction that represents this float exactly"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1469
+#: ../../src/wxMaximaFrame.cpp:1506
 msgid "Find a limit of an expression"
 msgstr "求表达式的极限"
 
-#: ../../src/wxMaximaFrame.cpp:1807
+#: ../../src/wxMaximaFrame.cpp:1844
 msgid "Find a nice fraction that is similar to this float"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1283
+#: ../../src/wxMaximaFrame.cpp:1317
 #, fuzzy
 msgid "Find a numerical solution for a first degree ODE"
 msgstr "求解一阶常微分方程的初值问题"
 
-#: ../../src/wxMaximaFrame.cpp:1252
+#: ../../src/wxMaximaFrame.cpp:1286
 msgid "Find a root of an equation on an interval"
 msgstr "求方程在某区间内的根"
 
-#: ../../src/wxMaximaFrame.cpp:1259
+#: ../../src/wxMaximaFrame.cpp:1293
 msgid "Find all roots of a polynomial"
 msgstr "求多项式所有的根"
 
-#: ../../src/wxMaximaFrame.cpp:1262
+#: ../../src/wxMaximaFrame.cpp:1296
 msgid "Find all roots of a polynomial (bfloat)"
 msgstr "求多项式所有的根（以大浮点数表示）"
 
-#: ../../src/wxMaxima.cpp:6589
+#: ../../src/MaximaCommandMenus.cpp:3103
 msgid "Find and Replace"
 msgstr "查找并替换"
 
-#: ../../src/ToolBar.cpp:222 ../../src/wxMaximaFrame.cpp:670
+#: ../../src/ToolBar.cpp:401 ../../src/ToolBar.cpp:403
+#: ../../src/wxMaximaFrame.cpp:707
 msgid "Find and replace"
 msgstr "查找并替换"
 
-#: ../../src/wxMaxima.cpp:7434
+#: ../../src/MaximaCommandMenus.cpp:4306
 msgid "Find char in string"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1172
+#: ../../src/wxMaximaFrame.cpp:1206
 msgid "Find char in string..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1534
+#: ../../src/wxMaximaFrame.cpp:1571
 msgid "Find common denominator"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1366
+#: ../../src/wxMaximaFrame.cpp:1400
 msgid "Find eigenvalues of a matrix"
 msgstr "求矩阵的特征值"
 
-#: ../../src/wxMaximaFrame.cpp:1369
+#: ../../src/wxMaximaFrame.cpp:1403
 msgid "Find eigenvectors of a matrix"
 msgstr "求矩阵的特征向量"
 
-#: ../../src/wxMaxima.cpp:7424
+#: ../../src/MaximaCommandMenus.cpp:4296
 msgid "Find first difference"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1170
+#: ../../src/wxMaximaFrame.cpp:1204
 msgid "Find first difference..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1256
+#: ../../src/wxMaximaFrame.cpp:1290
 #, fuzzy
 msgid "Find fractions that real roots of a polynomial and "
 msgstr "求多项式的实数根"
 
-#: ../../src/wxMaxima.cpp:9039
+#: ../../src/MaximaCommandMenus.cpp:293
 msgid "Find minimum"
 msgstr "求最小值"
 
-#: ../../src/wxMaximaFrame.cpp:1251
+#: ../../src/wxMaximaFrame.cpp:1285
 msgid "Find numerical solution..."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:10035
+#: ../../src/MaximaCommandMenus.cpp:3524
 msgid "Find root (solve numerically)"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8062 ../../src/wxMaxima.cpp:8083
+#: ../../src/MaximaCommandMenus.cpp:1248 ../../src/MaximaCommandMenus.cpp:1271
 #, fuzzy
 msgid "Find the maximum absolute value of a matrix entry"
 msgstr "求矩阵的特征值"
 
-#: ../../src/wxMaxima.cpp:8068 ../../src/wxMaxima.cpp:8089
+#: ../../src/MaximaCommandMenus.cpp:1254 ../../src/MaximaCommandMenus.cpp:1277
 msgid "Find the maximum sum of the absolute values of a matrix column"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8073 ../../src/wxMaxima.cpp:8094
+#: ../../src/MaximaCommandMenus.cpp:1259 ../../src/MaximaCommandMenus.cpp:1282
 msgid "Find the maximum sum of the absolute values of a matrix row"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1832
+#: ../../src/dialogs/FindReplacePane.cpp:46
+msgid "Find:"
+msgstr "查找："
+
+#: ../../src/wxMaximaFrame.cpp:1869
 msgid "Fine-tune the display of engineering-format numbers"
 msgstr "微调工程样式数字的显示方式"
 
-#: ../../src/wxMaximaFrame.cpp:1712
+#: ../../src/dialogs/ConfigDialogue.cpp:197
+msgid "Finnish"
+msgstr "芬兰语"
+
+#: ../../src/wxMaximaFrame.cpp:1749
 msgid "First"
 msgstr "第一个"
 
-#: ../../src/wxMaximaFrame.cpp:1918
+#: ../../src/wxMaximaFrame.cpp:1955
 msgid "Fitting curves to measurement data"
 msgstr "拟合曲线到测量的数据"
 
-#: ../../src/wxMaxima.cpp:7227
+#: ../../src/dialogs/ConfigDialogue.cpp:1404
+#, c-format
+msgid "Fix reordered reference indices (of %i, %o) before saving"
+msgstr "在保存前整理公式引用（%i，%o）序号"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:873
+msgid "Fixed font in text controls"
+msgstr "文本控件中使用等宽字体"
+
+#: ../../src/MaximaCommandMenus.cpp:4099
 msgid "Flush stream"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1103
+#: ../../src/wxMaximaFrame.cpp:1137
 msgid "Flush..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:922
+#: ../../src/wxMaximaFrame.cpp:956
 msgid "Fold All\tCtrl+Alt+["
 msgstr "折叠所有节\tCtrl+Alt+["
 
-#: ../../src/wxMaximaFrame.cpp:923
+#: ../../src/wxMaximaFrame.cpp:957
 msgid "Fold all sections"
 msgstr "折叠所有节"
 
-#: ../../src/ToolBar.cpp:240
+#: ../../src/ToolBar.cpp:424 ../../src/ToolBar.cpp:432
 msgid "Follow"
 msgstr "跟随"
 
-#: ../../src/ToolBar.cpp:285
+#: ../../src/dialogs/ConfigDialogue.cpp:2070
+msgid "Follow system"
+msgstr ""
+
+#: ../../src/wizards/DrawWiz.cpp:341
+msgid "Following plots use secondary x axis"
+msgstr ""
+
+#: ../../src/wizards/DrawWiz.cpp:347
+msgid "Following plots use secondary y axis"
+msgstr ""
+
+#: ../../src/sidebars/PerformanceSidebar.cpp:37
+msgid "Font cache hits:"
+msgstr ""
+
+#: ../../src/sidebars/PerformanceSidebar.cpp:38
+msgid "Font cache misses:"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:2047
+msgid "Fonts"
+msgstr "字体"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:442
+msgid "For each Text-, Sectioning or code cell wxMaxima can display a bracket showing the extend of the cell and allowing to fold it. This setting now tells if this bracket is to be printed, as well."
+msgstr "对于每个文本、节或代码单元格，wxMaxima 可以显示一个括号，用于表示单元格的范围和折叠单元格。此设置指示是否要打印该括号。"
+
+#: ../../src/ToolBar.cpp:495
 msgid ""
 "For faster creation of cells the following shortcuts exist:\n"
 "\n"
@@ -3245,418 +4784,622 @@ msgstr ""
 "   Ctrl+6：五级标题单元格\n"
 "   Ctrl+7：六级标题单元格\n"
 
-#: ../../src/wxMaxima.cpp:7038
+#: ../../src/MaximaCommandMenus.cpp:3910
 msgid "For loop"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1062
+#: ../../src/wxMaximaFrame.cpp:1096
 msgid "For loop..."
 msgstr ""
 
-#: ../../src/Worksheet.cpp:237 ../../src/wxMaxima.cpp:11217
+#: ../../src/wizards/Plot2dWiz.cpp:69 ../../src/wizards/Plot3dWiz.cpp:60
+msgid "Format:"
+msgstr "格式："
+
+#: ../../src/worksheet/Worksheet.cpp:301 ../../src/wxMaxima.cpp:3523
 msgid "Forwarding the keyboard focus to a text control"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:11220
+#: ../../src/wxMaxima.cpp:3526
 msgid "Forwarding the keyboard focus to the worksheet"
 msgstr ""
 
-#: ../../src/MaximaManual.cpp:452
+#: ../../src/MaximaManual.cpp:469
 #, c-format
 msgid "Found %li anchors, URLs (individual files): %li, URLs (singlepage): %li"
 msgstr ""
 
-#: ../../src/MaximaManual.cpp:313
+#: ../../src/graphical_io/Printout.cpp:182
+#, c-format
+msgid "Found %li line breaks"
+msgstr ""
+
+#: ../../src/MaximaManual.cpp:326
 #, c-format
 msgid "Found only %li keywords in maxima's manual. Not caching them to disc."
 msgstr "在 Maxima 用户手册中只找到 %li 个关键词，未将其缓存到硬盘。"
 
-#: ../../src/MaximaManual.cpp:513
+#: ../../src/MaximaManual.cpp:530
 #, fuzzy, c-format
 msgid "Found the maxima HTML manual in the folder %s."
 msgstr "Maxima 的用户手册（HTML 文件）位于目录 %s"
 
-#: ../../src/wxMaxima.cpp:8948
+#: ../../src/MaximaCommandMenus.cpp:202
 msgid "Fourier coefficients"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1476
+#: ../../src/wxMaximaFrame.cpp:1513
 msgid "Fourier coefficients..."
 msgstr ""
 
-#: ../../src/ToolBar.cpp:137
+#: ../../src/ToolBar.cpp:132
 #, fuzzy, c-format
 msgid "Frame %li of %li"
 msgstr "第 %i 帧（共 %i 帧）"
 
-#: ../../src/wxMaxima.cpp:9097
+#: ../../src/wizards/DrawWiz.cpp:488
+msgid "Frame counter"
+msgstr "帧计数"
+
+#: ../../src/wizards/DrawWiz.cpp:499
+msgid "Frame counter end"
+msgstr "帧计数结束"
+
+#: ../../src/wizards/DrawWiz.cpp:494
+msgid "Frame counter start"
+msgstr "开始帧计数"
+
+#: ../../src/MaximaCommandMenus.cpp:102
 msgid "Frame rate"
 msgstr "帧率"
 
-#: ../../src/wxMaximaFrame.cpp:1005 ../../src/wxMaximaFrame.cpp:1009
+#: ../../src/wxMaximaFrame.cpp:1039 ../../src/wxMaximaFrame.cpp:1043
 msgid "Free all unused items now"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1413
+#: ../../src/dialogs/ConfigDialogue.cpp:198
+msgid "French"
+msgstr "法语"
+
+#: ../../src/wxMaximaFrame.cpp:1447
 msgid "Frobenius Norm sqrt(sum((A(i,j))^2)) (complex)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1411
+#: ../../src/wxMaximaFrame.cpp:1445
 msgid "Frobenius Norm sqrt(sum((A(i,j))^2)) (real)"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:9064
+#: ../../src/MaximaCommandMenus.cpp:318 ../../src/wizards/IntegrateWiz.cpp:41
+#: ../../src/wizards/Plot2dWiz.cpp:48 ../../src/wizards/Plot2dWiz.cpp:58
+#: ../../src/wizards/Plot2dWiz.cpp:499 ../../src/wizards/Plot3dWiz.cpp:37
+#: ../../src/wizards/Plot3dWiz.cpp:46 ../../src/wizards/SumWiz.cpp:37
 msgid "From:"
 msgstr "从："
 
-#: ../../src/wxMaximaFrame.cpp:827
+#: ../../src/wxMaximaFrame.cpp:864
 msgid "Full Screen\tAlt+Enter"
 msgstr "全屏\tAlt+Enter"
 
-#: ../../src/wxMaximaFrame.cpp:824
+#: ../../src/wxMaximaFrame.cpp:861
 msgid "Full Screen\tF11"
 msgstr "全屏\tF11"
 
-#: ../../src/wxMaxima.cpp:7140
+#: ../../src/sidebars/PerformanceSidebar.cpp:48
+msgid "Full-window repaints:"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:4012
 #, fuzzy
 msgid "Function contents:"
 msgstr "函数名"
 
-#: ../../src/wxMaxima.cpp:7908
+#: ../../src/MaximaCommandMenus.cpp:1089
 #, fuzzy
 msgid "Function f(x):"
 msgstr "函数："
 
-#: ../../src/wxMaxima.cpp:8572
+#: ../../src/MaximaCommandMenus.cpp:1590
 msgid "Function name"
 msgstr "函数名"
 
-#: ../../src/wxMaxima.cpp:7167
+#: ../../src/MaximaCommandMenus.cpp:4039
 #, fuzzy
 msgid "Function name(s):"
 msgstr "函数名"
 
-#: ../../src/wxMaxima.cpp:7135 ../../src/wxMaxima.cpp:7684
+#: ../../src/MaximaCommandMenus.cpp:4007 ../../src/MaximaCommandMenus.cpp:4556
 #, fuzzy
 msgid "Function name:"
 msgstr "函数名"
 
-#: ../../src/wxMaxima.cpp:8135
+#: ../../src/MaximaCommandMenus.cpp:1323
 msgid "Function:"
 msgstr "函数："
 
-#: ../../src/wxMaximaFrame.cpp:1630
+#: ../../src/wxMaximaFrame.cpp:1667
 msgid "Functions for complex simplification"
 msgstr "用于复数化简的命令"
 
-#: ../../src/wxMaximaFrame.cpp:1588
+#: ../../src/wxMaximaFrame.cpp:1625
 msgid "Functions for simplifying factorials and gamma function"
 msgstr "用于阶乘和 Gamma 函数化简的命令"
 
-#: ../../src/wxMaximaFrame.cpp:1606
+#: ../../src/wxMaximaFrame.cpp:1643
 msgid "Functions for simplifying trigonometric expressions"
 msgstr "用于三角表达式化简的命令"
 
-#: ../../src/wxMaxima.cpp:8965 ../../src/wxMaxima.cpp:8970
+#: ../../src/MaximaCommandMenus.cpp:219 ../../src/MaximaCommandMenus.cpp:224
 msgid "GCD"
 msgstr "最大公因式"
 
-#: ../../src/wxMaxima.cpp:10186
+#: ../../src/MaximaCommandMenus.cpp:3715
 msgid "GIF image (*.gif)|*.gif"
 msgstr "GIF 图片 (*.gif)|*.gif"
 
-#: ../../src/Worksheet.cpp:103
-msgid "GTK_IM_MODULE is set to \"xim\". Expect the program to hideously flicker and hotkeys to be broken, see for example https://trac.wxwidgets.org/ticket/18462."
-msgstr "GTK_IM_MODULE 被设置为“xim”。输入时界面会闪烁，且快捷键会失效，见 https://trac.wxwidgets.org/ticket/18462。"
+#: ../../src/MaximaCommandMenus.cpp:3615
+msgid "GIF image (*.gif)|*.gif|Portable anymap (*.pnm)|*.pnm|Tagged image file format (*.tif)|*.tif|X pixmap (*.xpm)|*.xpm"
+msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:295
+#: ../../src/worksheet/Worksheet.cpp:117
+msgid "GTK_IM_MODULE is set to \"xim\". Expect the program to hideously flicker and hotkeys to be broken, see for example https://github.com/wxWidgets/wxWidgets/issues/18462."
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:199
+msgid "Galician"
+msgstr "加里西亚语"
+
+#: ../../src/sidebars/GreekSidebar.cpp:180
+msgid "Gamma"
+msgstr "Gamma"
+
+#: ../../src/wxMaximaFrame.cpp:316
 msgid "General Math"
 msgstr "常用数学"
 
-#: ../../src/wxMaximaFrame.cpp:699
+#: ../../src/wxMaximaFrame.cpp:734
 msgid "General Math\tAlt+Shift+M"
 msgstr "常用数学\tAlt+Shift+M"
 
-#: ../../src/wxMaximaFrame.cpp:1316
+#: ../../src/wxMaximaFrame.cpp:1350
 msgid "Generate Matrix from Expression..."
 msgstr "从表达式创建矩阵..."
 
-#: ../../src/wxMaximaFrame.cpp:1317
+#: ../../src/wxMaximaFrame.cpp:1351
 msgid "Generate a matrix from a lambda expression"
 msgstr "从 lambda 表达式创建一个矩阵"
 
-#: ../../src/wxMaximaFrame.cpp:1675
+#: ../../src/wxMaximaFrame.cpp:1712
 msgid "Generate a new list using a lists' elements"
 msgstr "从一个列表的部分元素创建新列表"
 
-#: ../../src/wxMaximaFrame.cpp:1681
+#: ../../src/wxMaximaFrame.cpp:1718
 msgid "Generate a storage for variable values that can be introduced into equations at any time"
 msgstr "储存变量的值，可以随时将其引入方程"
 
-#: ../../src/wxMaximaFrame.cpp:1672
+#: ../../src/wxMaximaFrame.cpp:1709
 msgid "Generate list elements using a rule"
 msgstr "从一个规则创建列表元素"
 
-#: ../../src/wxMaxima.cpp:8196
+#: ../../src/MaximaCommandMenus.cpp:1386
 #, fuzzy
 msgid "Generate matrix from a rule"
 msgstr "从表达式创建列表"
 
-#: ../../src/wxMaximaFrame.cpp:1094
+#: ../../src/wxMaximaFrame.cpp:1128
 msgid "Generate unused symbol name"
 msgstr ""
 
-#: ../../src/WXMXformat.cpp:231
+#: ../../src/WXMXformat.cpp:232
 #, fuzzy
 msgid "Generated the XML representation of the document"
 msgstr "开始计算整个文档"
 
-#: ../../src/wxMaxima.cpp:8197
+#: ../../src/MaximaCommandMenus.cpp:1387
 msgid "Generates a matrix and fills each element with the result of the expression \"Rule\"."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1619
+#: ../../src/dialogs/ConfigDialogue.cpp:200
+msgid "Georgian"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:201
+msgid "German"
+msgstr "德语"
+
+#: ../../src/wxMaximaFrame.cpp:1656
 msgid "Get &Imaginary Part"
 msgstr "求虚部(&I)"
 
-#: ../../src/wxMaximaFrame.cpp:1485
+#: ../../src/wxMaximaFrame.cpp:1522
 msgid "Get Laplace transformation of an expression"
 msgstr "求表达式的 Laplace 变换"
 
-#: ../../src/wxMaximaFrame.cpp:1615
+#: ../../src/wxMaximaFrame.cpp:1652
 msgid "Get Real P&art"
 msgstr "求实部(&A)"
 
-#: ../../src/wxMaximaFrame.cpp:1201
+#: ../../src/wxMaximaFrame.cpp:1235
 msgid "Get current directory"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1489
+#: ../../src/wxMaximaFrame.cpp:1526
 msgid "Get inverse Laplace transformation of an expression"
 msgstr "求表达式的 Laplace 逆变换"
 
-#: ../../src/wxMaxima.cpp:7223
+#: ../../src/MaximaCommandMenus.cpp:4095
 msgid "Get position in stream"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1102
+#: ../../src/wxMaximaFrame.cpp:1136
 #, fuzzy
 msgid "Get position..."
 msgstr "偏差..."
 
-#: ../../src/wxMaximaFrame.cpp:1620
+#: ../../src/wxMaximaFrame.cpp:1657
 msgid "Get the imaginary part of complex expression"
 msgstr "求复数表达式的虚部"
 
-#: ../../src/wxMaximaFrame.cpp:1616
+#: ../../src/wxMaximaFrame.cpp:1653
 msgid "Get the real part of complex expression"
 msgstr "求复数表达式的实部"
 
-#: ../../src/wxMaxima.cpp:3609
+#: ../../src/MaximaProcessManager.cpp:1220
 #, fuzzy, c-format
 msgid "Gnuplot (command line) found at: %s"
 msgstr "Gnuplot 所在的位置："
 
-#: ../../src/wxMaxima.cpp:3607
+#: ../../src/dialogs/ConfigDialogue.cpp:1629
+msgid "Gnuplot flavour"
+msgstr ""
+
+#: ../../src/MaximaProcessManager.cpp:1218
 #, fuzzy, c-format
 msgid "Gnuplot found at: %s"
 msgstr "Gnuplot 所在的位置："
 
-#: ../../src/wxMaxima.cpp:2974
+#: ../../src/MaximaProcessManager.cpp:994
 msgid "Gnuplot has closed."
 msgstr "Gnuplot 已关闭。"
 
-#: ../../src/wxMaxima.cpp:3598 ../../src/wxMaxima.cpp:3603
+#: ../../src/MaximaProcessManager.cpp:1209
+#: ../../src/MaximaProcessManager.cpp:1214
 #, fuzzy, c-format
 msgid "Gnuplot not found, using the default: %s"
 msgstr "Gnuplot 未找到，使用默认程序："
 
-#: ../../src/wxMaxima.cpp:9428 ../../src/wxMaximaFrame.cpp:1887
+#: ../../src/MaximaProcessManager.cpp:1097
+#, c-format
+msgid ""
+"Gnuplot reported the following while preparing the popped-out plot:\n"
+"%s"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:2071 ../../src/wxMaximaFrame.cpp:1924
 msgid "Go to URL"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3989
+#: ../../src/MaximaResponseReader.cpp:396
 #, fuzzy
 msgid "Got a new input prompt!"
 msgstr "插入新的数学单元格"
 
-#: ../../src/Worksheet.cpp:6354
+#: ../../src/worksheet/Worksheet.cpp:4306
 msgid "Got a request to undo an action that involves a delete which isn't possible at this moment."
 msgstr "Got a request to undo an action that involves a delete which isn't possible at this moment."
 
-#: ../../src/wxMaximaFrame.cpp:1031
+#: ../../src/wxMaximaFrame.cpp:1065
 msgid "Gradefs"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1967
+#: ../../src/worksheet/WorksheetContextMenu.cpp:739
 #, fuzzy
 msgid "Greater or less than a value"
 msgstr "大于等于"
 
-#: ../../src/wxMaximaFrame.cpp:1130
+#: ../../src/wxMaximaFrame.cpp:1164
 msgid "Greater, ignoring case?..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:260
+#: ../../src/dialogs/ConfigDialogue.cpp:202
+msgid "Greek"
+msgstr "希腊语"
+
+#: ../../src/wxMaximaFrame.cpp:281
 msgid "Greek Letters"
 msgstr "希腊字母"
 
-#: ../../src/wxMaximaFrame.cpp:703
+#: ../../src/wxMaximaFrame.cpp:738
 msgid "Greek Letters\tAlt+Shift+G"
 msgstr "希腊字母\tAlt+Shift+G"
 
-#: ../../src/wxMaximaFrame.cpp:1815
+#: ../../src/sidebars/DrawSidebar.cpp:97
+msgid "Grid"
+msgstr "网格"
+
+#: ../../src/wizards/Plot3dWiz.cpp:52
+msgid "Grid:"
+msgstr "网格："
+
+#: ../../src/wxMaximaFrame.cpp:1852
 msgid "Guess an exact number that could be meant by this float"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:6123
+#: ../../src/dialogs/ConfigDialogue.cpp:1215
+msgid "HTML"
+msgstr "HTML"
+
+#: ../../src/MaximaCommandMenus.cpp:2279
 msgid "HTML file (*.html)|*.html|maxima batch file (*.mac)|*.mac|LaTeX file (*.tex)|*.tex"
 msgstr "HTML 文件 (*.html)|*.html|Maxima 批处理文件 (*.mac)|*.mac|LaTeX 文件 (*.tex)|*.tex"
 
-#: ../../src/wxMaximaFrame.cpp:1341
+#: ../../src/wxMaximaFrame.cpp:1375
 #, fuzzy
 msgid "Hadamard (element-by-element) product..."
 msgstr "Hadamard 积（逐个对应元素相乘）"
 
-#: ../../src/wxMaxima.cpp:8004
+#: ../../src/MaximaCommandMenus.cpp:1188
 #, fuzzy
 msgid "Hadamard Product"
 msgstr "Hadamard 指数"
 
-#: ../../src/wxMaxima.cpp:8011
+#: ../../src/MaximaCommandMenus.cpp:1195
 msgid "Hadamard exponent"
 msgstr "Hadamard 指数"
 
-#: ../../src/wxMaximaFrame.cpp:1345
+#: ../../src/wxMaximaFrame.cpp:1379
 #, fuzzy
 msgid "Hadamard exponent..."
 msgstr "Hadamard 指数"
 
-#: ../../src/MaximaManual.cpp:260
+#: ../../src/MaximaManual.cpp:269
 #, c-format
 msgid "Have only %li keyword anchors at the end of parsing the maxima manual => Not caching the result of using the built-in keyword list"
 msgstr ""
 
-#: ../../src/Configuration.cpp:88 ../../src/ToolBar.cpp:276
+#: ../../src/Styles.cpp:117 ../../src/ToolBar.cpp:486
+#: ../../src/sidebars/FormatSidebar.cpp:60
 msgid "Heading 5"
 msgstr "五级标题"
 
-#: ../../src/Configuration.cpp:87 ../../src/ToolBar.cpp:277
+#: ../../src/Styles.cpp:116 ../../src/ToolBar.cpp:487
+#: ../../src/sidebars/FormatSidebar.cpp:63
 msgid "Heading 6"
 msgstr "六级标题"
 
-#: ../../src/ToolBar.cpp:328 ../../src/wxMaximaFrame.cpp:330
+#: ../../src/dialogs/ConfigDialogue.cpp:203
+msgid "Hebrew"
+msgstr ""
+
+#: ../../src/ToolBar.cpp:544 ../../src/ToolBar.cpp:546
+#: ../../src/wxMaximaFrame.cpp:351
 msgid "Help"
 msgstr "帮助"
 
-#: ../../src/ToolBar.cpp:635
+#: ../../src/dialogs/ConfigDialogue.cpp:1461
+msgid "Help browser:"
+msgstr "帮助浏览器："
+
+#: ../../src/ToolBar.cpp:835
 msgid "Help button"
 msgstr "帮助按钮"
 
-#: ../../src/Worksheet.cpp:1340 ../../src/Worksheet.cpp:1778
+#: ../../src/worksheet/WorksheetContextMenu.cpp:102
+#: ../../src/worksheet/WorksheetContextMenu.cpp:551
 #, c-format
 msgid "Help on \"%s\""
 msgstr "关于“%s”的帮助"
 
-#: ../../src/wxMaximaFrame.cpp:729
-msgid "Hide All Toolbars\tAlt+Shift+-"
-msgstr "隐藏所有工具栏\tAlt+Shift+-"
+#: ../../src/wizards/GenWizPanel.cpp:248
+#, c-format
+msgid "Help on %s"
+msgstr ""
 
-#: ../../src/ToolBar.cpp:264
+#: ../../src/sidebars/TableOfContents.cpp:510
+msgid "Hide"
+msgstr "隐藏"
+
+#: ../../src/ToolBar.cpp:471 ../../src/ToolBar.cpp:473
 msgid "Hide Code"
 msgstr "隐藏代码"
 
-#: ../../src/wxMaximaFrame.cpp:727
+#: ../../src/wxMaximaFrame.cpp:764
 msgid "Hide Code Cells\tAlt+Ctrl+H"
 msgstr "隐藏单元格\tAlt+Shift+H"
 
-#: ../../src/Worksheet.cpp:1896
+#: ../../src/worksheet/WorksheetContextMenu.cpp:668
 msgid "Hide Heading 5"
 msgstr "隐藏五级标题"
 
-#: ../../src/Worksheet.cpp:1907
+#: ../../src/worksheet/WorksheetContextMenu.cpp:679
 msgid "Hide Heading 6"
 msgstr "隐藏六级标题"
 
-#: ../../src/Worksheet.cpp:1855
+#: ../../src/worksheet/WorksheetContextMenu.cpp:627
 msgid "Hide Part"
 msgstr "隐藏此部分"
 
-#: ../../src/Worksheet.cpp:1863
+#: ../../src/worksheet/WorksheetContextMenu.cpp:635
 msgid "Hide Section"
 msgstr "隐藏节"
 
-#: ../../src/Worksheet.cpp:1874
+#: ../../src/worksheet/WorksheetContextMenu.cpp:646
 msgid "Hide Subsection"
 msgstr "隐藏小节"
 
-#: ../../src/Worksheet.cpp:1885
+#: ../../src/worksheet/WorksheetContextMenu.cpp:657
 msgid "Hide Subsubsection"
 msgstr "隐藏小小节"
 
-#: ../../src/wxMaximaFrame.cpp:730
+#: ../../src/wxMaximaFrame.cpp:766
+msgid "Hide all Sidebars\tAlt+Shift+-"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:487
+msgid "Hide all multiplication signs that aren't really necessary for understanding the equation"
+msgstr "隐藏理解公式时所有不必要的乘号"
+
+#: ../../src/wxMaximaFrame.cpp:767
 msgid "Hide all panes"
 msgstr "隐藏所有面板"
 
-#: ../../src/Worksheet.cpp:1491
+#: ../../src/worksheet/WorksheetContextMenu.cpp:262
 #, fuzzy
 msgid "Hide cell brackets"
 msgstr "活动单元格的括号"
 
-#: ../../src/Worksheet.cpp:1915
+#: ../../src/worksheet/WorksheetContextMenu.cpp:687
 msgid "Hide contents"
 msgstr "隐藏内容"
 
-#: ../../src/Worksheet.cpp:1552
+#: ../../src/worksheet/WorksheetContextMenu.cpp:325
 msgid "Hide multiplication dots"
 msgstr "隐藏乘点"
 
-#: ../../src/Worksheet.cpp:1930 ../../src/Worksheet.cpp:2063
+#: ../../src/dialogs/ConfigDialogue.cpp:854
+msgid "Hide multiplication signs, if possible"
+msgstr "隐藏乘号（如可能）"
+
+#: ../../src/wizards/DrawWiz.cpp:555
+msgid "Hide objects behind the surface"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:502
+msgid "Hide the brackets that mark the extend of the worksheet cells at the worksheet's right side and that contain the \"hide\" button of the cell if the cells aren't active."
+msgstr "如果单元格未处于活动状态，隐藏工作簿左侧标记单元格范围的方括号及其包含的“隐藏”按钮。"
+
+#: ../../src/worksheet/WorksheetContextMenu.cpp:702
+#: ../../src/worksheet/WorksheetContextMenu.cpp:835
 msgid "Hide yellow tooltip marker for this cell"
 msgstr "对此单元格隐藏黄色的提示标记"
 
-#: ../../src/Worksheet.cpp:1937 ../../src/Worksheet.cpp:2069
+#: ../../src/worksheet/WorksheetContextMenu.cpp:709
+#: ../../src/worksheet/WorksheetContextMenu.cpp:841
 msgid "Hide yellow tooltip marker for this message type"
 msgstr "对此消息类型隐藏黄色的提示标记"
 
-#: ../../src/Configuration.cpp:82
+#: ../../src/Styles.cpp:111
 #, fuzzy
 msgid "Highlight (box)"
 msgstr "高亮显示（对 dpart 函数）"
 
-#: ../../src/wxMaxima.cpp:9528
+#: ../../src/dialogs/ConfigDialogue.cpp:869
+#, fuzzy
+msgid "Highlight the matching parenthesis"
+msgstr "括号不匹配"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:463
+msgid "Highlight the opening or closing parenthesis for the parenthesis the cursor is at."
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:204
+msgid "Hindi"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:1766
 msgid "Histogram"
 msgstr "柱状图"
 
-#: ../../src/wxMaximaFrame.cpp:232
+#: ../../src/sidebars/StatSidebar.cpp:85
+msgid "Histogram..."
+msgstr "柱状图..."
+
+#: ../../src/wxMaximaFrame.cpp:246
 msgid "History"
 msgstr "历史记录"
 
-#: ../../src/wxMaximaFrame.cpp:709
+#: ../../src/wxMaximaFrame.cpp:744
 msgid "History\tAlt+Shift+I"
 msgstr "历史记录\tAlt+Shift+I"
 
-#: ../../src/wxMaximaFrame.cpp:1526
+#: ../../src/dialogs/TipOfTheDay.cpp:105
+msgid "Horizontal cursor works like a normal cursor, but it operates on cells: press up or down arrow to move it, holding down Shift while moving will select cells, pressing backspace or delete twice will delete a cell next to it."
+msgstr "水平光标的工作方式与普通光标类似，但它是对单元格操作的：按向上或向下箭头移动光标，在移动光标时按住 Shift 键将选择单元格，按 Backspace 键或 Delete 键两次将删除与水平光标相邻的单元格。"
+
+#: ../../src/wxMaximaFrame.cpp:1563
 msgid "Horner's rule"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:9207
+#: ../../src/dialogs/ConfigDialogue.cpp:918
+msgid "Hotkeys for sending commands to maxima"
+msgstr "将命令发送至 Maxima 的快捷键"
+
+#: ../../src/MaximaCommandMenus.cpp:398
 msgid "How many digits to show:"
 msgstr "要显示的数字位数："
 
-#: ../../src/wxMaximaFrame.cpp:759
+#: ../../src/wxMaximaFrame.cpp:796
 msgid "How to display new equations"
 msgstr "如何显示新式子"
 
-#: ../../src/wxMaximaFrame.cpp:1113
+#: ../../src/dialogs/ConfigDialogue.cpp:205
+msgid "Hungarian"
+msgstr "匈牙利语"
+
+#: ../../src/wxMaximaFrame.cpp:1147
 msgid "I/O"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7062
-msgid "If a program doesn't need local variables maxima allows to put the commands between parenthesis. The result of the last operation is the return value of the program."
+#: ../../src/sidebars/SymbolsSidebar.cpp:121
+msgid "Identical to"
+msgstr "等价于"
+
+#: ../../src/MaximaCommandMenus.cpp:3934
+msgid "If a program doesn't need local variables, Maxima allows putting the commands between parentheses. The result of the last operation is the return value of the program."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7172
+#: ../../src/dialogs/ConfigDialogue.cpp:145
+msgid "If maxima versions compiled with different lisps are installed: The name of the lisp to use by default"
+msgstr "如果安装了由不同 Lisp 编译器得到的 Maxima 版本：默认情况下要使用的 Lisp 的名称"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:174
+msgid "If maxima was compiled by GCL: Garbage Collect at minimum allocation past this heapsize"
+msgstr "If maxima was compiled by GCL: Garbage Collect at minimum allocation past this heapsize"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:171
+msgid "If maxima was compiled by GCL: Minimum allocation fraction between Garbage Collects"
+msgstr "If maxima was compiled by GCL: Minimum allocation fraction between Garbage Collects"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:168
+msgid "If maxima was compiled by GCL: Only garbage collect past this heapsize fraction of working mem"
+msgstr "If maxima was compiled by GCL: Only garbage collect past this heapsize fraction of working mem"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:180
+msgid "If maxima was compiled by GCL: Share the allocated memory between gcl processes. Allows more than one gcl-compiled maxima to run at the same time, but might provoke crashes."
+msgstr "If maxima was compiled by GCL: Share the allocated memory between gcl processes. Allows more than one gcl-compiled maxima to run at the same time, but might provoke crashes."
+
+#: ../../src/dialogs/ConfigDialogue.cpp:177
+msgid "If maxima was compiled by GCL: The fraction of the total installed RAM to reserve for maxima"
+msgstr "If maxima was compiled by GCL: The fraction of the total installed RAM to reserve for maxima"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:375
+msgid "If multiple cells are evaluated in one go: Abort evaluation if wxMaxima detects that maxima has encountered any error."
+msgstr "如果一次计算多个单元格：当 wxMaxima 检测到 Maxima 遇到任何错误时，中止计算。"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:727
+msgid "If not extremely long"
+msgstr "如果不是特别长"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:726
+msgid "If not very long"
+msgstr "如果不是很长"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:418
+msgid "If numbers are getting longer than this number of digits they will be displayed abbreviated by an ellipsis."
+msgstr "如果数值的长度超过这个数，超出的部分将显示为省略号。"
+
+#: ../../src/dialogs/TipOfTheDay.cpp:181
+msgid "If the \"Autosave\" functionality is enabled in the configuration dialogue wxMaxima acts like mobile apps that backup the file every few minutes and save it on closing."
+msgstr "如果在配置对话框中启用了“自动保存（autosave）”功能，那么 wxMaxima 会像手机上的应用程序一样，每隔几分钟备份文档，并在退出时保存文档。"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:396
+msgid "If the font provides big parenthesis symbols: Use them when big parenthesis are needed for maths display."
+msgstr "如果字体提供大型括号符号：当显示式子需要大型括号时使用它们。"
+
+#: ../../src/cells/TextCell.cpp:327
+msgid "If the thing maxima complains about actually looks like a polynomial you can try running it through ratdisrep() in order to fix that problem."
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:4044
 msgid ""
 "If the type of a function parameter is known when compiling a function the code can vastly be optimized.\n"
 "Known types:\n"
@@ -3664,1090 +5407,1716 @@ msgid ""
 "array, boolean, integer, fixnum (machine-length integer), float (machine-size floating-point numbers), real or any (which is useful for declaring arrays of any)"
 msgstr ""
 
-#: ../../src/MathParser.cpp:890
+#: ../../src/dialogs/ConfigDialogue.cpp:399
+msgid "If this checkbox is checked wxMaxima automatically saves the file closing and every few minutes giving wxMaxima a more cellphone-app-like feel as the file is virtually always saved. If this checkbox is unchecked from time to time a backup is made in the temp folder instead."
+msgstr "如果选中此复选框，wxMaxima 会每隔几分钟自动保存文件，表现得类似于手机应用程序，即文件实际上总是被保存。如果取消选中此复选框，则会不定期在临时文件夹中进行备份。"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:378
+msgid "If this checkbox is set a new code cell is opened as soon as maxima requests data. If it isn't set a new code cell is opened in this case as soon as the user starts typing in code."
+msgstr "如果设置了此复选框，则在 Maxima 请求数据时将打开一个新的代码单元格。如果没有设置，只有在用户开始输入代码时，才会打开一个新的代码单元格。"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:372
+msgid "If this checkbox isn't checked the current command is sent to maxima only on pressing Ctrl+Enter"
+msgstr "如果未选中此复选框，则仅当按下 Ctrl+Enter 时当前命令才发送到 Maxima。"
+
+#: ../../src/MathParser.cpp:945
 msgid "If this isn't a function returning a lambda() expression a multiplication sign (*) between closing and opening parenthesis is missing here."
 msgstr ""
 
-#: ../../src/MaximaManual.cpp:403
+#: ../../src/dialogs/ConfigDialogue.cpp:942
+msgid ""
+"If this option is enabled, the filename and path of images inserted with \"Cell\" -> \"Insert Image...\" is stored in the worksheet file on save. This enables reloading of the image file via the context menu after re-opening the worksheet, but storing the filenames and paths may be an undesired data leak. If this option is disabled, reloading still works as long as the worksheet is not closed.\n"
+"\n"
+"Note: Storing the filenames for the reload functionality is independent of the automatically generated image captions."
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:439
+msgid "If this option is set the .wxmx source of the current file is copied to a place a link to is put into the result of an export."
+msgstr "如果设置了此选项，则当前的 .wxmx 文件将复制到相关文件夹，且导出的文件将包含对应的链接。"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1873
+msgid "If unset, Maxima's output is announced to the screen reader as maths in a linear text form. Set this option if your screen reader can speak MathML properly."
+msgstr ""
+
+#: ../../src/dialogs/TipOfTheDay.cpp:247
+msgid "If you have ideas, how to improve the design or functionality of wxMaxima, please share your ideas at the issue list or discussion forum at https://github.com/wxMaxima-developers/wxmaxima/."
+msgstr ""
+
+#: ../../src/dialogs/TipOfTheDay.cpp:76
+msgid "If you type an operator (one of +*/^=,) as the first symbol in an input cell, % will be automatically inserted before the operator, as on a graphing calculator. You can disable this feature from the 'Edit->Configure' dialog."
+msgstr "如在图形计算器中一样，如果键入六个运算符 +*/^=，中的一个作为（数学）输入单元格中的第一个符号，wxMaxima 将自动在该运算符之前插入 %（表示上一个输出结果）。可以在“编辑->设置”对话框开启（禁用）此功能。"
+
+#: ../../src/dialogs/TipOfTheDay.cpp:122
+msgid "If your calculation is taking too long to evaluate, you can try 'Maxima->Interrupt' or 'Maxima->Restart Maxima' menu commands."
+msgstr "如果计算时花费了太长时间仍无结果，可以尝试用菜单命令“Maxima->中断”或“Maxima->重新启动”来中止计算。"
+
+#: ../../src/MaximaManual.cpp:420
 #, fuzzy
 msgid "Ignoring the cache version for the manual anchors."
 msgstr "用户手册所含主题的缓存中没有对应条目。"
 
-#: ../../src/Image.cpp:79
+#: ../../src/sidebars/FormatSidebar.cpp:66
+msgid "Image"
+msgstr "图片"
+
+#: ../../src/Image.cpp:110
 msgid "Image data had zero length!"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:10147 ../../src/wxMaxima.cpp:10855
-msgid "Image files (*.png, *.jpg, *.bmp, *.xpm, *.gif, *.svg, *.svgz)|*.png;*.jpg;*.bmp;*.xpm;*.gif;*.svg;*.svgz"
-msgstr "图片文件 (*.png, *.jpg, *.bmp, *.xpm, *.gif, *.svg, *.svgz)|*.png;*.jpg;*.bmp;*.xpm;*.gif;*.svg;*.svgz"
+#: ../../src/MaximaCommandMenus.cpp:2564 ../../src/MaximaCommandMenus.cpp:2933
+#: ../../src/MaximaCommandMenus.cpp:3642
+msgid "Image files ("
+msgstr ""
 
-#: ../../src/Worksheet.cpp:5509
+#: ../../src/Image.cpp:74
+#, c-format
+msgid "Image of type %s found."
+msgstr ""
+
+#: ../../src/worksheet/WorksheetExport.cpp:1407
 msgid "ImageCell without image."
 msgstr ""
 
-#: ../../src/MathParser.cpp:347
+#: ../../src/sidebars/DrawSidebar.cpp:60
+msgid "Implicit Plot"
+msgstr "隐式图形"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1028
+msgid "Import settings"
+msgstr "导入设置"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1013
+msgid "Import+Export"
+msgstr "导入和导出"
+
+#: ../../src/MathParser.cpp:395
 msgid "Importing compressed gnuplot sources for an animation"
 msgstr ""
 
-#: ../../src/MathParser.cpp:334
+#: ../../src/MathParser.cpp:382
 msgid "Importing uncompressed gnuplot sources for an animation"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7993
+#: ../../src/MaximaCommandMenus.cpp:1177
 msgid ""
 "In order to save memory the \":\" operator does clone the matrix, not copy it:\n"
 "If you change an element of one matrix the same element will change in all of its clones. copymatrix() instead generates a copy of a matrix: A new matrix that, if changed in any way, won't change the original."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7404
+#: ../../src/MaximaCommandMenus.cpp:4276
 msgid "In order to save memory the : operator doesn't create an individual copy of the string, but a clone that changes when the original string changes."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:9629
+#: ../../src/dialogs/TipOfTheDay.cpp:175
+#, fuzzy
+msgid ""
+"In order to visualize how a parameter affects an equation wxMaxima provides commands that start with \"with_slider_\" and that create animations. One example would be:\n"
+"\n"
+"    with_slider_draw(\n"
+"        a,[-16,-9,-4,-2,0,1,2,3,4,5,6,7],\n"
+"        title=concat(\"a=\",a),\n"
+"        grid=true,\n"
+"        explicit(\n"
+"            x^2-a*x,\n"
+"            x,-10,10\n"
+"        )\n"
+"    );"
+msgstr ""
+"为了将参数对方程的影响可视化，wxMaxima 提供了以“with_slider_”开头的命令，以生成动图。一个例子是：\n"
+"\n"
+"    with_slider_draw(\n"
+"        a,[-16,-9,-4,-2,0,1,2,3,4,5,6,7],\n"
+"        title=concat(\"a=\",a),\n"
+"        grid=true,\n"
+"        explicit(\n"
+"            x^2-a*x,\n"
+"            x,-10,10\n"
+"        )\n"
+"    );"
+
+#: ../../src/dialogs/TipOfTheDay.cpp:214
+#, fuzzy
+msgid "In text cells bullet lists can be created by beginning a line with \" * \". The number of spaces in front of the \"*\" determines the indentation level; Indentation can be continued in the next line by indenting the line using spaces."
+msgstr "在文本单元格中，可以通过以“*”开头的行来创建项目列表：“*”前面的空格数决定了缩进级别；在下一行继续使用空格可以维持缩进级别。"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:421
+msgid "In the LaTeX output: Put exponents after an eventual subscript instead of above it. Might increase readability for some fonts and short subscripts."
+msgstr "在 LaTeX 输出中，将上标文字放在下标文字之后，而不是之前；可能会增加某些字体和短下标的可读性。"
+
+#: ../../src/MaximaCommandMenus.cpp:1869
 msgid "Include columns:"
 msgstr "包含列："
 
-#: ../../src/Worksheet.cpp:2008
+#: ../../src/worksheet/WorksheetContextMenu.cpp:780
 msgid "Increasing function f(x)>x"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8470
+#: ../../src/dialogs/ConfigDialogue.cpp:884
+msgid "Incremental Search"
+msgstr "增量搜索"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:844
+msgid "Indent equations by the label width"
+msgstr "按标签的宽度缩进式子"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:512
+msgid "Indent maths so all lines are in par with the first line that starts after the label."
+msgstr "缩进式子，使所有行与标签后的第一行一致。"
+
+#: ../../src/sidebars/TableOfContents.cpp:583
+msgid "Indentation"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:1473
 msgid "Index End:"
 msgstr "指标结束："
 
-#: ../../src/wxMaxima.cpp:8470
+#: ../../src/MaximaCommandMenus.cpp:1473
 msgid "Index Start:"
 msgstr "指标开始："
 
-#: ../../src/wxMaxima.cpp:8471
+#: ../../src/MaximaCommandMenus.cpp:1474
 msgid "Index Step:"
 msgstr "指标步长："
 
-#: ../../src/wxMaxima.cpp:8467 ../../src/wxMaxima.cpp:8480
+#: ../../src/MaximaCommandMenus.cpp:1470 ../../src/MaximaCommandMenus.cpp:1484
 msgid "Index variable:"
 msgstr "指标变量："
 
-#: ../../src/wxMaximaFrame.cpp:1949
+#: ../../src/dialogs/ConfigDialogue.cpp:206
+msgid "Indonesian"
+msgstr ""
+
+#: ../../src/cells/TextCell.cpp:186
+msgid "Infinitesimal above zero."
+msgstr ""
+
+#: ../../src/cells/TextCell.cpp:188
+msgid "Infinitesimal below zero."
+msgstr ""
+
+#: ../../src/sidebars/SymbolsSidebar.cpp:91
+#: ../../src/wizards/IntegrateWiz.cpp:192
+#: ../../src/wizards/IntegrateWiz.cpp:200
+#: ../../src/wizards/IntegrateWiz.cpp:207
+#: ../../src/wizards/IntegrateWiz.cpp:215 ../../src/wizards/LimitWiz.cpp:132
+#: ../../src/wizards/LimitWiz.cpp:140
+msgid "Infinity"
+msgstr "无穷大"
+
+#: ../../src/wxMaximaFrame.cpp:1986
 msgid "Info about Maxima build"
 msgstr "关于 Maxima 的构建信息"
 
-#: ../../src/Worksheet.cpp:2046
+#: ../../src/worksheet/WorksheetContextMenu.cpp:818
 msgid "Inform maxima about facts you know for this symbol"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1988
+#: ../../src/worksheet/WorksheetContextMenu.cpp:760
 msgid "Inform maxima about the value of the function at a specific point, e.G. for declaring initial conditions"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7793 ../../src/wxMaxima.cpp:7804
+#: ../../src/MaximaCommandMenus.cpp:974 ../../src/MaximaCommandMenus.cpp:985
 #, fuzzy
 msgid "Initial Condition"
 msgstr "条件："
 
-#: ../../src/wxMaximaFrame.cpp:1270
+#: ../../src/wxMaximaFrame.cpp:1304
 msgid "Initial Value Problem (&1)..."
 msgstr "一阶常微分方程初值问题(&1)..."
 
-#: ../../src/wxMaximaFrame.cpp:1274
+#: ../../src/wxMaximaFrame.cpp:1308
 msgid "Initial Value Problem (&2)..."
 msgstr "二阶常微分方程初值问题(&2)..."
 
-#: ../../src/wxMaxima.cpp:9044
+#: ../../src/MaximaCommandMenus.cpp:298
 #, fuzzy
 msgid "Initial estimates:"
 msgstr "初始估计值："
 
-#: ../../src/wxMaxima.cpp:7840
+#: ../../src/MaximaCommandMenus.cpp:1021
 #, fuzzy
 msgid "Initial x:"
 msgstr "初始估计值："
 
-#: ../../src/Configuration.cpp:78
+#: ../../src/dialogs/FindReplacePane.cpp:107
+msgid "Input"
+msgstr ""
+
+#: ../../src/sidebars/RegexCtrl.cpp:38
+msgid ""
+"Input a RegEx here to filter the results.\n"
+"Right-click for options!"
+msgstr ""
+
+#: ../../src/Styles.cpp:107
 msgid "Input labels"
 msgstr "输入标签"
 
-#: ../../src/wxMaximaFrame.cpp:314
+#: ../../src/sidebars/RegexCtrl.cpp:42
+msgid ""
+"Input your filter text here.\n"
+"Right-click for options!"
+msgstr ""
+
+#: ../../src/wizards/GenWizPanel.cpp:103 ../../src/wxMaximaFrame.cpp:335
 msgid "Insert"
 msgstr "插入"
 
-#: ../../src/wxMaximaFrame.cpp:905
+#: ../../src/dialogs/ConfigDialogue.cpp:889
+msgid "Insert % before an operator at the beginning of a cell"
+msgstr "在单元格开头的运算符前插入 %"
+
+#: ../../src/wxMaximaFrame.cpp:939
 msgid "Insert &Section Cell\tCtrl+3"
 msgstr "插入节单元格(&S)\tCtrl+3"
 
-#: ../../src/wxMaximaFrame.cpp:901
+#: ../../src/wxMaximaFrame.cpp:935
 msgid "Insert &Text Cell\tCtrl+1"
 msgstr "插入文本单元格(&T)\tCtrl+1"
 
-#: ../../src/wxMaximaFrame.cpp:713
+#: ../../src/wxMaximaFrame.cpp:748
 msgid "Insert Cell\tAlt+Shift+C"
 msgstr "插入单元格\tAlt+Shift+C"
 
-#: ../../src/Worksheet.cpp:1669
+#: ../../src/worksheet/WorksheetContextMenu.cpp:442
 msgid "Insert Heading5 Cell"
 msgstr "插入五级标题单元格"
 
-#: ../../src/Worksheet.cpp:1671
+#: ../../src/worksheet/WorksheetContextMenu.cpp:444
 msgid "Insert Heading6 Cell"
 msgstr "插入六级标题单元格"
 
-#: ../../src/wxMaxima.cpp:10854
+#: ../../src/MaximaCommandMenus.cpp:2563
 msgid "Insert Image"
 msgstr "插入图片"
 
-#: ../../src/wxMaximaFrame.cpp:917
+#: ../../src/wxMaximaFrame.cpp:951
 msgid "Insert Image..."
 msgstr "插入图片..."
 
-#: ../../src/wxMaximaFrame.cpp:899
+#: ../../src/wxMaximaFrame.cpp:933
 msgid "Insert Input &Cell\tCtrl+0"
 msgstr "插入数学单元格(&C)\tCtrl+0"
 
-#: ../../src/wxMaximaFrame.cpp:919
+#: ../../src/wxMaximaFrame.cpp:953
 msgid "Insert Page Break"
 msgstr "插入分页符"
 
-#: ../../src/wxMaximaFrame.cpp:907
+#: ../../src/wxMaximaFrame.cpp:941
 msgid "Insert S&ubsection Cell\tCtrl+4"
 msgstr "插入小节单元格(&U)\tCtrl+4"
 
-#: ../../src/wxMaximaFrame.cpp:910
+#: ../../src/wxMaximaFrame.cpp:944
 msgid "Insert S&ubsubsection Cell\tCtrl+5"
 msgstr "插入小小节单元格(&U)\tCtrl+5"
 
-#: ../../src/Worksheet.cpp:1662
+#: ../../src/worksheet/WorksheetContextMenu.cpp:435
 msgid "Insert Section Cell"
 msgstr "插入节单元格"
 
-#: ../../src/Worksheet.cpp:1664
+#: ../../src/worksheet/WorksheetContextMenu.cpp:437
 msgid "Insert Subsection Cell"
 msgstr "插入小节单元格"
 
-#: ../../src/Worksheet.cpp:1667
+#: ../../src/worksheet/WorksheetContextMenu.cpp:440
 msgid "Insert Subsubsection Cell"
 msgstr "插入小小节单元格"
 
-#: ../../src/wxMaximaFrame.cpp:903
+#: ../../src/wxMaximaFrame.cpp:937
 msgid "Insert T&itle Cell\tCtrl+2"
 msgstr "插入标题单元格(&I)\tCtrl+2"
 
-#: ../../src/Worksheet.cpp:1658
+#: ../../src/worksheet/WorksheetContextMenu.cpp:431
 msgid "Insert Text Cell"
 msgstr "插入文本单元格"
 
-#: ../../src/Worksheet.cpp:1660
+#: ../../src/worksheet/WorksheetContextMenu.cpp:433
 msgid "Insert Title Cell"
 msgstr "插入标题单元格"
 
-#: ../../src/wxMaximaFrame.cpp:913
+#: ../../src/wxMaximaFrame.cpp:947
 msgid "Insert a new heading5 cell"
 msgstr "插入新的五级标题单元格"
 
-#: ../../src/wxMaximaFrame.cpp:915
+#: ../../src/wxMaximaFrame.cpp:949
 msgid "Insert a new heading6 cell"
 msgstr "插入新的六级标题单元格"
 
-#: ../../src/wxMaximaFrame.cpp:900
+#: ../../src/wxMaximaFrame.cpp:934
 msgid "Insert a new input cell"
 msgstr "插入新的数学单元格"
 
-#: ../../src/wxMaximaFrame.cpp:906
+#: ../../src/wxMaximaFrame.cpp:940
 msgid "Insert a new section cell"
 msgstr "插入新的节单元格"
 
-#: ../../src/wxMaximaFrame.cpp:908
+#: ../../src/wxMaximaFrame.cpp:942
 msgid "Insert a new subsection cell"
 msgstr "插入新的小节单元格"
 
-#: ../../src/wxMaximaFrame.cpp:911
+#: ../../src/wxMaximaFrame.cpp:945
 msgid "Insert a new subsubsection cell"
 msgstr "插入新的小小节单元格"
 
-#: ../../src/wxMaximaFrame.cpp:902
+#: ../../src/wxMaximaFrame.cpp:936
 msgid "Insert a new text cell"
 msgstr "插入新的文本单元格"
 
-#: ../../src/wxMaximaFrame.cpp:904
+#: ../../src/wxMaximaFrame.cpp:938
 msgid "Insert a new title cell"
 msgstr "插入新的标题单元格"
 
-#: ../../src/wxMaximaFrame.cpp:920
+#: ../../src/wxMaximaFrame.cpp:954
 msgid "Insert a page break"
 msgstr "插入一个换页符"
 
-#: ../../src/wxMaximaFrame.cpp:1164
+#: ../../src/MaximaCommandMenus.cpp:4261
+msgid "Insert a string into another"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1198
 #, fuzzy
 msgid "Insert char..."
 msgstr "插入图片..."
 
-#: ../../src/wxMaximaFrame.cpp:912
+#: ../../src/wxMaximaFrame.cpp:946
 msgid "Insert heading5 Cell\tCtrl+6"
 msgstr "插入五级标题单元格\tCtrl+6"
 
-#: ../../src/wxMaximaFrame.cpp:914
+#: ../../src/wxMaximaFrame.cpp:948
 msgid "Insert heading6 Cell\tCtrl+7"
 msgstr "插入六级标题单元格\tCtrl+7"
 
-#: ../../src/wxMaximaFrame.cpp:917
+#: ../../src/wxMaximaFrame.cpp:951
 msgid "Insert image"
 msgstr "插入图片"
 
-#: ../../src/wxMaximaFrame.cpp:916
+#: ../../src/wxMaximaFrame.cpp:950
 #, fuzzy
 msgid "Insert textbased cell"
 msgstr "插入文本单元格"
 
-#: ../../src/wxMaxima.cpp:3566
+#: ../../src/worksheet/Worksheet.cpp:6131
+msgid "Insertion point between cells"
+msgstr ""
+
+#: ../../src/sidebars/HelpBrowser.cpp:111
+msgid "Instantiating the HTML manual browser"
+msgstr ""
+
+#: ../../src/MaximaProcessManager.cpp:1177
 msgid "Instructed to prefer gnuplot over wgnuplot"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3554
+#: ../../src/MaximaProcessManager.cpp:1165
 msgid "Instructed to prefer wgnuplot over gnuplot"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8898 ../../src/wxMaxima.cpp:8919
+#: ../../src/dialogs/ConfigDialogue.cpp:749
+msgid "Integers and single letters"
+msgstr "整数和单个字母"
+
+#: ../../src/sidebars/SymbolsSidebar.cpp:113
+msgid "Integral sign"
+msgstr "积分号"
+
+#: ../../src/MaximaCommandMenus.cpp:149 ../../src/MaximaCommandMenus.cpp:170
 msgid "Integral/Sum:"
 msgstr "积分或求和："
 
-#: ../../src/wxMaxima.cpp:8986 ../../src/wxMaxima.cpp:10044
+#: ../../src/MaximaCommandMenus.cpp:240 ../../src/MaximaCommandMenus.cpp:3533
+#: ../../src/wizards/IntegrateWiz.cpp:73
 msgid "Integrate"
 msgstr "积分"
 
-#: ../../src/wxMaxima.cpp:8980
+#: ../../src/MaximaCommandMenus.cpp:234
 msgid "Integrate (risch)"
 msgstr "Risch 积分"
 
-#: ../../src/wxMaximaFrame.cpp:1454
+#: ../../src/wxMaximaFrame.cpp:1491
 msgid "Integrate expression"
 msgstr "对表达式求积分"
 
-#: ../../src/wxMaximaFrame.cpp:1456
+#: ../../src/wxMaximaFrame.cpp:1493
 msgid "Integrate expression with Risch algorithm"
 msgstr "使用 Risch 算法对表达式求积分"
 
-#: ../../src/wxMaximaFrame.cpp:1869
-#, fuzzy
-msgid "Integrate numerically"
-msgstr "Risch 积分"
+#: ../../src/wxMaximaFrame.cpp:1906
+msgid "Integrate numerically (QUADPACK)"
+msgstr ""
 
-#: ../../src/Worksheet.cpp:1588
+#: ../../src/sidebars/MathSidebar.cpp:83
+#: ../../src/worksheet/WorksheetContextMenu.cpp:361
 msgid "Integrate..."
 msgstr "积分..."
 
-#: ../../src/wxMaximaFrame.cpp:1737
+#: ../../src/dialogs/ConfigDialogue.cpp:834
+msgid "Intelligently hide cell brackets"
+msgstr "智能隐藏单元格左侧括号"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:881
+msgid "Interaction"
+msgstr "相互作用"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1349
+msgid "Interactive popup memory limit [MB/plot]:"
+msgstr "交互式弹出图形的内存限制 [MB/幅]："
+
+#: ../../src/wxMaximaFrame.cpp:1774
 msgid "Interleave"
 msgstr "交错"
 
-#: ../../src/wxMaximaFrame.cpp:1738
+#: ../../src/wxMaximaFrame.cpp:1775
 msgid "Interleave the values of two lists"
 msgstr "交错两个列表的值"
 
-#: ../../src/wxMaxima.cpp:8612
+#: ../../src/MaximaCommandMenus.cpp:1631
 msgid "Interleave two lists"
 msgstr "交错两个列表"
 
-#: ../../src/wxMaximaFrame.cpp:1087
+#: ../../src/dialogs/ConfigDialogue.cpp:1465
+#, fuzzy
+msgid "Internal"
+msgstr "积分"
+
+#: ../../src/wxMaximaFrame.cpp:1121
 msgid "Interpret like input..."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7104
+#: ../../src/MaximaCommandMenus.cpp:3976
 msgid "Interpret maxima's output as input"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7502
+#: ../../src/MaximaCommandMenus.cpp:4374
 #, fuzzy
 msgid "Interpret string as maxima code"
 msgstr "中断 Maxima：%s"
 
-#: ../../src/wxMaximaFrame.cpp:1089
+#: ../../src/wxMaximaFrame.cpp:1123
 #, fuzzy
 msgid "Interpret string..."
 msgstr "未封闭的字符串。"
 
-#: ../../src/ToolBar.cpp:231
+#: ../../src/ToolBar.cpp:413 ../../src/ToolBar.cpp:419
 msgid "Interrupt"
 msgstr "中断"
 
-#: ../../src/wxMaximaFrame.cpp:965
+#: ../../src/wxMaximaFrame.cpp:999
 msgid "Interrupt current computation"
 msgstr "中断当前计算"
 
-#: ../../src/ToolBar.cpp:232
+#: ../../src/ToolBar.cpp:414 ../../src/ToolBar.cpp:420
 msgid "Interrupt current computation. To completely restart maxima press the button left to this one."
 msgstr "中断当前计算。要完全重新启动 Maxima，请按此按钮左侧的按钮。"
 
-#: ../../src/wxMaxima.cpp:2766
+#: ../../src/MaximaProcessManager.cpp:876
 #, c-format
 msgid "Interrupting maxima: %s"
 msgstr "中断 Maxima：%s"
 
-#: ../../src/wxMaxima.cpp:8557
+#: ../../src/MaximaCommandMenus.cpp:1570
 msgid "Introduce a list of actual values into an equation"
 msgstr "将一列实际值引入方程"
 
-#: ../../src/wxMaximaFrame.cpp:1697
+#: ../../src/wxMaximaFrame.cpp:1734
 msgid "Introduce the actual values for variables stored in the list"
 msgstr "引入列表中变量的实际值"
 
-#: ../../src/wxMaxima.cpp:10062
+#: ../../src/MaximaCommandMenus.cpp:3551
 msgid "Introduces one or more assignments into an expression"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:9003
+#: ../../src/sidebars/RegexCtrl.cpp:40
+msgid "Invalid RegEx!"
+msgstr "不正确的正则表达式！"
+
+#: ../../src/MathParser.cpp:1338
+#, c-format
+msgid "Invalid XML: %s"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:257
 msgid "Inverse Laplace"
 msgstr "Laplace 逆变换"
 
-#: ../../src/wxMaximaFrame.cpp:1488
+#: ../../src/wxMaximaFrame.cpp:1525
 msgid "Inverse Laplace T&ransform..."
 msgstr "Laplace 逆变换(&R)..."
 
-#: ../../src/wxMaximaFrame.cpp:832
-msgid "Invert worksheet brightness"
-msgstr "反转工作簿亮度"
+#: ../../src/sidebars/GreekSidebar.cpp:186
+msgid "Iota"
+msgstr "Iota"
 
-#: ../../src/wxMaxima.cpp:7338
+#: ../../src/MaximaCommandMenus.cpp:4210
 msgid "Is Char 1 greater than Char2, if case is ignored?"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7333
+#: ../../src/MaximaCommandMenus.cpp:4205
 #, fuzzy
 msgid "Is Char 1 greater than Char2?"
 msgstr "远大于"
 
-#: ../../src/wxMaxima.cpp:7327
+#: ../../src/MaximaCommandMenus.cpp:4199
 msgid "Is Char 1 less than Char2, if case is ignored?"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7322
+#: ../../src/MaximaCommandMenus.cpp:4194
 msgid "Is Char 1 less than Char2?"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7280
+#: ../../src/MaximaCommandMenus.cpp:4152
 msgid "Is a char?"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1115
+#: ../../src/wxMaximaFrame.cpp:1149
 msgid "Is a char?..."
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1952
+#: ../../src/worksheet/WorksheetContextMenu.cpp:724
 #, fuzzy
 msgid "Is a complex variable"
 msgstr "指标变量："
 
-#: ../../src/wxMaxima.cpp:7292
+#: ../../src/MaximaCommandMenus.cpp:4164
 #, fuzzy
 msgid "Is a digit?"
 msgstr "显示算法"
 
-#: ../../src/wxMaximaFrame.cpp:1118
+#: ../../src/wxMaximaFrame.cpp:1152
 msgid "Is a digit?..."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7304
+#: ../../src/MaximaCommandMenus.cpp:4176
 msgid "Is a lowercase char?"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7296
+#: ../../src/MaximaCommandMenus.cpp:4168
 msgid "Is a printable char?"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1949
+#: ../../src/worksheet/WorksheetContextMenu.cpp:721
 #, fuzzy
 msgid "Is a real variable"
 msgstr "修改变量"
 
-#: ../../src/wxMaxima.cpp:7300
+#: ../../src/MaximaCommandMenus.cpp:4172
 msgid "Is a uppercase char?"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1116
+#: ../../src/wxMaximaFrame.cpp:1150
 msgid "Is alphabetic?..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1117
+#: ../../src/wxMaximaFrame.cpp:1151
 msgid "Is alphanumeric?..."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7284
+#: ../../src/MaximaCommandMenus.cpp:4156
 msgid "Is an alphabetic char?"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7288
+#: ../../src/MaximaCommandMenus.cpp:4160
 msgid "Is an alphanumeric char?"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1991
+#: ../../src/worksheet/WorksheetContextMenu.cpp:763
 #, fuzzy
 msgid "Is an even function"
 msgstr "用户函数列表"
 
-#: ../../src/Worksheet.cpp:1955
+#: ../../src/worksheet/WorksheetContextMenu.cpp:727
 #, fuzzy
 msgid "Is an imaginary variable"
 msgstr "修改变量"
 
-#: ../../src/Worksheet.cpp:1960
+#: ../../src/worksheet/WorksheetContextMenu.cpp:732
 #, fuzzy
 msgid "Is an integer variable"
 msgstr "修改变量"
 
-#: ../../src/Worksheet.cpp:1993
+#: ../../src/worksheet/WorksheetContextMenu.cpp:765
 #, fuzzy
 msgid "Is an odd function"
 msgstr "删除函数"
 
-#: ../../src/wxMaximaFrame.cpp:1122
+#: ../../src/wxMaximaFrame.cpp:1156
 msgid "Is equal?..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1128
+#: ../../src/wxMaximaFrame.cpp:1162
 #, fuzzy
 msgid "Is greater?..."
 msgstr "创建列表"
 
-#: ../../src/wxMaximaFrame.cpp:1125
+#: ../../src/wxMaximaFrame.cpp:1159
 msgid "Is lower?..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1121
+#: ../../src/wxMaximaFrame.cpp:1155
 msgid "Is lowercase?..."
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1962
+#: ../../src/worksheet/WorksheetContextMenu.cpp:734
 #, fuzzy
 msgid "Is no integer variable"
 msgstr "用户变量列表"
 
-#: ../../src/wxMaximaFrame.cpp:1119
+#: ../../src/wxMaximaFrame.cpp:1153
 msgid "Is printable?..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1120
+#: ../../src/wxMaximaFrame.cpp:1154
 msgid "Is uppercase?..."
 msgstr ""
 
-#: ../../src/Worksheet.cpp:6256
+#: ../../src/dialogs/ConfigDialogue.cpp:498
+msgid "Issue a notification if maxima finishes calculating while the wxMaxima window isn't in focus."
+msgstr "如果当 wxMaxima 窗口未处于激活状态时 Maxima 完成计算，则发出通知。"
+
+#: ../../src/worksheet/Worksheet.cpp:4247
 msgid "Issuing the active cell's undo function"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:6261
+#: ../../src/worksheet/Worksheet.cpp:4251
 msgid "Issuing the worksheet's undo function"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8598 ../../src/wxMaxima.cpp:8604
+#: ../../src/dialogs/TipOfTheDay.cpp:185
+msgid "It is possible to add custom symbols to the \"symbols\" sidebar by copying them into the respective field in the configuration dialogue."
+msgstr "只需复制各种符号到配置对话框的相应字段（见菜单“设置->选项”）内，就可以将这些符号添加到“符号”侧边栏。"
+
+#: ../../src/dialogs/TipOfTheDay.cpp:152
+#, fuzzy
+msgid "It is possible to define reusable Maxima libraries with wxMaxima that can be later loaded by using the load() function. All that has to be done is to export a file in the .mac or to save it in the .wxm format. Note, though, that a few special characters like the \"not equal\" symbol for \"#\" are handled by wxMaxima, not by Maxima and therefore cannot be recognized on load()."
+msgstr "使用 wxMaxima 能定义可重用的 Maxima 程序库，只需以 .mac 格式导出文件或以 .wxm 格式保存文件，该程序库随后可以使用 load() 命令加载。不过，应注意一些特殊字符，如表示“不相等”符号的“#”，是由 wxMaxima 而非 Maxima 处理的，因此用 load() 命令无法顺利识别。"
+
+#: ../../src/wizards/DrawWiz.cpp:476
+msgid "It needs to be filled with objects to draw afterwards."
+msgstr ""
+
+#: ../../src/wizards/ActualValuesStorageWiz.cpp:38
+msgid "It therefore makes sense to apply the known values for variables as late as possible."
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:207
+msgid "Italian"
+msgstr "意大利语"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:2111
+msgid "Italic"
+msgstr "斜体"
+
+#: ../../src/MaximaCommandMenus.cpp:1617 ../../src/MaximaCommandMenus.cpp:1623
 msgid "Item"
 msgstr "项"
 
-#: ../../src/wxMaxima.cpp:8581
+#: ../../src/MaximaCommandMenus.cpp:1599
 #, fuzzy
 msgid "Iterator name:"
 msgstr "迭代变量："
 
-#: ../../src/wxMaximaFrame.cpp:1048
-msgid "Jump to first error"
-msgstr "跳转至第一处错误"
+#: ../../src/dialogs/ConfigDialogue.cpp:208
+msgid "Japanese"
+msgstr "日本语"
 
-#: ../../src/wxMaximaFrame.cpp:1049
-msgid "Jump to the first cell Maxima has reported an error in."
-msgstr "跳转至 Maxima 报错的第一个单元格。"
+#: ../../src/MaximaCommandMenus.cpp:2255
+msgid "Jump to UUID"
+msgstr ""
 
-#: ../../src/wxMaxima.cpp:8960
+#: ../../src/wxMaximaFrame.cpp:661
+msgid "Jump to UUID..."
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1082
+msgid "Jump to last error"
+msgstr ""
+
+#: ../../src/dialogs/DiffFrame.cpp:405
+msgid "Jump to next difference"
+msgstr ""
+
+#: ../../src/dialogs/DiffFrame.cpp:404
+msgid "Jump to previous difference"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1083
+msgid "Jump to the last cell Maxima has reported an error in."
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:210
+msgid "Kabyle"
+msgstr "卡拜尔语"
+
+#: ../../src/sidebars/GreekSidebar.cpp:187
+msgid "Kappa"
+msgstr "Kappa"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:864
+#, c-format
+msgid "Keep percent sign with special symbols: %e, %i, etc."
+msgstr "保留特殊符号前的百分号，如 %e，%i 等。"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:212
+msgid "Korean"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:214
 msgid "LCM"
 msgstr "最小公倍式"
 
-#: ../../src/wxMaximaFrame.cpp:1407
+#: ../../src/wxMaximaFrame.cpp:1441
 msgid "L[1] Norm (complex)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1406
+#: ../../src/wxMaximaFrame.cpp:1440
 msgid "L[1] Norm (real)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1409
+#: ../../src/wxMaximaFrame.cpp:1443
 msgid "L[inf] Norm (complex)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1408
+#: ../../src/wxMaximaFrame.cpp:1442
 msgid "L[inf] Norm (real)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1025
+#: ../../src/dialogs/ConfigDialogue.cpp:1166
+msgid "LaTeX"
+msgstr "LaTeX"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1199
+msgid "LaTeX: Place exponents after, instead above subscripts"
+msgstr "LaTeX：将上标文字放在下标文字之后， 而不是之前"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1204
+msgid "LaTeX: Use the \"partial derivative\" symbol to represent diff()"
+msgstr "LaTeX：使用偏导数符号表示 diff()"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:758
+msgid "Label width:"
+msgstr "标签宽度："
+
+#: ../../src/wxMaximaFrame.cpp:1059
 #, fuzzy
 msgid "Labels"
 msgstr "数组的列表"
 
-#: ../../src/wxMaxima.cpp:7090
+#: ../../src/MaximaCommandMenus.cpp:3962
+#: ../../src/sidebars/GreekSidebar.cpp:188
 msgid "Lambda"
 msgstr "Lambda"
 
-#: ../../src/wxMaxima.cpp:7091
+#: ../../src/MaximaCommandMenus.cpp:3963
 msgid ""
 "Lambda generates a function, but doesn't give it a name.\n"
 "This is useful if you want to use a function only once, perhaps as a parameter to another function and don't need it to be named.\n"
 "Also you can fill a variable with a lambda() construct, effectively generating a function pointer: A variable that can be used as a function, and filled with a different function, if needed."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8997
+#: ../../src/dialogs/ConfigDialogue.cpp:470
+msgid "Language used for wxMaxima GUI."
+msgstr "wxMaxima 图形界面使用的语言。"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1311
+msgid "Language:"
+msgstr "语言："
+
+#: ../../src/MaximaCommandMenus.cpp:251
 msgid "Laplace"
 msgstr "Laplace 变换"
 
-#: ../../src/wxMaximaFrame.cpp:1484
+#: ../../src/wxMaximaFrame.cpp:1521
 msgid "Laplace &Transform..."
 msgstr "Laplace 变换(&T)..."
 
-#: ../../src/wxMaximaFrame.cpp:1718
+#: ../../src/wxMaximaFrame.cpp:1755
 msgid "Last"
 msgstr "最后一项"
 
-#: ../../src/wxMaxima.cpp:3006
+#: ../../src/MaximaProcessManager.cpp:557
 #, c-format
 msgid "Last message from maxima's stderr: %s"
 msgstr "来自 Maxima 的 stderr 的最后一个消息：%s"
 
-#: ../../src/wxMaxima.cpp:2993
+#: ../../src/MaximaProcessManager.cpp:544
 #, c-format
 msgid "Last message from maxima's stdout: %s"
 msgstr "来自 Maxima 的 stdout 的最后一个消息：%s"
 
-#: ../../src/wxMaximaFrame.cpp:1720
+#: ../../src/wxMaximaFrame.cpp:1757
 msgid "Last n"
 msgstr "最后 n 项"
 
-#: ../../src/wxMaxima.cpp:10400
+#: ../../src/wxMaxima.cpp:3087
 msgid "Last non-whitespace is a question mark"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:4899
+#: ../../src/dialogs/ConfigDialogue.cpp:213
+msgid "Latvian"
+msgstr ""
+
+#: ../../src/wxMaxima.cpp:1675
 #, fuzzy, c-format
 msgid "Launching the system's default help browser as %s."
 msgstr "启动系统的默认帮助浏览器失败。正在尝试执行 %s。"
 
-#: ../../src/wxMaxima.cpp:4909
+#: ../../src/wxMaxima.cpp:1666 ../../src/wxMaxima.cpp:1687
 #, fuzzy
 msgid "Launching the system's default help browser failed."
 msgstr "启动系统的默认帮助浏览器失败。正在尝试执行 %s。"
 
-#: ../../src/wxMaximaFrame.cpp:1493
+#: ../../src/sidebars/SymbolsSidebar.cpp:126
+msgid "Leads to"
+msgstr "导出"
+
+#: ../../src/wxMaximaFrame.cpp:1530
 msgid "Least Common Multiple..."
 msgstr "最小公倍式..."
 
-#: ../../src/wxMaxima.cpp:9587
+#: ../../src/MaximaCommandMenus.cpp:1827
 msgid "Least Squares Fit"
 msgstr " 最小二乘拟合"
 
-#: ../../src/wxMaxima.cpp:7982 ../../src/wxMaxima.cpp:7987
-#: ../../src/wxMaxima.cpp:8007 ../../src/wxMaxima.cpp:8013
+#: ../../src/sidebars/StatSidebar.cpp:79
+msgid "Least Squares Fit..."
+msgstr "最小二乘拟合..."
+
+#: ../../src/dialogs/ConfigDialogue.cpp:2007
+msgid "Left"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:1166 ../../src/MaximaCommandMenus.cpp:1171
+#: ../../src/MaximaCommandMenus.cpp:1191 ../../src/MaximaCommandMenus.cpp:1197
 #, fuzzy
 msgid "Left Matrix:"
 msgstr "左矩阵"
 
-#: ../../src/wxMaxima.cpp:8191
+#: ../../src/MaximaCommandMenus.cpp:1381
 msgid "Left end"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1297
+#: ../../src/wxMaximaFrame.cpp:1331
 msgid "Left side to the \"=\""
 msgstr "“=” 左边"
 
-#: ../../src/wxMaximaFrame.cpp:1741
+#: ../../src/wxMaximaFrame.cpp:1778
 msgid "Length"
 msgstr "长度"
 
-#: ../../src/wxMaximaFrame.cpp:1104 ../../src/wxMaximaFrame.cpp:1167
+#: ../../src/wxMaximaFrame.cpp:1138 ../../src/wxMaximaFrame.cpp:1201
 #, fuzzy
 msgid "Length..."
 msgstr "长度"
 
-#: ../../src/wxMaxima.cpp:7421
+#: ../../src/MaximaCommandMenus.cpp:4293
 #, fuzzy
 msgid "Length:"
 msgstr "长度"
 
-#: ../../src/wxMaximaFrame.cpp:1032
+#: ../../src/wxMaximaFrame.cpp:1066
 msgid "Letrules"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1976
+#: ../../src/dialogs/TipOfTheDay.cpp:163
+#, fuzzy
+msgid "Libraries can be accessed by any wxMaxima process regardless of which directory it runs in, if they are placed in the user directory. This directory can be found by typing maxima_userdir;"
+msgstr "只要将程序库放在特定用户目录中，那么不管当前 wxMaxima 进程运行的目录是什么，wxMaxima 进程都可以直接访问这些程序库。通过变量 maxima_userdir 的值能确定该特定目录。"
+
+#: ../../src/dialogs/LicenseDialog.cpp:63
+#: ../../src/dialogs/LicenseDialog.cpp:77
+msgid "License"
+msgstr "许可证"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:2068
+msgid "Light"
+msgstr ""
+
+#: ../../src/worksheet/WorksheetContextMenu.cpp:748
 #, fuzzy
 msgid "Likely to be the main variable"
 msgstr "删除变量"
 
-#: ../../src/wxMaxima.cpp:9028
+#: ../../src/MaximaCommandMenus.cpp:282 ../../src/wizards/LimitWiz.cpp:64
 msgid "Limit"
 msgstr "极限"
 
-#: ../../src/wxMaxima.cpp:7256
+#: ../../src/sidebars/MathSidebar.cpp:86
+msgid "Limit..."
+msgstr "极限..."
+
+#: ../../src/sidebars/DrawSidebar.cpp:88
+msgid "Line color"
+msgstr "线条颜色"
+
+#: ../../src/sidebars/StatSidebar.cpp:76
+msgid "Linear Regression..."
+msgstr "线性回归..."
+
+#: ../../src/MaximaCommandMenus.cpp:4128
 #, fuzzy
 msgid "Lisp format string:"
 msgstr "Maxima 位置"
 
-#: ../../src/wxMaxima.cpp:7258
+#: ../../src/MaximaCommandMenus.cpp:4130
 msgid "Lisp format strings are more powerful than c++ format strings"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:5066
+#: ../../src/wxMaxima.cpp:1874
 msgid "Lisp mode."
 msgstr "Lisp 模式"
 
-#: ../../src/wxMaximaFrame.cpp:1010 ../../src/wxMaximaFrame.cpp:1012
+#: ../../src/wxMaximaFrame.cpp:1044 ../../src/wxMaximaFrame.cpp:1046
 msgid "Lisp normally frees memory only when it has time or runs out of space"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3691
+#: ../../src/MaximaResponseReader.cpp:908
 #, c-format
 msgid "Lisp version: %s"
 msgstr "Lisp 版本：%s"
 
-#: ../../src/wxMaxima.cpp:8435 ../../src/wxMaxima.cpp:8539
-#: ../../src/wxMaxima.cpp:8548 ../../src/wxMaxima.cpp:8565
-#: ../../src/wxMaxima.cpp:8574 ../../src/wxMaxima.cpp:8594
-#: ../../src/wxMaxima.cpp:8599 ../../src/wxMaxima.cpp:8603
+#: ../../src/MaximaCommandMenus.cpp:1432 ../../src/MaximaCommandMenus.cpp:1552
+#: ../../src/MaximaCommandMenus.cpp:1561 ../../src/MaximaCommandMenus.cpp:1583
+#: ../../src/MaximaCommandMenus.cpp:1592 ../../src/MaximaCommandMenus.cpp:1613
+#: ../../src/MaximaCommandMenus.cpp:1618 ../../src/MaximaCommandMenus.cpp:1622
 msgid "List"
 msgstr "列表"
 
-#: ../../src/wxMaxima.cpp:8608 ../../src/wxMaxima.cpp:8613
+#: ../../src/MaximaCommandMenus.cpp:1627 ../../src/MaximaCommandMenus.cpp:1632
 #, fuzzy
 msgid "List #1"
 msgstr "列表 1"
 
-#: ../../src/wxMaxima.cpp:8609 ../../src/wxMaxima.cpp:8614
+#: ../../src/MaximaCommandMenus.cpp:1628 ../../src/MaximaCommandMenus.cpp:1633
 #, fuzzy
 msgid "List #2"
 msgstr "列表 2"
 
-#: ../../src/wxMaximaFrame.cpp:1200
+#: ../../src/wxMaximaFrame.cpp:1234
 #, fuzzy
 msgid "List directory"
 msgstr "Maxima 使用临时目录 %s"
 
-#: ../../src/wxMaximaFrame.cpp:1205
+#: ../../src/wxMaximaFrame.cpp:1239
 msgid "List directory..."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7385 ../../src/wxMaxima.cpp:7389
+#: ../../src/wizards/ListSortWiz.cpp:34
+msgid "List name:"
+msgstr "列表名："
+
+#: ../../src/sidebars/VariablesPane.cpp:188
+msgid "List of arrays"
+msgstr "数组的列表"
+
+#: ../../src/sidebars/VariablesPane.cpp:191
+msgid "List of changed options"
+msgstr "变更选项的列表"
+
+#: ../../src/MaximaCommandMenus.cpp:4257
 #, fuzzy
 msgid "List of char to String"
 msgstr "变更选项的列表"
 
-#: ../../src/wxMaximaFrame.cpp:1150
+#: ../../src/wxMaximaFrame.cpp:1184
 #, fuzzy
 msgid "List of chars to string..."
 msgstr "变更选项的列表"
 
-#: ../../src/wxMaxima.cpp:7386
+#: ../../src/MaximaCommandMenus.cpp:4258
 #, fuzzy
 msgid "List of chars:"
 msgstr "数组的列表"
 
-#: ../../src/wxMaxima.cpp:8559
+#: ../../src/sidebars/VariablesPane.cpp:179
+#, fuzzy
+msgid "List of functional dependencies"
+msgstr "用户函数列表"
+
+#: ../../src/sidebars/VariablesPane.cpp:203
+#, fuzzy
+msgid "List of labels"
+msgstr "数组的列表"
+
+#: ../../src/sidebars/VariablesPane.cpp:200
+msgid "List of structs"
+msgstr "结构列表"
+
+#: ../../src/sidebars/VariablesPane.cpp:197
+msgid "List of user aliases"
+msgstr "用户别名列表"
+
+#: ../../src/sidebars/VariablesPane.cpp:185
+msgid "List of user functions"
+msgstr "用户函数列表"
+
+#: ../../src/sidebars/VariablesPane.cpp:194
+msgid "List of user rules"
+msgstr "用户规则列表"
+
+#: ../../src/sidebars/VariablesPane.cpp:182
+msgid "List of user variables"
+msgstr "用户变量列表"
+
+#: ../../src/sidebars/VariablesPane.cpp:206
+msgid "List of user-defined derivatives"
+msgstr "用户定义的导数列表"
+
+#: ../../src/sidebars/VariablesPane.cpp:216
+msgid "List of user-defined let rule packages"
+msgstr "用户定义的 let 规则程序包列表"
+
+#: ../../src/sidebars/VariablesPane.cpp:212
+#, fuzzy
+msgid "List of user-defined macros"
+msgstr "用户定义的性质列表"
+
+#: ../../src/sidebars/VariablesPane.cpp:209
+msgid "List of user-defined properties"
+msgstr "用户定义的性质列表"
+
+#: ../../src/MaximaCommandMenus.cpp:1575
 msgid "List with values"
 msgstr "数值列表"
 
-#: ../../src/wxMaxima.cpp:8509 ../../src/wxMaxima.cpp:8527
-#: ../../src/wxMaxima.cpp:8533 ../../src/wxMaxima.cpp:8579
+#: ../../src/MaximaCommandMenus.cpp:1451 ../../src/MaximaCommandMenus.cpp:1510
+#: ../../src/MaximaCommandMenus.cpp:1515 ../../src/MaximaCommandMenus.cpp:1520
+#: ../../src/MaximaCommandMenus.cpp:1524 ../../src/MaximaCommandMenus.cpp:1528
+#: ../../src/MaximaCommandMenus.cpp:1532 ../../src/MaximaCommandMenus.cpp:1538
+#: ../../src/MaximaCommandMenus.cpp:1544 ../../src/MaximaCommandMenus.cpp:1597
+#: ../../src/MaximaCommandMenus.cpp:1608
 msgid "List:"
 msgstr "列表："
 
-#: ../../src/wxMaxima.cpp:6200
+#: ../../src/dialogs/ConfigDialogue.cpp:214
+msgid "Lithuanian"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:2162
+msgid "Load"
+msgstr "载入"
+
+#: ../../src/MaximaCommandMenus.cpp:2356
 msgid "Load Package"
 msgstr "载入程序包"
 
-#: ../../src/wxMaximaFrame.cpp:613
+#: ../../src/wxMaximaFrame.cpp:644
 msgid "Load Recent Package"
 msgstr "载入最近的程序包"
 
-#: ../../src/wxMaximaFrame.cpp:616
+#: ../../src/wxMaximaFrame.cpp:647
 msgid "Load a Maxima file using the batch command"
 msgstr "使用 batch() 命令载入 Maxima 文件"
 
-#: ../../src/wxMaximaFrame.cpp:611
+#: ../../src/wxMaximaFrame.cpp:642
 msgid "Load a Maxima package file"
 msgstr "载入 Maxima 程序包文件"
 
-#: ../../src/wxMaximaFrame.cpp:1678
-msgid "Load a list from a csv file"
-msgstr "从 csv 文件载入列表"
-
-#: ../../src/wxMaximaFrame.cpp:1324 ../../src/wxMaximaFrame.cpp:1330
+#: ../../src/wxMaximaFrame.cpp:1358 ../../src/wxMaximaFrame.cpp:1364
 msgid "Load a matrix from a csv file"
 msgstr "从 csv 文件载入矩阵"
 
-#: ../../src/wxMaximaFrame.cpp:1381 ../../src/wxMaximaFrame.cpp:1382
+#: ../../src/wxMaximaFrame.cpp:1715
+msgid "Load a nested list from a csv file"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1415 ../../src/wxMaximaFrame.cpp:1416
 #, fuzzy
 msgid "Load lapack"
 msgstr "载入程序包"
 
-#: ../../src/wxMaxima.cpp:7208
+#: ../../src/MaximaCommandMenus.cpp:4080
 #, fuzzy
 msgid "Load lisp code"
 msgstr "Lisp 模式"
 
-#: ../../src/wxMaximaFrame.cpp:1092
+#: ../../src/wxMaximaFrame.cpp:1126
 #, fuzzy
 msgid "Load lisp..."
 msgstr "载入程序包"
 
-#: ../../src/wxMaximaFrame.cpp:1198
+#: ../../src/dialogs/ConfigDialogue.cpp:2645
+msgid "Load style from file"
+msgstr "从文件载入样式"
+
+#: ../../src/wxMaximaFrame.cpp:1232
 msgid "Load the file/dir operations (operatingsystem)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1187
+#: ../../src/wxMaximaFrame.cpp:1221
 msgid "Load the regular expression package (sregex)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1224
+#: ../../src/wxMaximaFrame.cpp:1258
 msgid "Load the translation generator (gentran)"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8219
+#: ../../src/sidebars/SymbolsSidebar.cpp:128
+msgid "Long Right arrow"
+msgstr "长右箭头"
+
+#: ../../src/MaximaCommandMenus.cpp:1409
 #, fuzzy
 msgid "Loop variable"
 msgstr "新变量："
 
-#: ../../src/wxMaxima.cpp:7778 ../../src/wxMaxima.cpp:10040
+#: ../../src/MaximaCommandMenus.cpp:959 ../../src/MaximaCommandMenus.cpp:3529
 msgid "Lower bound:"
 msgstr "下限："
 
-#: ../../src/wxMaximaFrame.cpp:1127
+#: ../../src/wxMaximaFrame.cpp:1161
 msgid "Lower, ignoring case?..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1448
+#: ../../src/wxMaximaFrame.cpp:1485
 msgid "M&atrix"
 msgstr "矩阵(&A)"
 
-#: ../../src/wxMaxima.cpp:7153
+#: ../../src/sidebars/XmlInspector.cpp:104
+msgid "MAXIMA RESPONSE:"
+msgstr "Maxima 回应："
+
+#: ../../src/MaximaCommandMenus.cpp:4025
 #, fuzzy
 msgid "Macro contents:"
 msgstr "隐藏内容"
 
-#: ../../src/wxMaxima.cpp:7148
+#: ../../src/MaximaCommandMenus.cpp:4020
 #, fuzzy
 msgid "Macro name:"
 msgstr "矩阵名称："
 
-#: ../../src/wxMaximaFrame.cpp:1024
+#: ../../src/wxMaximaFrame.cpp:1058
 msgid "Macros"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:697
-msgid "Main Toolbar\tAlt+Shift+B"
-msgstr "主工具栏\tAlt+Shift+B"
+#: ../../src/wxMaximaFrame.cpp:869
+msgid "Main Toolbar\tShift+Alt+B"
+msgstr ""
 
-#: ../../src/wxMaxima.cpp:7906
+#: ../../src/MaximaCommandMenus.cpp:1087
 msgid "Make a function value at a specific point known"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:2028
+#: ../../src/worksheet/WorksheetContextMenu.cpp:800
 msgid "Make an eventual ev() evaluate this"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1070
+#: ../../src/wxMaximaFrame.cpp:1104
 #, fuzzy
 msgid "Make function local..."
 msgstr "映射函数至列表"
 
-#: ../../src/wxMaxima.cpp:8207
+#: ../../src/dialogs/ConfigDialogue.cpp:215
+msgid "Malay"
+msgstr ""
+
+#: ../../src/sidebars/PerformanceSidebar.cpp:33
+msgid "Manual anchors (built-in):"
+msgstr ""
+
+#: ../../src/sidebars/PerformanceSidebar.cpp:34
+msgid "Manual anchors (cache):"
+msgstr ""
+
+#: ../../src/sidebars/PerformanceSidebar.cpp:35
+msgid "Manual anchors (compiled):"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:1397
 msgid "Map"
 msgstr "映射"
 
-#: ../../src/wxMaxima.cpp:8215
+#: ../../src/MaximaCommandMenus.cpp:1405
 #, fuzzy
 msgid "Map an expression"
 msgstr "展开一个表达式"
 
-#: ../../src/wxMaximaFrame.cpp:1443
+#: ../../src/wxMaximaFrame.cpp:1480
 msgid "Map function to a matrix"
 msgstr "映射函数至矩阵"
 
-#: ../../src/wxMaximaFrame.cpp:1446
+#: ../../src/wxMaximaFrame.cpp:1483
 #, fuzzy
 msgid "Map function to a matrix, affecting all of its clones"
 msgstr "映射函数至矩阵"
 
-#: ../../src/Configuration.cpp:109
+#: ../../src/dialogs/FindReplacePane.cpp:71
+msgid "Match Case"
+msgstr "区分大小写"
+
+#: ../../src/Styles.cpp:139
 msgid "Math Default"
 msgstr "数学默认"
 
-#: ../../src/wxMaximaFrame.cpp:286
+#: ../../src/dialogs/ConfigDialogue.cpp:789
+msgid "Math layout strategy"
+msgstr ""
+
+#: ../../src/cells/Cell.cpp:1490
+msgid "Math output"
+msgstr "数学输出"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1221
+msgid "MathML (rendered by the browser)"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1222
+msgid "MathML + MathJaX fall-back for old browsers"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1906
+msgid "MathML as HTML"
+msgstr "MathML 的 HTML 代码"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1902
+msgid "MathML description"
+msgstr "MathML 描述"
+
+#: ../../src/wxMaximaFrame.cpp:307
 msgid "Mathematical Symbols"
 msgstr "数学符号"
 
-#: ../../src/ToolBar.cpp:270
+#: ../../src/ToolBar.cpp:480
 msgid "Maths"
 msgstr "数学（命令）"
 
-#: ../../src/wxMaxima.cpp:7945 ../../src/wxMaxima.cpp:8022
-#: ../../src/wxMaxima.cpp:8027 ../../src/wxMaxima.cpp:8032
-#: ../../src/wxMaxima.cpp:8037 ../../src/wxMaxima.cpp:8041
-#: ../../src/wxMaxima.cpp:8053 ../../src/wxMaxima.cpp:8059
-#: ../../src/wxMaxima.cpp:8064 ../../src/wxMaxima.cpp:8069
-#: ../../src/wxMaxima.cpp:8075 ../../src/wxMaxima.cpp:8080
-#: ../../src/wxMaxima.cpp:8085 ../../src/wxMaxima.cpp:8090
-#: ../../src/wxMaxima.cpp:8096 ../../src/wxMaxima.cpp:8101
-#: ../../src/wxMaxima.cpp:8152 ../../src/wxMaxima.cpp:8182
+#: ../../src/MaximaCommandMenus.cpp:1125 ../../src/MaximaCommandMenus.cpp:1206
+#: ../../src/MaximaCommandMenus.cpp:1211 ../../src/MaximaCommandMenus.cpp:1216
+#: ../../src/MaximaCommandMenus.cpp:1221 ../../src/MaximaCommandMenus.cpp:1225
+#: ../../src/MaximaCommandMenus.cpp:1239 ../../src/MaximaCommandMenus.cpp:1245
+#: ../../src/MaximaCommandMenus.cpp:1250 ../../src/MaximaCommandMenus.cpp:1255
+#: ../../src/MaximaCommandMenus.cpp:1261 ../../src/MaximaCommandMenus.cpp:1266
+#: ../../src/MaximaCommandMenus.cpp:1273 ../../src/MaximaCommandMenus.cpp:1278
+#: ../../src/MaximaCommandMenus.cpp:1284 ../../src/MaximaCommandMenus.cpp:1289
+#: ../../src/MaximaCommandMenus.cpp:1340 ../../src/MaximaCommandMenus.cpp:1370
 msgid "Matrix"
 msgstr "矩阵"
 
-#: ../../src/wxMaxima.cpp:7986
+#: ../../src/MaximaCommandMenus.cpp:1170
 #, fuzzy
 msgid "Matrix Exponent"
 msgstr "矩阵指数："
 
-#: ../../src/wxMaximaFrame.cpp:1339
+#: ../../src/wxMaximaFrame.cpp:1373
 #, fuzzy
 msgid "Matrix exponent..."
 msgstr "矩阵指数："
 
-#: ../../src/wxMaximaFrame.cpp:1329
+#: ../../src/wxMaximaFrame.cpp:1363
 msgid "Matrix from csv file"
 msgstr "矩阵（从 .csv 文件）"
 
-#: ../../src/wxMaximaFrame.cpp:1323
+#: ../../src/wxMaximaFrame.cpp:1357
 #, fuzzy
 msgid "Matrix from csv file..."
 msgstr "矩阵（从 .csv 文件）"
 
-#: ../../src/wxMaxima.cpp:8137
+#: ../../src/MaximaCommandMenus.cpp:1325
 msgid "Matrix map"
 msgstr "矩阵映射"
 
-#: ../../src/wxMaxima.cpp:9630
+#: ../../src/MaximaCommandMenus.cpp:1870
 msgid "Matrix name:"
 msgstr "矩阵名称："
 
-#: ../../src/wxMaximaFrame.cpp:798
+#: ../../src/wxMaximaFrame.cpp:835
 msgid "Matrix parenthesis"
 msgstr "矩阵括号"
 
-#: ../../src/wxMaximaFrame.cpp:1331
+#: ../../src/wxMaximaFrame.cpp:1365
 msgid "Matrix to csv file"
 msgstr "矩阵至 .csv 文件"
 
-#: ../../src/wxMaximaFrame.cpp:1334
+#: ../../src/wxMaximaFrame.cpp:1368
 msgid "Matrix to file or Matrix from file"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1761
+#: ../../src/wxMaximaFrame.cpp:1798
 msgid "Matrix to nested List"
 msgstr "矩阵至嵌套列表"
 
-#: ../../src/wxMaxima.cpp:7956 ../../src/wxMaxima.cpp:7961
-#: ../../src/wxMaxima.cpp:7966 ../../src/wxMaxima.cpp:7971
-#: ../../src/wxMaxima.cpp:7976 ../../src/wxMaxima.cpp:8000
-#: ../../src/wxMaxima.cpp:8136
+#: ../../src/MaximaCommandMenus.cpp:1456
+msgid "Matrix to nested list"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:1136 ../../src/MaximaCommandMenus.cpp:1141
+#: ../../src/MaximaCommandMenus.cpp:1146 ../../src/MaximaCommandMenus.cpp:1151
+#: ../../src/MaximaCommandMenus.cpp:1156 ../../src/MaximaCommandMenus.cpp:1161
+#: ../../src/MaximaCommandMenus.cpp:1184 ../../src/MaximaCommandMenus.cpp:1324
+#: ../../src/MaximaCommandMenus.cpp:1457
 msgid "Matrix:"
 msgstr "矩阵："
 
-#: ../../src/wxMaxima.cpp:8627
-msgid ""
-"Maxima allows to make functions \"nouns\", which means that they aren't automatically evaluated as soon as maxima encounters them.\n"
-"Ways make a function a noun include declaring it a noun, preceding it with a  ' or putting it between the parenthesis of '().\n"
-"\n"
-"This command tells maxima that the nouns in this expression shall now be evaluated, too."
+#: ../../src/dialogs/ConfigDialogue.cpp:1370
+msgid "Max. layout time [s] (0=no limit)"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3473
+#: ../../src/dialogs/ConfigDialogue.cpp:281
+msgid "Maxima"
+msgstr "Maxima"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1433
+msgid "Maxima Location"
+msgstr "Maxima 位置"
+
+#: ../../src/MaximaCommandMenus.cpp:619
+msgid ""
+"Maxima allows making functions \"nouns\", which means that they aren't automatically evaluated as soon as Maxima encounters them.\n"
+"Ways to make a function a noun include declaring it a noun, preceding it with a single quote or putting it between the parentheses of '().\n"
+"\n"
+"This command tells Maxima that the nouns in this expression shall now be evaluated, too."
+msgstr ""
+
+#: ../../src/MaximaResponseReader.cpp:803
 #, c-format
 msgid "Maxima architecture: %s"
 msgstr "Maxima 架构：%s"
 
-#: ../../src/StatusBar.cpp:252
+#: ../../src/StatusBar.cpp:330
 msgid "Maxima asks a question"
 msgstr "Maxima 提出问题"
 
-#: ../../src/wxMaxima.cpp:4066
+#: ../../src/MaximaResponseReader.cpp:560
 msgid "Maxima asks a question!"
 msgstr "Maxima 提出问题！"
 
-#: ../../src/wxMaxima.cpp:7118
+#: ../../src/dialogs/ConfigDialogue.cpp:362
+#, c-format
+msgid "Maxima assigns each command/equation an automatic label (which looks like %i1 or %o1). If a command begins with a descriptive name followed by a : wxMaxima will call the descriptive name a \"user-defined label\" instead. This selection now allows telling wxMaxima whether to show only automatic labels, automatic labels if there aren't user-defined ones or no label at all until a user-defined label can be found by wxMaxima's heuristics. If automatic labels are suppressed extra vertical space is added between equations in order to ease discerning which line starts a new equation and which one only continues the one from the last line."
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:3990
 msgid ""
 "Maxima automatically simplifies expressions it gets as input and then tries to evaluate their value. The ' operator tells maxima that we want a command to be in noun form, which means: stand here as is, and unevaluated.\n"
 "The ' operator can be undone by using the '' operator."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3304
+#: ../../src/cells/EditorCell.cpp:4516
+msgid "Maxima code"
+msgstr "wxMaxima 代码"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1110
+msgid "Maxima commands to be executed at every start of Maxima"
+msgstr "Maxima 每次启动时执行的 Maxima 命令"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1063
+msgid "Maxima commands to be executed every time wxMaxima starts Maxima"
+msgstr "wxMaxima 每次启动 Maxima 时执行的 Maxima 命令"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1507
+msgid "Maxima configuration"
+msgstr "Maxima 设置"
+
+#: ../../src/MaximaResponseReader.cpp:346
 msgid "Maxima didn't attempt to authenticate!"
 msgstr ""
 
-#: ../../src/Configuration.cpp:84
+#: ../../src/Styles.cpp:113
 msgid "Maxima errors"
 msgstr "Maxima 错误"
 
-#: ../../src/wxMaxima.cpp:3289
+#: ../../src/MaximaResponseReader.cpp:338
 #, fuzzy
 msgid "Maxima has authenticated!"
 msgstr "Maxima 已中止。"
 
-#: ../../src/wxMaxima.cpp:10533
+#: ../../src/MaximaEvaluator.cpp:369
 msgid "Maxima has finished calculating."
 msgstr "Maxima 已完成计算。"
 
-#: ../../src/wxMaxima.cpp:5832
+#: ../../src/MaximaEvaluator.cpp:191
 msgid "Maxima has issued an error!"
 msgstr "Maxima 抛出错误！"
 
-#: ../../src/wxMaxima.cpp:3696
+#: ../../src/MaximaResponseReader.cpp:913
 #, c-format
 msgid "Maxima has loaded the file %s."
 msgstr "Maxima 已载入文件 %s。"
 
-#: ../../src/wxMaxima.cpp:3382
+#: ../../src/MaximaResponseReader.cpp:761
 msgid "Maxima has sent a new variable value."
 msgstr "Maxima 已给出变量的新值。"
 
-#: ../../src/MaximaManual.cpp:552
+#: ../../src/StatusBar.cpp:349
+msgid ""
+"Maxima has stopped in a debugger and is waiting for a command.\n"
+"Common commands (type ':h' for the full list):\n"
+"  :bt        show a backtrace of the call stack\n"
+"  :continue  continue the computation\n"
+"  :top       return to the top level (abandon the computation)\n"
+"  :next / :step   step to the next line\n"
+"  :frame     show the current stack frame"
+msgstr ""
+
+#: ../../src/MaximaManual.cpp:576
 #, fuzzy
 msgid "Maxima help file not found!"
 msgstr "文件无法找到"
 
-#: ../../src/wxMaximaFrame.cpp:1043
+#: ../../src/wxMaximaFrame.cpp:1077
 msgid "Maxima input"
 msgstr "Maxima 输入"
 
-#: ../../src/StatusBar.cpp:236
+#: ../../src/StatusBar.cpp:299
 msgid "Maxima is calculating"
 msgstr "Maxima 正在计算"
 
-#: ../../src/wxMaxima.cpp:5068
+#: ../../src/wxMaxima.cpp:1876
 msgid "Maxima is ready for input."
 msgstr "Maxima 已就绪，等待输入。"
 
-#: ../../src/Dirstructure.cpp:144
+#: ../../src/Dirstructure.cpp:153
 #, c-format
 msgid "Maxima not found as %s"
 msgstr "Maxima 未作为 %s 被找到"
 
-#: ../../src/wxMaxima.cpp:6211
+#: ../../src/MaximaCommandMenus.cpp:2367
 msgid "Maxima package (*.mac)|*.mac"
 msgstr "Maxima 程序包 (*.mac)|*.mac"
 
-#: ../../src/wxMaxima.cpp:6202
+#: ../../src/MaximaCommandMenus.cpp:2358
 msgid "Maxima package (*.mac)|*.mac|Lisp package (*.lisp)|*.lisp|All|*"
 msgstr "Maxima 程序包 (*.mac)|*.mac|Lisp 程序包 (*.lisp)|*.lisp|全部类型|*"
 
-#: ../../src/wxMaxima.cpp:3012
+#: ../../src/MaximaProcessManager.cpp:569
 msgid "Maxima process terminated unexpectedly."
 msgstr "Maxima 进程意外中止。"
 
-#: ../../src/Configuration.cpp:79
+#: ../../src/dialogs/ConfigDialogue.cpp:1437
+msgid "Maxima program:"
+msgstr "Maxima 程序："
+
+#: ../../src/dialogs/ConfigDialogue.cpp:382
+msgid "Maxima provides no \"forget all\" command that flushes all settings a maxima session could make. wxMaxima therefore normally defaults to starting a fresh maxima process every time the worksheet is to be re-evaluated. As this needs a little bit of time this switch allows to disable this behavior."
+msgstr "Maxima 没有提供“忘记所有内容”命令来刷新当前 Maxima 会话已有的所有设置。因此，每次重新计算工作簿中的所有式子时，wxMaxima 默认启动一个新的 Maxima 进程。这个过程通常需要一点时间，而此选项可以禁用该过程。"
+
+#: ../../src/Styles.cpp:108
 #, fuzzy
 msgid "Maxima question labels"
 msgstr "Maxima 提的问题"
 
-#: ../../src/wxMaxima.cpp:3380
+#: ../../src/StatusBar.cpp:339
+msgid "Maxima returned an error message"
+msgstr ""
+
+#: ../../src/MaximaResponseReader.cpp:759
 msgid "Maxima sends a new set of auto-completable symbols."
 msgstr "Maxima 发送一组新的自动完成符号。"
 
-#: ../../src/wxMaxima.cpp:3908
+#: ../../src/MaximaResponseReader.cpp:1024
 msgid "Maxima sends us a new set of variables for the watch list."
 msgstr "Maxima 向监视列表发送一组新变量。"
 
-#: ../../src/wxMaximaFrame.cpp:1944
+#: ../../src/sidebars/History.cpp:153
+msgid "Maxima session (*.mac)|*.mac"
+msgstr "Maxima 会话 (*.mac)|*.mac"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1518 ../../src/wxMaximaFrame.cpp:1981
 msgid "Maxima shows help in a browser"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1940
+#: ../../src/dialogs/ConfigDialogue.cpp:1523 ../../src/wxMaximaFrame.cpp:1977
 msgid "Maxima shows help in a sidebar"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1935
+#: ../../src/dialogs/ConfigDialogue.cpp:1511 ../../src/wxMaximaFrame.cpp:1972
 #, fuzzy
 msgid "Maxima shows help in the console"
 msgstr "文件无法找到"
 
-#: ../../src/StatusBar.cpp:232
+#: ../../src/StatusBar.cpp:290
 #, fuzzy
 msgid "Maxima started. Waiting for authentication..."
 msgstr "Maxima 已启动。等待连接中..."
 
-#: ../../src/StatusBar.cpp:212
+#: ../../src/StatusBar.cpp:245
 msgid "Maxima started. Waiting for connection..."
 msgstr "Maxima 已启动。等待连接中..."
 
-#: ../../src/StatusBar.cpp:228
+#: ../../src/StatusBar.cpp:281
 #, fuzzy
 msgid "Maxima started. Waiting for initial prompt..."
 msgstr "Maxima 已启动。等待连接中..."
 
-#: ../../src/wxMaximaFrame.cpp:1231
+#: ../../src/sidebars/PerformanceSidebar.cpp:36
+msgid "Maxima starts:"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1143
+msgid "Maxima startup file location: "
+msgstr "Maxima 启动文件位置："
+
+#: ../../src/dialogs/TipOfTheDay.cpp:68
+msgid "Maxima supports three types of numbers: exact fractions (which can be generated for example by typing 1/10), IEEE floating-point numbers (0.2) and arbitrary precision big floats (1b-1). Note that, owing to their nature as binary (not decimal) numbers, there is for example no way to generate an IEEE floating-point number that exactly equals 0.1. If floating-point numbers are used instead of fractions, Maxima will therefore sometimes have to introduce a (very small) error and use things like 3602879701896397/36028797018963968 for 0.1."
+msgstr "Maxima 支持的数值类型有三种：表示准确数值的分数（如 1/10）、IEEE 浮点数（如 0.2）和任意精度大浮点数（如 1b-1）。注意，由于 IEEE 浮点数是由二进制（而非十进制）表示的，所以无法生成恰好等于 0.1 的 IEEE 浮点数。如果强制使用此种浮点数，如 0.1，Maxima 在计算时将使用类似于3602879701896397/36028797018963968 的分数来表示它，因此会引入一个（非常小的）误差。"
+
+#: ../../src/wxMaximaFrame.cpp:1265
 #, fuzzy
 msgid "Maxima to other language"
 msgstr "Maxima 位置"
 
-#: ../../src/wxMaxima.cpp:7213
+#: ../../src/MaximaCommandMenus.cpp:4085
 #, fuzzy
 msgid "Maxima to string"
 msgstr "Maxima 位置"
 
-#: ../../src/wxMaxima.cpp:3397
+#: ../../src/cells/TextCell.cpp:255
+msgid "Maxima tried to find out where between two points a curve crosses the zero line. Since the curve is on the same side of the zero line in both points its algorithms fails here. Set find_root_error to false if you want it to return false instead of an error."
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1615
+msgid "Maxima usage"
+msgstr "Maxima 用法"
+
+#: ../../src/MaximaResponseReader.cpp:776
 #, fuzzy, c-format
 msgid "Maxima user configuration is located in directory %s"
 msgstr "Maxima 用户配置文件位于目录 %s"
 
-#: ../../src/wxMaxima.cpp:3443
+#: ../../src/dialogs/TipOfTheDay.cpp:59
+msgid ""
+"Maxima uses ':' to assign values to a variable ('a : 3;'), not '=' as most programming languages do.\n"
+"This allows, that a mathematical equation can be assigned to a variable, e.g.\n"
+" eq1:3*x=4;\n"
+"which may then be solved for x with\n"
+"solve(eq1,x);"
+msgstr ""
+
+#: ../../src/dialogs/TipOfTheDay.cpp:63
+#, fuzzy
+msgid ""
+"Maxima uses ':=' to define functions, e.g.:\n"
+"f(x) := x^2;"
+msgstr "Maxima 使用“:”来赋值（如“a : 3;”) ，使用“:=”来定义函数（如“f(x) := x^2;”）。"
+
+#: ../../src/MaximaResponseReader.cpp:788
 #, c-format
 msgid "Maxima uses temp directory %s"
 msgstr "Maxima 使用临时目录 %s"
 
-#: ../../src/wxMaxima.cpp:3469
+#: ../../src/dialogs/AboutDialog.cpp:50
+#, fuzzy
+msgid "Maxima version: "
+msgstr ""
+"\n"
+"Maxima 版本："
+
+#: ../../src/MaximaResponseReader.cpp:799
 #, c-format
 msgid "Maxima version: %s"
 msgstr "Maxima 版本：%s"
 
-#: ../../src/MaximaManual.cpp:390
+#: ../../src/MaximaManual.cpp:407
 #, fuzzy, c-format
 msgid "Maxima version: %s, Anchors cache version"
 msgstr "Maxima 版本：%s"
 
-#: ../../src/wxMaximaFrame.cpp:1925
+#: ../../src/wxMaximaFrame.cpp:1962
 #, fuzzy
 msgid "Maxima vs. Programming languages"
 msgstr "显示五级标题"
 
-#: ../../src/Configuration.cpp:83
+#: ../../src/Styles.cpp:112
 msgid "Maxima warnings"
 msgstr "Maxima 警告"
 
-#: ../../src/wxMaxima.cpp:3687
+#: ../../src/MaximaResponseReader.cpp:904
 #, c-format
 msgid "Maxima was compiled using %s"
 msgstr "Maxima 使用 %s 编译"
 
-#: ../../src/wxMaxima.cpp:3487
+#: ../../src/dialogs/AboutDialog.cpp:53
+#, fuzzy
+msgid "Maxima was compiled using: "
+msgstr "Maxima 使用 %s 编译"
+
+#: ../../src/dialogs/TipOfTheDay.cpp:201
+msgid ""
+"Maxima's \"at\" function allows accessing arbitrary variables in a list of results:\n"
+"\n"
+"    g1:a*x+y=0;\n"
+"    g2:b*y+x*x=1;\n"
+"    solve([g1,g2],[a,b]);\n"
+"    %[1];\n"
+"    result_b:b=at(b,%);"
+msgstr ""
+
+#: ../../src/MaximaResponseReader.cpp:817
 #, c-format
 msgid "Maxima's HTML manuals are in directory %s"
 msgstr "Maxima 的用户手册（HTML 文件）位于目录 %s"
 
-#: ../../src/wxMaxima.cpp:3099
+#: ../../src/MaximaResponseReader.cpp:599
+msgid "Maxima's Lisp (sbcl) has stopped in its low-level debugger (LDB). The Lisp cannot continue; you can enter LDB commands - for example \"backtrace\" for a stack trace, or \"exit\" to quit it."
+msgstr ""
+
+#: ../../src/MaximaResponseReader.cpp:597
+msgid "Maxima's Lisp entered sbcl's low-level debugger (LDB)."
+msgstr ""
+
+#: ../../src/MaximaResponseReader.cpp:240
+#: ../../src/MaximaResponseReader.cpp:242
 #, c-format
 msgid "Maxima's PID is %li"
 msgstr "Maxima 的 PID 是 %li"
 
-#: ../../src/wxMaxima.cpp:3681
+#: ../../src/MaximaResponseReader.cpp:898
 #, fuzzy, c-format
 msgid "Maxima's demo files are located in directory %s"
 msgstr "Maxima 的共享文件位于目录 %s"
 
-#: ../../src/wxMaxima.cpp:3478
+#: ../../src/MaximaResponseReader.cpp:808
 #, fuzzy, c-format
 msgid "Maxima's manual is located in directory %s"
 msgstr "Maxima 的用户手册位于目录 %s"
 
-#: ../../src/wxMaxima.cpp:3670
+#: ../../src/wizards/ActualValuesStorageWiz.cpp:34
+msgid "Maxima's power lies in symbolic operations."
+msgstr ""
+
+#: ../../src/StatusBar.cpp:365
+msgid ""
+"Maxima's reader is in Lisp mode (after to_lisp()).\n"
+"Type Lisp forms; enter (to-maxima) to return to Maxima mode."
+msgstr ""
+
+#: ../../src/MaximaResponseReader.cpp:887
 #, fuzzy, c-format
 msgid "Maxima's share files are located in directory %s"
 msgstr "Maxima 的共享文件位于目录 %s"
 
-#: ../../src/StatusBar.cpp:66
+#: ../../src/dialogs/TipOfTheDay.cpp:188
+msgid ""
+"Maxima's strengths are manipulating equations and in symbolic calculations. It therefore makes sense to use functions (as opposed to equations with labels) sparingly and to keep the actual values of variables in a list, instead of directly assigning them values. An example session that does do so would be:\n"
+"\n"
+"/* We keep the actual values in a list so we can use them later on */\n"
+"    Values:[a=10,c=100];\n"
+"    Pyth:a^2+b^2=c^2;\n"
+"    solve(%,b);\n"
+"    result:%[2];\n"
+"    at(result,Values);\n"
+"    float(%);"
+msgstr ""
+"Maxima 的优势在于对方程变形和进行符号计算，因此与其使用函数，不如使用带（名称）标签的方程，以及储存变量的实际值为一个列表，而不是直接对变量赋值。一个例子如下：\n"
+"\n"
+"/* 将实际数值储存在列表中，以便于将来使用 */\n"
+"    Values:[a=10,c=100];\n"
+"    Pyth:a^2+b^2=c^2;\n"
+"    solve(%,b);\n"
+"    result:%[2];\n"
+"    at(result,Values);\n"
+"    float(%);"
+
+#: ../../src/StatusBar.cpp:73
 msgid "Maxima, the program that does the actual mathematics and wxMaxima, which displays the worksheet are kept in separate processes. This means that even if maxima crashes wxMaxima (and therefore the worksheet) stays intact. Both programs communicate over a local network socket. This time this socket could not be created which might be caused by a firewall that it setup to not only intercepts connections from the outside, but also to intercept connections between two programs that run on the same computer."
 msgstr "Maxima 是进行实际数学运算的程序，wxMaxima 是显示工作簿的程序，两者使用不同的进程。这意味着即使 Maxima 崩溃，wxMaxima（因此工作簿）也不受影响。两个程序通过本地网络套接字（socket）进行通信。这次无法创建此套接字，可能是由于防火墙设置为不仅拦截来自外部的连接，而且还拦截在同一台计算机上运行的两个程序之间的连接。"
 
-#: ../../src/StatusBar.cpp:75
+#: ../../src/StatusBar.cpp:82
 msgid "Maxima, the program that does the actual mathematics and wxMaxima, which displays the worksheet are kept in separate processes. This means that even if maxima crashes wxMaxima (and therefore the worksheet) stays intact. Currently the two programs aren't connected to each other which might mean that maxima is still starting up or couldn't be started. Alternatively it can be caused by a firewall that it setup to not only intercepts connections from the outside, but also to intercept connections between two programs that run on the same computer. Another reason for maxima not starting up might be that maxima cannot be found (see wxMaxima's Configuration dialogue for a way to specify maxima's location) or isn't in a working order."
 msgstr "Maxima 是进行实际数学运算的程序，wxMaxima 是显示工作簿的程序，两者使用不同的进程。这意味着即使 Maxima 崩溃，wxMaxima（因此工作簿）也不受影响。目前这两个程序没有连接，可能因为 Maxima 仍在启动中或无法启动；也可能是由于防火墙设置为不仅拦截来自外部的连接，而且还拦截在同一台计算机上运行的两个程序之间的连接。Maxima 不能启动的另一个原因可能是找不到 Maxima（关于指定 Maxima 位置的方法，可查看 wxMaxima 的设置对话框）或 Maxima 没有处于工作状态。"
 
-#: ../../src/StatusBar.cpp:61
+#: ../../src/StatusBar.cpp:68
 msgid ""
 "Maxima, the program that does the actual mathematics is started as a separate process. This has the advantage that an eventual crash of maxima cannot harm wxMaxima, which displays the worksheet.\n"
 "This icon indicates if data is transferred between maxima and wxMaxima."
@@ -4755,176 +7124,308 @@ msgstr ""
 "Maxima（计算实际数学的程序）使用单独的进程。这种设置的最大优点是即使 Maxima 崩溃也不会影响 wxMaxima（显示工作簿的程序）。\n"
 "此图标指示是否有数据在 Maxima 和 wxMaxima 之间传输。"
 
-#: ../../src/wxMaxima.cpp:9228
+#: ../../src/dialogs/MaximaNotStartingDialog.cpp:39
+msgid "Maxima, the program that does the actual maths, cannot be started. This might mean that it isn't installed (it can be found at ↗https://maxima.sourceforge.net) or that wxMaxima doesn't know where to search for it. In that case please choose the location of a working maxima binary"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:419
 #, fuzzy
 msgid "Maximum absolute value printed without exponent"
 msgstr "不自动转为工程数字表示的最大绝对值："
 
-#: ../../src/wxMaxima.cpp:9230
+#: ../../src/dialogs/ConfigDialogue.cpp:1931
+msgid "Maximum bitmap size on clipboard [Mb]:"
+msgstr "剪贴板上的最大位图大小 [Mb]："
+
+#: ../../src/MaximaCommandMenus.cpp:488 ../../src/MaximaCommandMenus.cpp:501
+#: ../../src/MaximaCommandMenus.cpp:516 ../../src/MaximaCommandMenus.cpp:530
+msgid "Maximum number of Chebyshev moments. Must be greater than 0."
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:421
 msgid "Maximum number of digits to be displayed:"
 msgstr "显示数值时的最大位数："
 
-#: ../../src/wxMaxima.cpp:9568
+#: ../../src/dialogs/ConfigDialogue.cpp:811
+#, fuzzy
+msgid "Maximum number of displayed digits:"
+msgstr "显示数值时的最大位数："
+
+#: ../../src/sidebars/StatSidebar.cpp:70
+msgid "Mean Difference Test..."
+msgstr "均值差检验..."
+
+#: ../../src/sidebars/StatSidebar.cpp:67
+msgid "Mean Test..."
+msgstr "均值检验..."
+
+#: ../../src/sidebars/StatSidebar.cpp:52
+msgid "Mean..."
+msgstr "均值..."
+
+#: ../../src/MaximaCommandMenus.cpp:1806
 msgid "Mean:"
 msgstr "均值："
 
-#: ../../src/wxMaximaFrame.cpp:1924
+#: ../../src/sidebars/StatSidebar.cpp:55
+msgid "Median..."
+msgstr "中值..."
+
+#: ../../src/wxMaximaFrame.cpp:1961
 msgid "Memoizing"
 msgstr "储存数据"
 
-#: ../../src/wxMaximaFrame.cpp:1013
+#: ../../src/wxMaximaFrame.cpp:1047
 #, fuzzy
 msgid "Memory"
 msgstr "清除内存(&C)"
 
-#: ../../src/Worksheet.cpp:1409 ../../src/wxMaximaFrame.cpp:935
+#: ../../src/worksheet/WorksheetContextMenu.cpp:180
+#: ../../src/wxMaximaFrame.cpp:969
 msgid "Merge Cells"
 msgstr "合并单元格"
 
-#: ../../src/wxMaxima.cpp:5780
+#: ../../src/MaximaResponseReader.cpp:641
 msgid "Message from the stdout of Maxima: "
 msgstr "来自 Maxima 标准输出（stdout）的消息："
 
-#: ../../src/wxMaximaFrame.cpp:1326
+#: ../../src/wizards/IntegrateWiz.cpp:55
+msgid "Method:"
+msgstr "方法："
+
+#: ../../src/wxMaximaFrame.cpp:1360
 msgid "Methods of generating a matrix"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:6866
+#: ../../src/worksheet/Worksheet.cpp:4869
 #, c-format
 msgid "Middle-click clipboard data: %s"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:9226
+#: ../../src/cells/TextCell.cpp:303
+msgid "Might also indicate a missing multiplication sign (\"*\")."
+msgstr ""
+
+#: ../../src/cells/TextCell.cpp:323
+msgid ""
+"Might be caused by reading an csv file with an empty last line:\n"
+"Technically that line can be described as having the length 0 which differs from the other lines of this file."
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:417
 msgid "Minimum absolute value printed without exponent:"
 msgstr "不自动转为工程数字表示的最小绝对值："
 
-#: ../../src/wxMaxima.cpp:10449 ../../src/wxMaxima.cpp:10451
+#: ../../src/dialogs/ConfigDialogue.cpp:1270
+msgid "Misc"
+msgstr "其他"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1963
+#, fuzzy
+msgid "Misc settings"
+msgstr "导入设置"
+
+#: ../../src/wxMaxima.cpp:3136 ../../src/wxMaxima.cpp:3138
 msgid "Mismatched parenthesis"
 msgstr "括号不匹配"
 
-#: ../../src/wxMaximaFrame.cpp:1352
+#: ../../src/cells/VisiblyInvalidCell.cpp:43
+#, fuzzy
+msgid "Missing contents. Bug?"
+msgstr "漏洞：缺少内容"
+
+#: ../../src/cells/TextCell.cpp:245
+msgid "Most probable cause: A dot instead a comma between two list items containing assignments."
+msgstr ""
+
+#: ../../src/cells/TextCell.cpp:308
+msgid "Most probable cause: A function was called with a parameter that causes it to return infinity and/or -infinity."
+msgstr ""
+
+#: ../../src/cells/TextCell.cpp:249
+msgid "Most probable cause: Two commas or similar separators in a row."
+msgstr ""
+
+#: ../../src/cells/TextCell.cpp:251
+msgid "Most probable cause: an operator was directly followed by a closing parenthesis."
+msgstr ""
+
+#: ../../src/cells/TextCell.cpp:318
+msgid ""
+"Most probably it was attempted to append something to a list that isn't a list.\n"
+"Enclosing the new element for the list in brackets ([]) converts it to a list and makes it appendable."
+msgstr ""
+
+#: ../../src/cells/TextCell.cpp:155
+msgid "Most questions can be avoided using the assume() and the declare() command. If that isn't possible the \"Automatically answer questions\" button makes wxMaxima automatically fill in all answers it still remembers from a previous run."
+msgstr ""
+
+#: ../../src/sidebars/GreekSidebar.cpp:189
+msgid "Mu"
+msgstr "Mu"
+
+#: ../../src/wxMaximaFrame.cpp:1386
 msgid "Multiplication, exponent and similar"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1998
+#: ../../src/worksheet/WorksheetContextMenu.cpp:770
 msgid "Multiplicative function: f(a*b)=f(a)*f(b)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1338
+#: ../../src/wxMaximaFrame.cpp:1372
 #, fuzzy
 msgid "Multiply matrices..."
 msgstr "矩阵相乘"
 
-#: ../../src/wxMaxima.cpp:7981
+#: ../../src/MaximaCommandMenus.cpp:1165
 #, fuzzy
 msgid "Multiply two matrices"
 msgstr "矩阵相乘"
 
-#: ../../src/wxMaxima.cpp:9581
-#, fuzzy
-msgid "Multivariate linear regression"
-msgstr "线性回归..."
-
-#: ../../src/wxMaxima.cpp:7842
+#: ../../src/MaximaCommandMenus.cpp:1023
 #, fuzzy
 msgid "Name of t:"
 msgstr "名称："
 
-#: ../../src/wxMaxima.cpp:7838
+#: ../../src/wizards/DrawWiz.cpp:750
+msgid "Name of the parameter"
+msgstr "参数名"
+
+#: ../../src/MaximaCommandMenus.cpp:1019
 #, fuzzy
 msgid "Name of x:"
 msgstr "名称："
 
-#: ../../src/wxMaximaFrame.cpp:1320 ../../src/wxMaximaFrame.cpp:1759
+#: ../../src/wizards/MatWiz.cpp:163
+msgid "Name:"
+msgstr "名称："
+
+#: ../../src/dialogs/ConfigDialogue.cpp:216
+msgid "Nepali"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1354 ../../src/wxMaximaFrame.cpp:1796
 msgid "Nested list to Matrix"
 msgstr "嵌套列表至矩阵"
 
-#: ../../src/wxMaximaFrame.cpp:769 ../../src/wxMaximaFrame.cpp:1053
+#: ../../src/MaximaCommandMenus.cpp:1450
+msgid "Nested list to matrix"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:748
+#: ../../src/dialogs/ConfigDialogue.cpp:772 ../../src/wxMaximaFrame.cpp:806
+#: ../../src/wxMaximaFrame.cpp:1087
 msgid "Never"
 msgstr "从不"
 
-#: ../../src/wxMaxima.cpp:6534
+#: ../../src/MaximaCommandMenus.cpp:3054
 msgid "Never autosubscript this variable"
 msgstr "从不将此变量自动显示为下标"
 
-#: ../../src/wxMaximaFrame.cpp:776
+#: ../../src/wxMaximaFrame.cpp:813
 msgid "Never display this variable with subscript"
 msgstr "从不显示此变量后的文字为下标"
 
-#: ../../src/Worksheet.cpp:1469 ../../src/Worksheet.cpp:1843
+#: ../../src/worksheet/WorksheetContextMenu.cpp:240
+#: ../../src/worksheet/WorksheetContextMenu.cpp:615
 msgid "Never offer known answers"
 msgstr "从不提供已知答案"
 
-#: ../../src/ToolBar.cpp:174
+#: ../../src/ToolBar.cpp:324 ../../src/ToolBar.cpp:326
 msgid "New"
 msgstr "新建"
 
-#: ../../src/wxMaximaFrame.cpp:597
+#: ../../src/wxMaximaFrame.cpp:628
 msgid "New\tCtrl+N"
 msgstr "新建\tCtrl+N"
 
-#: ../../src/ToolBar.cpp:611
+#: ../../src/ToolBar.cpp:811
 msgid "New button"
 msgstr "新按钮"
 
-#: ../../src/wxMaxima.cpp:2483
+#: ../../src/MaximaProcessManager.cpp:144
 msgid "New connection attempt whilst already connected."
 msgstr "已连接时仍尝试新连接。"
 
-#: ../../src/wxMaxima.cpp:2491
+#: ../../src/MaximaProcessManager.cpp:152
 #, fuzzy
 msgid "New connection attempt, but no currently no socket maxima could connect to."
 msgstr "尝试新的连接，但当前没有运行 Maxima 进程。"
 
-#: ../../src/wxMaxima.cpp:2487
+#: ../../src/MaximaProcessManager.cpp:148
 msgid "New connection attempt, but no currently running maxima process."
 msgstr "尝试新的连接，但当前没有运行 Maxima 进程。"
 
-#: ../../src/ToolBar.cpp:174
+#: ../../src/ToolBar.cpp:324 ../../src/ToolBar.cpp:326
 msgid "New document"
 msgstr "新建文档"
 
-#: ../../src/wxMaxima.cpp:3899
+#: ../../src/dialogs/ConfigDialogue.cpp:901
+msgid "New lines: Jump to text"
+msgstr "新行：跳转到文本"
+
+#: ../../src/MaximaResponseReader.cpp:1015
 #, fuzzy, c-format
 msgid "New maxima Operators detected: %s"
 msgstr "Maxima 架构：%s"
 
-#: ../../src/wxMaxima.cpp:7390
+#: ../../src/MaximaCommandMenus.cpp:4262
 #, fuzzy
 msgid "New part:"
 msgstr "新变量："
 
-#: ../../src/wxMaxima.cpp:8900 ../../src/wxMaxima.cpp:8920
-#: ../../src/wxMaxima.cpp:9000 ../../src/wxMaxima.cpp:9005
+#: ../../src/wizards/SubstituteWiz.cpp:35
+msgid "New value:"
+msgstr "新值："
+
+#: ../../src/MaximaCommandMenus.cpp:151 ../../src/MaximaCommandMenus.cpp:171
+#: ../../src/MaximaCommandMenus.cpp:254 ../../src/MaximaCommandMenus.cpp:259
 msgid "New variable:"
 msgstr "新变量："
 
-#: ../../src/wxMaximaFrame.cpp:929
+#: ../../src/wxMaximaFrame.cpp:963
 msgid "Next Command\tAlt+Down"
 msgstr "下一条命令\tAlt+Down"
 
-#: ../../src/wxMaximaFrame.cpp:748
+#: ../../src/dialogs/DiffFrame.cpp:405
+msgid "Next Difference"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:785
 msgid "Nice Graphical Equations"
 msgstr "美观的图形化式子"
 
-#: ../../src/wxMaximaFrame.cpp:1550
+#: ../../src/dialogs/ConfigDialogue.cpp:725
+#: ../../src/dialogs/ConfigDialogue.cpp:737 ../../src/wxMaximaFrame.cpp:1587
 msgid "No"
 msgstr "否"
 
-#: ../../src/Worksheet.cpp:1972
+#: ../../src/worksheet/WorksheetContextMenu.cpp:744
 #, fuzzy
 msgid "No Array"
 msgstr "数组："
 
-#: ../../src/Worksheet.cpp:1974
+#: ../../src/worksheet/WorksheetContextMenu.cpp:746
 msgid "No Scalar"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:10482
+#: ../../src/worksheet/Worksheet.cpp:5466
+msgid "No cells are selected. Anonymize the code in the whole document?"
+msgstr ""
+
+#: ../../src/wizards/DrawWiz.cpp:636
+msgid "No contour lines"
+msgstr ""
+
+#: ../../src/dialogs/DiffFrame.cpp:304
+msgid "No differences"
+msgstr ""
+
+#: ../../src/wxMaxima.cpp:3169
 msgid "No dollar ($) or semicolon (;) at the end of command"
 msgstr "命令末尾没有美元符号（$）或英文分号（;）"
 
-#: ../../src/MaximaManual.cpp:406
+#: ../../src/MaximaManual.cpp:423
 msgid "No entries in the caches for the subjects the manual contains."
 msgstr "用户手册所含主题的缓存中没有对应条目。"
 
@@ -4932,722 +7433,1081 @@ msgstr "用户手册所含主题的缓存中没有对应条目。"
 msgid "No file with the subjects the manual contained in the last wxMaxima run."
 msgstr "在上次 wxMaxima 运行中，没有包含用户手册主题的文件。"
 
-#: ../../src/Image.cpp:495
+#: ../../src/Image.cpp:547
 msgid "No gnuplot data!"
 msgstr "没有 gnuplot 数据！"
 
-#: ../../src/Image.cpp:530
+#: ../../src/Image.cpp:582
 msgid "No gnuplot source!"
 msgstr "没有 gnuplot 源文件！"
 
-#: ../../src/wxMaxima.cpp:6662 ../../src/wxMaxima.cpp:6668
-#: ../../src/wxMaxima.cpp:6687 ../../src/wxMaxima.cpp:6697
+#: ../../src/cells/GroupCell.cpp:1500
+msgid "No image to export"
+msgstr ""
+
+#: ../../src/wxMaxima.cpp:2653 ../../src/wxMaxima.cpp:2661
+#: ../../src/wxMaxima.cpp:2682 ../../src/wxMaxima.cpp:2694
 msgid "No matches found!"
 msgstr "没有找到匹配项！"
 
-#: ../../src/wxMaxima.cpp:3240
+#: ../../src/wizards/DrawWiz.cpp:651
+msgid "No plot, only contour lines"
+msgstr ""
+
+#: ../../src/wizards/DrawWiz.cpp:837
+msgid "No points"
+msgstr ""
+
+#: ../../src/MaximaResponseReader.cpp:145
 msgid "No topics found in topic flag"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3227
+#: ../../src/MaximaResponseReader.cpp:130
 msgid "No topics found in topic tag"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:797
+#: ../../src/Image.cpp:1037
+msgid "No usable image data was found."
+msgstr ""
+
+#: ../../src/sidebars/SymbolsSidebar.cpp:179
+msgid "Non-builtin symbols"
+msgstr "非内置符号"
+
+#: ../../src/wxMaximaFrame.cpp:834
 msgid "None"
 msgstr "无括号"
 
-#: ../../src/wxMaxima.cpp:8163
+#: ../../src/sidebars/StatSidebar.cpp:73
+msgid "Normality Test..."
+msgstr "正态分布检验..."
+
+#: ../../src/cells/TextCell.cpp:271
+msgid ""
+"Normally computers use floating-point numbers that can be handled incredibly fast while being accurate to dozens of digits. They will, though, introduce a small error into some common numbers. For example 0.1 is represented as 3602879701896397/36028797018963968.\n"
+"As mathematics is based on the fact that numbers that are exactly equal cancel each other out small errors can quickly add up to big errors (see Wilkinson's Polynomials or Rump's Polynomials). Some maxima commands therefore use rat() in order to automatically convert floats to exact numbers (like 1/10 or sqrt(2)/2) where floating-point errors might add up.\n"
+"\n"
+"This error message doesn't occur if exact numbers (1/10 instead of 0.1) are used.\n"
+"The info that numbers have automatically been converted can be suppressed by setting ratprint to false."
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:431
+msgid "Normally html expects images to be rather low-res but space saving. These images tend to look rather blurry when viewed on modern screens. Therefore this setting was introduces that selects the factor by which the HTML export increases the resolution in respect to the default value."
+msgstr "通常，HTML 使用的图片文件分辨率较低以节省储存空间。但是在现在的屏幕上查看时，这些图片往往显得相当模糊。因此引入此设置，用于选择当导出 HTML 文件时，相对于默认值分辨率而提高的因子。"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:217
+msgid "Norwegian"
+msgstr "挪威语"
+
+#: ../../src/MaximaCommandMenus.cpp:1351
 msgid "Not a valid matrix dimension!"
 msgstr "矩阵的大小无效！"
 
-#: ../../src/wxMaxima.cpp:7858 ../../src/wxMaxima.cpp:7880
+#: ../../src/MaximaCommandMenus.cpp:1039 ../../src/MaximaCommandMenus.cpp:1061
 msgid "Not a valid number of equations!"
 msgstr "方程的个数无效！"
 
-#: ../../src/StatusBar.cpp:256
+#: ../../src/StatusBar.cpp:375
 msgid "Not connected to Maxima"
 msgstr "没有连接至 Maxima"
 
-#: ../../src/wxMaxima.cpp:10496
+#: ../../src/MaximaResponseReader.cpp:841
+msgid "Not re-querying gnuplot's graphics drivers: same gnuplot as before."
+msgstr ""
+
+#: ../../src/MaximaFileIO.cpp:768
+msgid "Not saving: running non-interactively and no file name is set."
+msgstr ""
+
+#: ../../src/MaximaEvaluator.cpp:329
 msgid "Not triggering evaluation as maxima is still busy!"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:10503
+#: ../../src/MaximaEvaluator.cpp:336
 msgid "Not triggering evaluation as maxima still asks a question!"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:10511
+#: ../../src/MaximaEvaluator.cpp:344
 msgid "Not triggering evaluation as there is no working maxima process"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8926
+#: ../../src/sidebars/GreekSidebar.cpp:190
+msgid "Nu"
+msgstr "Nu"
+
+#: ../../src/MaximaCommandMenus.cpp:177
 msgid "Num. deg:"
 msgstr "分子次数："
 
-#: ../../src/wxMaxima.cpp:8540
+#: ../../src/MaximaCommandMenus.cpp:1553
 msgid "Number of elements"
 msgstr "元素个数"
 
-#: ../../src/wxMaxima.cpp:7852 ../../src/wxMaxima.cpp:7874
+#: ../../src/MaximaCommandMenus.cpp:1033 ../../src/MaximaCommandMenus.cpp:1055
 msgid "Number of equations:"
 msgstr "方程个数："
 
-#: ../../src/wxMaxima.cpp:7481
+#: ../../src/MaximaCommandMenus.cpp:4353
 #, fuzzy
 msgid "Number to octets"
 msgstr "数值类型"
 
-#: ../../src/wxMaximaFrame.cpp:1154
+#: ../../src/wxMaximaFrame.cpp:1188
 #, fuzzy
 msgid "Number to octets..."
 msgstr "元素个数"
 
-#: ../../src/wxMaximaFrame.cpp:1906
+#: ../../src/wxMaximaFrame.cpp:1943
 msgid "Number types"
 msgstr "数值类型"
 
-#: ../../src/wxMaxima.cpp:7482
+#: ../../src/MaximaCommandMenus.cpp:4354
 #, fuzzy
 msgid "Number:"
 msgstr "数字"
 
-#: ../../src/wxMaximaFrame.cpp:1786
+#: ../../src/wxMaximaFrame.cpp:1823
 msgid "Numeric output"
 msgstr "数值输出"
 
-#: ../../src/wxMaxima.cpp:8040
+#: ../../src/MaximaCommandMenus.cpp:1224
 msgid "Numerical QR decomposition of a matrix"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1417
+#: ../../src/wxMaximaFrame.cpp:1451
 #, fuzzy
 msgid "Numerical operations (lapack)"
 msgstr "数值积分(&N)"
 
-#: ../../src/wxMaxima.cpp:7831
+#: ../../src/MaximaCommandMenus.cpp:1012
 #, fuzzy
 msgid "Numerical solution for 1st degree ODE"
 msgstr "求解一阶常微分方程的初值问题"
 
-#: ../../src/wxMaximaFrame.cpp:1282
+#: ../../src/wxMaximaFrame.cpp:1316
 #, fuzzy
 msgid "Numerical solution..."
 msgstr "数值输出"
 
-#: ../../src/wxMaximaFrame.cpp:1261
+#: ../../src/wxMaximaFrame.cpp:1295
 #, fuzzy
 msgid "Numerical solutions of polynomial (bfloat)..."
 msgstr "求多项式所有的根"
 
-#: ../../src/wxMaximaFrame.cpp:1258
+#: ../../src/wxMaximaFrame.cpp:1292
 #, fuzzy
 msgid "Numerical solutions of polynomial..."
 msgstr "求多项式所有的根"
 
-#: ../../src/wxMaxima.cpp:9802 ../../src/wxMaxima.cpp:10161
+#: ../../src/MaximaCommandMenus.cpp:3265 ../../src/MaximaCommandMenus.cpp:3690
+#: ../../src/dialogs/ChangeLogDialog.cpp:131
+#: ../../src/dialogs/LicenseDialog.cpp:90
+#: ../../src/dialogs/MaxSizeChooser.cpp:44
+#: ../../src/dialogs/MaxSizeChooser.cpp:49
+#: ../../src/dialogs/MaximaNotStartingDialog.cpp:68
+#: ../../src/dialogs/MaximaNotStartingDialog.cpp:74
+#: ../../src/dialogs/ResolutionChooser.cpp:39
+#: ../../src/dialogs/ResolutionChooser.cpp:44
+#: ../../src/dialogs/TipOfTheDay.cpp:295
+#: ../../src/wizards/ActualValuesStorageWiz.cpp:60
+#: ../../src/wizards/ActualValuesStorageWiz.cpp:64
+#: ../../src/wizards/BC2Wiz.cpp:47 ../../src/wizards/BC2Wiz.cpp:51
+#: ../../src/wizards/CsvWiz.cpp:64 ../../src/wizards/CsvWiz.cpp:138
+#: ../../src/wizards/DrawWiz.cpp:110 ../../src/wizards/DrawWiz.cpp:221
+#: ../../src/wizards/DrawWiz.cpp:353 ../../src/wizards/DrawWiz.cpp:508
+#: ../../src/wizards/DrawWiz.cpp:567 ../../src/wizards/DrawWiz.cpp:664
+#: ../../src/wizards/DrawWiz.cpp:772 ../../src/wizards/DrawWiz.cpp:848
+#: ../../src/wizards/DrawWiz.cpp:986 ../../src/wizards/Gen1Wiz.cpp:43
+#: ../../src/wizards/Gen1Wiz.cpp:47 ../../src/wizards/Gen2Wiz.cpp:46
+#: ../../src/wizards/Gen2Wiz.cpp:50 ../../src/wizards/Gen3Wiz.cpp:54
+#: ../../src/wizards/Gen3Wiz.cpp:58 ../../src/wizards/Gen4Wiz.cpp:61
+#: ../../src/wizards/Gen4Wiz.cpp:65 ../../src/wizards/Gen5Wiz.cpp:69
+#: ../../src/wizards/Gen5Wiz.cpp:73 ../../src/wizards/GenWizPanel.cpp:106
+#: ../../src/wizards/GenWizPanel.cpp:114 ../../src/wizards/IntegrateWiz.cpp:61
+#: ../../src/wizards/IntegrateWiz.cpp:65 ../../src/wizards/LimitWiz.cpp:49
+#: ../../src/wizards/LimitWiz.cpp:53 ../../src/wizards/ListSortWiz.cpp:76
+#: ../../src/wizards/ListSortWiz.cpp:80 ../../src/wizards/MatWiz.cpp:39
+#: ../../src/wizards/MatWiz.cpp:43 ../../src/wizards/MatWiz.cpp:168
+#: ../../src/wizards/MatWiz.cpp:172 ../../src/wizards/Plot2dWiz.cpp:94
+#: ../../src/wizards/Plot2dWiz.cpp:98 ../../src/wizards/Plot2dWiz.cpp:511
+#: ../../src/wizards/Plot2dWiz.cpp:515 ../../src/wizards/Plot2dWiz.cpp:607
+#: ../../src/wizards/Plot2dWiz.cpp:611 ../../src/wizards/Plot3dWiz.cpp:89
+#: ../../src/wizards/Plot3dWiz.cpp:93 ../../src/wizards/PlotFormatWiz.cpp:47
+#: ../../src/wizards/PlotFormatWiz.cpp:51 ../../src/wizards/SeriesWiz.cpp:49
+#: ../../src/wizards/SeriesWiz.cpp:53 ../../src/wizards/SubstituteWiz.cpp:41
+#: ../../src/wizards/SubstituteWiz.cpp:45 ../../src/wizards/SumWiz.cpp:47
+#: ../../src/wizards/SumWiz.cpp:51 ../../src/wizards/SystemWiz.cpp:38
+#: ../../src/wizards/SystemWiz.cpp:42 ../../src/wizards/WizardHelp.cpp:37
 msgid "OK"
 msgstr "确认"
 
-#: ../../src/wxMaximaFrame.cpp:122
+#: ../../src/wxMaximaFrame.cpp:130
 #, fuzzy, c-format
 msgid "OS: %s Version %li.%li"
 msgstr "操作系统： %s 版本 %i.%i"
 
-#: ../../src/wxMaxima.cpp:8211 ../../src/wxMaxima.cpp:8221
+#: ../../src/MaximaCommandMenus.cpp:1401 ../../src/MaximaCommandMenus.cpp:1411
 #, fuzzy
 msgid "Object composed of elements"
 msgstr "元素个数"
 
-#: ../../src/wxMaxima.cpp:7680
+#: ../../src/MaximaCommandMenus.cpp:4552
 #, fuzzy
 msgid "Object name:"
 msgstr "列表名："
 
-#: ../../src/wxMaxima.cpp:7281
+#: ../../src/MaximaCommandMenus.cpp:4153
 #, fuzzy
 msgid "Object:"
 msgstr "列表名："
 
-#: ../../src/wxMaxima.cpp:7486
+#: ../../src/MaximaCommandMenus.cpp:4358
 msgid "Octets to Number"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7491
+#: ../../src/MaximaCommandMenus.cpp:4363
 msgid "Octets to String"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1156
+#: ../../src/wxMaximaFrame.cpp:1190
 msgid "Octets to number..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1158
+#: ../../src/wxMaximaFrame.cpp:1192
 #, fuzzy
 msgid "Octets to string..."
 msgstr "正在导出"
 
-#: ../../src/wxMaxima.cpp:7487 ../../src/wxMaxima.cpp:7492
+#: ../../src/MaximaCommandMenus.cpp:4359 ../../src/MaximaCommandMenus.cpp:4364
 msgid "Octets:"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1958
+#: ../../src/worksheet/WorksheetContextMenu.cpp:730
 #, fuzzy
 msgid "Odd number"
 msgstr "行号"
 
-#: ../../src/wxMaxima.cpp:8900 ../../src/wxMaxima.cpp:8921
-#: ../../src/wxMaxima.cpp:8999 ../../src/wxMaxima.cpp:9005
+#: ../../src/dialogs/ConfigDialogue.cpp:910
+msgid "Offer answers for questions known from previous runs"
+msgstr "提供上次运行后得到的问题的答案"
+
+#: ../../src/cells/TextCell.cpp:332
+msgid "Often caused by recursive function calls. Some lisps allow increasing the control stack size using command-line arguments."
+msgstr ""
+
+#: ../../src/wizards/SubstituteWiz.cpp:32
+msgid "Old value:"
+msgstr "旧值："
+
+#: ../../src/MaximaCommandMenus.cpp:151 ../../src/MaximaCommandMenus.cpp:172
+#: ../../src/MaximaCommandMenus.cpp:253 ../../src/MaximaCommandMenus.cpp:259
 msgid "Old variable:"
 msgstr "旧变量："
 
-#: ../../src/wxMaximaFrame.cpp:1055
+#: ../../src/sidebars/GreekSidebar.cpp:201
+msgid "Omega"
+msgstr "Omega"
+
+#: ../../src/sidebars/GreekSidebar.cpp:192
+msgid "Omicron"
+msgstr "Omicron"
+
+#: ../../src/wxMaximaFrame.cpp:1089
 #, fuzzy
 msgid "On all errors"
 msgstr "严重错误"
 
-#: ../../src/wxMaximaFrame.cpp:1054
+#: ../../src/wxMaximaFrame.cpp:1088
 msgid "On lisp errors"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:9566
+#: ../../src/MaximaCommandMenus.cpp:1804
 msgid "One sample t-test"
 msgstr "单样本 t-检验"
 
-#: ../../src/wxMaximaFrame.cpp:1927
+#: ../../src/wxMaximaFrame.cpp:1964
 msgid "Online tutorials"
 msgstr "在线教程"
 
-#: ../../src/wxMaximaFrame.cpp:766
+#: ../../src/wxMaximaFrame.cpp:803
 msgid "Only Integers and single letters"
 msgstr "仅限整数和单个字母"
 
-#: ../../src/ToolBar.cpp:176 ../../src/main.cpp:593 ../../src/wxMaxima.cpp:6074
+#: ../../src/dialogs/ConfigDialogue.cpp:771
+msgid "Only user-defined labels"
+msgstr "仅限用户定义的标签"
+
+#: ../../src/MaximaCommandMenus.cpp:2197 ../../src/ToolBar.cpp:330
+#: ../../src/ToolBar.cpp:333 ../../src/main.cpp:882
 msgid "Open"
 msgstr "打开"
 
-#: ../../src/wxMaximaFrame.cpp:598
+#: ../../src/dialogs/ConfigDialogue.cpp:905
+msgid "Open a cell when Maxima expects input"
+msgstr "当 Maxima 等待输入时打开一个新单元格"
+
+#: ../../src/wxMaximaFrame.cpp:629
 msgid "Open a document"
 msgstr "打开一个文档"
 
-#: ../../src/wxMaximaFrame.cpp:597
+#: ../../src/wxMaximaFrame.cpp:628
 msgid "Open a new window"
 msgstr "打开一个新窗口"
 
-#: ../../src/ToolBar.cpp:617
+#: ../../src/ToolBar.cpp:817
 msgid "Open and save button"
 msgstr "打开和保存按钮"
 
-#: ../../src/ToolBar.cpp:176
+#: ../../src/ToolBar.cpp:330 ../../src/ToolBar.cpp:333
 msgid "Open document"
 msgstr "打开文档"
 
-#: ../../src/wxMaxima.cpp:7239
+#: ../../src/MaximaCommandMenus.cpp:4111
 msgid "Open for appending"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1099
+#: ../../src/wxMaximaFrame.cpp:1133
 msgid "Open for appending..."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7244
+#: ../../src/MaximaCommandMenus.cpp:4116
 msgid "Open for reading"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1098
+#: ../../src/wxMaximaFrame.cpp:1132
 #, fuzzy
 msgid "Open for reading..."
 msgstr "正在导出"
 
-#: ../../src/wxMaxima.cpp:7249
+#: ../../src/MaximaCommandMenus.cpp:4121
 msgid "Open for writing"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1100
+#: ../../src/wxMaximaFrame.cpp:1134
 #, fuzzy
 msgid "Open for writing..."
 msgstr "正在导出"
 
-#: ../../src/wxMaxima.cpp:9598
+#: ../../src/MaximaCommandMenus.cpp:1838
 msgid "Open matrix"
 msgstr "打开矩阵"
 
-#: ../../src/wxMaximaFrame.cpp:600
+#: ../../src/wxMaximaFrame.cpp:631
 #, fuzzy
 msgid "Open recent"
 msgstr "打开最近的文件"
 
-#: ../../src/wxMaxima.cpp:4309
+#: ../../src/MaximaFileIO.cpp:231
 msgid "Opening a wxmx file"
 msgstr "正在打开一个 wxmx 文件"
 
-#: ../../src/wxMaxima.cpp:4153 ../../src/wxMaxima.cpp:4214
-#: ../../src/wxMaxima.cpp:4313 ../../src/wxMaxima.cpp:4622
+#: ../../src/MaximaFileIO.cpp:54 ../../src/MaximaFileIO.cpp:113
+#: ../../src/MaximaFileIO.cpp:235 ../../src/MaximaFileIO.cpp:545
 msgid "Opening file"
 msgstr "正在打开文件"
 
-#: ../../src/wxMaxima.cpp:5030
+#: ../../src/sidebars/HelpBrowser.cpp:175 ../../src/wxMaxima.cpp:1808
 #, c-format
 msgid "Opening help file %s"
 msgstr "正在打开帮助文件 %s"
 
-#: ../../src/wxMaximaFrame.cpp:1530
+#: ../../src/wxMaximaFrame.cpp:1567
 msgid "Optimize for CPU time"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1529
+#: ../../src/wxMaximaFrame.cpp:1566
 msgid "Optimize for memory"
 msgstr ""
 
-#: ../../src/ToolBar.cpp:199
+#: ../../src/wizards/DrawWiz.cpp:97
+msgid "Optional: A 2nd expression that defines a region to fill"
+msgstr ""
+
+#: ../../src/ToolBar.cpp:367 ../../src/ToolBar.cpp:369
+#: ../../src/dialogs/ConfigDialogue.cpp:284
 msgid "Options"
 msgstr "选项"
 
-#: ../../src/wxMaximaFrame.cpp:1225
+#: ../../src/wizards/Plot2dWiz.cpp:75 ../../src/wizards/Plot3dWiz.cpp:66
+msgid "Options:"
+msgstr "选项："
+
+#: ../../src/dialogs/FindReplacePane.cpp:109
+msgid "Output"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1259
 #, fuzzy
 msgid "Output C"
 msgstr "输出标签"
 
-#: ../../src/wxMaximaFrame.cpp:1226
+#: ../../src/wxMaximaFrame.cpp:1260
 msgid "Output Fortran"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1228
+#: ../../src/wxMaximaFrame.cpp:1262
 msgid "Output Rational Fortran"
 msgstr ""
 
-#: ../../src/Configuration.cpp:80
+#: ../../src/Styles.cpp:109
 msgid "Output labels"
 msgstr "输出标签"
 
-#: ../../src/Configuration.cpp:73
+#: ../../src/Styles.cpp:102
 #, fuzzy
 msgid "Output: Function names"
 msgstr "函数名"
 
-#: ../../src/Configuration.cpp:75
+#: ../../src/Styles.cpp:104
 msgid "Output: Latin names as greek symbols"
 msgstr ""
 
-#: ../../src/Configuration.cpp:72
+#: ../../src/Styles.cpp:101
 msgid "Output: Numbers and Digits"
 msgstr ""
 
-#: ../../src/Configuration.cpp:71
+#: ../../src/Styles.cpp:100
 #, fuzzy
 msgid "Output: Operators"
 msgstr "输出标签"
 
-#: ../../src/Configuration.cpp:74
+#: ../../src/Styles.cpp:103
 #, fuzzy, c-format
 msgid "Output: Special constants (%e,%i)"
 msgstr "特殊常数"
 
-#: ../../src/Configuration.cpp:76
+#: ../../src/Styles.cpp:105
 #, fuzzy
 msgid "Output: Strings"
 msgstr "字符串"
 
-#: ../../src/Configuration.cpp:70
+#: ../../src/Styles.cpp:99
 #, fuzzy
 msgid "Output: Variable names"
 msgstr "变量名"
 
-#: ../../src/wxMaxima.cpp:6442
-msgid "PNG image (*.png)|*.png|JPEG image (*.jpg)|*.jpg|GIF image (*.gif)|*.gif|Scaleable vector graphics (*.svg)|*.svg|Windows bitmap (*.bmp)|*.bmp|Portable anymap (*.pnm)|*.pnm|Tagged image file format (*.tif)|*.tif|X pixmap (*.xpm)|*.xpm"
-msgstr "PNG 图像 (*.png)|*.png|JPEG 图像 (*.jpg)|*.jpg|GIF 图像 (*.gif)|*.gif|可缩放矢量图像 (*.svg)|*.svg|Windows 位图 (*.bmp)|*.bmp|Portable anymap (*.pnm)|*.pnm|带标记图像文件 (*.tif)|*.tif|X pixmap (*.xpm)|*.xpm"
+#: ../../src/dialogs/ConfigDialogue.cpp:839
+msgid "Overlay scrollbars (slow: repaints the worksheet while they fade)"
+msgstr ""
 
-#: ../../src/wxMaxima.cpp:10117
-msgid "PNG image (*.png)|*.png|JPEG image (*.jpg)|*.jpg|Windows bitmap (*.bmp)|*.bmp|GIF image (*.gif)|*.gif|Portable anymap (*.pnm)|*.pnm|Tagged image file format (*.tif)|*.tif|X pixmap (*.xpm)|*.xpm"
-msgstr "PNG 图像 (*.png)|*.png|JPEG 图像 (*.jpg)|*.jpg|Windows 位图 (*.bmp)|*.bmp|GIF 图像 (*.gif)|*.gif|Portable anymap (*.pnm)|*.pnm|带标记图像文件 (*.tif)|*.tif|X pixmap (*.xpm)|*.xpm"
+#: ../../src/MaximaCommandMenus.cpp:3609
+msgid "PNG image (*.png)|*.png|JPEG image (*.jpg)|*.jpg|Windows bitmap (*.bmp)|*.bmp|"
+msgstr ""
 
-#: ../../src/wxMaxima.cpp:8924
+#: ../../src/dialogs/ConfigDialogue.cpp:458
+msgid "PNG images can be read by old wxMaxima versions - but aren't really scalable."
+msgstr "PNG 图像可以被旧版本的 wxMaxima 读取，但是不具有真正的可放缩性。"
+
+#: ../../src/MaximaCommandMenus.cpp:175
 msgid "Pade approximation"
 msgstr "Pade 近似"
 
-#: ../../src/wxMaximaFrame.cpp:1478
+#: ../../src/wxMaximaFrame.cpp:1515
 msgid "Pade approximation of a Taylor series"
 msgstr "Taylor（泰勒）级数的 Pade 近似"
 
-#: ../../src/wxMaximaFrame.cpp:1637
+#: ../../src/sidebars/FormatSidebar.cpp:69
+msgid "Pagebreak"
+msgstr "换页符"
+
+#: ../../src/wxMaximaFrame.cpp:1674
 #, fuzzy
 msgid "Parallel Substitute..."
 msgstr "代入..."
 
-#: ../../src/wxMaxima.cpp:8738
+#: ../../src/MaximaCommandMenus.cpp:735
 #, fuzzy
 msgid "Parallel substitution"
 msgstr "平行于"
 
-#: ../../src/wxMaxima.cpp:7179
+#: ../../src/sidebars/SymbolsSidebar.cpp:124
+msgid "Parallel to"
+msgstr "平行于"
+
+#: ../../src/MaximaCommandMenus.cpp:4051
 #, fuzzy
 msgid "Parameter name:"
 msgstr "迭代变量："
 
-#: ../../src/wxMaxima.cpp:7136 ../../src/wxMaxima.cpp:7149
+#: ../../src/MaximaCommandMenus.cpp:4008 ../../src/MaximaCommandMenus.cpp:4021
 #, fuzzy
 msgid "Parameter(s):"
 msgstr "变量："
 
-#: ../../src/wxMaxima.cpp:7399
+#: ../../src/sidebars/DrawSidebar.cpp:64
+msgid "Parametric Plot"
+msgstr "参数式绘图"
+
+#: ../../src/wizards/Plot2dWiz.cpp:417 ../../src/wizards/Plot2dWiz.cpp:523
+msgid "Parametric plot"
+msgstr "参数式绘图"
+
+#: ../../src/MaximaCommandMenus.cpp:4271
 msgid "Parse string"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1152
+#: ../../src/wxMaximaFrame.cpp:1186
 #, fuzzy
 msgid "Parse string only..."
 msgstr "未封闭的字符串。"
 
-#: ../../src/StatusBar.cpp:240
+#: ../../src/StatusBar.cpp:308
 msgid "Parsing output"
 msgstr "正在解析输出"
 
-#: ../../src/wxMaxima.cpp:7464
+#: ../../src/MaximaCommandMenus.cpp:4336
 msgid "Part:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1499 ../../src/wxMaximaFrame.cpp:1535
+#: ../../src/wxMaximaFrame.cpp:1536 ../../src/wxMaximaFrame.cpp:1572
 msgid "Partial &Fractions..."
 msgstr "部分分式(&F)..."
 
-#: ../../src/wxMaxima.cpp:8975
+#: ../../src/MaximaCommandMenus.cpp:229
 #, fuzzy
 msgid "Partial Fractions"
 msgstr "部分分式"
 
-#: ../../src/wxMaxima.cpp:4702
-msgid "Parts of the document will not be loaded correctly!"
-msgstr "文档的某些部分无法正确载入！"
-
-#: ../../src/ToolBar.cpp:210 ../../src/Worksheet.cpp:1654
-#: ../../src/Worksheet.cpp:1685
+#: ../../src/ToolBar.cpp:381 ../../src/ToolBar.cpp:385
+#: ../../src/worksheet/WorksheetContextMenu.cpp:427
+#: ../../src/worksheet/WorksheetContextMenu.cpp:458
 msgid "Paste"
 msgstr "粘贴"
 
-#: ../../src/wxMaximaFrame.cpp:667
+#: ../../src/wxMaximaFrame.cpp:704
 msgid "Paste\tCtrl+V"
 msgstr "粘贴\tCtrl+V"
 
-#: ../../src/ToolBar.cpp:211
+#: ../../src/ToolBar.cpp:381 ../../src/ToolBar.cpp:385
 msgid "Paste from clipboard"
 msgstr "粘贴自剪贴板"
 
-#: ../../src/wxMaximaFrame.cpp:668
+#: ../../src/wxMaximaFrame.cpp:705
 msgid "Paste text from clipboard"
 msgstr "粘贴文本自剪贴板"
 
-#: ../../src/wxMaxima.cpp:4841
+#: ../../src/wxMaximaFrame.cpp:272 ../../src/wxMaximaFrame.cpp:759
+msgid "Performance Monitor"
+msgstr ""
+
+#: ../../src/Configuration.cpp:1383
+msgid "Performance Statistics:"
+msgstr ""
+
+#: ../../src/sidebars/SymbolsSidebar.cpp:125
+msgid "Perpendicular to"
+msgstr "垂直于"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:218
+msgid "Persian"
+msgstr ""
+
+#: ../../src/sidebars/GreekSidebar.cpp:198
+msgid "Phi"
+msgstr "Phi"
+
+#: ../../src/sidebars/GreekSidebar.cpp:193
+msgid "Pi"
+msgstr "Pi"
+
+#: ../../src/sidebars/StatSidebar.cpp:94
+msgid "Piechart..."
+msgstr "饼图..."
+
+#: ../../src/wxMaxima.cpp:1587
 msgid "Please configure wxMaxima with 'Edit->Configure'."
 msgstr "请用“编辑->设置”来设置 wxMaxima。"
 
-#: ../../src/wxMaximaFrame.cpp:1768
+#: ../../src/dialogs/ConfigDialogue.cpp:2606
+msgid "Please restart wxMaxima for changes to take effect!"
+msgstr "请重启 wxMaxima 以使变更生效！"
+
+#: ../../src/MaximaCommandMenus.cpp:2250
+msgid "Please select exactly 2 or 3 files."
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1805
 msgid "Plot &2d..."
 msgstr "二维绘图(&2)..."
 
-#: ../../src/wxMaximaFrame.cpp:1770
+#: ../../src/wxMaximaFrame.cpp:1807
 msgid "Plot &3d..."
 msgstr "三维绘图(&3)..."
 
-#: ../../src/wxMaximaFrame.cpp:1772
+#: ../../src/wxMaximaFrame.cpp:1809
 msgid "Plot &Format..."
 msgstr "绘图格式(&F)..."
 
-#: ../../src/wxMaxima.cpp:9101 ../../src/wxMaxima.cpp:10068
+#: ../../src/MaximaCommandMenus.cpp:107 ../../src/MaximaCommandMenus.cpp:3557
+#: ../../src/wizards/Plot2dWiz.cpp:108 ../../src/wizards/Plot2dWiz.cpp:428
+#: ../../src/wizards/Plot2dWiz.cpp:441
 msgid "Plot 2D"
 msgstr "二维绘图"
 
-#: ../../src/Worksheet.cpp:1593
+#: ../../src/sidebars/MathSidebar.cpp:89
+#: ../../src/worksheet/WorksheetContextMenu.cpp:366
 msgid "Plot 2D..."
 msgstr "二维绘图..."
 
-#: ../../src/wxMaxima.cpp:9078 ../../src/wxMaxima.cpp:10079
+#: ../../src/MaximaCommandMenus.cpp:85 ../../src/MaximaCommandMenus.cpp:3568
+#: ../../src/wizards/Plot3dWiz.cpp:103
 msgid "Plot 3D"
 msgstr "三维绘图"
 
-#: ../../src/Worksheet.cpp:1595
+#: ../../src/sidebars/MathSidebar.cpp:92
+#: ../../src/worksheet/WorksheetContextMenu.cpp:368
 msgid "Plot 3D..."
 msgstr "三维绘图..."
 
-#: ../../src/wxMaxima.cpp:9538
+#: ../../src/wizards/DrawWiz.cpp:713
+msgid "Plot a parametric curve"
+msgstr ""
+
+#: ../../src/wizards/DrawWiz.cpp:45 ../../src/wizards/DrawWiz.cpp:148
+#: ../../src/wizards/DrawWiz.cpp:255
+msgid "Plot an explicit expression"
+msgstr "绘制显式表达式"
+
+#: ../../src/wizards/DrawWiz.cpp:53
+msgid "Plot an expression, for example sin(x) or (x+1)^2."
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:1776
 msgid "Plot as bars"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:9542
-msgid "Plot as error bars"
-msgstr ""
-
-#: ../../src/wxMaxima.cpp:9546
+#: ../../src/MaximaCommandMenus.cpp:1784
 msgid "Plot as pie chart"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:9112
+#: ../../src/MaximaCommandMenus.cpp:118
 msgid "Plot format"
 msgstr "绘图格式"
 
-#: ../../src/wxMaximaFrame.cpp:1768
+#: ../../src/wxMaximaFrame.cpp:1805
 msgid "Plot in 2 dimensions"
 msgstr "在二维平面绘图"
 
-#: ../../src/wxMaximaFrame.cpp:1770
+#: ../../src/wxMaximaFrame.cpp:1807
 msgid "Plot in 3 dimensions"
 msgstr "在三维空间绘图"
 
-#: ../../src/wxMaximaFrame.cpp:320 ../../src/wxMaximaFrame.cpp:714
+#: ../../src/sidebars/DrawSidebar.cpp:83
+msgid "Plot name"
+msgstr "图形名称"
+
+#: ../../src/wizards/Plot2dWiz.cpp:84 ../../src/wizards/Plot3dWiz.cpp:80
+msgid "Plot to file:"
+msgstr "绘图至文件："
+
+#: ../../src/wxMaximaFrame.cpp:341 ../../src/wxMaximaFrame.cpp:749
 msgid "Plot using Draw"
 msgstr "使用 draw() 函数绘图"
 
-#: ../../src/wxMaxima.cpp:7824
+#: ../../src/MaximaCommandMenus.cpp:1005
 #, fuzzy
 msgid "Point #1 with known value:"
 msgstr "数值列表"
 
-#: ../../src/wxMaxima.cpp:7826
+#: ../../src/MaximaCommandMenus.cpp:1007
 #, fuzzy
 msgid "Point #2 with known value:"
 msgstr "数值列表"
 
-#: ../../src/wxMaxima.cpp:7800 ../../src/wxMaxima.cpp:7811
+#: ../../src/MaximaCommandMenus.cpp:981 ../../src/MaximaCommandMenus.cpp:992
 msgid "Point the value is known at:"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7909 ../../src/wxMaxima.cpp:8935
+#: ../../src/wizards/DrawWiz.cpp:842
+msgid "Point type:"
+msgstr "点类型："
+
+#: ../../src/MaximaCommandMenus.cpp:186 ../../src/MaximaCommandMenus.cpp:1090
+#: ../../src/wizards/BC2Wiz.cpp:33 ../../src/wizards/BC2Wiz.cpp:39
+#: ../../src/wizards/LimitWiz.cpp:35 ../../src/wizards/SeriesWiz.cpp:36
 msgid "Point:"
 msgstr "点："
 
-#: ../../src/wxMaxima.cpp:8961 ../../src/wxMaxima.cpp:8966
-#: ../../src/wxMaxima.cpp:8971
+#: ../../src/sidebars/DrawSidebar.cpp:67
+msgid "Points"
+msgstr "点"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:219
+msgid "Polish"
+msgstr "波兰语"
+
+#: ../../src/MaximaCommandMenus.cpp:215 ../../src/MaximaCommandMenus.cpp:220
+#: ../../src/MaximaCommandMenus.cpp:225
 msgid "Polynomial 1:"
 msgstr "多项式 1："
 
-#: ../../src/wxMaxima.cpp:8961 ../../src/wxMaxima.cpp:8966
-#: ../../src/wxMaxima.cpp:8971
+#: ../../src/MaximaCommandMenus.cpp:215 ../../src/MaximaCommandMenus.cpp:220
+#: ../../src/MaximaCommandMenus.cpp:225
 msgid "Polynomial 2:"
 msgstr "多项式 2："
 
-#: ../../src/wxMaxima.cpp:7713 ../../src/wxMaxima.cpp:7724
-#: ../../src/wxMaxima.cpp:7739
+#: ../../src/MaximaCommandMenus.cpp:896 ../../src/MaximaCommandMenus.cpp:906
+#: ../../src/MaximaCommandMenus.cpp:920
 #, fuzzy
 msgid "Polynomial:"
 msgstr "多项式 1："
 
-#: ../../src/wxMaximaFrame.cpp:1754
+#: ../../src/wxMaximaFrame.cpp:1791
 msgid "Pop"
 msgstr "弹出（pop）"
 
-#: ../../src/Worksheet.cpp:1331 ../../src/Worksheet.cpp:1485
+#: ../../src/worksheet/WorksheetContextMenu.cpp:93
+#: ../../src/worksheet/WorksheetContextMenu.cpp:256
 msgid "Popout interactively"
 msgstr "交互式弹出"
 
-#: ../../src/wxMaximaFrame.cpp:1189
+#: ../../src/MaximaCommandMenus.cpp:3605
+msgid "Portable anymap (*.pnm)|*.pnm|Tagged image file format (*.tif)|*.tif|X pixmap (*.xpm)|*.xpm"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:220
+msgid "Portuguese"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:221
+msgid "Portuguese (Brazilian)"
+msgstr "葡萄牙语（巴西）"
+
+#: ../../src/wxMaximaFrame.cpp:1223
 msgid "Position of a match"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7220 ../../src/wxMaxima.cpp:7391
+#: ../../src/MaximaCommandMenus.cpp:4092 ../../src/MaximaCommandMenus.cpp:4263
 #, fuzzy
 msgid "Position:"
 msgstr "条件："
 
-#: ../../src/wxMaxima.cpp:8939
+#: ../../src/dialogs/DiffFrame.cpp:51
+msgid "Positions of the differences. Click to jump to one."
+msgstr ""
+
+#: ../../src/wizards/Plot2dWiz.cpp:474 ../../src/wizards/Plot3dWiz.cpp:422
+msgid "Postscript file (*.eps)|*.eps|All|*"
+msgstr "Postscript 文件 (*.eps)|*.eps|全部类型|*"
+
+#: ../../src/MaximaCommandMenus.cpp:190
 #, fuzzy
 msgid "Power series"
 msgstr "幂级数(&P)"
 
-#: ../../src/wxMaximaFrame.cpp:1475
+#: ../../src/wxMaximaFrame.cpp:1512
 #, fuzzy
 msgid "Power series..."
 msgstr "幂级数(&P)"
 
-#: ../../src/wxMaxima.cpp:9202
+#: ../../src/MaximaCommandMenus.cpp:393
 msgid "Precision"
 msgstr "精度"
 
-#: ../../src/Worksheet.cpp:1616
+#: ../../src/dialogs/ConfigDialogue.cpp:787
+msgid "Prefer 1D"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1492
+msgid "Prefer the all-in-one-file >1000 page manual"
+msgstr ""
+
+#: ../../src/worksheet/WorksheetContextMenu.cpp:389
 msgid "Prefer user labels"
 msgstr "倾向于使用用户标签"
 
-#: ../../src/main.cpp:437
+#: ../../src/main.cpp:676
 msgid "Preferences"
 msgstr "首选项"
 
-#: ../../src/ToolBar.cpp:626
+#: ../../src/ToolBar.cpp:826
 msgid "Preferences button"
 msgstr "首选项按钮"
 
-#: ../../src/wxMaximaFrame.cpp:685
+#: ../../src/wxMaximaFrame.cpp:722
 msgid "Preferences...\tCtrl+,"
 msgstr "首选项...\tCtrl+,"
 
-#: ../../src/wxMaximaFrame.cpp:1733
+#: ../../src/wxMaximaFrame.cpp:1770
 msgid "Prepend an element"
 msgstr "列首添加元素"
 
-#: ../../src/wxMaximaFrame.cpp:927
+#: ../../src/ToolBar.cpp:266 ../../src/sidebars/CharButton.cpp:137
+msgid "Press"
+msgstr ""
+
+#: ../../src/dialogs/TipOfTheDay.cpp:146
+msgid "Pressing Ctrl+Space or Ctrl+Tab starts an autocomplete function that can not only complete all functions that are integrated into the Maxima core and their parameters: It also knows about parameters from currently loaded packages and from functions that are defined in the current file."
+msgstr "按 Ctrl+K 或 Ctrl+Tab 组合键可以启动自动补全功能，该功能不仅可以补全所有集成到 Maxima 核心的函数，还可以补全当前文档内已加载程序包中的函数以及新定义的函数。"
+
+#: ../../src/wxMaximaFrame.cpp:961
 msgid "Previous Command\tAlt+Up"
 msgstr "上一条命令\tAlt+Up"
 
-#: ../../src/ToolBar.cpp:184
+#: ../../src/dialogs/DiffFrame.cpp:404
+msgid "Previous Difference"
+msgstr ""
+
+#: ../../src/ToolBar.cpp:343 ../../src/ToolBar.cpp:345
 msgid "Print"
 msgstr "打印"
 
-#: ../../src/ToolBar.cpp:620
+#: ../../src/dialogs/ConfigDialogue.cpp:1988
+#, fuzzy
+msgid "Print Margins"
+msgstr "正在输出"
+
+#: ../../src/ToolBar.cpp:820
 msgid "Print button"
 msgstr "打印按钮"
 
-#: ../../src/Worksheet.cpp:1493
+#: ../../src/worksheet/WorksheetContextMenu.cpp:264
 #, fuzzy
 msgid "Print cell brackets"
 msgstr "活动单元格的括号"
 
-#: ../../src/ToolBar.cpp:184 ../../src/wxMaximaFrame.cpp:622
+#: ../../src/ToolBar.cpp:343 ../../src/ToolBar.cpp:345
+#: ../../src/wxMaximaFrame.cpp:655
 msgid "Print document"
 msgstr "打印文档"
 
-#: ../../src/wxMaximaFrame.cpp:1829
+#: ../../src/wxMaximaFrame.cpp:1866
 msgid "Print floating-point numbers with exponents dividable by 3"
 msgstr "输出浮点数的指数形式，且指数位数是 3 的倍数"
 
-#: ../../src/WXMXformat.cpp:255
-msgid "Produced invalid XML. The erroneous XML data has therefore not been saved but has been put on the clipboard in order to allow to debug it."
-msgstr "生成了无效的 XML。因此，错误的 XML 数据没有保存，而是放在剪贴板上，以便进行调试。"
+#: ../../src/dialogs/ConfigDialogue.cpp:1968
+msgid "Print scale:"
+msgstr "输出范围："
 
-#: ../../src/wxMaxima.cpp:9061
+#: ../../src/dialogs/ConfigDialogue.cpp:1981
+msgid "Print the cell brackets [drawn to their left]"
+msgstr "输出单元格左侧的括号"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:287
+#, fuzzy
+msgid "Printout settings"
+msgstr "导入设置"
+
+#: ../../src/graphical_io/Printout.cpp:208
+msgid "Printout: Cannot find a suitable point for a page break!"
+msgstr ""
+
+#: ../../src/graphical_io/Printout.cpp:162
+msgid "Printout: Composing a list of all line starts as possible locations for page breaks"
+msgstr ""
+
+#: ../../src/graphical_io/Printout.cpp:279
+msgid "Printout: Layouting the whole worksheet as a endless scroll of the width of the paper"
+msgstr ""
+
+#: ../../src/graphical_io/Printout.cpp:201
+#, c-format
+msgid "Printout: PageStart=%li, PageHeight=%li, canvasSize=%li"
+msgstr ""
+
+#: ../../src/graphical_io/Printout.cpp:235
+#, c-format
+msgid "Printout: Print ppi: %lix%li"
+msgstr ""
+
+#: ../../src/graphical_io/Printout.cpp:134
+#, c-format
+msgid "Printout: Printing the region %li-%li"
+msgstr ""
+
+#: ../../src/graphical_io/Printout.cpp:76
+#, c-format
+msgid "Printout: Request to print page %li"
+msgstr ""
+
+#: ../../src/graphical_io/Printout.cpp:240
+#, c-format
+msgid "Printout: Scalefactor: %ex%e"
+msgstr ""
+
+#: ../../src/graphical_io/Printout.cpp:112
+#, c-format
+msgid "Printout: Setting the device origin to %lix%li"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:936
+#, fuzzy
+msgid "Privacy settings"
+msgstr "导入设置"
+
+#: ../../src/WXMXformat.cpp:256
+msgid ""
+"Produced invalid XML. The erroneous XML data has therefore not been saved but has been put on the clipboard in order to allow debugging it.\n"
+"Try saving the document in wxm format. Or maybe it helps to remove all output before saving the file, if the conversion of the output causes the problem."
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:315
 msgid "Product"
 msgstr "乘积"
 
-#: ../../src/wxMaximaFrame.cpp:1095
+#: ../../src/sidebars/SymbolsSidebar.cpp:123
+msgid "Product sign"
+msgstr "乘积符号"
+
+#: ../../src/wxMaximaFrame.cpp:1129
 #, fuzzy
 msgid "Program"
 msgstr "柱状图"
 
-#: ../../src/wxMaxima.cpp:7061
+#: ../../src/MaximaCommandMenus.cpp:3933
 #, fuzzy
 msgid "Program (no local variables)"
 msgstr "修改变量"
 
-#: ../../src/wxMaxima.cpp:7052
+#: ../../src/MaximaCommandMenus.cpp:3924
 msgid "Program block"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1066
+#: ../../src/wxMaximaFrame.cpp:1100
 msgid "Program block with local variables..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1068
+#: ../../src/wxMaximaFrame.cpp:1102
 msgid "Program block, no local variables..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1751
+#: ../../src/sidebars/GreekSidebar.cpp:200
+msgid "Psi"
+msgstr "Psi"
+
+#: ../../src/wxMaximaFrame.cpp:1788
 msgid "Push"
 msgstr "压入（push）"
 
-#: ../../src/wxMaxima.cpp:8508
+#: ../../src/MaximaCommandMenus.cpp:1514
 #, fuzzy
 msgid "Push an element to a list"
 msgstr "从列表中移除元素"
 
-#: ../../src/wxMaximaFrame.cpp:1395
+#: ../../src/wxMaximaFrame.cpp:1429
 msgid "QR decomposition"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3621
+#: ../../src/MaximaResponseReader.cpp:845
 msgid "Querying gnuplot which graphics drivers it supports."
 msgstr "正在询问 gnuplot 其支持的图形驱动程序。"
 
-#: ../../src/wxMaxima.cpp:8953
+#: ../../src/wxMaximaFrame.cpp:658
+msgid "Quit wxMaxima"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1910
+msgid "RTF with OMML maths"
+msgstr "带 OMML 的 RTF"
+
+#: ../../src/MaximaCommandMenus.cpp:207
 msgid "Range radius:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1374
+#: ../../src/wxMaximaFrame.cpp:1408
 msgid "Rank"
 msgstr "秩"
 
-#: ../../src/wxMaximaFrame.cpp:246 ../../src/wxMaximaFrame.cpp:722
+#: ../../src/wxMaximaFrame.cpp:260 ../../src/wxMaximaFrame.cpp:757
 msgid "Raw XML monitor"
 msgstr "原始 XML 内容监视器"
 
-#: ../../src/wxMaximaFrame.cpp:2117
+#: ../../src/wxMaximaFrame.cpp:2168
 #, c-format
 msgid "Re-Reading the config from %s."
 msgstr "重新读取 %s 中的设置。"
 
-#: ../../src/wxMaximaFrame.cpp:2114
+#: ../../src/wxMaximaFrame.cpp:2165
 msgid "Re-Reading the config from the default location."
 msgstr "重新读取默认位置的设置。"
 
-#: ../../src/wxMaximaFrame.cpp:867
+#: ../../src/wxMaximaFrame.cpp:901
 msgid "Re-evaluate all cells above the one the cursor is in"
 msgstr "对光标上方的所有单元格求值"
 
-#: ../../src/wxMaximaFrame.cpp:877
+#: ../../src/wxMaximaFrame.cpp:911
 msgid "Re-evaluate all cells below the one the cursor is in"
 msgstr "对光标下方的所有单元格求值"
 
-#: ../../src/main.cpp:366
+#: ../../src/main.cpp:605
 msgid "Re-opening STDERR failed."
 msgstr ""
 
-#: ../../src/main.cpp:367
+#: ../../src/main.cpp:606
 #, fuzzy
 msgid "Re-opening STDIN failed."
 msgstr "正在打开文件"
 
-#: ../../src/main.cpp:365
+#: ../../src/main.cpp:604
 msgid "Re-opening STDOUT failed."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7512
+#: ../../src/wxMaxima.cpp:2889
+#, c-format
+msgid "Re-pointed the .wxmx file association at %s"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:4384
 msgid "Re-using a compiled regex is faster that using the same regex string multiple times."
 msgstr ""
 
-#: ../../src/Worksheet.cpp:6668
+#: ../../src/worksheet/Worksheet.cpp:4659
 msgid "Read .wxm data from clipboard"
 msgstr "从剪贴板读取 .wxm 格式数据"
 
-#: ../../src/wxMaxima.cpp:7599
+#: ../../src/MaximaCommandMenus.cpp:4471
 msgid "Read Directory"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1677
-#, fuzzy
-msgid "Read List from csv file..."
-msgstr "从 csv 文件读取列表"
+#: ../../src/sidebars/StatSidebar.cpp:103
+msgid "Read Matrix..."
+msgstr "读取矩阵..."
 
-#: ../../src/wxMaxima.cpp:7196
+#: ../../src/MaximaCommandMenus.cpp:4068
 msgid "Read a structure field"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7270 ../../src/wxMaxima.cpp:7274
+#: ../../src/MaximaCommandMenus.cpp:4142 ../../src/MaximaCommandMenus.cpp:4146
 msgid "Read byte"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7266
+#: ../../src/MaximaCommandMenus.cpp:4138
 #, fuzzy
 msgid "Read char"
 msgstr "读取矩阵..."
 
-#: ../../src/wxMaxima.cpp:7593
+#: ../../src/dialogs/ConfigDialogue.cpp:2488
+msgid "Read config to file"
+msgstr "从文件读取设置"
+
+#: ../../src/MaximaCommandMenus.cpp:4465
 #, fuzzy
 msgid "Read environment variable"
 msgstr "Maxima 的环境变量（附加参数）"
 
-#: ../../src/wxMaximaFrame.cpp:1219
+#: ../../src/wxMaximaFrame.cpp:1253
 #, fuzzy
 msgid "Read environment variable..."
 msgstr "删除变量"
 
-#: ../../src/wxMaxima.cpp:7262
+#: ../../src/MaximaCommandMenus.cpp:4134
 msgid "Read line"
 msgstr ""
 
-#: ../../src/MaximaManual.cpp:113
+#: ../../src/wxMaximaFrame.cpp:1714
+msgid "Read nested list from csv file..."
+msgstr ""
+
+#: ../../src/MaximaManual.cpp:114
 #, c-format
 msgid "Read the entries the maxima manual offers from %s"
 msgstr "从 %s 读取 Maxima 用户手册提供的条目"
 
-#: ../../src/StatusBar.cpp:245
+#: ../../src/StatusBar.cpp:318
 msgid "Reading Maxima output"
 msgstr "正在读取 Maxima 输入"
 
-#: ../../src/StatusBar.cpp:247
+#: ../../src/StatusBar.cpp:320
 #, c-format
 msgid "Reading Maxima output: %li bytes"
 msgstr "正在读取 Maxima 输出：%li 字节"
@@ -5661,532 +8521,792 @@ msgstr ""
 msgid "Reading the Lisp part of wxMaxima from the included header file."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:148
+#: ../../src/wxMaximaFrame.cpp:156
 #, c-format
 msgid "Reading the config from %s."
 msgstr "正在从 %s 读取设置。"
 
-#: ../../src/wxMaximaFrame.cpp:151
+#: ../../src/wxMaximaFrame.cpp:159
 msgid "Reading the config from the default location."
 msgstr "正在从默认位置读取设置。"
 
-#: ../../src/StatusBar.cpp:224
+#: ../../src/StatusBar.cpp:272
 msgid "Ready for user input"
 msgstr "等待用户输入"
 
-#: ../../src/Worksheet.cpp:960
-msgid "Recalculated the whole worksheet at once => Updating its size"
+#: ../../src/sidebars/PerformanceSidebar.cpp:43
+msgid "Recalc (Cells appended):"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:946
-msgid "Recalculation hit the end of the worksheet => Updating its size"
+#: ../../src/sidebars/PerformanceSidebar.cpp:42
+msgid "Recalc (Config changed):"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:930
+#: ../../src/sidebars/PerformanceSidebar.cpp:44
+msgid "Recalc (Editor dirty):"
+msgstr ""
+
+#: ../../src/sidebars/PerformanceSidebar.cpp:39
+msgid "Recalc (Font invalid):"
+msgstr ""
+
+#: ../../src/sidebars/PerformanceSidebar.cpp:41
+msgid "Recalc (Font mismatch):"
+msgstr ""
+
+#: ../../src/sidebars/PerformanceSidebar.cpp:40
+msgid "Recalc (Size invalid):"
+msgstr ""
+
+#: ../../src/worksheet/WorksheetLayout.cpp:162
+#, c-format
+msgid "Recalculated the whole worksheet at once => Updating its size (Visited %d cells, recalculated %d, in %ld ms)"
+msgstr ""
+
+#: ../../src/worksheet/WorksheetLayout.cpp:125
+#, c-format
+msgid "Recalculation covered the whole dirty range => stopping early (Visited %d cells, recalculated %d, in %ld ms)"
+msgstr ""
+
+#: ../../src/worksheet/WorksheetLayout.cpp:146
+#, c-format
+msgid "Recalculation hit the end of the worksheet => Updating its size (Visited %d cells, recalculated %d, in %ld ms)"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:964
 msgid "Recall next command from history"
 msgstr "重调历史记录中的下一条命令"
 
-#: ../../src/wxMaximaFrame.cpp:928
+#: ../../src/wxMaximaFrame.cpp:962
 msgid "Recall previous command from history"
 msgstr "重调历史记录中的上一条命令"
 
-#: ../../src/wxMaxima.cpp:3235
+#: ../../src/MaximaResponseReader.cpp:138
 #, fuzzy, c-format
 msgid "Received manual topic request: %s"
 msgstr "已收到 Maxima 的第一个请求：%s"
 
-#: ../../src/wxMaxima.cpp:3097
+#: ../../src/MaximaResponseReader.cpp:237
 #, c-format
 msgid "Received maxima's first prompt: %s"
 msgstr "已收到 Maxima 的第一个请求：%s"
 
-#: ../../src/wxMaximaFrame.cpp:603
+#: ../../src/dialogs/ConfigDialogue.cpp:1327
+msgid "Recent files list length:"
+msgstr "最近的文件列表长度："
+
+#: ../../src/wxMaximaFrame.cpp:634
 #, fuzzy
 msgid "Recover unsaved"
 msgstr "未保存"
 
-#: ../../src/wxMaximaFrame.cpp:1640
+#: ../../src/sidebars/MathSidebar.cpp:56
+msgid "Rectform"
+msgstr "直角坐标形式"
+
+#: ../../src/wxMaximaFrame.cpp:1677
 #, fuzzy
 msgid "Recursive Substitute..."
 msgstr "代入..."
 
-#: ../../src/wxMaxima.cpp:8746
+#: ../../src/MaximaCommandMenus.cpp:744
 msgid "Recursive substitution"
 msgstr ""
 
-#: ../../src/ToolBar.cpp:192
+#: ../../src/ToolBar.cpp:355 ../../src/ToolBar.cpp:358
 msgid "Redo"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:633
+#: ../../src/wxMaximaFrame.cpp:670
 msgid "Redo\tCtrl+Y"
 msgstr "重做\tCtrl+Y"
 
-#: ../../src/wxMaximaFrame.cpp:633
+#: ../../src/wxMaximaFrame.cpp:670
 msgid "Redo last change"
 msgstr "重做上次变更"
 
-#: ../../src/wxMaximaFrame.cpp:1595
+#: ../../src/sidebars/MathSidebar.cpp:71
+msgid "Reduce (tr)"
+msgstr "化简（三角）"
+
+#: ../../src/wxMaximaFrame.cpp:1632
 msgid "Reduce trigonometric expression"
 msgstr "化简三角函数表达式"
 
-#: ../../src/wxMaxima.cpp:2366 ../../src/wxMaxima.cpp:10630
+#: ../../src/MaximaEvaluator.cpp:395
+msgid ""
+"Refusing to evaluate cell: its text changed between being queued and being evaluated (see GH #2196).\n"
+"Queued as: "
+msgstr ""
+
+#: ../../src/MaximaEvaluator.cpp:123 ../../src/MaximaEvaluator.cpp:515
 msgid "Refusing to send cell to maxima: "
 msgstr "正在拒绝向 Maxima 传输单元格内容："
 
-#: ../../src/wxMaxima.cpp:7523
+#: ../../src/dialogs/FindReplacePane.cpp:85
+msgid "Regex"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:4395
 msgid "Regex match"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7518
+#: ../../src/MaximaCommandMenus.cpp:4390
 msgid "Regex match position"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1195
+#: ../../src/wxMaximaFrame.cpp:2009
+msgid "Register wxMaxima as the tool that compares .wxmx files in TortoiseSVN and TortoiseGit"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1229
 #, fuzzy
 msgid "Regular expression that matches a string"
 msgstr "以逗号分隔的式子"
 
-#: ../../src/wxMaximaFrame.cpp:1196
+#: ../../src/wxMaximaFrame.cpp:1230
 #, fuzzy
 msgid "Regular expressions"
 msgstr "对表达式求积分"
 
-#: ../../src/Worksheet.cpp:1314
+#: ../../src/worksheet/WorksheetContextMenu.cpp:76
 #, fuzzy
 msgid "Reload Image"
 msgstr "复制为图片"
 
-#: ../../src/Worksheet.cpp:1320
+#: ../../src/worksheet/WorksheetContextMenu.cpp:82
 #, c-format
 msgid "Reload Image \"%s\""
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:9809
+#: ../../src/dialogs/ConfigDialogue.cpp:997
+msgid "Reload all GUI settings from disc"
+msgstr "从硬盘重新载入所有 GUI 设置"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1004
+msgid "Reload the style settings from disc"
+msgstr "从硬盘重新载入所有样式设置"
+
+#: ../../src/MaximaCommandMenus.cpp:3272
 #, fuzzy, c-format
 msgid "Reloading image file %s."
 msgstr "自动保存为临时文件 %s"
 
-#: ../../src/wxMaximaFrame.cpp:883
+#: ../../src/dialogs/ConfigDialogue.cpp:2573
+msgid "Reloading the configuration from disc"
+msgstr "从硬盘重新载入设置"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:2581
+msgid "Reloading the styles from disc"
+msgstr "从硬盘重新载入样式"
+
+#: ../../src/sidebars/VariablesPane.cpp:220
+msgid "Remove"
+msgstr "移除"
+
+#: ../../src/wxMaximaFrame.cpp:917
 msgid "Remove All Output"
 msgstr "移除所有输出"
 
-#: ../../src/wxMaximaFrame.cpp:1426
-#, fuzzy
-msgid "Remove Rows or Columns..."
-msgstr "移除行或列"
+#: ../../src/wxMaximaFrame.cpp:1463
+msgid "Remove Columns..."
+msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1748
+#: ../../src/wxMaximaFrame.cpp:1460
+msgid "Remove Rows..."
+msgstr ""
+
+#: ../../src/sidebars/VariablesPane.cpp:225
+msgid "Remove all"
+msgstr "移除所有"
+
+#: ../../src/wxMaximaFrame.cpp:1785
 msgid "Remove all list elements that appear twice in a row. Normally used in conjunction with sort."
 msgstr "移除列表中的重复元素。通常与 sort 一起使用。"
 
-#: ../../src/wxMaximaFrame.cpp:1174
+#: ../../src/wxMaximaFrame.cpp:1208
 msgid "Remove all occurrences of a word..."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7439
+#: ../../src/MaximaCommandMenus.cpp:4311
 msgid "Remove all occurrences of part"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8592
+#: ../../src/MaximaCommandMenus.cpp:1611
 msgid "Remove an element from a list"
 msgstr "从列表中移除元素"
 
-#: ../../src/wxMaxima.cpp:7566
+#: ../../src/MaximaCommandMenus.cpp:1519
+msgid "Remove and return the first element of a list"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1464
+msgid "Remove columns from a matrix"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:4438
 #, fuzzy
 msgid "Remove directory"
 msgstr "移除重复项"
 
-#: ../../src/wxMaximaFrame.cpp:1204
+#: ../../src/wxMaximaFrame.cpp:1238
 #, fuzzy
 msgid "Remove directory..."
 msgstr "移除重复项"
 
-#: ../../src/wxMaximaFrame.cpp:1747
+#: ../../src/wxMaximaFrame.cpp:1784
 msgid "Remove duplicates"
 msgstr "移除重复项"
 
-#: ../../src/wxMaximaFrame.cpp:1176
+#: ../../src/wxMaximaFrame.cpp:1210
 msgid "Remove first occurrence of a word..."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7444
+#: ../../src/MaximaCommandMenus.cpp:4316
 msgid "Remove first occurrence of part"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:884
+#: ../../src/MaximaCommandMenus.cpp:1155
+msgid "Remove matrix columns"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:1160
+msgid "Remove matrix rows"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:918
 msgid "Remove output from input cells"
 msgstr "移除所有输入单元格的输出"
 
-#: ../../src/wxMaxima.cpp:7975
-#, fuzzy
-msgid "Remove rows and/or columns"
-msgstr "移除行或列"
+#: ../../src/wxMaximaFrame.cpp:1461
+msgid "Remove rows from the a matrix"
+msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1427
-msgid "Remove rows and/or columns from the matrix"
-msgstr "从矩阵中移除行或列"
-
-#: ../../src/wxMaxima.cpp:7582
+#: ../../src/MaximaCommandMenus.cpp:4454
 #, fuzzy
 msgid "Rename file"
 msgstr "正在打开文件"
 
-#: ../../src/wxMaximaFrame.cpp:1215
+#: ../../src/wxMaximaFrame.cpp:1249
 #, fuzzy
 msgid "Rename file..."
 msgstr "删除变量"
 
-#: ../../src/wxMaximaFrame.cpp:1527
+#: ../../src/wxMaximaFrame.cpp:1564
 #, fuzzy
 msgid "Reorganize an expression using horner's rule"
 msgstr "因式分解一个表达式，使其系数为复数（Gauss 数）"
 
-#: ../../src/wxMaximaFrame.cpp:1346
+#: ../../src/wxMaximaFrame.cpp:1380
 msgid "Repetitive element-by-element multiplication"
 msgstr "重复计算逐个对应元素相乘"
 
-#: ../../src/wxMaxima.cpp:7538
+#: ../../src/dialogs/FindReplacePane.cpp:117
+msgid "Replace All"
+msgstr "全部替换"
+
+#: ../../src/MaximaCommandMenus.cpp:4410
 msgid "Replace all regex matches"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7533
+#: ../../src/MaximaCommandMenus.cpp:4405
 msgid "Replace first regex match"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7463
+#: ../../src/wxMaximaFrame.cpp:1990
+msgid "Replace non-builtin variable and function names in the selected code cells (or the whole document) with random names, so a worksheet can be shared without revealing its original names"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:4335
 #, fuzzy
 msgid "Replace the first occurrence of Part"
 msgstr "替换了 %d 次。"
 
-#: ../../src/wxMaximaFrame.cpp:1180
+#: ../../src/wxMaximaFrame.cpp:1214
 #, fuzzy
 msgid "Replace..."
 msgstr "全部替换"
 
-#: ../../src/wxMaxima.cpp:6719
+#: ../../src/wxMaxima.cpp:2720
 #, fuzzy, c-format
 msgid "Replaced %li occurrences."
 msgstr "替换了 %d 次。"
 
-#: ../../src/wxMaximaFrame.cpp:1950
+#: ../../src/dialogs/FindReplacePane.cpp:62
+msgid "Replacement:"
+msgstr "替换："
+
+#: ../../src/MaximaCommandMenus.cpp:768
+msgid "Replaces the subexpression that part(expr, n_1, n_2, ...) would select by a new value. The part numbers form a path: n_1 selects a part of the expression, n_2 a part of that, and so on."
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1987
 msgid "Report bug"
 msgstr "报告错误"
 
-#: ../../src/wxMaximaFrame.cpp:996
+#: ../../src/dialogs/ConfigDialogue.cpp:983
+msgid "Reset all GUI settings"
+msgstr "重置所有 GUI 设置"
+
+#: ../../src/wxMaximaFrame.cpp:1030
 #, fuzzy
 msgid "Reset option variables"
 msgstr "修改变量"
 
-#: ../../src/ToolBar.cpp:229 ../../src/wxMaximaFrame.cpp:974
+#: ../../src/dialogs/ConfigDialogue.cpp:990
+msgid "Reset the Style settings"
+msgstr "重置所有样式设置"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:2557
+#: ../../src/dialogs/ConfigDialogue.cpp:2565
+msgid "Resetting all configuration settings"
+msgstr "重置所有设置"
+
+#: ../../src/ToolBar.cpp:411 ../../src/ToolBar.cpp:417
+#: ../../src/wxMaximaFrame.cpp:1008
 msgid "Restart Maxima"
 msgstr "重启 Maxima"
 
-#: ../../src/Worksheet.cpp:1304 ../../src/Worksheet.cpp:1477
+#: ../../src/worksheet/WorksheetContextMenu.cpp:66
+#: ../../src/worksheet/WorksheetContextMenu.cpp:248
 msgid "Restrict Maximum size"
 msgstr "限制最大尺寸"
 
-#: ../../src/wxMaxima.cpp:10031
+#: ../../src/MaximaCommandMenus.cpp:3520
 #, fuzzy
 msgid "Result variables:"
 msgstr "删除变量："
 
-#: ../../src/wxMaxima.cpp:8135
+#: ../../src/MaximaCommandMenus.cpp:1323
 msgid "Resulting Matrix name (may be empty):"
 msgstr "生成的矩阵名称（可以为空）："
 
-#: ../../src/wxMaximaFrame.cpp:1190
+#: ../../src/wxMaximaFrame.cpp:1224
 msgid "Return a match"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7077
+#: ../../src/MaximaCommandMenus.cpp:3949
 msgid "Return from a block or loop"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1069
+#: ../../src/wxMaximaFrame.cpp:1103
 msgid "Return from current block/loop..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1755
+#: ../../src/wxMaximaFrame.cpp:1792
 msgid "Return the first item of the list and remove it from the list. Useful for creating stacks."
 msgstr "返回列表的第一项并将其从列表中移除。可用于创建堆栈。"
 
-#: ../../src/wxMaxima.cpp:8526
+#: ../../src/MaximaCommandMenus.cpp:1537
 msgid "Return the list without its first n elements"
 msgstr "返回移除了前 n 项的列表"
 
-#: ../../src/wxMaxima.cpp:8532
+#: ../../src/MaximaCommandMenus.cpp:1543
 msgid "Return the list without its last n elements"
 msgstr "返回移除了后 n 项的列表"
 
-#: ../../src/ToolBar.cpp:241
+#: ../../src/ToolBar.cpp:424 ../../src/ToolBar.cpp:433
 msgid "Return to the cell that is currently being evaluated"
 msgstr "返回至当前被计算的单元格"
 
-#: ../../src/wxMaximaFrame.cpp:1711
+#: ../../src/wxMaximaFrame.cpp:1748
 msgid "Returns an arbitrary list item"
 msgstr "返回列表的任意一项"
 
-#: ../../src/wxMaximaFrame.cpp:1713
+#: ../../src/MaximaCommandMenus.cpp:1527
+msgid "Returns the first element of a list"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1750
 msgid "Returns the first item of the list"
 msgstr "返回列表首项"
 
-#: ../../src/wxMaximaFrame.cpp:1719
+#: ../../src/MaximaCommandMenus.cpp:1531
+msgid "Returns the last element of a list"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1756
 msgid "Returns the last item of the list"
 msgstr "返回列表末项"
 
-#: ../../src/wxMaximaFrame.cpp:1721
+#: ../../src/wxMaximaFrame.cpp:1758
 msgid "Returns the last n items of the list"
 msgstr "返回列表最后 n 项"
 
-#: ../../src/wxMaximaFrame.cpp:1742
+#: ../../src/wxMaximaFrame.cpp:1779
 msgid "Returns the length of the list"
 msgstr "返回列表长度"
 
-#: ../../src/wxMaximaFrame.cpp:1715
+#: ../../src/wxMaximaFrame.cpp:1752
 msgid "Returns the list without its first n elements"
 msgstr "返回列表，不包括原列表前 n 项"
 
-#: ../../src/wxMaximaFrame.cpp:1717
+#: ../../src/wxMaximaFrame.cpp:1754
 msgid "Returns the list without its last n elements"
 msgstr "返回列表，不包括原列表最后 n 项"
 
-#: ../../src/wxMaximaFrame.cpp:1743
+#: ../../src/MaximaCommandMenus.cpp:1509
+msgid "Returns the number of elements of a list"
+msgstr ""
+
+#: ../../src/wizards/DrawWiz.cpp:836
+msgid "Reuse last"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1780
 msgid "Reverse"
 msgstr "逆序"
 
-#: ../../src/wxMaximaFrame.cpp:1744
+#: ../../src/wxMaximaFrame.cpp:1781
 msgid "Reverse the order of the list items"
 msgstr "逆序排列列表元素"
 
-#: ../../src/wxMaxima.cpp:7983 ../../src/wxMaxima.cpp:7988
-#: ../../src/wxMaxima.cpp:8008 ../../src/wxMaxima.cpp:8014
+#: ../../src/MaximaCommandMenus.cpp:1523
+msgid "Reverses the order of the members of a list"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:295
+msgid "Revert all to defaults"
+msgstr "还原为默认值"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:980
+msgid "Revert changes"
+msgstr "撤销修改"
+
+#: ../../src/sidebars/GreekSidebar.cpp:194
+msgid "Rho"
+msgstr "Rho"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:2015
+#, fuzzy
+msgid "Right"
+msgstr "右"
+
+#: ../../src/MaximaCommandMenus.cpp:1167 ../../src/MaximaCommandMenus.cpp:1172
+#: ../../src/MaximaCommandMenus.cpp:1192 ../../src/MaximaCommandMenus.cpp:1198
 #, fuzzy
 msgid "Right Matrix:"
 msgstr "右矩阵："
 
-#: ../../src/wxMaxima.cpp:8190
+#: ../../src/sidebars/SymbolsSidebar.cpp:127
+msgid "Right arrow"
+msgstr "右箭头"
+
+#: ../../src/MaximaCommandMenus.cpp:1380
 #, fuzzy
 msgid "Right end"
 msgstr "右箭头"
 
-#: ../../src/wxMaximaFrame.cpp:1301
+#: ../../src/wxMaximaFrame.cpp:1335
 msgid "Right side to the \"=\""
 msgstr "“=”右侧"
 
-#: ../../src/wxMaximaFrame.cpp:1455
+#: ../../src/wxMaximaFrame.cpp:1492
 msgid "Risch Integration..."
 msgstr "Risch 积分..."
 
-#: ../../src/wxMaximaFrame.cpp:785
+#: ../../src/dialogs/ConfigDialogue.cpp:222
+msgid "Romanian"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:822
 msgid "Rounded"
 msgstr "圆括号"
 
-#: ../../src/wxMaximaFrame.cpp:1437
+#: ../../src/wxMaximaFrame.cpp:1474
 msgid "Row and column operations"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7957 ../../src/wxMaxima.cpp:7967
-#: ../../src/wxMaxima.cpp:7972
+#: ../../src/MaximaCommandMenus.cpp:1137 ../../src/MaximaCommandMenus.cpp:1147
 msgid "Row number:"
 msgstr "行号"
 
-#: ../../src/wxMaxima.cpp:7977
+#: ../../src/MaximaCommandMenus.cpp:1162
 #, fuzzy
 msgid "Row numbers:"
 msgstr "行号"
 
-#: ../../src/wxMaxima.cpp:8203
+#: ../../src/MaximaCommandMenus.cpp:1393
 #, fuzzy
 msgid "Rows"
 msgstr "行："
 
-#: ../../src/wxMaxima.cpp:8201
+#: ../../src/wizards/MatWiz.cpp:152
+msgid "Rows:"
+msgstr "行："
+
+#: ../../src/MaximaCommandMenus.cpp:1391
 #, fuzzy
 msgid "Rule"
 msgstr "规则："
 
-#: ../../src/wxMaxima.cpp:8464 ../../src/wxMaxima.cpp:8477
+#: ../../src/MaximaCommandMenus.cpp:1467
 msgid "Rule:"
 msgstr "规则："
 
-#: ../../src/wxMaximaFrame.cpp:1027
+#: ../../src/wxMaximaFrame.cpp:1061
 #, fuzzy
 msgid "Rules"
 msgstr "规则："
 
-#: ../../src/wxMaximaFrame.cpp:1693
+#: ../../src/wxMaximaFrame.cpp:1730
 #, fuzzy
 msgid "Run each element through an expression"
 msgstr "作用函数至每个元素"
 
-#: ../../src/wxMaxima.cpp:6355
+#: ../../src/MaximaCommandMenus.cpp:2790
 #, fuzzy, c-format
 msgid "Running %s on the file %s: "
 msgstr "自动保存为临时文件 %s"
 
-#: ../../src/wxMaxima.cpp:2633
+#: ../../src/MaximaProcessManager.cpp:297
 #, c-format
 msgid "Running maxima as: %s"
 msgstr "运行 Maxima 为：%s"
 
-#: ../../src/wxMaximaFrame.cpp:130
+#: ../../src/wxMaximaFrame.cpp:138
 msgid "Running on DirectFB"
 msgstr "运行于 DirectFB"
 
-#: ../../src/wxMaximaFrame.cpp:114
+#: ../../src/wxMaximaFrame.cpp:122
 msgid "Running on MS Windows"
 msgstr "运行于微软 Windows 上"
 
-#: ../../src/wxMaximaFrame.cpp:116
+#: ../../src/wxMaximaFrame.cpp:124
 msgid "Running on MS Windows using DirectDraw"
 msgstr "运行于微软 Windows 上并使用 DirectDraw"
 
-#: ../../src/wxMaximaFrame.cpp:136
+#: ../../src/wxMaximaFrame.cpp:144
 msgid "Running on Mac OS"
 msgstr "运行于 Mac OS"
 
-#: ../../src/wxMaximaFrame.cpp:127
+#: ../../src/wxMaximaFrame.cpp:135
 msgid "Running on Motif"
 msgstr "运行于 Motif"
 
-#: ../../src/wxMaximaFrame.cpp:133
+#: ../../src/wxMaximaFrame.cpp:141
 msgid "Running on the universal wxWidgets port"
 msgstr "运行于 universal wxWidgets port"
 
-#: ../../src/wxMaxima.cpp:8208
+#: ../../src/MaximaCommandMenus.cpp:1398
 #, fuzzy
 msgid "Runs each element of an object (list, matrix, equation,...) through a function individually"
 msgstr "作用函数至每个元素"
 
-#: ../../src/wxMaxima.cpp:8216
+#: ../../src/MaximaCommandMenus.cpp:1406
 #, fuzzy
 msgid "Runs each element of an object (list, matrix, equation,...) through an expression individually"
 msgstr "作用函数至每个元素"
 
-#: ../../src/wxMaximaFrame.cpp:1691
+#: ../../src/wxMaximaFrame.cpp:1728
 msgid "Runs each element through a function"
 msgstr "作用函数至每个元素"
 
-#: ../../src/wxMaximaFrame.cpp:1694
+#: ../../src/wxMaximaFrame.cpp:1731
 #, fuzzy
 msgid "Runs each element through an expression"
 msgstr "作用函数至每个元素"
 
-#: ../../src/wxMaxima.cpp:9572
+#: ../../src/dialogs/ConfigDialogue.cpp:223
+msgid "Russian"
+msgstr "俄语"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1578
+msgid "SBCL: use <int>Mbytes of heap"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1585
+msgid "SBCL: use <int>Mbytes of stack for function calls"
+msgstr ""
+
+#: ../../src/sidebars/XmlInspector.cpp:78
+msgid "SENT TO MAXIMA:"
+msgstr "发送至 Maxima："
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1224
+msgid "SVG graphics"
+msgstr "SVG 图片"
+
+#: ../../src/MaximaCommandMenus.cpp:1810
 msgid "Sample 1:"
 msgstr "样本 1："
 
-#: ../../src/wxMaxima.cpp:9573
+#: ../../src/MaximaCommandMenus.cpp:1811
 msgid "Sample 2:"
 msgstr "样本 2："
 
-#: ../../src/wxMaxima.cpp:9567
+#: ../../src/MaximaCommandMenus.cpp:1805
 msgid "Sample:"
 msgstr "样本："
 
-#: ../../src/ToolBar.cpp:177 ../../src/wxMaxima.cpp:11203
+#: ../../src/wizards/DrawWiz.cpp:956
+msgid "Samples for explicit and parametric plots:"
+msgstr ""
+
+#: ../../src/wizards/DrawWiz.cpp:969
+msgid "Samples for implicit plots and regions:"
+msgstr ""
+
+#: ../../src/wizards/DrawWiz.cpp:937
+msgid "Samples for implicit plots:"
+msgstr ""
+
+#: ../../src/wizards/DrawWiz.cpp:924
+msgid "Samples on a line:"
+msgstr ""
+
+#: ../../src/ToolBar.cpp:331 ../../src/ToolBar.cpp:334
+#: ../../src/dialogs/ConfigDialogue.cpp:2163 ../../src/wxMaxima.cpp:3509
 msgid "Save"
 msgstr "保存"
 
-#: ../../src/Worksheet.cpp:1294
+#: ../../src/worksheet/WorksheetContextMenu.cpp:55
 msgid "Save Animation..."
 msgstr "保存动图..."
 
-#: ../../src/wxMaxima.cpp:5672
+#: ../../src/MaximaFileIO.cpp:779
 msgid "Save As"
 msgstr "另存为"
 
-#: ../../src/wxMaximaFrame.cpp:609
+#: ../../src/wxMaximaFrame.cpp:640
 msgid "Save As...\tShift+Ctrl+S"
 msgstr "另存为...\tShift+Ctrl+S"
 
-#: ../../src/Worksheet.cpp:1291
+#: ../../src/worksheet/WorksheetContextMenu.cpp:50
 msgid "Save Image..."
 msgstr "保存图片..."
 
-#: ../../src/wxMaxima.cpp:6440
+#: ../../src/MaximaCommandMenus.cpp:2926
 msgid "Save Selection to Image"
 msgstr "保存所选区域到图片"
 
-#: ../../src/wxMaximaFrame.cpp:675
+#: ../../src/wxMaximaFrame.cpp:712
 msgid "Save Selection to Image..."
 msgstr "保存所选区域到图片..."
 
-#: ../../src/wxMaxima.cpp:10184
+#: ../../src/MaximaCommandMenus.cpp:3713
 msgid "Save animation to file"
 msgstr "保存动图到文件"
 
-#: ../../src/wxMaxima.cpp:7203
+#: ../../src/MaximaCommandMenus.cpp:4075
 msgid "Save as lisp code"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1091
+#: ../../src/wxMaximaFrame.cpp:1125
 #, fuzzy
 msgid "Save as lisp..."
 msgstr "载入程序包"
 
-#: ../../src/ToolBar.cpp:177 ../../src/wxMaximaFrame.cpp:608
+#: ../../src/dialogs/ConfigDialogue.cpp:2478
+msgid "Save config to file"
+msgstr "保存设置到文件"
+
+#: ../../src/ToolBar.cpp:331 ../../src/ToolBar.cpp:334
+#: ../../src/wxMaximaFrame.cpp:639
 msgid "Save document"
 msgstr "保存文档"
 
-#: ../../src/wxMaximaFrame.cpp:609
+#: ../../src/wxMaximaFrame.cpp:640
 msgid "Save document as"
 msgstr "另存文档为"
 
-#: ../../src/wxMaximaFrame.cpp:676
+#: ../../src/wizards/Plot2dWiz.cpp:473 ../../src/wizards/Plot3dWiz.cpp:421
+msgid "Save plot to file"
+msgstr "保存绘图到文件"
+
+#: ../../src/wxMaximaFrame.cpp:713
 msgid "Save selection from document to an image file"
 msgstr "保存文档中所选区域到图片文件"
 
-#: ../../src/wxMaxima.cpp:10125
+#: ../../src/MaximaCommandMenus.cpp:3620
 msgid "Save selection to file"
 msgstr "保存所选区域到文件"
 
-#: ../../src/wxMaximaFrame.cpp:573
+#: ../../src/dialogs/ConfigDialogue.cpp:2640
+msgid "Save style to file"
+msgstr "保存样式到文件"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1384
+msgid "Save the worksheet automatically"
+msgstr "自动保存工作簿"
+
+#: ../../src/MaximaFileIO.cpp:873
+msgid "Saving failed!"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:594
 msgid "Saving failed."
 msgstr "保存失败。"
 
-#: ../../src/WXMXformat.cpp:310
+#: ../../src/WXMXformat.cpp:312
 msgid "Saving succeeded, but the resulting files has disappeared ?!?."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:10107
-msgid "Scalable Vector image (*.svg)|*.svg|Compressed Scalable Vector Image (*.svgz)|*.svgz|PNG image (*.png)|*.png|JPEG image (*.jpg)|*.jpg|GIF image (*.gif)|*.gif|Windows bitmap (*.bmp)|*.bmp|Portable anymap (*.pnm)|*.pnm|Tagged image file format (*.tif)|*.tif|X pixmap (*.xpm)|*.xpm"
-msgstr "可缩放矢量图像 (*.svg)|*.svg|压缩后的可缩放矢量图像 (*.svgz)|*.svgz|PNG 图像 (*.png)|*.png|JPEG 图像 (*.jpg)|*.jpg|GIF 图像 (*.gif)|*.gif|Windows 位图 (*.bmp)|*.bmp|Portable anymap (*.pnm)|*.pnm|带标签的图像文件 (*.tif)|*.tif|X pixmap (*.xpm)|*.xpm"
+#: ../../src/dialogs/ConfigDialogue.cpp:1914
+msgid "Scalable Vector Graphics (svg)"
+msgstr "可缩放矢量图像（svg）"
 
-#: ../../src/wxMaxima.cpp:9533
+#: ../../src/MaximaCommandMenus.cpp:3596
+msgid "Scalable Vector image (*.svg)|*.svg|Compressed Scalable Vector Image (*.svgz)|*.svgz|PNG image (*.png)|*.png|JPEG image (*.jpg)|*.jpg|GIF image (*.gif)|*.gif|Windows bitmap (*.bmp)|*.bmp|"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:1771
 msgid "Scatterplot"
 msgstr "散点图"
 
-#: ../../src/Autocomplete.cpp:125
+#: ../../src/sidebars/StatSidebar.cpp:88
+msgid "Scatterplot..."
+msgstr "散点图..."
+
+#: ../../src/Autocomplete.cpp:157
 msgid "Scheduling a background task that compiles a new list of autocompletable maxima commands."
 msgstr "调度后台任务，以生成一个新的可自动完成的 Maxima 命令列表。"
 
-#: ../../src/Autocomplete.cpp:458
+#: ../../src/Autocomplete.cpp:586
 msgid "Scheduling a background task that scans for autocompletable file names."
 msgstr "调度后台任务，以扫描可自动完成的文件的名称。"
 
-#: ../../src/ToolBar.cpp:632
+#: ../../src/dialogs/ConfigDialogue.cpp:1867
+msgid "Screen reader"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:662
+msgid "Scroll to a cell with a certain UUID"
+msgstr ""
+
+#: ../../src/ToolBar.cpp:832
 msgid "Search button"
 msgstr "查询按钮"
 
-#: ../../src/wxMaxima.cpp:7454
+#: ../../src/MaximaCommandMenus.cpp:4326
 msgid "Search first occurrence of part"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1178
+#: ../../src/dialogs/DiffFrame.cpp:420
+msgid "Search input / UUID"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1212
 msgid "Search..."
 msgstr ""
 
-#: ../../src/ToolBar.cpp:273
+#: ../../src/ToolBar.cpp:483 ../../src/sidebars/FormatSidebar.cpp:51
 msgid "Section"
 msgstr "节"
 
-#: ../../src/Configuration.cpp:91
+#: ../../src/Styles.cpp:120
 msgid "Section cell (Heading 2)"
 msgstr "节单元格（二级标题）"
 
-#: ../../src/wxMaxima.cpp:7218
+#: ../../src/sidebars/TableOfContents.cpp:585
+msgid "Section numbers"
+msgstr ""
+
+#: ../../src/wizards/DrawWiz.cpp:158
+msgid "See also the speed <-> accuracy button."
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:4090
 #, fuzzy
 msgid "Seek to position"
 msgstr "Pade 近似"
@@ -6195,1095 +9315,1567 @@ msgstr "Pade 近似"
 msgid "Seems like something is broken with a font."
 msgstr "似乎字体文件有错误。"
 
-#: ../../src/Autocomplete.cpp:350
+#: ../../src/Autocomplete.cpp:438
 msgid "Seems like the package with the maxima share files isn't installed."
 msgstr "似乎没有安装带 Maxima 共享文件的程序包。"
 
-#: ../../src/Worksheet.cpp:1655 ../../src/Worksheet.cpp:1687
+#: ../../src/sidebars/TableOfContents.cpp:511
+msgid "Select"
+msgstr "选择"
+
+#: ../../src/MaximaCommandMenus.cpp:2239
+msgid "Select 2 or 3 files to compare"
+msgstr ""
+
+#: ../../src/worksheet/WorksheetContextMenu.cpp:428
+#: ../../src/worksheet/WorksheetContextMenu.cpp:460
 msgid "Select All"
 msgstr "选择全部"
 
-#: ../../src/wxMaximaFrame.cpp:673
+#: ../../src/wxMaximaFrame.cpp:710
 msgid "Select All\tCtrl+A"
 msgstr "选择全部\tCtrl+A"
 
-#: ../../src/ToolBar.cpp:629
+#: ../../src/ToolBar.cpp:829
 msgid "Select All button"
 msgstr "选择所有按钮"
 
-#: ../../src/wxMaxima.cpp:9631
+#: ../../src/MaximaCommandMenus.cpp:1871
 msgid "Select Subsample"
 msgstr "选择子样本"
 
-#: ../../src/ToolBar.cpp:214 ../../src/ToolBar.cpp:215
-#: ../../src/wxMaximaFrame.cpp:673
+#: ../../src/wizards/IntegrateWiz.cpp:193
+#: ../../src/wizards/IntegrateWiz.cpp:208 ../../src/wizards/LimitWiz.cpp:133
+#: ../../src/wizards/SeriesWiz.cpp:105
+msgid "Select a constant"
+msgstr "选择一个常量"
+
+#: ../../src/ToolBar.cpp:390 ../../src/ToolBar.cpp:392
+#: ../../src/wxMaximaFrame.cpp:710
 msgid "Select all"
 msgstr "选择全部"
 
-#: ../../src/wxMaxima.cpp:6971
+#: ../../src/dialogs/BinaryNameCtrl.cpp:64
+msgid "Select binary location program"
+msgstr ""
+
+#: ../../src/wizards/CsvWiz.cpp:92 ../../src/wizards/CsvWiz.cpp:166
+msgid "Select csv file to read"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:3843
 msgid "Select math display algorithm"
 msgstr "选择数学式显示算法"
 
-#: ../../src/Configuration.cpp:98
+#: ../../src/dialogs/TipOfTheDay.cpp:109
+msgid "Selecting a part of an output and right-clicking on the selection will bring up a menu with convenient functions that will operate on the selection."
+msgstr "选择输出结果（或其一部分）并右键单击，将打开一个菜单，以对所选部分进行更多操作。"
+
+#: ../../src/Styles.cpp:127
 #, fuzzy
 msgid "Selection color"
 msgstr "选择"
 
-#: ../../src/ToolBar.cpp:252
+#: ../../src/wizards/CsvWiz.cpp:40 ../../src/wizards/CsvWiz.cpp:111
+msgid "Semicolon"
+msgstr ""
+
+#: ../../src/ToolBar.cpp:446 ../../src/ToolBar.cpp:458
 msgid "Send all cells to maxima"
 msgstr "发送所有单元格至 Maxima"
 
-#: ../../src/ToolBar.cpp:249
+#: ../../src/ToolBar.cpp:443 ../../src/ToolBar.cpp:455
 msgid "Send the current cell to maxima"
 msgstr "发送当前单元格至 Maxima"
 
-#: ../../src/wxMaxima.cpp:2810
+#: ../../src/MaximaProcessManager.cpp:921
 msgid "Sending Maxima a SIGINT signal."
 msgstr "发送 SIGINT 信号至 Maxima。"
 
-#: ../../src/StatusBar.cpp:220
+#: ../../src/StatusBar.cpp:263
 msgid "Sending a command to Maxima"
 msgstr "发送命令至 Maxima"
 
-#: ../../src/wxMaxima.cpp:10598
+#: ../../src/MaximaEvaluator.cpp:471
 #, fuzzy
 msgid "Sending a new command to Maxima."
 msgstr "发送命令至 Maxima"
 
-#: ../../src/wxMaxima.cpp:2792
+#: ../../src/MaximaProcessManager.cpp:902
 msgid "Sending an interrupt signal to Maxima."
 msgstr "发送中断信号至 Maxima。"
 
-#: ../../src/wxMaxima.cpp:169
+#: ../../src/wxMaxima.cpp:218
 msgid "Sending configuration data to maxima."
 msgstr "发送设置数据至 Maxima。"
 
-#: ../../src/wxMaxima.cpp:4718
+#: ../../src/MaximaEvaluator.cpp:558
 msgid "Sending maxima the info how to express 2d maths as XML"
 msgstr "发送如何将 2D 数学式用 XML 表示的信息至 Maxima。"
 
-#: ../../src/wxMaximaFrame.cpp:1533
+#: ../../src/wxMaximaFrame.cpp:1570
 #, fuzzy
 msgid "Sequential Comparative Simplification"
 msgstr "复数化简(&C)"
 
-#: ../../src/wxMaxima.cpp:9016
+#: ../../src/dialogs/ConfigDialogue.cpp:224
+msgid "Serbian"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:270 ../../src/wizards/SeriesWiz.cpp:60
 msgid "Series"
 msgstr "级数"
 
-#: ../../src/wxMaximaFrame.cpp:1479
+#: ../../src/wxMaximaFrame.cpp:1516
 #, fuzzy
 msgid "Series approximation"
 msgstr "Pade 近似"
 
-#: ../../src/wxMaxima.cpp:2561
+#: ../../src/MaximaProcessManager.cpp:227
 msgid "Server started"
 msgstr "已启动服务器"
 
-#: ../../src/wxMaximaFrame.cpp:1824
+#: ../../src/wxMaximaFrame.cpp:1861
 msgid "Set &displayed Precision..."
 msgstr "设置显示精度(&D)..."
 
-#: ../../src/wxMaximaFrame.cpp:1563
+#: ../../src/wxMaximaFrame.cpp:1600
 msgid "Set Maxima option variable logexpand:all"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1567
+#: ../../src/wxMaximaFrame.cpp:1604
 msgid "Set Maxima option variable logexpand:super"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1560
+#: ../../src/wxMaximaFrame.cpp:1597
 msgid "Set Maxima option variable logexpand:true"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:822
+#: ../../src/wxMaximaFrame.cpp:859
 msgid "Set Zoom"
 msgstr "设置显示比例"
 
-#: ../../src/wxMaximaFrame.cpp:1819
+#: ../../src/wxMaximaFrame.cpp:1856
 msgid "Set bigfloat &Precision..."
 msgstr "设置大浮点数精度(&P)..."
 
-#: ../../src/Worksheet.cpp:1306 ../../src/Worksheet.cpp:1479
+#: ../../src/dialogs/ConfigDialogue.cpp:479
+msgid "Set fixed font in text controls."
+msgstr "设置文本控件中使用固定字体"
+
+#: ../../src/worksheet/WorksheetContextMenu.cpp:68
+#: ../../src/worksheet/WorksheetContextMenu.cpp:250
 #, fuzzy
 msgid "Set image resolution"
 msgstr "重复使用所得的解\n"
 
-#: ../../src/wxMaximaFrame.cpp:1510
+#: ../../src/dialogs/ResolutionChooser.cpp:29
+#, fuzzy
+msgid "Set image resolution [in ppi]"
+msgstr "重复使用所得的解\n"
+
+#: ../../src/wxMaximaFrame.cpp:1547
 #, fuzzy
 msgid "Set main variable..."
 msgstr "删除变量"
 
-#: ../../src/wxMaximaFrame.cpp:1773
+#: ../../src/dialogs/MaxSizeChooser.cpp:29
+msgid "Set maximum image size [in mm]"
+msgstr "设置图片最大尺寸（单位：mm）"
+
+#: ../../src/wxMaximaFrame.cpp:1810
 msgid "Set plot format"
 msgstr "设置绘图格式"
 
-#: ../../src/wxMaximaFrame.cpp:1101
+#: ../../src/wxMaximaFrame.cpp:1135
 #, fuzzy
 msgid "Set position..."
 msgstr "保存动图..."
 
-#: ../../src/wxMaximaFrame.cpp:1656
+#: ../../src/wxMaximaFrame.cpp:1693
 msgid "Set the \"algebraic\" flag"
 msgstr "打开代数标志"
 
-#: ../../src/wxMaxima.cpp:8314
+#: ../../src/MaximaCommandMenus.cpp:1960
 msgid "Set the diagram title"
 msgstr "设置图表标题"
 
-#: ../../src/wxMaximaFrame.cpp:1779
+#: ../../src/wxMaximaFrame.cpp:1816
 msgid "Set the frame rate for animations."
 msgstr "设置动画帧率"
 
-#: ../../src/wxMaxima.cpp:8377
+#: ../../src/MaximaCommandMenus.cpp:2023
 msgid "Set the grid density."
 msgstr "设置网格密度。"
 
-#: ../../src/wxMaxima.cpp:8327
+#: ../../src/MaximaCommandMenus.cpp:1973
 msgid "Set the next plot's title. Empty = no title."
 msgstr "设置下一个图形的标题，空字符串表示无标题。"
 
-#: ../../src/wxMaximaFrame.cpp:1820
+#: ../../src/wxMaximaFrame.cpp:1857
 msgid "Set the precision for numbers that are defined as bigfloat. Such numbers can be generated by entering 1.5b12 or as bfloat(1.234)"
 msgstr "为定义为大浮点的数字设置精度。可以通过输入1.5b12 或 bfloat(1.234) 命令生成这些数字"
 
-#: ../../src/wxMaximaFrame.cpp:811
+#: ../../src/wxMaximaFrame.cpp:848
 msgid "Set zoom to 100%"
 msgstr "设置显示比例为 100%"
 
-#: ../../src/wxMaximaFrame.cpp:813
+#: ../../src/wxMaximaFrame.cpp:850
 msgid "Set zoom to 120%"
 msgstr "设置显示比例为 120%"
 
-#: ../../src/wxMaximaFrame.cpp:815
+#: ../../src/wxMaximaFrame.cpp:852
 msgid "Set zoom to 150%"
 msgstr "设置显示比例为 150%"
 
-#: ../../src/wxMaximaFrame.cpp:817
+#: ../../src/wxMaximaFrame.cpp:854
 msgid "Set zoom to 200%"
 msgstr "设置显示比例为 200%"
 
-#: ../../src/wxMaximaFrame.cpp:819
+#: ../../src/wxMaximaFrame.cpp:856
 msgid "Set zoom to 300%"
 msgstr "设置显示比例为 300%"
 
-#: ../../src/wxMaximaFrame.cpp:809
+#: ../../src/wxMaximaFrame.cpp:846
 msgid "Set zoom to 80%"
 msgstr "设置显示比例为 80%"
 
-#: ../../src/wxMaxima.cpp:4731
+#: ../../src/dialogs/ConfigDialogue.cpp:163
+msgid "Sets the language, line ending type and charset encoding programs will use"
+msgstr "设置程序使用的语言、行结束符和字符集编码"
+
+#: ../../src/MaximaEvaluator.cpp:574
 #, c-format
 msgid "Setting gnuplot_binary to %s"
 msgstr "设置 gnuplot 程序为 %s"
 
-#: ../../src/wxMaxima.cpp:4804
+#: ../../src/MaximaEvaluator.cpp:642
 #, fuzzy
 msgid "Setting prompt and help format"
 msgstr "设置绘图格式"
 
-#: ../../src/wxMaximaFrame.cpp:1292
+#: ../../src/dialogs/ConfigDialogue.cpp:165
+msgid "Setting this to \"cat\" causes gnuplot not to halt if there is much output"
+msgstr "将此变量设置为“cat”可使 gnuplot 不会因为要输出的数据太多而停止。"
+
+#: ../../src/wizards/DrawWiz.cpp:546
+msgid "Settings for the following 3d plots"
+msgstr ""
+
+#: ../../src/wizards/DrawWiz.cpp:462
+#, c-format
+msgid "Setup a %iD scene"
+msgstr ""
+
+#: ../../src/sidebars/DrawSidebar.cpp:48
+msgid "Setup a 2D plot"
+msgstr "设置二维绘图"
+
+#: ../../src/sidebars/DrawSidebar.cpp:52
+msgid "Setup a 3D plot"
+msgstr "设置三维绘图"
+
+#: ../../src/wxMaximaFrame.cpp:1326
 msgid "Setup atvalues for solving ODE with Laplace transformation"
 msgstr "设置边界条件，以使用 Laplace 变换解常微分方程"
 
-#: ../../src/wxMaximaFrame.cpp:1661
+#: ../../src/wxMaximaFrame.cpp:1698
 msgid "Setup modulus computation"
 msgstr "设置模运算"
 
-#: ../../src/wxMaxima.cpp:9220
+#: ../../src/sidebars/DrawSidebar.cpp:78
+msgid "Setup the axis"
+msgstr "设置坐标轴"
+
+#: ../../src/wizards/DrawWiz.cpp:263
+msgid "Setup the axis for the current plot."
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:411
 #, fuzzy
 msgid "Setup the engineering format"
 msgstr "设置工程数值格式..."
 
-#: ../../src/wxMaximaFrame.cpp:1831
+#: ../../src/wxMaximaFrame.cpp:1868
 msgid "Setup the engineering format..."
 msgstr "设置工程数值格式..."
 
-#: ../../src/wxMaxima.cpp:9576
+#: ../../src/MaximaCommandMenus.cpp:1814
 msgid "Shapiro-Wilk test for normality"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1543
+#: ../../src/worksheet/WorksheetContextMenu.cpp:316
 msgid "Show \"%\" in special constants"
 msgstr "显示特殊常量前的“%”"
 
-#: ../../src/wxMaximaFrame.cpp:1889
+#: ../../src/wxMaximaFrame.cpp:1926
 msgid "Show &Tips..."
 msgstr "显示提示(&T)..."
 
-#: ../../src/Worksheet.cpp:1556
+#: ../../src/worksheet/WorksheetContextMenu.cpp:329
 msgid "Show * as multiplication dot"
 msgstr "显示“*”为乘点"
 
-#: ../../src/wxMaximaFrame.cpp:895
+#: ../../src/wxMaximaFrame.cpp:929
 msgid "Show Template\tCtrl+Shift+Space"
 msgstr "显示模板\tCtrl+Shift+K"
 
-#: ../../src/wxMaximaFrame.cpp:753
+#: ../../src/wxMaximaFrame.cpp:790
 #, fuzzy
 msgid "Show XML representation"
 msgstr "显示长表达式："
 
-#: ../../src/wxMaximaFrame.cpp:1889
+#: ../../src/wxMaximaFrame.cpp:1926
 msgid "Show a tip"
 msgstr "显示提示"
 
-#: ../../src/Worksheet.cpp:1607
+#: ../../src/worksheet/WorksheetContextMenu.cpp:380
 msgid "Show all + allow linebreaks in long numbers"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:9475
+#: ../../src/MaximaCommandMenus.cpp:2118
 msgid "Show all commands similar to:"
 msgstr "显示所有与此相似的命令："
 
-#: ../../src/wxMaxima.cpp:9468
+#: ../../src/sidebars/SymbolsSidebar.cpp:206
+msgid "Show all unicode symbols"
+msgstr "显示所有 Unicode 符号"
+
+#: ../../src/MaximaCommandMenus.cpp:2111
 msgid "Show an example for the command:"
 msgstr "显示此命令的示例："
 
-#: ../../src/wxMaximaFrame.cpp:1883
+#: ../../src/wxMaximaFrame.cpp:1920
 msgid "Show an example of usage"
 msgstr "显示用法示例"
 
-#: ../../src/wxMaximaFrame.cpp:1884
+#: ../../src/sidebars/History.cpp:121
+msgid "Show commands from current session only"
+msgstr "只显示当前会话的命令"
+
+#: ../../src/wxMaximaFrame.cpp:1921
 msgid "Show commands similar to"
 msgstr "显示与其相似的命令"
 
-#: ../../src/wxMaximaFrame.cpp:1020
+#: ../../src/wxMaximaFrame.cpp:1054
 msgid "Show defined functions"
 msgstr "显示已定义函数"
 
-#: ../../src/wxMaximaFrame.cpp:1022
+#: ../../src/wxMaximaFrame.cpp:1056
 msgid "Show defined variables"
 msgstr "显示已定义变量"
 
-#: ../../src/wxMaximaFrame.cpp:1074
+#: ../../src/wxMaximaFrame.cpp:1108
 msgid "Show definition of a function"
 msgstr "显示函数的定义"
 
-#: ../../src/wxMaximaFrame.cpp:740
+#: ../../src/wxMaximaFrame.cpp:777
 msgid "Show equations in their linear form"
 msgstr "显示式子的线性形式"
 
-#: ../../src/wxMaximaFrame.cpp:1073
+#: ../../src/wxMaximaFrame.cpp:1107
 #, fuzzy
 msgid "Show function &Definition..."
 msgstr "显示定义(&D)..."
 
-#: ../../src/wxMaximaFrame.cpp:896
+#: ../../src/wxMaximaFrame.cpp:930
 msgid "Show function template"
 msgstr "显示函数模板"
 
-#: ../../src/Worksheet.cpp:1614
+#: ../../src/worksheet/WorksheetContextMenu.cpp:387
 #, fuzzy
 msgid "Show input labels"
 msgstr "输入标签"
 
-#: ../../src/wxMaximaFrame.cpp:750
+#: ../../src/dialogs/ConfigDialogue.cpp:766
+msgid "Show labels:"
+msgstr "显示标签："
+
+#: ../../src/wxMaximaFrame.cpp:787
 #, fuzzy
 msgid "Show lisp representation"
 msgstr "显示长表达式："
 
-#: ../../src/Worksheet.cpp:1604
+#: ../../src/dialogs/ConfigDialogue.cpp:465
+msgid "Show long expressions in wxMaxima document."
+msgstr "在 wxMaxima 文档中显示长表达式"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:722
+msgid "Show long expressions:"
+msgstr "显示长表达式："
+
+#: ../../src/worksheet/WorksheetContextMenu.cpp:377
 msgid "Show max. 100 digits"
 msgstr "显示最多 100 个数字"
 
-#: ../../src/Worksheet.cpp:1602
+#: ../../src/worksheet/WorksheetContextMenu.cpp:375
 msgid "Show max. 20 digits"
 msgstr "显示最多 20 个数字"
 
-#: ../../src/Worksheet.cpp:1603
+#: ../../src/worksheet/WorksheetContextMenu.cpp:376
 msgid "Show max. 50 digits"
 msgstr "显示最多 50 个数字"
 
-#: ../../src/wxMaximaFrame.cpp:835
+#: ../../src/wxMaximaFrame.cpp:868
 msgid "Show or hide the wxMaxima logging window"
 msgstr ""
 
-#: ../../src/ToolBar.cpp:612
+#: ../../src/ToolBar.cpp:812
 msgid "Show the \"New\" button?"
 msgstr "显示“新建”按钮？"
 
-#: ../../src/ToolBar.cpp:636
+#: ../../src/ToolBar.cpp:836
 msgid "Show the \"help\" button?"
 msgstr "显示“帮助”按钮？"
 
-#: ../../src/ToolBar.cpp:633
+#: ../../src/ToolBar.cpp:833
 msgid "Show the \"search\" button?"
 msgstr "显示“查询”按钮？"
 
-#: ../../src/ToolBar.cpp:630
+#: ../../src/ToolBar.cpp:830
 msgid "Show the \"select all\" button?"
 msgstr "显示“选择所有”按钮？"
 
-#: ../../src/ToolBar.cpp:624
+#: ../../src/ToolBar.cpp:824
 msgid "Show the Copy, Cut and the Paste button?"
 msgstr "显示“复制”“剪切”和“粘贴”按钮？"
 
-#: ../../src/wxMaxima.cpp:7033
+#: ../../src/wxMaximaFrame.cpp:650
+msgid "Show the differences between 2 or 3 files"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:3905
 #, fuzzy
 msgid "Show the function's definition"
 msgstr "显示此函数的定义："
 
-#: ../../src/ToolBar.cpp:618
+#: ../../src/ToolBar.cpp:818
 msgid "Show the open and the save button?"
 msgstr "显示“打开”和”保存“按钮？"
 
-#: ../../src/ToolBar.cpp:627
+#: ../../src/ToolBar.cpp:827
 msgid "Show the preferences button?"
 msgstr "显示“首选项”按钮？"
 
-#: ../../src/ToolBar.cpp:621
+#: ../../src/ToolBar.cpp:821
 msgid "Show the print button?"
 msgstr "显示“打印”按钮？"
 
-#: ../../src/ToolBar.cpp:615
+#: ../../src/ToolBar.cpp:815
 #, fuzzy
 msgid "Show the undo and redo button?"
 msgstr "显示“打开”和”保存“按钮？"
 
-#: ../../src/wxMaximaFrame.cpp:1006 ../../src/wxMaximaFrame.cpp:1011
+#: ../../src/dialogs/TipOfTheDay.cpp:288
+msgid "Show tips at Startup"
+msgstr "启动时显示提示"
+
+#: ../../src/wxMaximaFrame.cpp:1040 ../../src/wxMaximaFrame.cpp:1045
 msgid "Show used + to-be-freed memory"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1033
+#: ../../src/wxMaximaFrame.cpp:1067
 #, fuzzy
 msgid "Show user definitions"
 msgstr "显示此函数的定义："
 
-#: ../../src/ToolBar.cpp:328 ../../src/wxMaximaFrame.cpp:1877
-#: ../../src/wxMaximaFrame.cpp:1879
+#: ../../src/ToolBar.cpp:544 ../../src/ToolBar.cpp:546
+#: ../../src/wxMaximaFrame.cpp:1914 ../../src/wxMaximaFrame.cpp:1916
 msgid "Show wxMaxima help"
 msgstr "显示 wxMaxima 帮助"
 
-#: ../../src/wxMaximaFrame.cpp:1825
+#: ../../src/wxMaximaFrame.cpp:1862
 msgid "Shows how many digits of a numbers are displayed"
 msgstr "设置数值显示的数字位数"
 
-#: ../../src/wxMaximaFrame.cpp:732
+#: ../../src/wxMaximaFrame.cpp:769
 #, fuzzy
 msgid "Sidebars"
 msgstr "停靠所有侧边栏"
 
-#: ../../src/wxMaximaFrame.cpp:1513
+#: ../../src/sidebars/GreekSidebar.cpp:195
+msgid "Sigma"
+msgstr "Sigma"
+
+#: ../../src/dialogs/FindReplacePane.cpp:88
+#, fuzzy
+msgid "Simple"
+msgstr "样本："
+
+#: ../../src/MaximaCommandMenus.cpp:1819
+msgid "Simple linear regression"
+msgstr ""
+
+#: ../../src/sidebars/MathSidebar.cpp:44
+msgid "Simplify"
+msgstr "化简"
+
+#: ../../src/wxMaximaFrame.cpp:1550
 #, fuzzy
 msgid "Simplify &Radicals..."
 msgstr "化简根式(&R)"
 
-#: ../../src/Worksheet.cpp:1579
+#: ../../src/sidebars/MathSidebar.cpp:47
+msgid "Simplify (r)"
+msgstr "化简根式"
+
+#: ../../src/sidebars/MathSidebar.cpp:65
+msgid "Simplify (tr)"
+msgstr "化简三角式"
+
+#: ../../src/worksheet/WorksheetContextMenu.cpp:352
 msgid "Simplify Expression"
 msgstr "化简表达式"
 
-#: ../../src/wxMaximaFrame.cpp:1568
+#: ../../src/wxMaximaFrame.cpp:1605
 #, fuzzy
 msgid "Simplify Logarithms"
 msgstr "化简求和表达式"
 
-#: ../../src/wxMaximaFrame.cpp:1582
+#: ../../src/wxMaximaFrame.cpp:1619
 msgid "Simplify an expression containing factorials"
 msgstr "化简含阶乘的表达式"
 
-#: ../../src/wxMaximaFrame.cpp:1539
+#: ../../src/wxMaximaFrame.cpp:1576
 #, fuzzy
 msgid "Simplify equations"
 msgstr "简单方程\n"
 
-#: ../../src/wxMaximaFrame.cpp:1514
+#: ../../src/wxMaximaFrame.cpp:1551
 msgid "Simplify expression containing radicals"
 msgstr "化简含根式的表达式"
 
-#: ../../src/wxMaxima.cpp:8649
+#: ../../src/MaximaCommandMenus.cpp:641
 #, fuzzy
 msgid "Simplify radicals"
 msgstr "化简根式(&R)"
 
-#: ../../src/wxMaximaFrame.cpp:1512
+#: ../../src/wxMaximaFrame.cpp:1549
 msgid "Simplify rational expression"
 msgstr "化简有理式"
 
-#: ../../src/wxMaximaFrame.cpp:1538
+#: ../../src/wxMaximaFrame.cpp:1575
 msgid "Simplify sum() commands..."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8636
+#: ../../src/MaximaCommandMenus.cpp:628
 #, fuzzy
 msgid "Simplify sums"
 msgstr "化简"
 
-#: ../../src/wxMaximaFrame.cpp:1592
+#: ../../src/wizards/SumWiz.cpp:68
+msgid "Simplify the sum"
+msgstr "化简求和表达式"
+
+#: ../../src/wxMaximaFrame.cpp:1629
 msgid "Simplify trigonometric expression"
 msgstr "化简三角式"
 
-#: ../../src/wxMaximaFrame.cpp:1399
+#: ../../src/dialogs/TipOfTheDay.cpp:139
+#, fuzzy
+msgid "Since wxMaxima 0.8.2 you can also insert images into your documents. Use 'Cell->Insert Image...' menu command."
+msgstr "从 wxMmaxima 0.8.2 起，用户可以在文档中插入图像，方法是使用“单元格->插入图像…”菜单命令。注意，如果希望保存文档时也保存插入的图像，必须使用（默认的）“.wxmx”格式。"
+
+#: ../../src/wxMaximaFrame.cpp:1433
 msgid "Singular Values"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1400 ../../src/wxMaximaFrame.cpp:1403
+#: ../../src/wxMaximaFrame.cpp:1434 ../../src/wxMaximaFrame.cpp:1437
 msgid "Singular values using dgesvd"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1402
+#: ../../src/wxMaximaFrame.cpp:1436
 msgid "Singular values, left + right vectors"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1635
+#: ../../src/MaximaCommandMenus.cpp:487 ../../src/MaximaCommandMenus.cpp:500
+msgid "Size of internal work array. (limit - limlst)/2 is the maximum number of subintervals to use."
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:436 ../../src/MaximaCommandMenus.cpp:449
+#: ../../src/MaximaCommandMenus.cpp:462 ../../src/MaximaCommandMenus.cpp:476
+#: ../../src/MaximaCommandMenus.cpp:547 ../../src/MaximaCommandMenus.cpp:562
+#: ../../src/MaximaCommandMenus.cpp:577 ../../src/MaximaCommandMenus.cpp:592
+#: ../../src/MaximaCommandMenus.cpp:606
+msgid "Size of internal work array. limit is the maximum number of subintervals to use."
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:515 ../../src/MaximaCommandMenus.cpp:529
+msgid "Size of internal work array. limit/2 is the maximum number of subintervals to use."
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:2113
+msgid "Slanted"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:225
+msgid "Slovak"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:226
+msgid "Slovenian"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1672
 #, fuzzy
 msgid "Smart Substitute..."
 msgstr "代入..."
 
-#: ../../src/wxMaxima.cpp:8730
+#: ../../src/MaximaCommandMenus.cpp:725
 #, fuzzy
 msgid "Smart substitution"
 msgstr "代入"
 
-#: ../../src/wxMaxima.cpp:7799 ../../src/wxMaxima.cpp:7810
-#: ../../src/wxMaxima.cpp:7823
+#: ../../src/MaximaCommandMenus.cpp:980 ../../src/MaximaCommandMenus.cpp:991
+#: ../../src/MaximaCommandMenus.cpp:1004
 #, fuzzy
 msgid "Solution of the ODE:"
 msgstr "解："
 
-#: ../../src/wxMaxima.cpp:10017
+#: ../../src/wizards/BC2Wiz.cpp:30
+msgid "Solution:"
+msgstr "解："
+
+#: ../../src/MaximaCommandMenus.cpp:3506
 msgid "Solve"
 msgstr "求解"
 
-#: ../../src/wxMaximaFrame.cpp:1244
+#: ../../src/wxMaximaFrame.cpp:1278
 msgid "Solve &Algebraic System..."
 msgstr "求解代数系统(&A)..."
 
-#: ../../src/wxMaximaFrame.cpp:1242
+#: ../../src/wxMaximaFrame.cpp:1276
 msgid "Solve &Linear System..."
 msgstr "求解线性系统(&L)..."
 
-#: ../../src/wxMaximaFrame.cpp:1266
+#: ../../src/wxMaximaFrame.cpp:1300
 msgid "Solve &ODE..."
 msgstr "求解常微分方程(&O)..."
 
-#: ../../src/wxMaximaFrame.cpp:1240
+#: ../../src/wxMaximaFrame.cpp:1274
 msgid "Solve (to_poly)..."
 msgstr "求解 (to_poly)..."
 
-#: ../../src/wxMaxima.cpp:8045
+#: ../../src/MaximaCommandMenus.cpp:1231
 msgid "Solve A*x=b numerically"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1397
+#: ../../src/wxMaximaFrame.cpp:1431
 #, fuzzy
 msgid "Solve Ax=b"
 msgstr "求解"
 
-#: ../../src/wxMaxima.cpp:7783
+#: ../../src/MaximaCommandMenus.cpp:964
 msgid "Solve ODE"
 msgstr "求解常微分方程"
 
-#: ../../src/wxMaximaFrame.cpp:1287
+#: ../../src/wxMaximaFrame.cpp:1321
 msgid "Solve ODE with Lapla&ce..."
 msgstr "利用 Laplace 变换求解常微分方程(&C)..."
 
-#: ../../src/wxMaximaFrame.cpp:1398
+#: ../../src/sidebars/MathSidebar.cpp:77
+msgid "Solve ODE..."
+msgstr "求解常微分方程..."
+
+#: ../../src/wxMaximaFrame.cpp:1432
 #, fuzzy
 msgid "Solve a linear equation system using dgesv"
 msgstr "求解线性方程组"
 
-#: ../../src/wxMaxima.cpp:7852 ../../src/wxMaxima.cpp:7863
+#: ../../src/MaximaCommandMenus.cpp:1033 ../../src/MaximaCommandMenus.cpp:1044
 msgid "Solve algebraic system"
 msgstr "求解代数系统"
 
-#: ../../src/wxMaximaFrame.cpp:1245
+#: ../../src/wxMaximaFrame.cpp:1279
 msgid "Solve algebraic system of equations"
 msgstr "求解代数方程组"
 
-#: ../../src/wxMaximaFrame.cpp:1279
+#: ../../src/wxMaximaFrame.cpp:1313
 msgid "Solve boundary value problem for second degree ODE"
 msgstr "求解二阶常微分方程的边值问题"
 
-#: ../../src/wxMaxima.cpp:7895
+#: ../../src/MaximaCommandMenus.cpp:1076
 #, fuzzy
 msgid "Solve differential equations using laplace()"
 msgstr "求解 (常) 微分方程"
 
-#: ../../src/wxMaxima.cpp:7744 ../../src/wxMaximaFrame.cpp:1238
+#: ../../src/MaximaCommandMenus.cpp:925 ../../src/wxMaximaFrame.cpp:1272
 msgid "Solve equation(s)"
 msgstr "求解方程（组）"
 
-#: ../../src/wxMaximaFrame.cpp:1241
+#: ../../src/wxMaximaFrame.cpp:1275
 msgid "Solve equation(s) with to_poly_solve"
 msgstr "使用 to_poly_solve() 命令求解方程"
 
-#: ../../src/wxMaxima.cpp:7773
+#: ../../src/MaximaCommandMenus.cpp:954
 #, fuzzy
 msgid "Solve equations numerically"
 msgstr "求解方程（组）"
 
-#: ../../src/wxMaxima.cpp:7757
+#: ../../src/MaximaCommandMenus.cpp:938
 #, fuzzy
 msgid "Solve equations to polynom"
 msgstr "使用 to_poly_solve() 命令求解方程"
 
-#: ../../src/wxMaximaFrame.cpp:1271
+#: ../../src/wxMaximaFrame.cpp:1305
 msgid "Solve initial value problem for first degree ODE"
 msgstr "求解一阶常微分方程的初值问题"
 
-#: ../../src/wxMaximaFrame.cpp:1275
+#: ../../src/wxMaximaFrame.cpp:1309
 msgid "Solve initial value problem for second degree ODE"
 msgstr "求解二阶常微分方程的初值问题"
 
-#: ../../src/wxMaxima.cpp:7874 ../../src/wxMaxima.cpp:7884
+#: ../../src/MaximaCommandMenus.cpp:1055 ../../src/MaximaCommandMenus.cpp:1065
 msgid "Solve linear system"
 msgstr "求解线性系统"
 
-#: ../../src/wxMaximaFrame.cpp:1243
+#: ../../src/wxMaximaFrame.cpp:1277
 msgid "Solve linear system of equations"
 msgstr "求解线性方程组"
 
-#: ../../src/wxMaximaFrame.cpp:1263
+#: ../../src/wxMaximaFrame.cpp:1297
 msgid "Solve numerical, 1 Variable"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1267
+#: ../../src/wxMaximaFrame.cpp:1301
 msgid "Solve ordinary differential equation of maximum degree 2"
 msgstr "求解一阶和二阶常微分方程"
 
-#: ../../src/wxMaximaFrame.cpp:1288
+#: ../../src/wxMaximaFrame.cpp:1322
 msgid "Solve ordinary differential equations with Laplace transformation"
 msgstr "利用 Laplace 变换求解常微分方程"
 
-#: ../../src/wxMaxima.cpp:7708
+#: ../../src/MaximaCommandMenus.cpp:891
 #, fuzzy
 msgid "Solve polynomials numerically"
 msgstr "求解方程（组）"
 
-#: ../../src/wxMaxima.cpp:7718
+#: ../../src/MaximaCommandMenus.cpp:900
 #, fuzzy
 msgid "Solve polynomials numerically (bfloats)"
 msgstr "求解方程（组）"
 
-#: ../../src/wxMaxima.cpp:7729
+#: ../../src/MaximaCommandMenus.cpp:910
 #, fuzzy
 msgid "Solve polynomials numerically (real roots)"
 msgstr "求解方程（组）"
 
-#: ../../src/wxMaximaFrame.cpp:1249
+#: ../../src/wxMaximaFrame.cpp:1283
 #, fuzzy
 msgid "Solve symbolically"
 msgstr "求解方程（组）"
 
-#: ../../src/Worksheet.cpp:1574
+#: ../../src/sidebars/MathSidebar.cpp:74
+#: ../../src/worksheet/WorksheetContextMenu.cpp:347
 msgid "Solve..."
 msgstr "求解..."
 
-#: ../../src/wxMaximaFrame.cpp:1916
+#: ../../src/wxMaximaFrame.cpp:1953
 msgid "Solving differential equations"
 msgstr "求解 (常) 微分方程"
 
-#: ../../src/wxMaximaFrame.cpp:1904
+#: ../../src/wxMaximaFrame.cpp:1941
 msgid "Solving equations with Maxima"
 msgstr "利用 Maxima 解方程（组）"
 
-#: ../../src/wxMaxima.cpp:7105
+#: ../../src/MaximaCommandMenus.cpp:3977
 #, c-format
 msgid ""
 "Sometimes one wants maxima to loose the information that a function name was used with the ' operator in order to make maxima not evaluate it. In other places one wants % to mean \"the last expression at the time this function was created\", not \"the last expression now\".\n"
 "In both cases the '' operator will do what is requested."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1746
+#: ../../src/wxMaximaFrame.cpp:1783
 msgid "Sort"
 msgstr "排序"
 
-#: ../../src/wxMaxima.cpp:8496
+#: ../../src/wizards/ListSortWiz.cpp:41
+msgid "Sort Criterion:"
+msgstr "排序标准："
+
+#: ../../src/MaximaCommandMenus.cpp:1500
 msgid "Sort a list"
 msgstr "列表排序"
 
-#: ../../src/wxMaxima.cpp:7459
+#: ../../src/MaximaCommandMenus.cpp:4331
 msgid "Sort all characters in string"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1179
+#: ../../src/wxMaximaFrame.cpp:1213
 #, fuzzy
 msgid "Sort the characters..."
 msgstr "Unicode 字符"
 
-#: ../../src/wxMaxima.cpp:8482
+#: ../../src/MaximaCommandMenus.cpp:1486
 msgid "Source list:"
 msgstr "源列表："
 
-#: ../../src/wxMaxima.cpp:7429
+#: ../../src/dialogs/ConfigDialogue.cpp:227
+msgid "Spanish"
+msgstr "西班牙语"
+
+#: ../../src/wizards/IntegrateWiz.cpp:44 ../../src/wizards/IntegrateWiz.cpp:50
+#: ../../src/wizards/LimitWiz.cpp:38 ../../src/wizards/SeriesWiz.cpp:39
+msgid "Special"
+msgstr "特殊"
+
+#: ../../src/wizards/DrawWiz.cpp:918
+msgid "Speed versus accuracy"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:4301
 msgid "Split"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1191
+#: ../../src/wxMaximaFrame.cpp:1225
 msgid "Split on match"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7528
+#: ../../src/MaximaCommandMenus.cpp:4400
 msgid "Split on regex match"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7449
+#: ../../src/MaximaCommandMenus.cpp:4321
 msgid "Split string into tokens"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1171
+#: ../../src/wxMaximaFrame.cpp:1205
 #, fuzzy
 msgid "Split..."
 msgstr "箱线图..."
 
-#: ../../src/wxMaximaFrame.cpp:788
+#: ../../src/wxMaximaFrame.cpp:825
 msgid "Square"
 msgstr "方括号"
 
-#: ../../src/Configuration.cpp:86
+#: ../../src/dialogs/ConfigDialogue.cpp:1300
+#, fuzzy
+msgid "Standard Options"
+msgstr "标准曲面\n"
+
+#: ../../src/Styles.cpp:115
 #, fuzzy
 msgid "Standard Text"
 msgstr "标准曲面\n"
 
-#: ../../src/Worksheet.cpp:1298
+#: ../../src/worksheet/WorksheetContextMenu.cpp:60
 msgid "Start Animation"
 msgstr "开始显示动图"
 
-#: ../../src/wxMaxima.cpp:7842
+#: ../../src/dialogs/ConfigDialogue.cpp:1622
+msgid "Start a new maxima for each re-evaluation"
+msgstr "每次重新计算时启动新的 Maxima 进程"
+
+#: ../../src/MaximaCommandMenus.cpp:1023
 #, fuzzy
 msgid "Start of t:"
 msgstr "x 的初始值"
 
-#: ../../src/ToolBar.cpp:305
+#: ../../src/wizards/DrawWiz.cpp:66 ../../src/wizards/DrawWiz.cpp:171
+msgid "Start of the x value"
+msgstr "x 的初始值"
+
+#: ../../src/wizards/DrawWiz.cpp:83 ../../src/wizards/DrawWiz.cpp:186
+msgid "Start of the y value"
+msgstr "y 的初始值"
+
+#: ../../src/wizards/DrawWiz.cpp:203
+msgid "Start of the z value"
+msgstr "z 的初始值"
+
+#: ../../src/ToolBar.cpp:507 ../../src/ToolBar.cpp:519
 msgid "Start or Stop animation"
 msgstr "开始或停止显示动图"
 
-#: ../../src/ToolBar.cpp:306
+#: ../../src/ToolBar.cpp:508 ../../src/ToolBar.cpp:520
 msgid "Start or stop the currently selected animation that has been created with the with_slider class of commands"
 msgstr "开始或停止显示当前选中的由 with_slider 类命令绘制的动图"
 
-#: ../../src/wxMaxima.cpp:386
+#: ../../src/dialogs/ConfigDialogue.cpp:496
+msgid "Start searching while the phrase to search for is still being typed."
+msgstr "要查询的内容仍在键入中时，立即开始查询。"
+
+#: ../../src/wizards/DrawWiz.cpp:755
+msgid "Start value of the parameter"
+msgstr "参数的起始值"
+
+#: ../../src/wxMaxima.cpp:403
 msgid "Starting Maxima process failed"
 msgstr "启动 Maxima 进程失败"
 
-#: ../../src/main.cpp:667
+#: ../../src/main.cpp:956
 #, fuzzy
 msgid "Starting a new wxMaxima process for a new window"
 msgstr "启动 Maxima 进程失败"
 
-#: ../../src/wxMaxima.cpp:3105 ../../src/wxMaxima.cpp:5633
+#: ../../src/wxMaxima.cpp:1858 ../../src/wxMaxima.cpp:1884
 msgid "Starting evaluation of the document"
 msgstr "开始计算整个文档"
 
-#: ../../src/wxMaxima.cpp:2544
+#: ../../src/MaximaProcessManager.cpp:205
 msgid "Starting server failed"
 msgstr "启动服务器失败"
 
-#: ../../src/WXMXformat.cpp:64
-msgid "Starting to save the worksheet as .wxmx"
-msgstr "开始保存工作簿为 wxmx 文件"
+#: ../../src/WXMXformat.cpp:65
+#, c-format
+msgid "Starting to save the worksheet as .wxmx. Filename: %s"
+msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:252
+#: ../../src/dialogs/ConfigDialogue.cpp:286
+msgid "Startup commands"
+msgstr "启动命令"
+
+#: ../../src/wxMaximaFrame.cpp:266
 msgid "Statistics"
 msgstr "统计"
 
-#: ../../src/wxMaximaFrame.cpp:701
+#: ../../src/wxMaximaFrame.cpp:736
 msgid "Statistics\tAlt+Shift+S"
 msgstr "统计\tAlt+Shift+S"
 
-#: ../../src/wxMaxima.cpp:7844
+#: ../../src/MaximaCommandMenus.cpp:1025
 #, fuzzy
 msgid "Step width:"
 msgstr "标签宽度："
 
-#: ../../src/wxMaximaFrame.cpp:794
+#: ../../src/dialogs/ConfigDialogue.cpp:939
+msgid "Store filenames in image cells to enable image reloading after re-opening the worksheet"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:831
 msgid "Straight lines"
 msgstr "直线"
 
-#: ../../src/wxMaximaFrame.cpp:1106
+#: ../../src/wxMaximaFrame.cpp:1140
 msgid "Stream"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7231
+#: ../../src/MaximaCommandMenus.cpp:4103
 msgid "Stream length"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7219 ../../src/wxMaxima.cpp:7224
-#: ../../src/wxMaxima.cpp:7228 ../../src/wxMaxima.cpp:7232
-#: ../../src/wxMaxima.cpp:7236 ../../src/wxMaxima.cpp:7240
-#: ../../src/wxMaxima.cpp:7245 ../../src/wxMaxima.cpp:7250
-#: ../../src/wxMaxima.cpp:7256 ../../src/wxMaxima.cpp:7263
-#: ../../src/wxMaxima.cpp:7267 ../../src/wxMaxima.cpp:7271
-#: ../../src/wxMaxima.cpp:7276
+#: ../../src/MaximaCommandMenus.cpp:4091 ../../src/MaximaCommandMenus.cpp:4096
+#: ../../src/MaximaCommandMenus.cpp:4100 ../../src/MaximaCommandMenus.cpp:4104
+#: ../../src/MaximaCommandMenus.cpp:4108 ../../src/MaximaCommandMenus.cpp:4112
+#: ../../src/MaximaCommandMenus.cpp:4117 ../../src/MaximaCommandMenus.cpp:4122
+#: ../../src/MaximaCommandMenus.cpp:4128 ../../src/MaximaCommandMenus.cpp:4135
+#: ../../src/MaximaCommandMenus.cpp:4139 ../../src/MaximaCommandMenus.cpp:4143
+#: ../../src/MaximaCommandMenus.cpp:4148
 msgid "Stream:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1185
+#: ../../src/dialogs/ConfigDialogue.cpp:2117
+msgid "Strike Through"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1219
 #, fuzzy
 msgid "String"
 msgstr "字符串"
 
-#: ../../src/wxMaxima.cpp:7345 ../../src/wxMaxima.cpp:7350
-#: ../../src/wxMaxima.cpp:7425
+#: ../../src/MaximaCommandMenus.cpp:4217 ../../src/MaximaCommandMenus.cpp:4222
+#: ../../src/MaximaCommandMenus.cpp:4297
 #, fuzzy
 msgid "String #1:"
 msgstr "字符串"
 
-#: ../../src/wxMaxima.cpp:7346 ../../src/wxMaxima.cpp:7351
-#: ../../src/wxMaxima.cpp:7426
+#: ../../src/MaximaCommandMenus.cpp:4218 ../../src/MaximaCommandMenus.cpp:4223
+#: ../../src/MaximaCommandMenus.cpp:4298
 #, fuzzy
 msgid "String #2:"
 msgstr "字符串"
 
-#: ../../src/wxMaximaFrame.cpp:1136
+#: ../../src/wxMaximaFrame.cpp:1170
 #, fuzzy
 msgid "String Tests"
 msgstr "字符串"
 
-#: ../../src/wxMaxima.cpp:7415
+#: ../../src/MaximaCommandMenus.cpp:4287
 #, fuzzy
 msgid "String length"
 msgstr "字符串"
 
-#: ../../src/wxMaxima.cpp:7381
+#: ../../src/MaximaCommandMenus.cpp:4253
 msgid "String to list of char"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1148
+#: ../../src/wxMaximaFrame.cpp:1182
 msgid "String to list of chars..."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7496
+#: ../../src/MaximaCommandMenus.cpp:4368
 #, fuzzy
 msgid "String to octets"
 msgstr "字符串"
 
-#: ../../src/wxMaximaFrame.cpp:1160
+#: ../../src/wxMaximaFrame.cpp:1194
 msgid "String to octets..."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7377 ../../src/wxMaxima.cpp:7382
-#: ../../src/wxMaxima.cpp:7391 ../../src/wxMaxima.cpp:7396
-#: ../../src/wxMaxima.cpp:7400 ../../src/wxMaxima.cpp:7407
-#: ../../src/wxMaxima.cpp:7412 ../../src/wxMaxima.cpp:7416
-#: ../../src/wxMaxima.cpp:7420 ../../src/wxMaxima.cpp:7430
-#: ../../src/wxMaxima.cpp:7436 ../../src/wxMaxima.cpp:7441
-#: ../../src/wxMaxima.cpp:7446 ../../src/wxMaxima.cpp:7450
-#: ../../src/wxMaxima.cpp:7456 ../../src/wxMaxima.cpp:7460
-#: ../../src/wxMaxima.cpp:7465 ../../src/wxMaxima.cpp:7470
-#: ../../src/wxMaxima.cpp:7474 ../../src/wxMaxima.cpp:7478
-#: ../../src/wxMaxima.cpp:7497
+#: ../../src/MaximaCommandMenus.cpp:4249 ../../src/MaximaCommandMenus.cpp:4254
+#: ../../src/MaximaCommandMenus.cpp:4263 ../../src/MaximaCommandMenus.cpp:4268
+#: ../../src/MaximaCommandMenus.cpp:4272 ../../src/MaximaCommandMenus.cpp:4279
+#: ../../src/MaximaCommandMenus.cpp:4284 ../../src/MaximaCommandMenus.cpp:4288
+#: ../../src/MaximaCommandMenus.cpp:4292 ../../src/MaximaCommandMenus.cpp:4302
+#: ../../src/MaximaCommandMenus.cpp:4308 ../../src/MaximaCommandMenus.cpp:4313
+#: ../../src/MaximaCommandMenus.cpp:4318 ../../src/MaximaCommandMenus.cpp:4322
+#: ../../src/MaximaCommandMenus.cpp:4328 ../../src/MaximaCommandMenus.cpp:4332
+#: ../../src/MaximaCommandMenus.cpp:4337 ../../src/MaximaCommandMenus.cpp:4342
+#: ../../src/MaximaCommandMenus.cpp:4346 ../../src/MaximaCommandMenus.cpp:4350
+#: ../../src/MaximaCommandMenus.cpp:4369
 #, fuzzy
 msgid "String:"
 msgstr "字符串"
 
-#: ../../src/wxMaxima.cpp:7197
+#: ../../src/MaximaCommandMenus.cpp:4069
 msgid "Struct :"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7184 ../../src/wxMaxima.cpp:7190
+#: ../../src/MaximaCommandMenus.cpp:4056 ../../src/MaximaCommandMenus.cpp:4062
 msgid "Struct type name:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1029
+#: ../../src/wxMaximaFrame.cpp:1063
 msgid "Structs"
 msgstr ""
 
-#: ../../src/ToolBar.cpp:274
+#: ../../src/dialogs/ConfigDialogue.cpp:282
+msgid "Style"
+msgstr "样式"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:2082
+msgid "Styles"
+msgstr "样式"
+
+#: ../../src/sidebars/StatSidebar.cpp:112
+msgid "Subsample..."
+msgstr "子样本..."
+
+#: ../../src/ToolBar.cpp:484 ../../src/sidebars/FormatSidebar.cpp:54
 msgid "Subsection"
 msgstr "小节"
 
-#: ../../src/Configuration.cpp:90
+#: ../../src/Styles.cpp:119
 msgid "Subsection cell (Heading 3)"
 msgstr "小节（三级标题）"
 
-#: ../../src/wxMaximaFrame.cpp:1643
+#: ../../src/wxMaximaFrame.cpp:1680
 msgid "Subst constant t into eq with diff(x,t)..."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8724
+#: ../../src/MaximaCommandMenus.cpp:716
 msgid "Subst is a better string-search-and-replace for expressions."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7688 ../../src/wxMaxima.cpp:8723
-#: ../../src/wxMaxima.cpp:10061 ../../src/wxMaximaFrame.cpp:1651
+#: ../../src/sidebars/MathSidebar.cpp:59
+msgid "Subst..."
+msgstr "代入..."
+
+#: ../../src/MaximaCommandMenus.cpp:715 ../../src/MaximaCommandMenus.cpp:3550
+#: ../../src/MaximaCommandMenus.cpp:4560 ../../src/wizards/SubstituteWiz.cpp:53
+#: ../../src/wxMaximaFrame.cpp:1688
 msgid "Substitute"
 msgstr "代入"
 
-#: ../../src/wxMaximaFrame.cpp:1193
+#: ../../src/wxMaximaFrame.cpp:1227
 #, fuzzy
 msgid "Substitute all matches"
 msgstr "代入..."
 
-#: ../../src/wxMaximaFrame.cpp:1192
+#: ../../src/wxMaximaFrame.cpp:1226
 msgid "Substitute first match"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1646
+#: ../../src/MaximaCommandMenus.cpp:767
+msgid "Substitute only in a specific part"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1683
 #, fuzzy
 msgid "Substitute only in parts..."
 msgstr "代入..."
 
-#: ../../src/wxMaxima.cpp:8763
-msgid "Substitute only in specific parts"
-msgstr ""
-
-#: ../../src/wxMaximaFrame.cpp:1647
+#: ../../src/wxMaximaFrame.cpp:1684
 msgid "Substitute only in the elements n_1, n_2,..."
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1585 ../../src/wxMaximaFrame.cpp:1633
+#: ../../src/worksheet/WorksheetContextMenu.cpp:358
+#: ../../src/wxMaximaFrame.cpp:1670
 msgid "Substitute..."
 msgstr "代入..."
 
-#: ../../src/wxMaximaFrame.cpp:1641 ../../src/wxMaximaFrame.cpp:1644
+#: ../../src/wxMaximaFrame.cpp:1678 ../../src/wxMaximaFrame.cpp:1681
 msgid "Substitutes until the equation no more changes"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8747
+#: ../../src/MaximaCommandMenus.cpp:745
 msgid "Substitutes up to lrats_max_iter times, or until the expression stops changing when substituting."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8756
+#: ../../src/MaximaCommandMenus.cpp:757
 #, c-format
 msgid "Substitutes, but makes sure that if substituting t=0 in diff(x,t) the result isn't 0 (as t no more changes), but %at(diff(x,t),t=0)."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8739
+#: ../../src/MaximaCommandMenus.cpp:736
 msgid "Substitutes, but makes sure that nothing is substituted into the other substituents."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1638
+#: ../../src/wxMaximaFrame.cpp:1675
 msgid "Substitutes, but not in the other substituents"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8764
-msgid "Substitutes, but only in the n_1th, n_2th and so on term of the equation."
-msgstr ""
-
-#: ../../src/ToolBar.cpp:275
+#: ../../src/ToolBar.cpp:485 ../../src/sidebars/FormatSidebar.cpp:57
 msgid "Subsubsection"
 msgstr "小小节"
 
-#: ../../src/Configuration.cpp:89
+#: ../../src/Styles.cpp:118
 msgid "Subsubsection cell (Heading 4)"
 msgstr "小小节（四级标题）"
 
-#: ../../src/Worksheet.cpp:1831
+#: ../../src/worksheet/WorksheetContextMenu.cpp:603
 #, fuzzy
 msgid "Suggestion: "
 msgstr "小节"
 
-#: ../../src/Worksheet.cpp:2030
+#: ../../src/worksheet/WorksheetContextMenu.cpp:802
 msgid "Suitable as flag for ev()"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:9049
+#: ../../src/MaximaCommandMenus.cpp:303 ../../src/wizards/SumWiz.cpp:60
 msgid "Sum"
 msgstr "求和"
 
-#: ../../src/wxMaximaFrame.cpp:1551
+#: ../../src/sidebars/SymbolsSidebar.cpp:122
+msgid "Sum sign"
+msgstr "求和符号"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:228
+msgid "Swedish"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1588
 msgid "Switch off simplifications of log(). Set Maxima option variable logexpand:false"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:4090
+#: ../../src/MaximaResponseReader.cpp:569
 #, fuzzy
 msgid "Switched to lisp mode after receiving a lisp debug prompt!"
 msgstr "在接收 Lisp 命令后切换到 Lisp 模式！"
 
-#: ../../src/wxMaxima.cpp:4092
+#: ../../src/MaximaResponseReader.cpp:428
+#: ../../src/MaximaResponseReader.cpp:571
 msgid "Switched to lisp mode after receiving a lisp prompt!"
 msgstr "在接收 Lisp 命令后切换到 Lisp 模式！"
 
-#: ../../src/Worksheet.cpp:1971
+#: ../../src/worksheet/WorksheetContextMenu.cpp:743
 #, fuzzy
 msgid "Symbolic Constant"
 msgstr "选择一个常量"
 
-#: ../../src/wxMaximaFrame.cpp:705
+#: ../../src/wxMaximaFrame.cpp:740
 msgid "Symbols\tAlt+Shift+Y"
 msgstr "符号\tAlt+Shift+Y"
 
-#: ../../src/Worksheet.cpp:2006
+#: ../../src/dialogs/ConfigDialogue.cpp:472
+msgid "Symbols that are entered or copied here will appear in the symbols sidebar so they can be entered into the worksheet easily."
+msgstr "输入或复制到此处的符号将显示在符号侧边栏中，以便可以轻松地将它们输入工作簿。"
+
+#: ../../src/worksheet/WorksheetContextMenu.cpp:778
 msgid "Symmetric function: f(x)=f(-x)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:238
+#: ../../src/dialogs/DiffFrame.cpp:370 ../../src/dialogs/DiffFrame.cpp:387
+msgid "Sync Horizontal"
+msgstr ""
+
+#: ../../src/dialogs/DiffFrame.cpp:382 ../../src/dialogs/DiffFrame.cpp:388
+msgid "Sync Vertical"
+msgstr ""
+
+#: ../../src/wizards/CsvWiz.cpp:42 ../../src/wizards/CsvWiz.cpp:113
+msgid "Tab"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:252
 msgid "Table of Contents"
 msgstr "目录"
 
-#: ../../src/wxMaximaFrame.cpp:711
+#: ../../src/wxMaximaFrame.cpp:746
 msgid "Table of Contents\tAlt+Shift+T"
 msgstr "目录\tAlt+Shift+T"
 
-#: ../../src/wxMaxima.cpp:8930
+#: ../../src/wizards/DrawWiz.cpp:561
+msgid "Take surface color from steepness"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:229
+msgid "Tamil"
+msgstr ""
+
+#: ../../src/sidebars/GreekSidebar.cpp:196
+msgid "Tau"
+msgstr "Tau"
+
+#: ../../src/MaximaCommandMenus.cpp:181
 #, fuzzy
 msgid "Taylor series"
 msgstr "Taylor（泰勒）级数："
 
-#: ../../src/wxMaximaFrame.cpp:1474
+#: ../../src/wxMaximaFrame.cpp:1511
 #, fuzzy
 msgid "Taylor series..."
 msgstr "Taylor（泰勒）级数："
 
-#: ../../src/wxMaxima.cpp:8925
+#: ../../src/MaximaCommandMenus.cpp:176
 msgid "Taylor series:"
 msgstr "Taylor（泰勒）级数："
 
-#: ../../src/wxMaxima.cpp:4132
+#: ../../src/wxMaxima.cpp:1488
 msgid "Telling maxima about the new working directory."
 msgstr "告诉 Maxima 新的工作目录。"
 
-#: ../../src/wxMaxima.cpp:7907
+#: ../../src/MaximaCommandMenus.cpp:1088
 msgid "Tells maxima for an f(x), that f(x=t)=a"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1945
+#: ../../src/wxMaximaFrame.cpp:1982
 msgid "Tells maxima to show the help for ?, ?? and describe() in a separate browser window"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1941
+#: ../../src/wxMaximaFrame.cpp:1978
 msgid "Tells maxima to show the help for ?, ?? and describe() in a wxMaxima sidebar"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1936
+#: ../../src/wxMaximaFrame.cpp:1973
 msgid "Tells maxima to show the help for ?, ?? and describe() on the console"
 msgstr ""
 
-#: ../../src/ToolBar.cpp:271
+#: ../../src/dialogs/ConfigDialogue.cpp:148
+msgid "Tells maxima where to store the result of compiling libraries"
+msgstr "告诉 Maxima 编译库的结果存储的位置"
+
+#: ../../src/ToolBar.cpp:481 ../../src/sidebars/FormatSidebar.cpp:45
 msgid "Text"
 msgstr "文本"
 
-#: ../../src/Configuration.cpp:93
+#: ../../src/dialogs/ConfigDialogue.cpp:739
+msgid "Text & Code"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:738
+msgid "Text Only"
+msgstr "仅为文本"
+
+#: ../../src/Styles.cpp:122
 msgid "Text cell background"
 msgstr "文本单元格背景"
 
-#: ../../src/wxMaxima.cpp:6541
+#: ../../src/dialogs/TipOfTheDay.cpp:219
+#, fuzzy
+msgid "Text cells can hold citations that as marked as such by beginning a line with \" > \". The number of spaces in front of the \">\" determines the indentation level, as it does with bullet lists."
+msgstr "文本单元格中以“>”开始的行将显示为引用，而“>”前面的空格数决定了缩进级别。这一功能类似于对项目列表的支持。"
+
+#: ../../src/MaximaCommandMenus.cpp:3061
 msgid "Text snippet"
 msgstr "文本片段"
 
-#: ../../src/wxMaxima.cpp:4632
+#: ../../src/dialogs/TipOfTheDay.cpp:205
+msgid ""
+"The \"at\" function allows introducing one equation into another:\n"
+"\n"
+"    ohm:U=R*I;\n"
+"    r_parallel:R=R_1*R_2/(R_1+R_2);\n"
+"    result:at(ohm,r_parallel);"
+msgstr ""
+
+#: ../../src/MaximaFileIO.cpp:555
 msgid "The .xml file doesn't seem to be valid xml or isn't a content.xml extracted from a .wxmx zip archive"
 msgstr "XML 文件似乎无效，或者其内容并非从 .wxmx 型的 zip 压缩包中提取"
 
-#: ../../src/wxMaxima.cpp:2734
+#: ../../src/MaximaProcessManager.cpp:844
 msgid "The Maxima process doesn't offer a shared memory segment we can send an interrupt signal to."
 msgstr "Maxima 进程没有提供共享内存段，以供向它发送中断信号。"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:392
+msgid "The URL MathJaX.js should be downloaded from by our HTML export."
+msgstr "包含在导出的 HTML 文件中的 URL，用于自动下载 MathJaX.js。"
+
+#: ../../src/cells/TextCell.cpp:336
+msgid "The [] or the part() command tried to access a list or matrix element that doesn't exist."
+msgstr ""
+
+#: ../../src/sidebars/DrawSidebar.cpp:106
+msgid "The accuracy versus speed tradeoff"
+msgstr "精度与速度的权衡"
+
+#: ../../src/cells/TextCell.cpp:357
+msgid "The argument of a function was of the wrong type. Most probably an equation was expected but was lacking an \"=\"."
+msgstr ""
 
 #: ../../src/MaximaManual.cpp:107
 msgid "The cache for the subjects the manual contains cannot be read."
 msgstr "无法读取包含用户手册主题的缓存。"
 
-#: ../../src/MaximaManual.cpp:378
+#: ../../src/MaximaManual.cpp:395
 msgid "The cache for the subjects the manual contains has no head node."
 msgstr "包含用户手册主题的缓存没有头节点。"
 
-#: ../../src/MaximaManual.cpp:396
+#: ../../src/MaximaManual.cpp:413
 msgid "The cache for the subjects the manual contains is from a different Maxima version."
 msgstr "包含用户手册主题的缓存来自另一版本的 Maxima。"
 
-#: ../../src/wxMaximaFrame.cpp:1379
+#: ../../src/wxMaximaFrame.cpp:1413
 msgid "The classic operations one typically uses matrices for"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7193
+#: ../../src/sidebars/DrawSidebar.cpp:91
+msgid "The color of the next line to draw"
+msgstr "用于绘制下一条线的颜色"
+
+#: ../../src/MaximaCommandMenus.cpp:4065
 msgid "The comma-separated contents of the struct fields"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7186
+#: ../../src/MaximaCommandMenus.cpp:4058
 #, fuzzy
 msgid "The comma-separated names of the struct fields"
 msgstr "输入变量列表，以逗号分割。"
 
-#: ../../src/wxMaxima.cpp:7070
-msgid "The command local() allows to tell maxima which functions to make local to the current program when defined."
+#: ../../src/MaximaCommandMenus.cpp:3942
+msgid "The command local() allows telling Maxima which functions to make local to the current program when defined."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:303
+#: ../../src/wxMaximaFrame.cpp:324
 msgid "The current Wizard"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:9592
+#: ../../src/dialogs/ConfigDialogue.cpp:415
+msgid "The default height for embedded plots. Can be read out or overridden by the maxima variable wxplot_size."
+msgstr "嵌入绘图的默认高度，可以被 Maxima 变量 wxplot_size 读取或改写。"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:492
+msgid "The default port used for communication between Maxima and wxMaxima."
+msgstr "Maxima 和 wxMaxima 之间用于通信的默认端口。"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:412
+msgid "The default width for embedded plots. Can be read out or overridden by the maxima variable wxplot_size"
+msgstr "嵌入绘图的默认宽度，可以被 Maxima 变量 wxplot_size 读取或改写。"
+
+#: ../../src/sidebars/DrawSidebar.cpp:74
+msgid "The diagram title"
+msgstr "图表标题"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:2401
+#, c-format
+msgid "The directory %s with maxima's startup file doesn't exist. Trying to create it..."
+msgstr "包含 Maxima 启动文件的目录 %s 不存在。尝试新建此目录..."
+
+#: ../../src/dialogs/ConfigDialogue.cpp:150
+msgid "The directory containing the startup files, any user libraries and, if MAXIMA_OBJDIR isn't set the subdirectory with the results from compiling maxima libraries."
+msgstr "包含启动文件、任何用户库的目录，以及含 Maxima 库的编译结果的子目录（如果没有设置变量 MAXIMA_OBJDIR）。"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:154
+msgid "The directory maxima places temporary files in, for example plots that are to be included in the worksheet."
+msgstr "Maxima 放置临时文件（例如要嵌入工作簿的绘图）的目录。"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:157
+msgid "The directory the compiled versions of maxima are placed in"
+msgstr "已编译的 Maxima 所在的目录"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:159
+msgid "The directory the maxima manual can be found in"
+msgstr "Maxima 用户手册所在的目录"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:160
+msgid "The directory the user's home directory is in"
+msgstr "用户家（home）目录"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:475
+msgid "The document class LaTeX is instructed to use for our documents."
+msgstr "导出 LaTeX 文档所用的文档类（document class）。"
+
+#: ../../src/MaximaCommandMenus.cpp:1832
 #, fuzzy
 msgid "The equation to fit the data to"
 msgstr "显示式子的线性形式"
 
-#: ../../src/wxMaxima.cpp:8447
+#: ../../src/MaximaCommandMenus.cpp:774
+msgid "The expression to substitute in"
+msgstr ""
+
+#: ../../src/MaximaFileIO.cpp:444
+#, c-format
+msgid "The file claims %ld watch variables; capping at %ld."
+msgstr ""
+
+#: ../../src/sidebars/DrawSidebar.cpp:96
+msgid "The fill color for the next objects"
+msgstr "下一个对象的填充颜色"
+
+#: ../../src/cells/TextCell.cpp:354
+msgid "The first argument of subst() isn't an equation or a list of equations. Most probably it was lacking an \"=\"."
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:1444
 msgid "The function call whose arguments to extract"
 msgstr "要提取其参数的函数调用"
 
-#: ../../src/wxMaximaFrame.cpp:1298
+#: ../../src/sidebars/DrawSidebar.cpp:100
+msgid "The grid in the background of the diagram"
+msgstr "图表背景的网格"
+
+#: ../../src/wxMaximaFrame.cpp:1332
 msgid "The half of the equation that is to the left of the \"=\""
 msgstr "“=”左侧的式子"
 
-#: ../../src/wxMaximaFrame.cpp:1302
+#: ../../src/wxMaximaFrame.cpp:1336
 msgid "The half of the equation that is to the right of the \"=\""
 msgstr "“=”右侧的式子"
 
-#: ../../src/MaximaManual.cpp:399
+#: ../../src/MaximaManual.cpp:416
 msgid "The help dir from the cache differs from the current one."
 msgstr ""
 
-#: ../../src/Image.cpp:985
+#: ../../src/Image.cpp:1136
 msgid ""
 "The image could not be displayed. It may be broken, in a wrong format or be the result of gnuplot not being able to write the image or not being able to understand what maxima wanted to plot.\n"
 "One example of the latter would be: Gnuplot refuses to plot entirely empty images"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:9799 ../../src/wxMaxima.cpp:10158
+#: ../../src/MaximaCommandMenus.cpp:3262 ../../src/MaximaCommandMenus.cpp:3687
 #, c-format
 msgid "The image file \"%s\" cannot be found."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:718
+#: ../../src/wxMaximaFrame.cpp:753
 #, fuzzy
 msgid "The integrated help browser"
 msgstr "选择帮助浏览器"
 
-#: ../../src/wxMaxima.cpp:9591
+#: ../../src/cells/TextCell.cpp:397
+msgid "The inverse laplace transform."
+msgstr "Laplace 逆变换"
+
+#: ../../src/dialogs/TipOfTheDay.cpp:223
+msgid "The key combination Shift+Space results in a non-breakable space."
+msgstr "使用 Shift+Space 组合键可以生成不可断开（换行）的空格。"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:162
+msgid "The list of directories the operating system looks for programs in"
+msgstr "操作系统用来寻找程序的一组目录"
+
+#: ../../src/cells/TextCell.cpp:293
+msgid "The list of time-dependent variables to solve to doesn't match the time-dependent variables the list of dgls contains."
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:1831
 msgid "The list of variables contained in each matrix row"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:214
+#: ../../src/dialogs/TipOfTheDay.cpp:166
+#, fuzzy
+msgid "The load() command of Maxima versions >5.38 is able to load .wxm files as library of Maxima's commands."
+msgstr "Maxima 5.38 及更新的版本中，load() 命令可以载入 .wxm 文件作为 Maxima 的程序库。"
+
+#: ../../src/wxMaximaFrame.cpp:228
 msgid "The main toolbar"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1882
+#: ../../src/wxMaximaFrame.cpp:1919
 #, fuzzy
 msgid "The manual of Maxima"
 msgstr "Maxima 离线用户手册"
 
-#: ../../src/wxMaximaFrame.cpp:1881
+#: ../../src/wxMaximaFrame.cpp:1918
 #, fuzzy
 msgid "The manual of wxMaxima"
 msgstr "wxMaxima 离线用户手册"
 
-#: ../../src/wxMaxima.cpp:7125
+#: ../../src/dialogs/MaxSizeChooser.cpp:59
+msgid "The maximum size for this image. Values <= 0 mean: Unspecified."
+msgstr "此图片的最小尺寸，小于等于零的值对应“未指定”。"
+
+#: ../../src/MaximaCommandMenus.cpp:3997
 msgid "The name of a function we don't want to be evaluated here"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7131
+#: ../../src/MaximaCommandMenus.cpp:4003
 msgid "The name of an expression that we don't want to be evaluated."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7199
+#: ../../src/MaximaCommandMenus.cpp:4071
 #, fuzzy
 msgid "The name of the field to read"
 msgstr "用于绘制下一条线的颜色"
 
-#: ../../src/wxMaxima.cpp:7185
+#: ../../src/MaximaCommandMenus.cpp:4057
 msgid "The name of the new struct type"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7198
+#: ../../src/MaximaCommandMenus.cpp:4070
 #, fuzzy
 msgid "The name of the struct"
 msgstr "参数名"
 
-#: ../../src/wxMaxima.cpp:7191
+#: ../../src/MaximaCommandMenus.cpp:4063
 msgid "The name of the struct type"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8220
+#: ../../src/MaximaCommandMenus.cpp:1410
 #, fuzzy
 msgid "The name of the variable that shall contain the current element"
 msgstr "存储当前源列表项的值的变量。"
 
-#: ../../src/wxMaxima.cpp:8468
+#: ../../src/sidebars/DrawSidebar.cpp:86
+msgid "The next plot's title"
+msgstr "下一个绘图的标题"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:494
+msgid "The number of recently opened files that is to be remembered."
+msgstr "记录的最近打开的文件数量。"
+
+#: ../../src/MaximaCommandMenus.cpp:1471
 msgid "The number of the item which is stepped from \"Index Start\" to \"Index End\"."
 msgstr "从“索引开始”到“索引结束”的项数。"
 
-#: ../../src/wxMaxima.cpp:8465 ../../src/wxMaxima.cpp:8478
+#: ../../src/dialogs/ConfigDialogue.cpp:477
+msgid "The options the document class LaTeX is instructed to use for our documents gets."
+msgstr "指示导出的 LaTeX 文档所用文档类（document class）的选项。"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1065
+#: ../../src/dialogs/ConfigDialogue.cpp:1112
+msgid "The part of the output of these commands that isn't declared as \"math\" might be suppressed by wxMaxima. As always maxima commands are required to end in a \";\" or a \"$\""
+msgstr "这些命令的输出中没有声明为“math”的部分可能被 wxMaxima 抑制。Maxima 命令必须以“;”或“$”结尾。"
+
+#: ../../src/dialogs/ResolutionChooser.cpp:51
+msgid "The resolution for this image."
+msgstr ""
+
+#: ../../src/cells/TextCell.cpp:182
+msgid "The result was indefinite, which might be infinity, both plus or minus infinity or something additionally potentially involving a complex infinity."
+msgstr ""
+
+#: ../../src/cells/TextCell.cpp:180
+msgid "The result was undefined."
+msgstr ""
+
+#: ../../src/dialogs/TipOfTheDay.cpp:209
+msgid ""
+"The rhs() (\"right hand side\") command allows retrieving the result of an equation in exactly the format a function would have:\n"
+"\n"
+"    Values:[\n"
+"        /* m=1.2 tons */\n"
+"        m=1.2*10^3,\n"
+"        /* 100 km/h*/\n"
+"        v=100*10^3/(60*60)\n"
+"    ];\n"
+"    Energy:W=1/2*m*v^2;\n"
+"    at(Energy,Values);\n"
+"    W_mech:rhs(%);"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:1468
 msgid ""
 "The rule that explains how to generate the value of a list item.\n"
 "Might be something like \"i\", \"i^2\" or \"sin(i)\""
@@ -7291,53 +10883,92 @@ msgstr ""
 "解释如何生成列表项的值的规则。\n"
 "可以是 i，i^2，sin(i) 等"
 
-#: ../../src/wxMaxima.cpp:7785
+#: ../../src/cells/TextCell.cpp:351
+msgid "The second argument of at() isn't an equation or a list of equations. Most probably it was lacking an \"=\"."
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:3481
+msgid "The selection contains no output that could be exported."
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:966
 msgid "The solution of an ODE describes the general shape of the resulting curve. The actual height of that curve is defined by the initial condition or boundary values, later on."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7818
+#: ../../src/MaximaCommandMenus.cpp:999
 msgid ""
 "The solution of an ODE tells the shape, but not the height of the solution.\n"
 "If the ODE's result is known at two points this function fills in the correct values for the  constants"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7794 ../../src/wxMaxima.cpp:7805
+#: ../../src/MaximaCommandMenus.cpp:975 ../../src/MaximaCommandMenus.cpp:986
 msgid ""
 "The solution of an ODE tells the shape, but not the height of the solution.\n"
 "If the ODE's state is known at a point this function fills in the correct values for the constants"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7896
+#: ../../src/MaximaCommandMenus.cpp:1077
 msgid ""
 "The solution variable needs to be in the form\n"
 "   U(t)=1/2*U(t)+3*diff(U(t),t)\n"
 "for this to work; Initial conditions can be specified using atvalue()."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8481 ../../src/wxMaxima.cpp:8582
+#: ../../src/sidebars/DrawSidebar.cpp:58
+msgid "The standard plot command: Plot an equation as a curve"
+msgstr "标准绘图命令：绘制方程对应的曲线"
+
+#: ../../src/cells/TextCell.cpp:267
+msgid "The value of few special variables is assigned by Maxima and cannot be changed by the user. Also a few constructs aren't variable names and therefore cannot be written to."
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:1485 ../../src/MaximaCommandMenus.cpp:1600
 msgid "The variable the value of the current source item is stored in."
 msgstr "存储当前源列表项的值的变量。"
 
-#: ../../src/wxMaxima.cpp:9594
+#: ../../src/MaximaCommandMenus.cpp:1834
 msgid "The variables to search the optimum solution for"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:193
+#: ../../src/wxMaximaFrame.cpp:207
 #, fuzzy
 msgid "The worksheet"
 msgstr "工作簿"
 
-#: ../../src/Worksheet.cpp:8122
+#: ../../src/worksheet/Worksheet.cpp:6371
 msgid "The worksheet containing maxima's input and output"
 msgstr "包含 Maxima 的输入和输出的工作簿"
 
-#: ../../src/MathParser.cpp:629
+#: ../../src/MathParser.cpp:682
 msgid ""
 "The xml data from maxima or from the .wxmx file was missing data here.\n"
 "If you find a way how to reproduce this problem please file a bug report against wxMaxima."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2143
+#: ../../src/MaximaCommandMenus.cpp:1481
+msgid ""
+"The ‘j’th element is equal to ‘ev (<expr>, <x>=<list>[j])’ \n"
+"j are the elements of the source list.\n"
+"Might be something like \"x=i\""
+msgstr ""
+
+#: ../../src/dialogs/TipOfTheDay.cpp:95
+msgid "There are many resources about Maxima and wxMaxima on the internet. Visit https://wxMaxima-developers.github.io/wxmaxima/help.html for more information and to find tutorials on using wxMaxima and Maxima."
+msgstr "互联网上有很多关于 Maxima 和 wxMaxima 的资源。访问 https://wxMaxima-developers.github.io/wxMaxima/help.html 可以了解更多信息，以及查找 wxMaxima 和Maxima 的相关教程。"
+
+#: ../../src/dialogs/TipOfTheDay.cpp:251
+msgid ""
+"There is a discussion forum for wxMaxima at https://github.com/wxMaxima-developers/wxmaxima/discussions.\n"
+"You can ask questions there - and please help other users, by answering their questions, if you know an answer."
+msgstr ""
+
+#: ../../src/MaximaResponseReader.cpp:63
+msgid ""
+"There was an error in the XML describing a worksheet-export request.\n"
+"Please report this as a bug to the wxMaxima project."
+msgstr ""
+
+#: ../../src/MaximaOutputAppender.cpp:66 ../../src/MaximaOutputAppender.cpp:194
 #, fuzzy
 msgid ""
 "There was an error in the XML maxima has generated.\n"
@@ -7347,25 +10978,25 @@ msgstr ""
 "\n"
 "请报告这一错误。"
 
-#: ../../src/wxMaxima.cpp:3911
+#: ../../src/MaximaResponseReader.cpp:1027
 msgid ""
 "There was an error in the XML that should contain a list of watch variables.\n"
 "Please report this as a bug to the wxMaxima project."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3869
+#: ../../src/MaximaResponseReader.cpp:986
 msgid ""
 "There was an error in the XML that should contain the list of operators.\n"
 "Please report this as a bug to the wxMaxima project."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3321
+#: ../../src/MaximaResponseReader.cpp:719
 msgid ""
 "There was an error in the XML that should describe the contents of some variables.\n"
 "Please report this as a bug to the wxMaxima project."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3257
+#: ../../src/MaximaResponseReader.cpp:163
 #, fuzzy
 msgid ""
 "There was an error in the XML that should describe the manual topics.\n"
@@ -7375,13 +11006,27 @@ msgstr ""
 "\n"
 "请报告这一错误。"
 
-#: ../../src/wxMaxima.cpp:3202
+#: ../../src/MaximaResponseReader.cpp:42
 msgid ""
 "There was an error in the XML that should describe the status bar message.\n"
 "Please report this as a bug to the wxMaxima project."
 msgstr ""
 
-#: ../../src/MaximaManual.cpp:363
+#: ../../src/sidebars/GreekSidebar.cpp:185
+msgid "Theta"
+msgstr "Theta"
+
+#: ../../src/dialogs/LicenseDialog.cpp:85
+msgid "Third-party notices"
+msgstr ""
+
+#: ../../src/cells/TextCell.cpp:312
+msgid ""
+"This error message is most probably caused by a try to assign a value to a number instead of a variable name.\n"
+"One probable cause is using a variable that already has a numeric value as a loop counter."
+msgstr ""
+
+#: ../../src/MaximaManual.cpp:376
 msgid ""
 "This file is generated by wxMaxima\n"
 "It caches the list of subjects maxima's manual offers and is automatically\n"
@@ -7391,130 +11036,207 @@ msgstr ""
 "它缓存了 Maxima 用户手册提供的主题列表，并且如果变更了 Maxima\n"
 "的版本或无法读取该文件，则自动重新生成"
 
-#: ../../src/Worksheet.cpp:1992
+#: ../../src/dialogs/ConfigDialogue.cpp:1097
+msgid "This file won't be read by maxima if maxima is used without wxMaxima. In order to add startup commands that are executed in this case, too, please add them to maxima-init.mac, instead."
+msgstr "如果未通过 wxMaxima 使用 Maxima，后者将不会读取此文件。为了在这种情况下添加启动时执行的命令，请将这些命令写入 Maxima 会读取的 init.mac 文件。"
+
+#: ../../src/worksheet/WorksheetContextMenu.cpp:764
 msgid "This function will return even integers"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1994
+#: ../../src/worksheet/WorksheetContextMenu.cpp:766
 msgid "This function will return odd integers"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1950
+#: ../../src/cells/TextCell.cpp:229
+msgid "This message can appear when trying to numerically find an optimum. In this case it might indicate that a starting point lies in a local optimum that fits the data best if one parameter is increased to infinity or decreased to -infinity. It also can indicate that an attempt was made to fit data to an equation that actually matches the data best if one parameter is set to +/- infinity."
+msgstr ""
+
+#: ../../src/worksheet/WorksheetContextMenu.cpp:722
 msgid "This symbol has no imaginary part"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1956
+#: ../../src/worksheet/WorksheetContextMenu.cpp:728
 msgid "This symbol has no real part"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1953
+#: ../../src/worksheet/WorksheetContextMenu.cpp:725
 msgid "This symbol might have both real and imaginary part"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1980
+#: ../../src/cells/TextCell.cpp:300
+msgid "This warning can be deactivated by setting factor_max_degree_print_warning to false."
+msgstr ""
+
+#: ../../src/wizards/DrawWiz.cpp:471
+#, c-format
+msgid "This wizard setups a %iD scene."
+msgstr ""
+
+#: ../../src/worksheet/WorksheetContextMenu.cpp:752
 msgid "Throw an error if this symbol is used before assigning it any contents"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:9013 ../../src/wxMaxima.cpp:10058
+#: ../../src/wizards/Plot2dWiz.cpp:65 ../../src/wizards/Plot2dWiz.cpp:505
+msgid "Ticks:"
+msgstr "坐标刻度："
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1359
+msgid "Time [in Minutes] between autosaves"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:267 ../../src/MaximaCommandMenus.cpp:3547
 msgid "Times:"
 msgstr "微分次数："
 
-#: ../../src/ToolBar.cpp:272
+#: ../../src/dialogs/TipOfTheDay.cpp:49 ../../src/dialogs/TipOfTheDay.cpp:267
+msgid "Tip of the day"
+msgstr "每日提示"
+
+#: ../../src/ToolBar.cpp:482 ../../src/sidebars/FormatSidebar.cpp:48
 msgid "Title"
 msgstr "标题"
 
-#: ../../src/wxMaxima.cpp:8315 ../../src/wxMaxima.cpp:8328
+#: ../../src/MaximaCommandMenus.cpp:1961 ../../src/MaximaCommandMenus.cpp:1974
 msgid "Title (Sub- and superscripts as x_{10} or x^{10})"
 msgstr "标题（参考 x_{10} 和 x^{10} 来输入上、下标）"
 
-#: ../../src/Configuration.cpp:92
+#: ../../src/Styles.cpp:121
 msgid "Title cell (Heading 1)"
 msgstr "标题单元格（一级标题）"
 
-#: ../../src/wxMaximaFrame.cpp:1794
+#: ../../src/dialogs/TipOfTheDay.cpp:89
+msgid "Title, section and subsection cells can be folded to hide their contents. To fold or unfold, click in the square next to the cell. If you shift-click, all sublevels of that cell will also fold/unfold."
+msgstr "标题、节和小节单元格可以折叠以隐藏其内容。要折叠或展开，请单击单元格左侧的正方形。如果按住 Shift 键并单击，该单元格的所有子单元格也将折叠或展开。"
+
+#: ../../src/wxMaximaFrame.cpp:1831
 msgid "To &Bigfloat"
 msgstr "转换为大浮点数(&B)"
 
-#: ../../src/wxMaximaFrame.cpp:1791
+#: ../../src/wxMaximaFrame.cpp:1828
 msgid "To &Float"
 msgstr "转换为浮点数(&F)"
 
-#: ../../src/Worksheet.cpp:1571
+#: ../../src/worksheet/WorksheetContextMenu.cpp:344
 msgid "To Float"
 msgstr "转换为浮点数"
 
-#: ../../src/wxMaximaFrame.cpp:1797
+#: ../../src/wxMaximaFrame.cpp:1834
 msgid "To Numeri&c\tCtrl+Shift+N"
 msgstr "转换为数值(&C)\tCtrl+Shift+N"
 
-#: ../../src/wxMaximaFrame.cpp:1803
+#: ../../src/wxMaximaFrame.cpp:1840
 #, fuzzy
 msgid "To exact fraction"
 msgstr "部分分式"
 
-#: ../../src/wxMaximaFrame.cpp:1814
+#: ../../src/wxMaximaFrame.cpp:1851
 #, fuzzy
 msgid "To exact number"
 msgstr "准确数值\n"
 
-#: ../../src/wxMaxima.cpp:9064
+#: ../../src/dialogs/TipOfTheDay.cpp:124
+msgid "To plot in polar coordinates, select 'set polar' in the Options entry for Plot2d dialog. You can also plot in spherical and cylindrical coordinates in 3D."
+msgstr "要按极坐标绘图，可以在菜单“绘图->二维绘图”的“选项”中选择“设置极轴（set polar）”。在菜单“绘图->三维绘图”中则可以选择按球面坐标或柱面坐标绘图。"
+
+#: ../../src/dialogs/TipOfTheDay.cpp:131
+msgid "To put parentheses around an expression, select it, and press '(' or ')' depending on where you want the cursor to appear afterwards."
+msgstr "若要对表达式整体加括号，可以先选择该表达式，然后按“(”或“)”（括号类型决定了光标随后出现的位置）。"
+
+#: ../../src/dialogs/TipOfTheDay.cpp:137
+msgid "To save the size and position of wxMaxima windows between session, use 'Edit->Configure' dialog."
+msgstr "要在不同会话之间使用相同的 wxMaxima 窗口的大小和位置，可使用“编辑->配置”对话框。"
+
+#: ../../src/dialogs/TipOfTheDay.cpp:51
+msgid "To start using wxMaxima right away, start typing your command. An input cell should appear. Then press Shift-Enter to evaluate your command."
+msgstr "开始使用 wxMaxima 时，键入的命令会出现在（数学）输入单元格中，输入完成后按 Shift+Enter 键执行命令（开始计算）。"
+
+#: ../../src/MaximaCommandMenus.cpp:318 ../../src/wizards/IntegrateWiz.cpp:47
+#: ../../src/wizards/Plot2dWiz.cpp:51 ../../src/wizards/Plot2dWiz.cpp:61
+#: ../../src/wizards/Plot2dWiz.cpp:502 ../../src/wizards/Plot3dWiz.cpp:40
+#: ../../src/wizards/Plot3dWiz.cpp:49 ../../src/wizards/SumWiz.cpp:40
 msgid "To:"
 msgstr "到："
 
-#: ../../src/wxMaximaFrame.cpp:825 ../../src/wxMaximaFrame.cpp:828
+#: ../../src/sidebars/TableOfContents.cpp:579
+msgid "Toc levels shown here"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:862 ../../src/wxMaximaFrame.cpp:865
 msgid "Toggle full screen editing"
 msgstr "切换全屏编辑"
 
-#: ../../src/ToolBar.cpp:265
+#: ../../src/dialogs/DiffFrame.cpp:370 ../../src/dialogs/DiffFrame.cpp:387
+msgid "Toggle horizontal scroll synchronization"
+msgstr ""
+
+#: ../../src/ToolBar.cpp:471 ../../src/ToolBar.cpp:473
 msgid "Toggle the visibility of code cells"
 msgstr "切换数学单元格的可见性"
 
-#: ../../src/wxMaximaFrame.cpp:1177
+#: ../../src/dialogs/DiffFrame.cpp:382 ../../src/dialogs/DiffFrame.cpp:388
+msgid "Toggle vertical scroll synchronization"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1211
 msgid "Tokenize..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1909
+#: ../../src/wxMaximaFrame.cpp:1946
 msgid "Tolerance calculations with Maxima"
 msgstr "使用 Maxima 进行误差计算"
 
-#: ../../src/wxMaxima.cpp:8192
+#: ../../src/ToolBar.cpp:176
+msgid "Toolbar"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1991
+#, fuzzy
+msgid "Top"
+msgstr "弹出（pop）"
+
+#: ../../src/MaximaCommandMenus.cpp:1382
 msgid "Top end"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1078
+#: ../../src/wxMaxima.cpp:2862
+msgid "Tortoise diff tool"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1112
 #, fuzzy
 msgid "Trace a function..."
 msgstr "删除函数"
 
-#: ../../src/wxMaxima.cpp:7084
+#: ../../src/MaximaCommandMenus.cpp:3956
 #, fuzzy
 msgid "Trace function(s)"
 msgstr "删除函数："
 
-#: ../../src/wxMaximaFrame.cpp:1184
+#: ../../src/wxMaximaFrame.cpp:1218
 #, fuzzy
 msgid "Transformations"
 msgstr "转置矩阵"
 
-#: ../../src/wxMaximaFrame.cpp:1376
+#: ../../src/wxMaximaFrame.cpp:1410
 msgid "Transpose a matrix"
 msgstr "转置矩阵"
 
-#: ../../src/wxMaxima.cpp:7832
+#: ../../src/MaximaCommandMenus.cpp:1013
 msgid "Tries to find a numerical solution for a 1st order ODE (or in other words: a equation of the format depends(x,t);diff(x,t)=(something containing x and t)"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:10036
+#: ../../src/MaximaCommandMenus.cpp:3525
 #, fuzzy
 msgid "Tries to find a solution of the equation that lies between the two bounds."
 msgstr "“=”左侧的式子"
 
-#: ../../src/wxMaxima.cpp:7774
+#: ../../src/MaximaCommandMenus.cpp:955
 #, fuzzy
 msgid "Tries to find a value of the variable that solves the equation between the two bonds"
 msgstr "“=”左侧的式子"
 
-#: ../../src/wxMaxima.cpp:7719
+#: ../../src/MaximaCommandMenus.cpp:901
 msgid ""
 "Tries to find all solutions of a polynomial numerically using bfloats.\n"
 "Might be able to detect solutions in non-polynomials, as well, if the expression is approximated by an polynomial, beforehand:\n"
@@ -7522,7 +11244,7 @@ msgid ""
 "    bfallroots(ratdisrep(taylor(expression,0,30)));"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7709
+#: ../../src/MaximaCommandMenus.cpp:892
 msgid ""
 "Tries to find all solutions of a polynomial numerically.\n"
 "Might be able to detect solutions in non-polynomials, as well, if the expression is approximated by an polynomial, beforehand:\n"
@@ -7530,7 +11252,7 @@ msgid ""
 "    allroots(ratdisrep(taylor(expression,0,30)));"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7730
+#: ../../src/MaximaCommandMenus.cpp:911
 #, c-format
 msgid ""
 "Tries to find exact fractions that match the numerical solutions of a polynomial.\n"
@@ -7542,291 +11264,404 @@ msgid ""
 "See also guess_exact_value()"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1181
+#: ../../src/wxMaximaFrame.cpp:1215
 msgid "Trim both ends..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1182
+#: ../../src/wxMaximaFrame.cpp:1216
 #, fuzzy
 msgid "Trim left..."
 msgstr "极限..."
 
-#: ../../src/wxMaximaFrame.cpp:1183
+#: ../../src/wxMaximaFrame.cpp:1217
 #, fuzzy
 msgid "Trim right..."
 msgstr "极限..."
 
-#: ../../src/wxMaxima.cpp:7473
+#: ../../src/MaximaCommandMenus.cpp:4345
 msgid "Trim string left"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7469
+#: ../../src/MaximaCommandMenus.cpp:4341
 msgid "Trim string on both ends"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7477
+#: ../../src/MaximaCommandMenus.cpp:4349
 msgid "Trim string right"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1511
+#: ../../src/wxMaximaFrame.cpp:1548
 msgid "Try to guess which form is &simple"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8637
+#: ../../src/MaximaCommandMenus.cpp:629
 msgid "Try to simplify sums that result from sum() commands."
 msgstr ""
 
-#: ../../src/MaximaManual.cpp:369
+#: ../../src/MaximaManual.cpp:382
 #, c-format
 msgid "Trying to cache the list of subjects the manual contains in the file %s."
 msgstr "尝试将用户手册的主题列表缓存到文件 %s 中。"
 
-#: ../../src/wxMaxima.cpp:4423
+#: ../../src/MaximaFileIO.cpp:357
 msgid "Trying to discard all output."
 msgstr "尝试丢弃所有输出。"
 
-#: ../../src/wxMaxima.cpp:4380
+#: ../../src/MaximaFileIO.cpp:326
 #, fuzzy
 msgid "Trying to extract content.xml out of a broken .zip file."
 msgstr "尝试从一个损坏的 zip 文件中提取 xml 内容。"
 
-#: ../../src/wxMaxima.cpp:5519
+#: ../../src/MaximaFileIO.cpp:610
 msgid "Trying to open a file with an empty name!"
 msgstr "尝试打开无名文件！"
 
-#: ../../src/wxMaxima.cpp:5523
+#: ../../src/MaximaFileIO.cpp:622
 #, c-format
 msgid "Trying to open the non-existing file %s"
 msgstr "尝试打开不存在的 %s 文件"
 
-#: ../../src/wxMaxima.cpp:4457
+#: ../../src/MaximaFileIO.cpp:378
 msgid "Trying to reconstruct the xml closing markers."
 msgstr "尝试重建 xml 结束标记。"
 
-#: ../../src/wxMaxima.cpp:4376
+#: ../../src/MaximaFileIO.cpp:322
 msgid "Trying to recover a broken .wxmx file."
 msgstr "尝试恢复损坏的 .wxmx 文件。"
 
-#: ../../src/wxMaxima.cpp:6026
+#: ../../src/MaximaFileIO.cpp:907
 #, c-format
 msgid "Trying to remove the old temp file %s"
 msgstr "尝试删除旧的临时文件 %s"
 
-#: ../../src/wxMaxima.cpp:2507
+#: ../../src/MaximaProcessManager.cpp:168
 msgid "Trying to restart maxima."
 msgstr "尝试重启 Maxima。"
 
-#: ../../src/wxMaxima.cpp:2523
+#: ../../src/MaximaProcessManager.cpp:184
 #, c-format
 msgid "Trying to start the socket a Maxima on the local machine can connect to on port %i"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1928
+#: ../../src/dialogs/ConfigDialogue.cpp:230
+msgid "Turkish"
+msgstr "土耳其语"
+
+#: ../../src/wxMaximaFrame.cpp:1965
 msgid "Tutorials"
 msgstr "教程"
 
-#: ../../src/wxMaxima.cpp:9571
+#: ../../src/MaximaCommandMenus.cpp:1809
 msgid "Two sample t-test"
 msgstr "双样本 t-检验"
 
-#: ../../src/Worksheet.cpp:8013
+#: ../../src/worksheet/Worksheet.cpp:6249
 msgid "Type"
 msgstr "类型"
 
-#: ../../src/wxMaxima.cpp:7180
+#: ../../src/cells/EditorCell.cpp:4550
+msgid "Type in text"
+msgstr "文本类型"
+
+#: ../../src/MaximaCommandMenus.cpp:4052 ../../src/wizards/MatWiz.cpp:158
 msgid "Type:"
 msgstr "类型："
 
-#: ../../src/wxMaxima.cpp:9429
+#: ../../src/MaximaCommandMenus.cpp:2072
 msgid "URL"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1146
+#: ../../src/dialogs/ConfigDialogue.cpp:1231
+msgid "URL MathJaX.js is located at:"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1180
 msgid "UTF8 to Unicode code point..."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:10479
+#: ../../src/dialogs/ConfigDialogue.cpp:231
+msgid "Ukrainian"
+msgstr "乌克兰语"
+
+#: ../../src/wxMaxima.cpp:3166
 msgid "Un-closed parenthesis"
 msgstr "未配对的括号"
 
-#: ../../src/wxMaxima.cpp:10467
+#: ../../src/wxMaxima.cpp:3154
 msgid "Un-closed parenthesis on encountering ; or $"
 msgstr "在遇到 ; 或 $ 时有未配对的括号"
 
-#: ../../src/wxMaxima.cpp:11160
-msgid "Unable to interpret the version info I got from http://wxMaxima-developers.github.io/wxmaxima/version.txt: "
-msgstr "无法解释来自 http://wxMaxima-developers.github.io/wxMaxima/version.txt 的版本信息："
+#: ../../src/wxMaxima.cpp:3468
+#, c-format
+msgid "Unable to interpret the version info I got from %s: %s"
+msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1007
+#: ../../src/wxMaxima.cpp:3414
+#, c-format
+msgid "Unable to interpret the version info I got: %s"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1041
 #, fuzzy
 msgid "Undefine"
 msgstr "未定义"
 
-#: ../../src/ToolBar.cpp:191
+#: ../../src/sidebars/VariablesPane.cpp:303
+#: ../../src/sidebars/VariablesPane.cpp:386
+msgid "Undefined"
+msgstr "未定义"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:2115
+msgid "Underlined"
+msgstr "下划线"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:745
+msgid "Underscore converts to subscripts:"
+msgstr "下划线转换为下标："
+
+#: ../../src/ToolBar.cpp:354 ../../src/ToolBar.cpp:357
 msgid "Undo"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:631
+#: ../../src/wxMaximaFrame.cpp:668
 msgid "Undo\tCtrl+Z"
 msgstr "撤销\tCtrl+Z"
 
-#: ../../src/ToolBar.cpp:614
+#: ../../src/ToolBar.cpp:814
 #, fuzzy
 msgid "Undo and redo button"
 msgstr "打开和保存按钮"
 
-#: ../../src/wxMaximaFrame.cpp:631
+#: ../../src/wxMaximaFrame.cpp:668
 msgid "Undo last change"
 msgstr "撤销上一次更改"
 
-#: ../../src/wxMaximaFrame.cpp:924
+#: ../../src/cells/TextCell.cpp:115
+#, c-format
+msgid "Unexpected text style %li for TextCell"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:958
 msgid "Unfold All\tCtrl+Alt+]"
 msgstr "展开全部\tCtrl+Alt+]"
 
-#: ../../src/wxMaximaFrame.cpp:925
+#: ../../src/wxMaximaFrame.cpp:959
 msgid "Unfold all folded sections"
 msgstr "展开所有已折叠节单元"
 
-#: ../../src/Worksheet.cpp:1893
+#: ../../src/sidebars/TableOfContents.cpp:507
+msgid "Unhide"
+msgstr "显示"
+
+#: ../../src/worksheet/WorksheetContextMenu.cpp:665
 msgid "Unhide Heading 5"
 msgstr "显示五级标题"
 
-#: ../../src/Worksheet.cpp:1904
+#: ../../src/worksheet/WorksheetContextMenu.cpp:676
 msgid "Unhide Heading 6"
 msgstr "显示六级标题"
 
-#: ../../src/Worksheet.cpp:1852
+#: ../../src/worksheet/WorksheetContextMenu.cpp:624
 msgid "Unhide Part"
 msgstr "显示此部分"
 
-#: ../../src/Worksheet.cpp:1860
+#: ../../src/worksheet/WorksheetContextMenu.cpp:632
 msgid "Unhide Section"
 msgstr "显示节"
 
-#: ../../src/Worksheet.cpp:1871
+#: ../../src/worksheet/WorksheetContextMenu.cpp:643
 msgid "Unhide Subsection"
 msgstr "显示小节"
 
-#: ../../src/Worksheet.cpp:1882
+#: ../../src/worksheet/WorksheetContextMenu.cpp:654
 msgid "Unhide Subsubsection"
 msgstr "显示小小节"
 
-#: ../../src/Worksheet.cpp:1912
+#: ../../src/worksheet/WorksheetContextMenu.cpp:684
 msgid "Unhide contents"
 msgstr "显示内容"
 
-#: ../../src/wxMaximaFrame.cpp:266
+#: ../../src/wxMaximaFrame.cpp:287
 msgid "Unicode characters"
 msgstr "Unicode 字符"
 
-#: ../../src/wxMaximaFrame.cpp:707
+#: ../../src/wxMaximaFrame.cpp:742
 msgid "Unicode chars\tAlt+Shift+U"
 msgstr "Unicode 字符\tAlt+Shift+U"
 
-#: ../../src/wxMaximaFrame.cpp:1144
+#: ../../src/wxMaximaFrame.cpp:1178
 msgid "Unicode code point to UTF8..."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7366
+#: ../../src/MaximaCommandMenus.cpp:4238
 msgid "Unicode code point to char"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1142
+#: ../../src/wxMaximaFrame.cpp:1176
 msgid "Unicode code point to char..."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7371
+#: ../../src/MaximaCommandMenus.cpp:4243
 msgid "Unicode code point to utf8 numbers"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7078
+#: ../../src/sidebars/SymbolsSidebar.cpp:180
+msgid "Unicode symbols:"
+msgstr "Unicode 符号："
+
+#: ../../src/MaximaCommandMenus.cpp:3950
 msgid "Unlike in other programming language return() only exits from the current loop or block(), not from the whole function."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:10418
+#: ../../src/wxMaxima.cpp:3105
 msgid "Unterminated comment."
 msgstr "未封闭的注释。"
 
-#: ../../src/wxMaxima.cpp:10461
+#: ../../src/wxMaxima.cpp:3148
 msgid "Unterminated string."
 msgstr "未封闭的字符串。"
 
-#: ../../src/wxMaxima.cpp:4786
+#: ../../src/wizards/ActualValuesStorageWiz.cpp:43
+msgid "Until then the actual values for all variables can be kept in a list."
+msgstr ""
+
+#: ../../src/dialogs/DiffFrame.cpp:429 ../../src/dialogs/FindReplacePane.cpp:80
+msgid "Up"
+msgstr "上"
+
+#: ../../src/MaximaEvaluator.cpp:629
 msgid "Updating maxima's configuration"
 msgstr "更新 Maxima 设置"
 
-#: ../../src/wxMaxima.cpp:11150 ../../src/wxMaxima.cpp:11157
-#: ../../src/wxMaxima.cpp:11163
+#: ../../src/wxMaxima.cpp:3407 ../../src/wxMaxima.cpp:3412
+#: ../../src/wxMaxima.cpp:3414 ../../src/wxMaxima.cpp:3461
+#: ../../src/wxMaxima.cpp:3466 ../../src/wxMaxima.cpp:3469
 msgid "Upgrade"
 msgstr "升级"
 
-#: ../../src/wxMaxima.cpp:7779 ../../src/wxMaxima.cpp:10041
+#: ../../src/MaximaCommandMenus.cpp:489 ../../src/MaximaCommandMenus.cpp:502
+#: ../../src/MaximaCommandMenus.cpp:517 ../../src/MaximaCommandMenus.cpp:531
+msgid "Upper bound on the number of cycles. Must be greater than or equal to 3."
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:960 ../../src/MaximaCommandMenus.cpp:3530
 msgid "Upper bound:"
 msgstr "上限："
 
-#: ../../src/wxMaximaFrame.cpp:792
+#: ../../src/sidebars/GreekSidebar.cpp:197
+msgid "Upsilon"
+msgstr "Upsilon"
+
+#: ../../src/wxMaximaFrame.cpp:829
 msgid "Use \"<\" and \">\" as parenthesis for matrices"
 msgstr "使用“<”和“>”作为矩阵的括号"
 
-#: ../../src/wxMaximaFrame.cpp:1708 ../../src/wxMaximaFrame.cpp:1739
+#: ../../src/dialogs/ConfigDialogue.cpp:507
+msgid "Use GTK's overlay scrollbars, which appear over the worksheet and fade out when unused. Looks modern, but GTK repaints the whole worksheet on every frame of the fade animation - which runs after every mouse movement - so classic scrollbars are much faster."
+msgstr ""
+
+#: ../../src/wizards/SumWiz.cpp:69
+msgid "Use Gosper algorithm"
+msgstr "使用 Gosper 算法"
+
+#: ../../src/sidebars/RegexCtrl.cpp:133
+msgid "Use RegEx filtering"
+msgstr ""
+
+#: ../../src/sidebars/RegexCtrl.cpp:134
+msgid "Use Text search filtering"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1745 ../../src/wxMaximaFrame.cpp:1776
 msgid "Use a list"
 msgstr "使用列表"
 
-#: ../../src/wxMaxima.cpp:8571
+#: ../../src/MaximaCommandMenus.cpp:1589
 msgid "Use a list as parameter list for a function"
 msgstr "使用列表作为函数的参数列表"
 
-#: ../../src/wxMaximaFrame.cpp:1708
+#: ../../src/wxMaximaFrame.cpp:2008
+msgid "Use as TortoiseSVN/Git diff tool"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:485
+msgid "Use centered dot and Minus, not Star and Hyphen"
+msgstr "使用居中的点和减号，而不是星号和连字符"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:849
+msgid "Use centered dot character for multiplication"
+msgstr "使用居中的点（∙）表示乘法"
+
+#: ../../src/wxMaximaFrame.cpp:1745
 msgid "Use list"
 msgstr "使用列表"
 
-#: ../../src/wxMaximaFrame.cpp:1701
+#: ../../src/wxMaximaFrame.cpp:1738
 msgid "Use list as the arguments of a function"
 msgstr "使用列表作为函数的参数列表"
 
-#: ../../src/wxMaximaFrame.cpp:786
+#: ../../src/wxMaximaFrame.cpp:823
 msgid "Use rounded parenthesis for matrices"
 msgstr "使用圆括号作为矩阵括号"
 
-#: ../../src/wxMaximaFrame.cpp:789
+#: ../../src/wxMaximaFrame.cpp:826
 msgid "Use square parenthesis for matrices"
 msgstr "使用方括号作为矩阵括号"
 
-#: ../../src/wxMaximaFrame.cpp:1083
+#: ../../src/wxMaximaFrame.cpp:1117
 #, fuzzy
 msgid "Use struct field..."
 msgstr "连分数(&C)"
 
-#: ../../src/wxMaximaFrame.cpp:795
+#: ../../src/dialogs/ConfigDialogue.cpp:425
+msgid "Use the \"partial derivative\" symbol to represent the fraction that represents a diff() when exporting LaTeX"
+msgstr "导出为 LaTeX 文件时，使用偏导数符号表示 diff() 命令的结果"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:2052
+msgid "Use unicode Math Symbols, if available"
+msgstr "尽可能使用 Unicode 数学符号"
+
+#: ../../src/wxMaximaFrame.cpp:832
 msgid "Use vertical lines instead of parenthesis for matrices"
 msgstr "使用竖线作为矩阵括号"
 
-#: ../../src/Worksheet.cpp:1619
+#: ../../src/worksheet/WorksheetContextMenu.cpp:392
 msgid "User labels only"
 msgstr "只使用用户定义的标签"
 
-#: ../../src/Configuration.cpp:81
+#: ../../src/dialogs/ConfigDialogue.cpp:1248
+#: ../../src/dialogs/ConfigDialogue.cpp:1452
+#: ../../src/dialogs/ConfigDialogue.cpp:1480
+#: ../../src/dialogs/MaximaNotStartingDialog.cpp:54
+msgid "User specified"
+msgstr "用户指定"
+
+#: ../../src/Styles.cpp:110
 msgid "User-defined labels"
 msgstr "用户定义的标签"
 
-#: ../../src/MaximaManual.cpp:483
+#: ../../src/dialogs/ConfigDialogue.cpp:770
+msgid "User-defined labels if available"
+msgstr "尽可能使用用户定义的标签"
+
+#: ../../src/MaximaManual.cpp:500
 msgid "Using Maxima help file from wxMaxima configuration file (helpFile=...))"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:4825
+#: ../../src/wxMaxima.cpp:1566
 msgid "Using Maxima path from command line."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:4822
+#: ../../src/wxMaxima.cpp:1563
 #, fuzzy
 msgid "Using configured Maxima path."
 msgstr "设置 wxMaxima"
 
-#: ../../src/wxMaxima.cpp:2961
+#: ../../src/MaximaProcessManager.cpp:976
 msgid "Using gnuplot's antialiassing-less png driver for embedded plots as pngcairo could not be found"
 msgstr "在找不到 pngcairo 时，为嵌入式绘图使用 gnuplot 的抗锯齿 png 驱动程序"
 
-#: ../../src/wxMaxima.cpp:2956
+#: ../../src/MaximaProcessManager.cpp:971
 msgid "Using gnuplot's pngcairo driver for embedded plots"
 msgstr "为嵌入式绘图使用 gnuplot 的 pngcairo 驱动程序"
 
@@ -7834,124 +11669,165 @@ msgstr "为嵌入式绘图使用 gnuplot 的 pngcairo 驱动程序"
 msgid "Using the built-in list of manual anchors."
 msgstr "使用内置的用户手册锚列表。"
 
-#: ../../src/WXMXformat.cpp:266
+#: ../../src/dialogs/AboutDialog.cpp:46
+#, c-format
+msgid ""
+"Using: %s\n"
+"\n"
+msgstr ""
+
+#: ../../src/WXMXformat.cpp:268
 msgid "Validated that the XML representation of the document actually is valid XML"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8755
+#: ../../src/dialogs/ConfigDialogue.cpp:542
+#: ../../src/wizards/ActualValuesStorageWiz.cpp:49
+msgid "Value"
+msgstr "值"
+
+#: ../../src/MaximaCommandMenus.cpp:756
 #, fuzzy
 msgid "Value at a given point"
 msgstr "计算到此处"
 
-#: ../../src/Worksheet.cpp:1987
+#: ../../src/worksheet/WorksheetContextMenu.cpp:759
 msgid "Value at a specific point"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7801
+#: ../../src/MaximaCommandMenus.cpp:982
 #, fuzzy
 msgid "Value at that point:"
 msgstr "计算到此处"
 
-#: ../../src/wxMaxima.cpp:7812 ../../src/wxMaxima.cpp:7825
-#: ../../src/wxMaxima.cpp:7827
+#: ../../src/MaximaCommandMenus.cpp:993 ../../src/MaximaCommandMenus.cpp:1006
+#: ../../src/MaximaCommandMenus.cpp:1008
 #, fuzzy
 msgid "Value y at that point:"
 msgstr "计算到此处"
 
-#: ../../src/wxMaxima.cpp:7910
+#: ../../src/MaximaCommandMenus.cpp:1091 ../../src/wizards/BC2Wiz.cpp:36
+#: ../../src/wizards/BC2Wiz.cpp:42
 msgid "Value:"
 msgstr "值："
 
-#: ../../src/wxMaxima.cpp:8201
+#: ../../src/MaximaCommandMenus.cpp:1391
 msgid "Var #1"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8202
+#: ../../src/MaximaCommandMenus.cpp:1392
 msgid "Var #2"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:6852 ../../src/wxMaxima.cpp:8183
+#: ../../src/MaximaCommandMenus.cpp:1371 ../../src/MaximaCommandMenus.cpp:1755
+#: ../../src/dialogs/ConfigDialogue.cpp:541
+#: ../../src/sidebars/VariablesPane.cpp:54
 msgid "Variable"
 msgstr "变量"
 
-#: ../../src/wxMaxima.cpp:6530 ../../src/wxMaxima.cpp:6536
-#: ../../src/wxMaxima.cpp:8568
+#: ../../src/wizards/DrawWiz.cpp:61 ../../src/wizards/DrawWiz.cpp:166
+msgid "Variable for the x value"
+msgstr ""
+
+#: ../../src/wizards/DrawWiz.cpp:78 ../../src/wizards/DrawWiz.cpp:181
+msgid "Variable for the y value"
+msgstr ""
+
+#: ../../src/wizards/DrawWiz.cpp:198
+msgid "Variable for the z value"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:1586 ../../src/MaximaCommandMenus.cpp:3050
+#: ../../src/MaximaCommandMenus.cpp:3056
+#: ../../src/wizards/ActualValuesStorageWiz.cpp:48
 msgid "Variable name"
 msgstr "变量名"
 
-#: ../../src/wxMaximaFrame.cpp:1085
+#: ../../src/wxMaximaFrame.cpp:1119
 #, fuzzy
 msgid "Variable name, not contents..."
 msgstr "变量名"
 
-#: ../../src/wxMaxima.cpp:7157 ../../src/wxMaxima.cpp:7675
+#: ../../src/MaximaCommandMenus.cpp:4029 ../../src/MaximaCommandMenus.cpp:4547
 #, fuzzy
 msgid "Variable name:"
 msgstr "变量名"
 
-#: ../../src/wxMaxima.cpp:7752 ../../src/wxMaxima.cpp:7766
+#: ../../src/MaximaCommandMenus.cpp:933 ../../src/MaximaCommandMenus.cpp:947
 #, fuzzy
 msgid "Variable(s)"
 msgstr "变量："
 
-#: ../../src/wxMaxima.cpp:7849 ../../src/wxMaxima.cpp:7901
-#: ../../src/wxMaxima.cpp:9012 ../../src/wxMaxima.cpp:10057
+#: ../../src/MaximaCommandMenus.cpp:266 ../../src/MaximaCommandMenus.cpp:1030
+#: ../../src/MaximaCommandMenus.cpp:1082 ../../src/MaximaCommandMenus.cpp:3546
 msgid "Variable(s):"
 msgstr "变量："
 
-#: ../../src/wxMaxima.cpp:7714 ../../src/wxMaxima.cpp:7725
-#: ../../src/wxMaxima.cpp:7777 ../../src/wxMaxima.cpp:8934
-#: ../../src/wxMaxima.cpp:8941 ../../src/wxMaxima.cpp:8952
-#: ../../src/wxMaxima.cpp:8977 ../../src/wxMaxima.cpp:8982
-#: ../../src/wxMaxima.cpp:9063 ../../src/wxMaxima.cpp:10039
+#: ../../src/MaximaCommandMenus.cpp:185 ../../src/MaximaCommandMenus.cpp:195
+#: ../../src/MaximaCommandMenus.cpp:206 ../../src/MaximaCommandMenus.cpp:231
+#: ../../src/MaximaCommandMenus.cpp:236 ../../src/MaximaCommandMenus.cpp:317
+#: ../../src/MaximaCommandMenus.cpp:958 ../../src/MaximaCommandMenus.cpp:3528
+#: ../../src/wizards/IntegrateWiz.cpp:36 ../../src/wizards/LimitWiz.cpp:32
+#: ../../src/wizards/Plot2dWiz.cpp:45 ../../src/wizards/Plot2dWiz.cpp:55
+#: ../../src/wizards/Plot2dWiz.cpp:496 ../../src/wizards/Plot3dWiz.cpp:34
+#: ../../src/wizards/Plot3dWiz.cpp:43 ../../src/wizards/SeriesWiz.cpp:33
+#: ../../src/wizards/SumWiz.cpp:34
 msgid "Variable:"
 msgstr "变量："
 
-#: ../../src/wxMaximaFrame.cpp:277 ../../src/wxMaximaFrame.cpp:720
+#: ../../src/wxMaximaFrame.cpp:298 ../../src/wxMaximaFrame.cpp:755
 msgid "Variables"
 msgstr "变量"
 
-#: ../../src/wxMaxima.cpp:9043 ../../src/wxMaxima.cpp:9593
+#: ../../src/MaximaCommandMenus.cpp:297 ../../src/MaximaCommandMenus.cpp:1833
+#: ../../src/wizards/SystemWiz.cpp:72
 msgid "Variables:"
 msgstr "变量："
 
-#: ../../src/WXMXformat.cpp:337
+#: ../../src/sidebars/StatSidebar.cpp:58
+msgid "Variance..."
+msgstr "方差..."
+
+#: ../../src/WXMXformat.cpp:339
 msgid "Verified that we are able to read the whole .zip archive we produced."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:836
+#: ../../src/dialogs/ConfigDialogue.cpp:232
+msgid "Vietnamese"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:870
 msgid "View"
 msgstr "视图"
 
-#: ../../src/Autocomplete.cpp:235
+#: ../../src/Autocomplete.cpp:305
 msgid "Waiting for m_addFiles_backgroundThread to finish"
 msgstr ""
 
-#: ../../src/Autocomplete.cpp:122 ../../src/Autocomplete.cpp:240
+#: ../../src/Autocomplete.cpp:154 ../../src/Autocomplete.cpp:310
 msgid "Waiting for m_addSymbols_backgroundThread to finish"
 msgstr ""
 
-#: ../../src/MaximaManual.cpp:533
-msgid "Waiting for the Manual anchors background task."
-msgstr ""
-
-#: ../../src/MaximaManual.cpp:562
+#: ../../src/MaximaManual.cpp:586
 #, fuzzy
 msgid "Waiting for the thread that parses the maxima manual to finish"
 msgstr "正在编译 Maxima 用户手册提供的锚列表"
 
-#: ../../src/MathParser.cpp:1229 ../../src/wxMaxima.cpp:3296
-#: ../../src/wxMaxima.cpp:3308 ../../src/wxMaxima.cpp:4613
-#: ../../src/wxMaxima.cpp:4703 ../../src/wxMaxima.cpp:4840
+#: ../../src/dialogs/ConfigDialogue.cpp:1410
+msgid "Warn if an inactive window is idle"
+msgstr "非活动窗口空闲时发出警告"
+
+#: ../../src/MathParser.cpp:1343 ../../src/MaximaFileIO.cpp:536
+#: ../../src/MaximaProcessManager.cpp:1100
+#: ../../src/MaximaResponseReader.cpp:361 ../../src/wxMaxima.cpp:1585
 msgid "Warning"
 msgstr "警告"
 
-#: ../../src/wxMaximaFrame.cpp:1556
+#: ../../src/wxMaximaFrame.cpp:1593
 #, fuzzy
 msgid "Warning:"
 msgstr "警告"
 
-#: ../../src/Dirstructure.cpp:72
+#: ../../src/Dirstructure.cpp:73
 #, c-format
 msgid ""
 "Warning: Cannot create %s, the directory maxima keeps configuration, user packages and caches in.\n"
@@ -7960,282 +11836,639 @@ msgstr ""
 "警告：不能新建 %s，该目录被 Maxima 用于保存配置信息、用户程序包和缓存文件.\n"
 "请确认系统中的家目录（home）设置正确"
 
-#: ../../src/wxMaximaFrame.cpp:1546
+#: ../../src/cells/GroupCell.cpp:400 ../../src/cells/GroupCell.cpp:406
+msgid "Warning: Lookalike chars: "
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1583
 msgid "Warning: No test if the argument of the log is complex, positive or negative"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:5063
+#: ../../src/dialogs/BinaryNameCtrl.cpp:76
+msgid ""
+"We weren't searching for the location of wxMaxima!\n"
+"\n"
+"Please enter the path to the program again."
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:3603 ../../src/MaximaCommandMenus.cpp:3613
+msgid "WebP (*.webp)|*.webp|"
+msgstr ""
+
+#: ../../src/wxMaxima.cpp:1871
 msgid "Welcome to wxMaxima"
 msgstr "欢迎使用 wxMaxima"
 
-#: ../../src/wxMaxima.cpp:8583
+#: ../../src/MaximaCommandMenus.cpp:1601
 msgid "What to do:"
 msgstr "如何操作："
 
-#: ../../src/wxMaximaFrame.cpp:1058
+#: ../../src/dialogs/TipOfTheDay.cpp:134
+msgid "When applying functions with one argument from menus, the default argument is '%'. To apply the function to some other value, select it in the document before executing a menu command."
+msgstr "从菜单中选择带一个参数的函数时，默认值参数为“%”。若要将该函数应用于其他式子，可在执行菜单命令前，先选择对应的式子。"
+
+#: ../../src/wxMaximaFrame.cpp:1092
 msgid "When to invoke the lisp compiler's debugger"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7046
+#: ../../src/MaximaCommandMenus.cpp:3918
 msgid "While loop"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1063
+#: ../../src/wxMaximaFrame.cpp:1097
 msgid "While loop..."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:5673
+#: ../../src/dialogs/TipOfTheDay.cpp:243
+msgid "While wxMaxima is programmed mostly in C++, it also uses some Lisp code. You can help to improve wxMaxima, if you have knowledge of Common Lisp."
+msgstr ""
+
+#: ../../src/MaximaFileIO.cpp:780
 #, fuzzy
 msgid "Whole document (*.wxmx)|*.wxmx|The input, readable by load() (maxima > 5.38) (*.wxm)|*.wxm|All Files (*.*)|*"
 msgstr "整个文档 (*.wxmx)|*.wxmx|输入的命令，可被 load() 命令读取 (maxima > 5.38) (*.wxm)|*.wxm"
 
-#: ../../src/wxMaxima.cpp:210
+#: ../../src/wxMaxima.cpp:309
 msgid "Will try to generate a stack backtrace, if the program ever crashes"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:6920
+#: ../../src/dialogs/ConfigDialogue.cpp:280
+msgid "Worksheet"
+msgstr "工作簿"
+
+#: ../../src/MaximaResponseReader.cpp:117
+#, c-format
+msgid "Worksheet export of type \"%s\" is not supported yet."
+msgstr ""
+
+#: ../../src/worksheet/Worksheet.cpp:4911
 msgid "Worksheet got activated"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:6840
+#: ../../src/worksheet/Worksheet.cpp:4843
 msgid "Worksheet got the mouse focus"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:7191 ../../src/Worksheet.cpp:7279
+#: ../../src/sidebars/PerformanceSidebar.cpp:47
+msgid "Worksheet repaints:"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:428
+msgid "Wrap equations exported by the \"copy as LaTeX\" feature between \\[ and \\] as equation markers"
+msgstr "对由“复制为 LaTeX”功能导出的式子，使用 \\[ 和 \\] 作为公式环境标志"
+
+#: ../../src/worksheet/Worksheet.cpp:5200
 msgid "Wrapped search"
 msgstr "Wrapped search"
 
-#: ../../src/WXMXformat.cpp:282
+#: ../../src/WXMXformat.cpp:284
 msgid "Wrote all image and gnuplot files to the zip archive"
 msgstr ""
 
-#: ../../src/WXMXformat.cpp:272
+#: ../../src/WXMXformat.cpp:274
 msgid "Wrote the XML representation of the document to the zip archive"
 msgstr ""
 
-#: ../../src/WXMXformat.cpp:116
+#: ../../src/WXMXformat.cpp:117
 msgid "Wrote the mimetype info"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:11147
-#, fuzzy, c-format
+#: ../../src/wizards/DrawWiz.cpp:942 ../../src/wizards/DrawWiz.cpp:949
+#: ../../src/wizards/DrawWiz.cpp:961 ../../src/wizards/DrawWiz.cpp:974
+#: ../../src/wizards/DrawWiz.cpp:977
+msgid "X"
+msgstr ""
+
+#: ../../src/MathParser.cpp:1279
+msgid "XML nesting limit exceeded"
+msgstr ""
+
+#: ../../src/sidebars/GreekSidebar.cpp:191
+msgid "Xi"
+msgstr "Xi"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:728
+msgid "Yes"
+msgstr "是"
+
+#: ../../src/dialogs/TipOfTheDay.cpp:64
+msgid "You can access the last output using the variable '%'. You can access the output of previous commands using variables '%on' where n is the number of output."
+msgstr "可以使用变量“%”访问上一个输出结果，也可以访问使用变量“%on”访问任意输出结果，其中 n 是输出结果的编号。"
+
+#: ../../src/dialogs/TipOfTheDay.cpp:118
+msgid "You can evaluate your whole document by using 'Cell->Evaluate All Cells' menu command or the appropriate key shortcut. The cells will be evaluated in the order they appear in the document."
+msgstr "可以使用菜单命令“单元格->计算所有单元格”或相应的快捷键来计算整个文档中的数学单元格，计算顺序为单元格在文档中出现的顺序。"
+
+#: ../../src/dialogs/TipOfTheDay.cpp:98
+#, fuzzy
+msgid "You can get help on a Maxima function by selecting or clicking on the function name and pressing F1. wxMaxima will search the help index for the selection or the word under the cursor."
+msgstr "选择或单击输入的函数（命令）名称并按下 F1 键后，wxMaxima 将在帮助文档中搜索该函数相关的内容。"
+
+#: ../../src/dialogs/TipOfTheDay.cpp:92
+msgid "You can hide output part of cells by clicking in the triangle on the left side of cells. This works on text cells also."
+msgstr "可以通过单击（数学）输入单元格左侧的三角形来隐藏该单元格的输出结果。文本单元格也提供了类似的功能。"
+
+#: ../../src/dialogs/TipOfTheDay.cpp:81
+msgid "You can insert different types of 'cells' in wxMaxima documents using the 'Cell' menu. Note that only 'input cells' can be evaluated, while others are used for commenting and structuring your calculations."
+msgstr "可以使用“单元格”菜单在 wxMaxima 文档中插入不同类型的“单元格”。注意，只有“（数学）输入单元格”可以用于计算，而其他单元格则用于组织文档内容。"
+
+#: ../../src/dialogs/TipOfTheDay.cpp:112
+msgid "You can select multiple cells either with a mouse - click'n'drag from between cells or from a cell bracket on the left - or with a keyboard - hold down Shift while moving the horizontal cursor - and then operate on selection. This comes in handy when you want to delete or evaluate multiple cells."
+msgstr "有两种方法可以选择连续的多个单元格：按住鼠标左键并在单元格之间（或其左侧）拖动，或者移动水平光标时按住 Shift 键。接着可以对所选内容进行操作。当需要删除或计算多个单元格时，使用这两种方法会更方便。"
+
+#: ../../src/dialogs/TipOfTheDay.cpp:232
 msgid ""
-"You have version %s. The newest version source code is available for is %s.\n"
+"You found a bug in wxMaxima? Please report it at https://github.com/wxMaxima-developers/wxmaxima/issues\n"
+"A mathematical bug is maybe a bug in Maxima (the backend), which can be reported at https://sourceforge.net/p/maxima/bugs/\n"
+"Please check, before, if the bug was not already reported."
+msgstr ""
+
+#: ../../src/dialogs/TipOfTheDay.cpp:238
+msgid "You got an idea for an improvement of wxMaxima? Great! Please submit your idea at https://github.com/wxMaxima-developers/wxmaxima/issues. "
+msgstr ""
+
+#: ../../src/wxMaxima.cpp:3404 ../../src/wxMaxima.cpp:3458
+#, c-format
+msgid ""
+"You have version %s. The newest wxMaxima release is %s.\n"
 "\n"
 "Select OK to visit the wxMaxima webpage."
 msgstr ""
-"当前的版本是：%s. 最新版本是：%s。\n"
-"\n"
-"按“确认”后，会访问 wxMaxima 网页。"
 
-#: ../../src/wxMaxima.cpp:11202
+#: ../../src/wxMaxima.cpp:3508
 msgid "Your changes will be lost if you don't save them."
 msgstr "如果不保存，所有更改将会丢失。"
 
-#: ../../src/wxMaxima.cpp:11156
+#: ../../src/wxMaxima.cpp:3412 ../../src/wxMaxima.cpp:3466
 msgid "Your version of wxMaxima is up to date."
 msgstr "当前的 wxMaxima 是最新版本。"
 
-#: ../../src/wxMaximaFrame.cpp:805
+#: ../../src/sidebars/GreekSidebar.cpp:183
+msgid "Zeta"
+msgstr "Zeta"
+
+#: ../../src/wxMaximaFrame.cpp:842
 msgid "Zoom &In\tCtrl++"
 msgstr "放大(&I)\tCtrl++"
 
-#: ../../src/wxMaximaFrame.cpp:806
+#: ../../src/wxMaximaFrame.cpp:843
 msgid "Zoom Ou&t\tCtrl+-"
 msgstr "缩小(&T)\tCtrl+-"
 
-#: ../../src/wxMaximaFrame.cpp:805
+#: ../../src/wxMaximaFrame.cpp:842
 msgid "Zoom in 10%"
 msgstr "将显示比例增大 10%"
 
-#: ../../src/wxMaximaFrame.cpp:806
+#: ../../src/wxMaximaFrame.cpp:843
 msgid "Zoom out 10%"
 msgstr "将显示比例减小 10%"
 
-#: ../../src/wxMaxima.cpp:10915 ../../src/wxMaximaFrame.cpp:187
+#: ../../src/wxMaxima.cpp:3204 ../../src/wxMaximaFrame.cpp:201
 msgid "[ unsaved ]"
 msgstr "[ 未保存 ]"
 
-#: ../../src/wxMaxima.cpp:10920
+#: ../../src/wxMaxima.cpp:3206
 msgid "[ unsaved* ]"
 msgstr "[ 未保存* ]"
 
-#: ../../src/Worksheet.cpp:5278
-#, fuzzy, c-format
-msgid "_%d.gif\"  alt=\"Animated Diagram\" loading=\"lazy\" style=\"max-width:90%%;\">\n"
-msgstr "_%d.gif\"  alt=\"动态图表\" loading=\"lazy\" style=\"max-width:90%%;\" />\n"
+#: ../../src/wizards/DrawWiz.cpp:819 ../../src/wizards/DrawWiz.cpp:825
+msgid "[[x_1,x_2,...],[y_1,y_2,...]]"
+msgstr ""
 
-#: ../../src/Worksheet.cpp:5484
-#, fuzzy, c-format
-msgid "_%d.gif\" alt=\"Animated Diagram\" style=\"max-width:90%%;\" loading=\"lazy\">"
-msgstr "_%d.gif\" alt=\"动态图表\" style=\"max-width:90%%;\" loading=\"lazy\" />"
+#: ../../src/wizards/DrawWiz.cpp:814
+msgid "[x_1, x_2,...] or [x_1, x_2,...],[y_1, y_2,...] or matrix([x_1,y_1],[x_2,y_2],...)"
+msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1690
+#: ../../src/wizards/ListSortWiz.cpp:46
+msgid "a<b (Maxima default)"
+msgstr ""
+
+#: ../../src/sidebars/GreekSidebar.cpp:151
+msgid "alpha"
+msgstr "alpha"
+
+#: ../../src/sidebars/SymbolsSidebar.cpp:95
+msgid "and"
+msgstr "且"
+
+#: ../../src/wizards/MatWiz.cpp:160
+msgid "antisymmetric"
+msgstr "非对称"
+
+#: ../../src/wxMaximaFrame.cpp:1727
 msgid "apply function to each element"
 msgstr "应用函数至各元素"
 
-#: ../../src/wxMaximaFrame.cpp:739
+#: ../../src/wxMaximaFrame.cpp:776
 msgid "as 1D ASCII"
 msgstr "一维 ASCII"
 
-#: ../../src/wxMaximaFrame.cpp:742
+#: ../../src/wxMaximaFrame.cpp:779
 msgid "as ASCII Art"
 msgstr "ASCII 艺术"
 
-#: ../../src/wxMaximaFrame.cpp:745
+#: ../../src/wxMaximaFrame.cpp:782
 #, fuzzy
 msgid "as ASCII+Unicode Art"
 msgstr "ASCII 艺术"
 
-#: ../../src/wxMaximaFrame.cpp:1680
+#: ../../src/wxMaximaFrame.cpp:1717
 msgid "as storage for actual values for variables"
 msgstr "存储变量的实际值"
 
-#: ../../src/wxMaximaFrame.cpp:1139
+#: ../../src/sidebars/GreekSidebar.cpp:152
+msgid "beta"
+msgstr "beta"
+
+#: ../../src/wizards/LimitWiz.cpp:42
+msgid "both sides"
+msgstr "两边"
+
+#: ../../src/wxMaximaFrame.cpp:1173
 msgid "char to Ascii code..."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7836
+#: ../../src/sidebars/GreekSidebar.cpp:172
+msgid "chi"
+msgstr "chi"
+
+#: ../../src/MaximaFileIO.cpp:318
+#, c-format
+msgid "content.xml exceeds the sanity limit of %zu bytes; the file may be corrupt or a decompression bomb."
+msgstr ""
+
+#: ../../src/wizards/Plot2dWiz.cpp:70 ../../src/wizards/Plot2dWiz.cpp:372
+#: ../../src/wizards/Plot3dWiz.cpp:61 ../../src/wizards/Plot3dWiz.cpp:358
+msgid "default"
+msgstr "默认"
+
+#: ../../src/sidebars/GreekSidebar.cpp:154
+msgid "delta"
+msgstr "delta"
+
+#: ../../src/wizards/MatWiz.cpp:159
+msgid "diagonal"
+msgstr "对角"
+
+#: ../../src/cells/FracCell.cpp:73
+msgid "diff(): Cannot find the multiplication sign I should hide"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:1017
 msgid "diff(x,t)="
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1064 ../../src/wxMaximaFrame.cpp:1702
+#: ../../src/wxMaximaFrame.cpp:1098 ../../src/wxMaximaFrame.cpp:1739
 msgid "do for each element"
 msgstr "对每个元素操作"
 
-#: ../../src/Worksheet.cpp:2027
+#: ../../src/sidebars/SymbolsSidebar.cpp:92
+msgid "empty"
+msgstr "空集"
+
+#: ../../src/sidebars/GreekSidebar.cpp:155
+msgid "epsilon"
+msgstr "epsilon"
+
+#: ../../src/sidebars/SymbolsSidebar.cpp:100
+msgid "equivalent"
+msgstr "等价于"
+
+#: ../../src/sidebars/GreekSidebar.cpp:157
+msgid "eta"
+msgstr "eta"
+
+#: ../../src/worksheet/WorksheetContextMenu.cpp:799
 #, fuzzy
 msgid "ev() shall evaluate this automatically"
 msgstr "自动保存工作簿"
 
-#: ../../src/wxMaxima.cpp:7130
+#: ../../src/sidebars/SymbolsSidebar.cpp:88
+msgid "exists"
+msgstr "存在"
+
+#: ../../src/MaximaCommandMenus.cpp:4002
 #, fuzzy
 msgid "expression:"
 msgstr "表达式："
 
-#: ../../src/Worksheet.cpp:2025
+#: ../../src/worksheet/WorksheetContextMenu.cpp:797
 msgid "f(x) stays f(x) even if the value of f(x) is computable"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7204 ../../src/wxMaxima.cpp:7209
+#: ../../src/dialogs/ConfigDialogue.cpp:467
+msgid ""
+"false=Don't generate subscripts\n"
+"true=Automatically convert underscores to subscript markers if the would-be subscript is a number or a single letter\n"
+"all=_ marks subscripts."
+msgstr ""
+"false = 不生成下标\n"
+"true = 如果下划线后是数字或单个字母，则自动将其转换为下标\n"
+"all = 符号“_”后文本均为下标"
+
+#: ../../src/MaximaCommandMenus.cpp:4076 ../../src/MaximaCommandMenus.cpp:4081
 #, fuzzy
 msgid "filename:"
 msgstr "变量名"
 
-#: ../../src/wxMaximaFrame.cpp:1674
+#: ../../src/wxMaximaFrame.cpp:1711
 msgid "from a list"
 msgstr "从列表"
 
-#: ../../src/wxMaximaFrame.cpp:1671
+#: ../../src/wxMaximaFrame.cpp:1708
 msgid "from a rule"
 msgstr "从规则"
 
-#: ../../src/wxMaximaFrame.cpp:1685
+#: ../../src/wxMaximaFrame.cpp:1722
 msgid "from function arguments"
 msgstr "从函数参数"
 
-#: ../../src/wxMaximaFrame.cpp:1669
+#: ../../src/wxMaximaFrame.cpp:1706
 msgid "from individual elements"
 msgstr "从独立元素"
 
-#: ../../src/wxMaxima.cpp:8210 ../../src/wxMaxima.cpp:8553
+#: ../../src/MaximaCommandMenus.cpp:1400 ../../src/MaximaCommandMenus.cpp:1566
 #, fuzzy
 msgid "function"
 msgstr "函数"
 
-#: ../../src/wxMaximaFrame.cpp:747
+#: ../../src/sidebars/GreekSidebar.cpp:153
+msgid "gamma"
+msgstr "gamma"
+
+#: ../../src/wizards/MatWiz.cpp:159
+msgid "general"
+msgstr "通用"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1630
+msgid "gnuplot: Without command console"
+msgstr ""
+
+#: ../../src/sidebars/SymbolsSidebar.cpp:118
+msgid "greater than or equal"
+msgstr "大于等于"
+
+#: ../../src/sidebars/SymbolsSidebar.cpp:87
+msgid "in"
+msgstr "属于"
+
+#: ../../src/wxMaximaFrame.cpp:784
 msgid "in 2D"
 msgstr "2D 公式"
 
-#: ../../src/wxMaxima.cpp:8554
+#: ../../src/wizards/Plot2dWiz.cpp:70 ../../src/wizards/Plot2dWiz.cpp:198
+#: ../../src/wizards/Plot2dWiz.cpp:372 ../../src/wizards/Plot2dWiz.cpp:402
+#: ../../src/wizards/Plot3dWiz.cpp:61 ../../src/wizards/Plot3dWiz.cpp:194
+#: ../../src/wizards/Plot3dWiz.cpp:358 ../../src/wizards/Plot3dWiz.cpp:386
+msgid "inline"
+msgstr ""
+
+#: ../../src/sidebars/SymbolsSidebar.cpp:104
+msgid "intersection"
+msgstr "交集"
+
+#: ../../src/sidebars/GreekSidebar.cpp:159
+msgid "iota"
+msgstr "iota"
+
+#: ../../src/sidebars/GreekSidebar.cpp:160
+msgid "kappa"
+msgstr "kappa"
+
+#: ../../src/sidebars/GreekSidebar.cpp:161
+msgid "lambda"
+msgstr "lambda"
+
+#: ../../src/wizards/LimitWiz.cpp:42
+msgid "left"
+msgstr "左"
+
+#: ../../src/sidebars/SymbolsSidebar.cpp:117
+msgid "less or equal"
+msgstr "小于等于"
+
+#: ../../src/MaximaCommandMenus.cpp:1567
 #, fuzzy
 msgid "list"
 msgstr "使用列表"
 
-#: ../../src/wxMaximaFrame.cpp:1405
+#: ../../src/wizards/Plot2dWiz.cpp:54 ../../src/wizards/Plot2dWiz.cpp:64
+msgid "logscale"
+msgstr "对数尺度"
+
+#: ../../src/wizards/DrawWiz.cpp:822
+msgid "matrix([x_1,x_2,...],[y_1,y_2,...])"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1439
 msgid "max(abs(A(i,j))) (complex)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1404
+#: ../../src/wxMaximaFrame.cpp:1438
 msgid "max(abs(A(i,j))) (real)"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8046
+#: ../../src/sidebars/GreekSidebar.cpp:162
+msgid "mu"
+msgstr "mu"
+
+#: ../../src/sidebars/SymbolsSidebar.cpp:120
+msgid "much greater than"
+msgstr "远大于"
+
+#: ../../src/sidebars/SymbolsSidebar.cpp:119
+msgid "much less than"
+msgstr "远小于"
+
+#: ../../src/MaximaCommandMenus.cpp:1232
 #, fuzzy
 msgid "m×n Matrix A:"
 msgstr "矩阵 #1："
 
-#: ../../src/wxMaxima.cpp:7378 ../../src/wxMaxima.cpp:8527
-#: ../../src/wxMaxima.cpp:8533
+#: ../../src/MaximaCommandMenus.cpp:1538 ../../src/MaximaCommandMenus.cpp:1544
+#: ../../src/MaximaCommandMenus.cpp:4250
 #, fuzzy
 msgid "n:"
 msgstr "n"
 
-#: ../../src/Worksheet.cpp:2000
+#: ../../src/sidebars/SymbolsSidebar.cpp:112
+msgid "nabla sign"
+msgstr "nabla 符号"
+
+#: ../../src/sidebars/SymbolsSidebar.cpp:98
+msgid "nand"
+msgstr "且非"
+
+#: ../../src/worksheet/WorksheetContextMenu.cpp:772
 msgid "nary: f(x, f(y,z)) = foo(x,y,z)"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:2024
+#: ../../src/sidebars/SymbolsSidebar.cpp:99
+msgid "nor"
+msgstr "或非"
+
+#: ../../src/sidebars/SymbolsSidebar.cpp:102
+msgid "not"
+msgstr "非"
+
+#: ../../src/sidebars/SymbolsSidebar.cpp:116
+msgid "not bytewise identical"
+msgstr "不全等"
+
+#: ../../src/sidebars/SymbolsSidebar.cpp:108
+msgid "not subset"
+msgstr "非子集"
+
+#: ../../src/sidebars/SymbolsSidebar.cpp:107
+msgid "not subset or equal"
+msgstr "非子集（可相等）"
+
+#: ../../src/worksheet/WorksheetContextMenu.cpp:796
 msgid "noun: Not evaluated by default"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1710
+#: ../../src/wxMaximaFrame.cpp:1747
 msgid "nth"
 msgstr "第 n 个元素"
 
-#: ../../src/Worksheet.cpp:2021
+#: ../../src/sidebars/GreekSidebar.cpp:163
+msgid "nu"
+msgstr "nu"
+
+#: ../../src/MaximaCommandMenus.cpp:1233
+msgid "n×1 Matrix b:"
+msgstr ""
+
+#: ../../src/sidebars/GreekSidebar.cpp:174
+msgid "omega"
+msgstr "omega"
+
+#: ../../src/sidebars/GreekSidebar.cpp:165
+msgid "omicron"
+msgstr "omicron"
+
+#: ../../src/sidebars/SymbolsSidebar.cpp:96
+msgid "or"
+msgstr "或"
+
+#: ../../src/worksheet/WorksheetContextMenu.cpp:793
 msgid "outative: f(2*x) = 2*f(x)"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7440 ../../src/wxMaxima.cpp:7445
-#: ../../src/wxMaxima.cpp:7455
+#: ../../src/cells/TextCell.cpp:260
+msgid "part() or the [] operator was used in order to extract the nth element of something that was less than n elements long."
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:4312 ../../src/MaximaCommandMenus.cpp:4317
+#: ../../src/MaximaCommandMenus.cpp:4327
 msgid "part:"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8942
+#: ../../src/sidebars/SymbolsSidebar.cpp:111
+msgid "partial sign"
+msgstr "偏导数"
+
+#: ../../src/sidebars/GreekSidebar.cpp:171
+msgid "phi"
+msgstr "phi"
+
+#: ../../src/sidebars/GreekSidebar.cpp:166
+msgid "pi"
+msgstr "pi"
+
+#: ../../src/sidebars/SymbolsSidebar.cpp:101
+msgid "plus or minus"
+msgstr "加减"
+
+#: ../../src/MaximaCommandMenus.cpp:196
 #, fuzzy
 msgid "point:"
 msgstr "点："
 
-#: ../../src/wxMaxima.cpp:7740
+#: ../../src/MaximaCommandMenus.cpp:921
 #, fuzzy
 msgid "precision:"
 msgstr "精度"
 
-#: ../../src/wxMaxima.cpp:7255
+#: ../../src/graphical_io/Printout.cpp:95
+#, c-format
+msgid "printOut: Setting the page size to (%li,%li)"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:4127
 #, fuzzy
 msgid "printf"
 msgstr "打印"
 
-#: ../../src/wxMaximaFrame.cpp:1108
+#: ../../src/wxMaximaFrame.cpp:1142
 #, fuzzy
 msgid "printf..."
 msgstr "求导..."
 
-#: ../../src/wxMaxima.cpp:8650
+#: ../../src/sidebars/SymbolsSidebar.cpp:115
+msgid "proportional to"
+msgstr "成比例"
+
+#: ../../src/sidebars/GreekSidebar.cpp:173
+msgid "psi"
+msgstr "psi"
+
+#: ../../src/MaximaCommandMenus.cpp:642
 msgid "radcan() is a powerful tools for simplification trigonometric functions but needs to be taken with care: If a function has more than one branch radcan uses the one that looks like it would fit best, not necessarily the one that makes sense for the problem that resulted in the Expression that is to be simplified."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8731
+#: ../../src/MaximaCommandMenus.cpp:726
 msgid "ratsubst works like subst, but it knows some basic maths, if needed."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1111
+#: ../../src/wxMaximaFrame.cpp:1145
 #, fuzzy
 msgid "readbyte..."
 msgstr "积分..."
 
-#: ../../src/wxMaximaFrame.cpp:1110
+#: ../../src/wxMaximaFrame.cpp:1144
 #, fuzzy
 msgid "readchar..."
 msgstr "饼图..."
 
-#: ../../src/wxMaximaFrame.cpp:1109
+#: ../../src/wxMaximaFrame.cpp:1143
 #, fuzzy
 msgid "readline..."
 msgstr "方差..."
 
-#: ../../src/wxMaxima.cpp:10018
+#: ../../src/cells/TextCell.cpp:264
+msgid "rest() tried to drop more entries from a list than the list was long."
+msgstr ""
+
+#: ../../src/sidebars/GreekSidebar.cpp:167
+msgid "rho"
+msgstr "rho"
+
+#: ../../src/wizards/LimitWiz.cpp:42
+msgid "right"
+msgstr "右"
+
+#: ../../src/wizards/DrawWiz.cpp:310
+msgid "secondary x axis label"
+msgstr "二级 x 轴标签"
+
+#: ../../src/wizards/DrawWiz.cpp:315
+msgid "secondary x range (automatic if incomplete)"
+msgstr ""
+
+#: ../../src/wizards/DrawWiz.cpp:325
+msgid "secondary y axis label"
+msgstr "二级 y 轴标签"
+
+#: ../../src/wizards/DrawWiz.cpp:330
+msgid "secondary y range (automatic if incomplete)"
+msgstr ""
+
+#: ../../src/sidebars/GreekSidebar.cpp:168
+msgid "sigma"
+msgstr "sigma"
+
+#: ../../src/MaximaCommandMenus.cpp:3507
 #, fuzzy
 msgid ""
 "solve() will solve a list of equations only if for n independent equations there are n variables to solve to.\n"
@@ -8245,7 +12478,7 @@ msgstr ""
 "只有当方程组含 n 个独立方程和需要求解的 n 个变量时，solve() 命令才能解出该方程组。\n"
 "如果只对其中一个变量感兴趣，也可以填写额外的变量，以告诉 solve() 命令消除结果中额外的变量。"
 
-#: ../../src/wxMaxima.cpp:7745
+#: ../../src/MaximaCommandMenus.cpp:926
 msgid ""
 "solve() will solve a list of equations only if for n independent equations there are n variables to solve to.\n"
 "If only one result variable is of interest the other result variables solve needs to do its work can be used to tell solve() which variables to eliminate in the solution for the interesting variable."
@@ -8253,62 +12486,136 @@ msgstr ""
 "只有当方程组含 n 个独立方程和需要求解的 n 个变量时，solve() 命令才能解出该方程组。\n"
 "如果只对其中一个变量感兴趣，也可以填写额外的变量，以告诉 solve() 命令消除结果中额外的变量。"
 
-#: ../../src/wxMaxima.cpp:7784
+#: ../../src/MaximaCommandMenus.cpp:965
 msgid ""
 "solves an equation of the form\n"
 "    'diff(y,t) = -y;"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7789
+#: ../../src/sidebars/SymbolsSidebar.cpp:81
+msgid "sqrt (needs parenthesis for its argument to work as a Maxima command)"
+msgstr "开平方（需要将被开方数放入括号，以生成正确的 Maxima 命令）"
+
+#: ../../src/sidebars/SymbolsSidebar.cpp:106
+msgid "subset"
+msgstr "子集"
+
+#: ../../src/sidebars/SymbolsSidebar.cpp:105
+msgid "subset or equal"
+msgstr "子集（可相等）"
+
+#: ../../src/wizards/MatWiz.cpp:160
+msgid "symmetric"
+msgstr "对称"
+
+#: ../../src/MaximaCommandMenus.cpp:970
 msgid "t:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1075
+#: ../../src/sidebars/GreekSidebar.cpp:169
+msgid "tau"
+msgstr "tau"
+
+#: ../../src/cells/TextCell.cpp:340
+msgid ""
+"the [] operator tried to extract an element of a list, a matrix, an equation or an array. But instead of an integer number something was used whose numerical value is unknown or not an integer.\n"
+"Floating-point numbers are bound to contain small rounding errors and therefore in most cases don't work as an array index thatneeds to be an exact integer number."
+msgstr ""
+
+#: ../../src/wizards/DrawWiz.cpp:725
+msgid "the x and the y coordinate."
+msgstr "x 轴和y 轴"
+
+#: ../../src/wizards/DrawWiz.cpp:729
+msgid "the x, the y and the z coordinate."
+msgstr "x 轴、y 轴和 z 轴"
+
+#: ../../src/sidebars/SymbolsSidebar.cpp:89
+msgid "there is no"
+msgstr "不存在"
+
+#: ../../src/sidebars/GreekSidebar.cpp:158
+msgid "theta"
+msgstr "theta"
+
+#: ../../src/sidebars/SymbolsSidebar.cpp:78
+msgid "to the power of 2"
+msgstr "2 次幂"
+
+#: ../../src/sidebars/SymbolsSidebar.cpp:79
+msgid "to the power of 3"
+msgstr "3 次幂"
+
+#: ../../src/sidebars/SymbolsSidebar.cpp:103
+msgid "union"
+msgstr "并"
+
+#: ../../src/wxMaximaFrame.cpp:1109
 msgid "unnamed function (lambda)..."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:11190
+#: ../../src/wxMaxima.cpp:3496
 msgid "unsaved"
 msgstr "未保存"
 
-#: ../../src/wxMaxima.cpp:5667 ../../src/wxMaxima.cpp:6114
-#: ../../src/wxMaximaFrame.cpp:189
+#: ../../src/MaximaCommandMenus.cpp:2270 ../../src/MaximaFileIO.cpp:774
+#: ../../src/wxMaximaFrame.cpp:203
 msgid "untitled"
 msgstr "未命名"
 
-#: ../../src/wxMaximaFrame.cpp:1700
+#: ../../src/sidebars/GreekSidebar.cpp:170
+msgid "upsilon"
+msgstr "upsilon"
+
+#: ../../src/wxMaximaFrame.cpp:1737
 msgid "use as function arguments"
 msgstr "作为函数参数"
 
-#: ../../src/wxMaximaFrame.cpp:1696
+#: ../../src/wxMaximaFrame.cpp:1733
 msgid "use the actual values stored"
 msgstr "使用储存的实际值"
 
-#: ../../src/wxMaximaFrame.cpp:1112
+#: ../../src/dialogs/ConfigDialogue.cpp:1633
+msgid "wgnuplot: Steals the mouse focus during plotting"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1146
 msgid "writebyte..."
 msgstr ""
 
-#: ../../src/main.cpp:509
+#: ../../src/dialogs/AboutDialog.cpp:64 ../../src/main.cpp:796
 msgid "wxMaxima"
 msgstr "wxMaxima"
 
-#: ../../src/main.cpp:516
+#: ../../src/main.cpp:805
 #, fuzzy, c-format
 msgid "wxMaxima %ld"
 msgstr "wxMaxima %d"
 
-#: ../../src/wxMaxima.cpp:10913 ../../src/wxMaxima.cpp:10918
-#: ../../src/wxMaxima.cpp:10929 ../../src/wxMaxima.cpp:10934
-#: ../../src/wxMaximaFrame.cpp:185
+#: ../../src/wxMaxima.cpp:3193 ../../src/wxMaximaFrame.cpp:199
 #, fuzzy, c-format
 msgid "wxMaxima %s (%s) "
 msgstr "wxMaxima %s "
 
-#: ../../src/wxMaxima.cpp:4490
+#: ../../src/dialogs/DiffFrame.cpp:352
+msgid "wxMaxima Diff Viewer"
+msgstr ""
+
+#: ../../src/dialogs/TipOfTheDay.cpp:159
+#, fuzzy
+msgid "wxMaxima can be made to execute commands at every start-up by placing them in a text file with the name wxmaxima.rc in the user directory. This directory can be found by typing maxima_userdir;"
+msgstr "可以设置 wxMaxima 在每次启动时自动执行一些命令，这些命令应保存在特定用户目录下名为 wxMaxima.rc 的文本文件中。通过变量 maxima_userdir 的值能确定该目录。"
+
+#: ../../src/MaximaFileIO.cpp:398
 msgid "wxMaxima cannot read the xml contents of "
 msgstr "wxMaxima 无法读取该文件的 XML 内容："
 
-#: ../../src/wxMaxima.cpp:2546
+#: ../../src/dialogs/ConfigDialogue.cpp:142
+#: ../../src/dialogs/ConfigDialogue.cpp:311
+msgid "wxMaxima configuration"
+msgstr "wxMaxima 设置"
+
+#: ../../src/MaximaProcessManager.cpp:211
 msgid ""
 "wxMaxima could not start a server.\n"
 "\n"
@@ -8316,85 +12623,204 @@ msgid ""
 "enabled, that no internet safety appliance is configured to intercept creation of servers even if said server only accepts connections from local application (maxima insists on the graphical frontend acting as a server it can connect on over a local socket) and try again!"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:5285
+#: ../../src/dialogs/TipOfTheDay.cpp:127
+msgid "wxMaxima dialogs set default values for inputs entries, one of which is '%'. If you have made a selection in your document, the selection will be used instead of '%'."
+msgstr "wxMaxima 对话框为输入项设置了默认值，其中之一是“%”。但如果提前在文档中选择表达式，则对话框中将使用该表达式而不是“%”。"
+
+#: ../../src/MaximaCommandMenus.cpp:4604
 msgid "wxMaxima document"
 msgstr "wxMaxima 文档"
 
-#: ../../src/wxMaxima.cpp:4162 ../../src/wxMaxima.cpp:4221
-#: ../../src/wxMaxima.cpp:4230
+#: ../../src/MaximaCommandMenus.cpp:2241
+msgid "wxMaxima document (*.wxm, *.wxmx)|*.wxm;*.wxmx"
+msgstr "wxMaxima 文档 (*.wxm, *.wxmx)|*.wxm;*.wxmx"
+
+#: ../../src/MaximaFileIO.cpp:63 ../../src/MaximaFileIO.cpp:120
+#: ../../src/MaximaFileIO.cpp:129
 msgid "wxMaxima encountered an error loading "
 msgstr "wxMaxima 在载入下列文件时出现错误："
 
-#: ../../src/wxMaximaFrame.cpp:1881
+#: ../../src/wxMaximaFrame.cpp:1918
 msgid "wxMaxima help"
 msgstr "wxMaxima 帮助"
 
-#: ../../src/Worksheet.cpp:1465 ../../src/Worksheet.cpp:1839
+#: ../../src/dialogs/AboutDialog.cpp:41
+#, fuzzy
+msgid "wxMaxima is a cross-platform graphical user interface for the computer algebra system Maxima based on wxWidgets.\n"
+msgstr "wxMaxima 是计算机代数系统 Maxima 的图形用户界面，基于 wxWidgets。"
+
+#: ../../src/wxMaxima.cpp:2854
+#, c-format
+msgid ""
+"wxMaxima is now the .wxmx diff tool for:%s\n"
+"\n"
+"Open a .wxmx file's \"Diff\" in TortoiseSVN/TortoiseGit to compare it side by side."
+msgstr ""
+
+#: ../../src/dialogs/TipOfTheDay.cpp:240
+msgid "wxMaxima is programmed in C++ using the wxWidgets toolkit and uses CMake as build system. You can contribute to wxMaxima, if you have some knowledge with this environment."
+msgstr ""
+
+#: ../../src/dialogs/TipOfTheDay.cpp:228
+msgid "wxMaxima needs more developers. It is an open source project where you can contribute. Join the wxMaxima development at: https://github.com/wxMaxima-developers/wxmaxima"
+msgstr "wxMaxima 需要更多的开发者。它是一个开源项目，每个人都可以对其做出贡献。如果想加入 wxMaxima 的开发工作，可访问网页：https://github.com/wxMaxima-developers/wxMaxima。"
+
+#: ../../src/dialogs/TipOfTheDay.cpp:224
+msgid "wxMaxima needs more translators. We do not speak every language. Help us to translate wxMaxima and the manual to your language. Join the wxMaxima development at: https://github.com/wxMaxima-developers/wxmaxima"
+msgstr "wxMaxima 需要更多的翻译者，因为开发者并没有掌握所有的语言。帮助我们将 wxMaxima 的文本和用户手册翻译成本地语言。如果想加入 wxMaxima 的开发工作，可访问网页：https://github.com/wxMaxima-developers/wxMaxima。"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:407
+msgid "wxMaxima normally stores the gnuplot sources for every plot made using draw() in order to be able to open plots interactively in gnuplot later. This setting defines the limit [in Megabytes per plot] for this feature."
+msgstr "wxMaxima 通常会储存由 draw() 命令得到的每个绘图的 gnuplot 源文件，以便以后能在 gnuplot 中交互式打开绘图。此设置定义了该功能的储存限制（单位：MB/图）。"
+
+#: ../../src/dialogs/TipOfTheDay.cpp:172
+msgid ""
+"wxMaxima provides the \"table_form\" command that shows lists in an alternative form. One example would be:\n"
+"\n"
+"table_form([1,2,3,4,5]);"
+msgstr ""
+"wxMaxima 提供“table_form”命令以竖向显示列表。例如：\n"
+"\n"
+"table_form([1,2,3,4,5]);"
+
+#: ../../src/worksheet/WorksheetContextMenu.cpp:236
+#: ../../src/worksheet/WorksheetContextMenu.cpp:611
 msgid "wxMaxima remembers answers from the last run and is able to automatically send them to maxima, if requested"
 msgstr "wxMaxima 会记住上次运行的答案，在需要时可以自动将它们发送到 Maxima"
 
-#: ../../src/Worksheet.cpp:1470 ../../src/Worksheet.cpp:1844
+#: ../../src/worksheet/WorksheetContextMenu.cpp:241
+#: ../../src/worksheet/WorksheetContextMenu.cpp:616
 msgid "wxMaxima remembers answers from the last run and is able to offer them as the default answer"
 msgstr "wxMaxima 会记住上次运行的答案，且能将它们作为默认答案"
 
-#: ../../src/wxMaximaFrame.cpp:1896
+#: ../../src/dialogs/ConfigDialogue.cpp:481
+msgid "wxMaxima remembers the answers to maxima's questions. If this checkbox is set it automatically offers to enter the last answer to this question the user has input."
+msgstr "wxMaxima 记得 Maxima 所提问题的答案。如果设置了此复选框，它将自动输入用户对此问题的最后一个答案。"
+
+#: ../../src/wxMaximaFrame.cpp:1933
 #, fuzzy
 msgid "wxMaxima shows help in a browser"
 msgstr "文件无法找到"
 
-#: ../../src/wxMaximaFrame.cpp:1894
+#: ../../src/wxMaximaFrame.cpp:1931
 #, fuzzy
 msgid "wxMaxima shows help in the sidebar"
 msgstr "文件无法找到"
 
-#: ../../src/wxMaximaFrame.cpp:111
+#: ../../src/dialogs/ConfigDialogue.cpp:1095
+msgid "wxMaxima startup file location: "
+msgstr "wxMaxima 启动文件位置："
+
+#: ../../src/wxMaximaFrame.cpp:119
 #, c-format
 msgid "wxMaxima version %s"
 msgstr "wxMaxima 版本 %s"
 
-#: ../../src/wxMaximaFrame.cpp:1954
+#: ../../src/worksheet/Worksheet.cpp:6164
+msgid "wxMaxima worksheet"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1997
 #, fuzzy
 msgid "wxMaxima's ChangeLog"
 msgstr "wxMaxima 的许可证"
 
-#: ../../src/wxMaximaFrame.cpp:1952
+#: ../../src/wxMaximaFrame.cpp:1995
 msgid "wxMaxima's license"
 msgstr "wxMaxima 的许可证"
 
-#: ../../src/wxMaximaFrame.cpp:144
+#: ../../src/wxMaximaFrame.cpp:152
 msgid "wxWidgets is using GTK 2"
 msgstr "wxWidgets 使用 GTK 2"
 
-#: ../../src/wxMaximaFrame.cpp:142
+#: ../../src/wxMaximaFrame.cpp:150
 msgid "wxWidgets is using GTK 3"
 msgstr "wxWidgets 使用 GTK 3"
 
-#: ../../src/WXMXformat.cpp:367
+#: ../../src/WXMXformat.cpp:369
 msgid "wxmx file saved"
 msgstr "已保存为 .wxmx 文件"
 
-#: ../../src/wxMaxima.cpp:8375
+#: ../../src/MaximaResponseReader.cpp:104
+msgid "wxworksheettohtml/totex: no target file name was given."
+msgstr ""
+
+#: ../../src/wxMaxima.cpp:2204
+#, c-format
+msgid "wxworksheettohtml: could not write \"%s\"."
+msgstr ""
+
+#: ../../src/wxMaxima.cpp:2178
+#, c-format
+msgid "wxworksheettohtml: unknown flavor \"%s\"; using native MathML. Known flavors: mathml, mathjax, svg, bitmap."
+msgstr ""
+
+#: ../../src/wxMaxima.cpp:2246
+#, c-format
+msgid "wxworksheettotex: could not write \"%s\"."
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:709
+msgid "x"
+msgstr "x"
+
+#: ../../src/wizards/DrawWiz.cpp:266
+msgid "x axis label"
+msgstr "x 轴标签"
+
+#: ../../src/MaximaCommandMenus.cpp:2021
 msgid "x direction [in multiples of the tick frequency]"
 msgstr "x 轴方向的刻度分隔份数"
 
-#: ../../src/wxMaxima.cpp:4500 ../../src/wxMaxima.cpp:4643
+#: ../../src/wizards/DrawWiz.cpp:269
+msgid "x range (automatic if incomplete)"
+msgstr ""
+
+#: ../../src/sidebars/GreekSidebar.cpp:164
+msgid "xi"
+msgstr "xi"
+
+#: ../../src/MaximaFileIO.cpp:408 ../../src/MaximaFileIO.cpp:566
 msgid "xml contained in the file claims not to be a wxMaxima worksheet. "
 msgstr "文件中包含的 xml 声明其不是 wxMaxima 工作簿。"
 
-#: ../../src/wxMaxima.cpp:8376
+#: ../../src/sidebars/SymbolsSidebar.cpp:97
+msgid "xor"
+msgstr "异或"
+
+#: ../../src/wizards/DrawWiz.cpp:279
+msgid "y axis label"
+msgstr "y 轴标签"
+
+#: ../../src/MaximaCommandMenus.cpp:2022
 msgid "y direction [in multiples of the tick frequency]"
 msgstr "y 轴方向的刻度分隔份数"
 
-#: ../../src/wxMaxima.cpp:7789
+#: ../../src/wizards/DrawWiz.cpp:282
+msgid "y range (automatic if incomplete)"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:970
 msgid "y:"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:2
-#, fuzzy
-#| msgid "The wxMaxima user manual {-}"
-msgid "# The wxMaxima user manual"
-msgstr "wxMaxima 用户手册 {-}"
+#: ../../src/wizards/DrawWiz.cpp:294
+msgid "z axis label"
+msgstr "z 轴标签"
+
+#: ../../src/wizards/DrawWiz.cpp:298
+msgid "z range (automatic if incomplete)"
+msgstr ""
+
+#: ../../src/sidebars/GreekSidebar.cpp:156
+msgid "zeta"
+msgstr "zeta"
+
+#. type: Title #
+#: ../../info/wxmaxima.md:1
+#, no-wrap
+msgid "The wxMaxima user manual"
+msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:4
@@ -8408,27 +12834,17 @@ msgstr "wxMaxima 是计算机代数系统（CAS，computer algebra system）Maxi
 msgid "![wxMaxima logo](./wxMaximaLogo.png){ id=img_wxMaximaLogo }"
 msgstr "![wxMaxima 的 logo](./wxMaximaLogo.png){ id=img_wxMaximaLogo }"
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:7 ../../info/wxmaxima.md:425
-#: ../../info/wxmaxima.md:880 ../../info/wxmaxima.md:1090
-#: ../../info/wxmaxima.md:1137 ../../info/wxmaxima.md:1161
+#. type: Title #
+#: ../../info/wxmaxima.md:9
 #, no-wrap
-msgid "______________________________________________________________________\n"
+msgid "Introduction to wxMaxima"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:10
-#, fuzzy
-#| msgid "Introduction to wxMaxima"
-msgid "# Introduction to wxMaxima"
-msgstr "wxMaxima 简介"
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:12
-#, fuzzy
-#| msgid "_Maxima_ and wxMaxima"
-msgid "## _Maxima_ and wxMaxima"
-msgstr "Maxima 和 wxMaxima"
+#. type: Title ##
+#: ../../info/wxmaxima.md:11
+#, no-wrap
+msgid "_Maxima_ and wxMaxima"
+msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:14
@@ -8442,12 +12858,11 @@ msgstr "在开源领域，大型项目通常被分割成小型项目，后者对
 msgid "A computer algebra system (CAS) like _Maxima_ fits into this framework. A CAS can provide the logic behind an arbitrary precision calculator application or it can do automatic transforms of formulas in the background of a bigger system (e.g., [Sage](https://www.sagemath.org/)). Alternatively, it can be used directly as a free-standing system. _Maxima_ can be accessed via a command line. Often, however, an interface like _wxMaxima_ proves a more efficient way to access the software, especially for newcomers."
 msgstr "一个像 Maxima 这样的计算机代数系统（CAS，computer algebra system）也适合前述框架。Maxima 可以用作任意精度计算器程序的底层软件，也可以在更大计算系统中作为公式转换程序来帮助计算（例如 [Sage](https://www.sagemath.org/)）。Maxima 也可以直接作为独立的计算系统使用，它可以通过命令行来访问。然而，在通常情况下，像 wxMaxima 这样的用户界面是使用 Maxima 的一种更有效的方法，特别是对于新手而言更是如此。"
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:18
-#, fuzzy
-#| msgid "_Maxima_"
-msgid "### _Maxima_"
-msgstr "Maxima"
+#. type: Title ###
+#: ../../info/wxmaxima.md:17
+#, no-wrap
+msgid "_Maxima_"
+msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:20
@@ -8461,17 +12876,15 @@ msgstr "![Maxima 截图，命令行](./maxima_screenshot.png){ id=img_maxima_scr
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:24
-#, fuzzy
-#| msgid "Extensive documentation for _Maxima_ is [available in the internet](http://maxima.sourceforge.net/documentation.html). Part of this documentation is also available in wxMaxima’s help menu. Pressing the Help key (on most systems the F1 key) causes _wxMaxima_’s context-sensitive help feature to automatically jump to _Maxima_’s manual page for the command at the cursor."
-msgid "Extensive documentation for _Maxima_ is [available in the internet](https://maxima.sourceforge.io/documentation.html). Part of this documentation is also available in wxMaxima’s help menu. Pressing the Help key (on most systems the <kbd>F1</kbd> key) causes _wxMaxima_’s context-sensitive help feature to automatically jump to _Maxima_’s manual page for the command at the cursor."
-msgstr "大量关于 Maxima 的文档[可在互联网上获得](https://maxima.sourceforge.io/documentation.html)。wxMaxima 的“帮助”菜单中也提供了部分文档。按下帮助键（在大多数系统上是按 F1 键）后，wxMaxima 的上下文相关帮助功能会自动打开 Maxima 的手册页，并跳转到光标处命令对应的内容。"
+#, no-wrap
+msgid "Extensive documentation for _Maxima_ is  [available in the internet](https://maxima.sourceforge.io/documentation.html). Part of this documentation is also available in wxMaxima’s help menu. Pressing the Help key (on most systems the <kbd>F1</kbd> key) causes _wxMaxima_’s context-sensitive help feature to automatically jump to _Maxima_’s manual page for the command at the cursor.\n"
+msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:26
-#, fuzzy
-#| msgid "wxMaxima"
-msgid "### WxMaxima"
-msgstr "wxMaxima"
+#. type: Title ###
+#: ../../info/wxmaxima.md:25
+#, no-wrap
+msgid "WxMaxima"
+msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:28
@@ -8490,12 +12903,11 @@ msgstr "![wxMaxima 界面](./wxMaximaWindow.png){ id=img_wxMaximaWindow }"
 msgid "The calculations that are entered in _wxMaxima_ are performed by the _Maxima_ command-line tool in the background."
 msgstr "在 wxMaxima 中输入的计算式是由 Maxima 命令行工具在后台执行的。"
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:34
-#, fuzzy
-#| msgid "Workbook basics"
-msgid "## Workbook basics"
-msgstr "工作簿（Workbook）基础"
+#. type: Title ##
+#: ../../info/wxmaxima.md:33
+#, no-wrap
+msgid "Workbook basics"
+msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:36
@@ -8504,12 +12916,11 @@ msgstr "工作簿（Workbook）基础"
 msgid "Much of _wxMaxima_ is self-explaining, but some details require attention. [This site](https://wxMaxima-developers.github.io/wxmaxima/help.html) contains a number of workbooks that address various aspects of _wxMaxima_. Working through some of these (particularly the \"10 minute _(wx)Maxima_ tutorial\") will increase one’s familiarity with both the content of _Maxima_ and the use of _wxMaxima_ to interact with _Maxima_. This manual concentrates on describing aspects of _wxMaxima_ that are not likely to be self-evident and that might not be covered in the online material."
 msgstr "大部分 wxMaxima 功能是不言自明的，但有些细节需要注意。[这个网站](https://wxMaxima-developers.github.io/wxMaxima/help.html)包含多个工作簿，这些工作簿涉及 wxMaxima 的各个方面。学习其中的一些（特别是“10 minute _(wx)Maxima_ tutorial”，即“十分钟 (wx)Maxima 教程”）将增加用户对 Maxima 的内容和 wxMaxima 与 Maxima 交互过程的熟悉度。本手册集中描述 wxMaxima 的某些功能，这些功能可能并非不言而喻的，也可能不会被在线文档涵盖。"
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:38
-#, fuzzy
-#| msgid "The workbook approach"
-msgid "### The workbook approach"
-msgstr "工作簿的使用"
+#. type: Title ###
+#: ../../info/wxmaxima.md:37
+#, no-wrap
+msgid "The workbook approach"
+msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:40
@@ -8550,12 +12961,11 @@ msgstr "下图显示了不同的单元格类型（标题单元格、节单元格
 msgid "![Example of different wxMaxima cells](./cell-example.png){ id=img_cell-example }"
 msgstr "![wxMaxima 的不同类型单元格](./cell-example.png){ id=img_cell-example }"
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:54
-#, fuzzy
-#| msgid "Cells"
-msgid "### Cells"
-msgstr "单元格"
+#. type: Title ###
+#: ../../info/wxmaxima.md:53
+#, no-wrap
+msgid "Cells"
+msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:56
@@ -8617,12 +13027,11 @@ msgstr "额外的注释文本可以输入到一个数学单元格中，格式为
 msgid "\"`/*`\" marks the start of the comment, \"`*/`\" the end."
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:71
-#, fuzzy
-#| msgid "Horizontal and vertical cursors"
-msgid "### Horizontal and vertical cursors"
-msgstr "水平光标和竖直光标"
+#. type: Title ###
+#: ../../info/wxmaxima.md:70
+#, no-wrap
+msgid "Horizontal and vertical cursors"
+msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:73
@@ -8652,7 +13061,8 @@ msgstr "如果在单元格内输入时，则会使用垂直光标。此种光标
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:80
-msgid "When you start wxMaxima, you will only see the blinking horizontal cursor. If you start typing, a math cell will be automatically created and the cursor will change to a regular vertical one (you will see a right arrow as \"prompt\", after the Math cell is evaluated (<kbd>CTRL</kbd>+<kbd>ENTER</kbd>), you will see the labels, e.g. `(%i1)`, `(%o1)`)."
+#, no-wrap
+msgid "When you start wxMaxima, you will only see the blinking horizontal cursor. If you start typing, a math cell will be automatically created and the cursor will change to a regular vertical one (you will see a right arrow as \"prompt\", after the Math cell is evaluated (<kbd>CTRL</kbd>+<kbd>ENTER</kbd>), you will see the labels, e.g. `(%i1)`, `(%o1)`).\n"
 msgstr ""
 
 #. type: Plain text
@@ -8675,33 +13085,29 @@ msgstr ""
 msgid "![(blinking) horizontal cursor between cells](./horizontal-cursor-between-cells.png){ id=img_horizontal_cursor_between_cells }"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:90
-#, fuzzy
-#| msgid "Sending cells to Maxima"
-msgid "### Sending cells to Maxima"
-msgstr "向 Maxima 发送单元格"
+#. type: Title ###
+#: ../../info/wxmaxima.md:89
+#, no-wrap
+msgid "Sending cells to Maxima"
+msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:92
-#, fuzzy
-#| msgid "The command in a code cell are executed once <kbd>CTRL</kbd>+<kbd>ENTER</kbd>, <kbd>SHIFT</kbd>+<kbd>ENTER</kbd> or the <kbd>ENTER</kbd> key on the keypad is pressed. The _wxMaxima_ default is to enter commands when either <kbd>CTRL+ENTER</kbd> or <kbd>SHIFT+ENTER</kbd> is entered, but _wxMaxima_ can be configured to execute commands in response to <kbd>ENTER</kbd>.\n"
-msgid "The command in a code cell is executed once by pressing <kbd>CTRL</kbd>+<kbd>ENTER</kbd>, <kbd>SHIFT</kbd>+<kbd>ENTER</kbd> or the <kbd>ENTER</kbd> key on the keypad. The _wxMaxima_ default is to enter commands when either <kbd>CTRL</kbd>+<kbd>ENTER</kbd> or <kbd>SHIFT</kbd>+<kbd>ENTER</kbd> is entered, but _wxMaxima_ can be configured to execute commands in response to <kbd>ENTER</kbd>."
-msgstr "只要按下键盘上的 <kbd>CTRL</kbd>+<kbd>ENTER</kbd>、<kbd>SHIFT</kbd>+<kbd>ENTER</kbd> 或 <kbd>ENTER</kbd> 键，（数学）代码单元格中的命令就会执行。wxMaxima 的默认设置是 <kbd>CTRL</kbd>+<kbd>ENTER</kbd> 或 <kbd>SHIFT</kbd>+ENTER</kbd> 键会使得命令由 Maxima 执行，但也可以设置为按下 <kbd>ENTER</kbd> 键执行命令。\n"
+#, no-wrap
+msgid "The command in a code cell is executed once by pressing <kbd>CTRL</kbd>+<kbd>ENTER</kbd>, <kbd>SHIFT</kbd>+<kbd>ENTER</kbd> or the <kbd>ENTER</kbd> key on the keypad. The _wxMaxima_ default is to enter commands when either <kbd>CTRL</kbd>+<kbd>ENTER</kbd> or <kbd>SHIFT</kbd>+<kbd>ENTER</kbd> is entered, but _wxMaxima_ can be configured to execute commands in response to <kbd>ENTER</kbd>.\n"
+msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:94
-#, fuzzy
-#| msgid "Command autocompletion"
-msgid "### Command autocompletion"
-msgstr "命令自动补全"
+#. type: Title ###
+#: ../../info/wxmaxima.md:93
+#, no-wrap
+msgid "Command autocompletion"
+msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:96
-#, fuzzy
-#| msgid "_wxMaxima_ contains an autocompletion feature that is triggered via the menu (Cell/Complete Word) or alternatively by pressing the key combination <kbd>CTRL</kbd>+<kbd>SPACE</kbd>. The autocompletion is context-sensitive. For example if activated within an unit specification for ezUnits it will offer a list of applicable units.\n"
-msgid "_WxMaxima_ contains an autocompletion feature that is triggered via the menu (Cell/Complete Word) or alternatively by pressing the key combination <kbd>CTRL</kbd>+<kbd>SPACE</kbd>. The autocompletion is context-sensitive. For example, if activated within a unit specification for ezUnits it will offer a list of applicable units."
-msgstr "wxMaxima 包含自动补全功能，该功能可以通过菜单“单元格->自动补全”（Cell->Complete Word）或按组合键 <kbd>CTRL</kbd>+<kbd>K</kbd> 来触发。自动补全是上下文相关的。例如，如果在使用 ezUnits （单位换算包）的单元格中激活，它将提供适用的单位列表。\n"
+#, no-wrap
+msgid "_WxMaxima_ contains an autocompletion feature that is triggered via the menu (Cell/Complete Word) or alternatively by pressing the key combination <kbd>CTRL</kbd>+<kbd>SPACE</kbd>. The autocompletion is context-sensitive. For example, if activated within a unit specification for ezUnits it will offer a list of applicable units.\n"
+msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:98
@@ -8710,17 +13116,15 @@ msgstr "![ezUnits](./ezUnits.png){ id=img_ezUnits }"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:100
-#, fuzzy
-#| msgid "Besides completing a file name, a unit name or the current command’s or variable’s name the autocompletion is able to show a template for most of the commands indicating the type (and meaning) of the parameters this program expects. To activate this feature press <kbd>SHIFT</kbd>+<kbd>CTRL</kbd>+<kbd>SPACE</kbd> or select the respective menu item (Cell/Show Template).\n"
-msgid "Besides completing a file name, a unit name, or the current command or variable name, the autocompletion is able to show a template for most of the commands indicating the type (and meaning) of the parameters this program expects. To activate this feature press <kbd>SHIFT</kbd>+<kbd>CTRL</kbd>+<kbd>SPACE</kbd> or select the respective menu item (Cell/Show Template)."
-msgstr "除了补全文件名、单位名、当前命令或变量的名称之外，自动补全功能还可以显示大多数命令的模板，指示该命令所需参数的类型（和含义）。要激活此功能，可按下 <kbd>SHIFT</kbd> +<kbd>CTRL</kbd> +<kbd>K</kbd> 或选择相应的菜单项（“单元格->显示模板”，Cell->Show Template）。\n"
+#, no-wrap
+msgid "Besides completing a file name, a unit name, or the current command or variable name, the autocompletion is able to show a template for most of the commands indicating the type (and meaning) of the parameters this program expects. To activate this feature press <kbd>SHIFT</kbd>+<kbd>CTRL</kbd>+<kbd>SPACE</kbd> or select the respective menu item (Cell/Show Template).\n"
+msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:102
-#, fuzzy
-#| msgid "Greek characters"
-msgid "#### Greek characters"
-msgstr "希腊字母"
+#. type: Title ####
+#: ../../info/wxmaxima.md:101
+#, no-wrap
+msgid "Greek characters"
+msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:104
@@ -8821,9 +13225,10 @@ msgstr ""
 msgid "You can also use the \"Greek letters\"-sidebar to enter the Greek letters."
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:134
-msgid "##### Attention: Lookalike characters"
+#. type: Title #####
+#: ../../info/wxmaxima.md:133
+#, no-wrap
+msgid "Attention: Lookalike characters"
 msgstr ""
 
 #. type: Plain text
@@ -9012,17 +13417,15 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:203
-#, fuzzy
-#| msgid "If a special symbol isn’t in the list it is possible to input arbitrary Unicode characters by pressing <kbd>ESC</kbd> [number of the character (hexadecimal)] <kbd>ESC</kbd>.\n"
-msgid "If a special symbol isn’t in the list, it is possible to input arbitrary Unicode characters by pressing <kbd>ESC</kbd> \\[number of the character (hexadecimal)\\] <kbd>ESC</kbd>. Additionally the \"symbols\" sidebar has a right-click menu that allow to display a list of all available Unicode symbols one can add to this toolbar or to the worksheet."
-msgstr "如果某个特殊的 Unicode 字符不在上表中，则可以用如下方式输入：按下 <kbd>ESC</kbd> 后，输入该字符的 16 进制编码，再按下 <kbd>ESC</kbd>。\n"
+#, no-wrap
+msgid "If a special symbol isn’t in the list, it is possible to input arbitrary Unicode characters by pressing <kbd>ESC</kbd> \\[number of the character (hexadecimal)\\] <kbd>ESC</kbd>. Additionally the \"symbols\" sidebar has a right-click menu that allow to display a list of all available Unicode symbols one can add to this toolbar or to the worksheet.\n"
+msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:205
-#, fuzzy
-#| msgid "<kbd>ESC</kbd> <kbd>61</kbd> <kbd>ESC</kbd> therefore results in an `a`.\n"
-msgid "<kbd>ESC</kbd><kbd>6</kbd><kbd>1</kbd><kbd>ESC</kbd> therefore results in an `a`."
-msgstr "因此 <kbd>ESC</kbd> <kbd>61</kbd> <kbd>ESC</kbd> 输入了字符 `a`.\n"
+#, no-wrap
+msgid "<kbd>ESC</kbd><kbd>6</kbd><kbd>1</kbd><kbd>ESC</kbd> therefore results in an `a`.\n"
+msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:207
@@ -9033,12 +13436,16 @@ msgstr "请注意，这些符号中的大多数（逻辑符号除外）在 Maxim
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:210
-msgid "It may be the case that e.g. Greek characters or mathematical symbols are not included in the selected font, then they can not be displayed.  To solve that problem, select other fonts (using: Edit -> Configure -> Style)."
+#, no-wrap
+msgid ""
+"It may be the case that e.g. Greek characters or mathematical symbols are not included in the selected font, then they can not be displayed.\n"
+"To solve that problem, select other fonts (using: Edit -> Configure -> Style).\n"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:212
-msgid "### Unicode replacement"
+#. type: Title ###
+#: ../../info/wxmaxima.md:211
+#, no-wrap
+msgid "Unicode replacement"
 msgstr ""
 
 #. type: Plain text
@@ -9061,12 +13468,11 @@ msgstr ""
 msgid "It is recommended to use **Maxima code** (not these Unicode code points) in input cells (Rationale: (a) it might be possible, that the used font for math input does not contain them; (b) if you save the document as `wxm`-file, it is usually readable by (command line) Maxima, but these changes will of course not work in command line Maxima); but they may occur, if you cut&paste a formula from another document."
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:223
-#, fuzzy
-#| msgid "Side Panes"
-msgid "### Side Panes"
-msgstr "侧边栏"
+#. type: Title ###
+#: ../../info/wxmaxima.md:222
+#, no-wrap
+msgid "Side Panes"
+msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:225
@@ -9090,12 +13496,11 @@ msgstr ""
 msgid "![Increase or decrease headings in the TOC side pane](./Sidepane-TOC-convert-headings.png){ id=Sidepane-TOC-convert-headings }"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:234
-#, fuzzy
-#| msgid "MathML output"
-msgid "### MathML output"
-msgstr "MathML 输出"
+#. type: Title ###
+#: ../../info/wxmaxima.md:233
+#, no-wrap
+msgid "MathML output"
+msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:236
@@ -9104,12 +13509,11 @@ msgstr "MathML 输出"
 msgid "Several word processors and similar programs either recognize [MathML](https://www.w3.org/Math/) input and automatically insert it as an editable 2D equation - or (like LibreOffice) have an equation editor that offers an “import MathML from clipboard” feature. Others support RTF maths. _WxMaxima_, therefore, offers several entries in the right-click menu."
 msgstr "一些文字处理程序可以识别 MathML 输入并自动将其作为可编辑的数学公式插入，或者（像 LibreOffice 7.1 那样）有一个提供“从剪贴板导入 MathML”功能的公式编辑器。有些程序也支持 RTF 公式。因此，wxMaxima 在右键单击菜单中提供了多种复制公式的方法。"
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:238
-#, fuzzy
-#| msgid "Markdown support"
-msgid "### Markdown support"
-msgstr "标记语言（Markdown）支持"
+#. type: Title ###
+#: ../../info/wxmaxima.md:237
+#, no-wrap
+msgid "Markdown support"
+msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:240
@@ -9118,19 +13522,10 @@ msgstr "标记语言（Markdown）支持"
 msgid "_WxMaxima_ offers a set of standard [Markdown](https://en.wikipedia.org/wiki/Markdown) conventions that don’t collide with mathematical notation. One of these elements is bullet lists."
 msgstr "wxMaxima 提供了一些标准的标记（markdown）语言支持，而这些记号不会与数学符号相冲突。其中一个支持是项目符号列表。"
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:250
-#, fuzzy, no-wrap
-#| msgid ""
-#| "Ordinary text\n"
-#| " * One item, indentation level 1\n"
-#| " * Another item at indentation level 1\n"
-#| "   * An item at a second indentation level\n"
-#| "   * A second item at the second indentation level\n"
-#| " * A third item at the first indentation level\n"
-#| "Ordinary text\n"
+#. type: Fenced code block (text)
+#: ../../info/wxmaxima.md:241
+#, no-wrap
 msgid ""
-"```text\n"
 "Ordinary text\n"
 " * One item, indentation level 1\n"
 " * Another item at indentation level 1\n"
@@ -9138,67 +13533,48 @@ msgid ""
 "   * A second item at the second indentation level\n"
 " * A third item at the first indentation level\n"
 "Ordinary text\n"
-"```\n"
 msgstr ""
-"普通文本\n"
-" *一个条目，缩进级别为 1\n"
-" *另一个条目，缩进级别为 1\n"
-"   *一个条目，缩进级别为 2\n"
-"   *另一个条目，缩进级别为 2\n"
-"*第三个条目，缩进级别为 1\n"
-"普通文本\n"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:252
-#, fuzzy
-#| msgid "_wxMaxima_ will recognize text starting with `>` chars as block quotes:\n"
-msgid "_WxMaxima_ will recognize text starting with `>` chars as block quotes:"
-msgstr "wxMaxima 也能将以 `>` 字符开头的文本识别为引用块：\n"
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:260
-#, fuzzy
-#| msgid ""
-#| "Ordinary text\n"
-#| "> quote quote quote quote\n"
-#| "> quote quote quote quote\n"
-#| "> quote quote quote quote\n"
-#| "Ordinary text\n"
-msgid "```text Ordinary text > quote quote quote quote > quote quote quote quote > quote quote quote quote Ordinary text ```"
+#, no-wrap
+msgid "_WxMaxima_ will recognize text starting with `>` chars as block quotes:\n"
 msgstr ""
-"普通文本\n"
-">引用文字\n"
-">引用文字\n"
-">引用文字\n"
-"普通文本\n"
+
+#. type: Fenced code block (text)
+#: ../../info/wxmaxima.md:253
+#, no-wrap
+msgid ""
+"Ordinary text\n"
+"> quote quote quote quote\n"
+"> quote quote quote quote\n"
+"> quote quote quote quote\n"
+"Ordinary text\n"
+msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:262
-#, fuzzy
-#| msgid "_wxMaxima_'s TeX and HTML output will also recognize `=>` and replace it by the corresponding Unicode sign:\n"
-msgid "_WxMaxima_’s TeX and HTML output will also recognize `=>` and replace it by the corresponding Unicode sign:"
-msgstr "wxMaxima 的 TeX 和 HTML 输出也能识别 `=>`，并将其替换为相应的 Unicode 符号：\n"
+#, no-wrap
+msgid "_WxMaxima_’s TeX and HTML output will also recognize `=>` and replace it by the corresponding Unicode sign:\n"
+msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:266
-#, fuzzy
-#| msgid "cogito => sum.\n"
-msgid "```text cogito => sum.  ```"
-msgstr "cogito => sum.\n"
+#. type: Fenced code block (text)
+#: ../../info/wxmaxima.md:263
+#, no-wrap
+msgid "cogito => sum.\n"
+msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:268
-#, fuzzy
-#| msgid "Other symbols the HTML and TeX export will recognize are `<=` and `>=` for comparisons, a double-pointed double arrow (`<=>`), single- headed arrows (`<->`, `->` and `<-`) and `+/-` as the respective sign. For TeX output also `<<` and `>>` are recognized.\n"
-msgid "Other symbols the HTML and TeX export will recognize are `<=` and `>=` for comparisons, a double-pointed double arrow (`<=>`), single-headed arrows (`<->`, `->` and `<-`) and `+/-` as the respective sign. For TeX output also `<<` and `>>` are recognized."
-msgstr "导出 TeX 和 HTML 文件时将识别的其他符号还有不等号（`<=` 和 `>=`）、双线箭头（`<=>`）、单线箭头（`<->`、`->` 和 `<-`）以及 `+/-`。对于 TeX 输出，还可以识别 `<<` 和 `>>`。\n"
+#, no-wrap
+msgid "Other symbols the HTML and TeX export will recognize are `<=` and `>=` for comparisons, a double-pointed double arrow (`<=>`), single-headed arrows (`<->`, `->` and `<-`) and `+/-` as the respective sign. For TeX output also `<<` and `>>` are recognized.\n"
+msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:270
-#, fuzzy
-#| msgid "Hotkeys"
-msgid "### Hotkeys"
-msgstr "快捷键"
+#. type: Title ###
+#: ../../info/wxmaxima.md:269
+#, no-wrap
+msgid "Hotkeys"
+msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:272
@@ -9222,36 +13598,33 @@ msgstr "<kbd>CTRL</kbd>+<kbd>SHIFT</kbd>+<kbd>DELETE</kbd> 删除一个单元格
 msgid "<kbd>SHIFT</kbd>+<kbd>SPACE</kbd> inserts a non-breaking space."
 msgstr "<kbd>SHIFT</kbd>+<kbd>SPACE</kbd> 插入一个不可断行的空格。"
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:278
-#, fuzzy
-#| msgid "Raw TeX in the TeX export"
-msgid "### Raw TeX in the TeX export"
-msgstr "导出 TeX 时的原始 TeX 代码"
+#. type: Title ###
+#: ../../info/wxmaxima.md:277
+#, no-wrap
+msgid "Raw TeX in the TeX export"
+msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:280
 msgid "If a text cell begins with `TeX:` the TeX export contains the literal text that follows the `TeX:` marker. Using this feature allows the entry of TeX markup within the _wxMaxima_ workbook."
 msgstr "如果文本单元格以 `TeX: ` 开头，则导出 TeX 时，文件将包含 `TeX: ` 标记后面的文本。使用此功能可以在 wxMaxima 工作簿中输入 TeX 代码。"
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:282
-#, fuzzy
-#| msgid "File Formats"
-msgid "## File Formats"
-msgstr "文件格式"
+#. type: Title ##
+#: ../../info/wxmaxima.md:281
+#, no-wrap
+msgid "File Formats"
+msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:284
 msgid "The material that is developed in a _wxMaxima_ session can be stored for later use in any of three ways:"
 msgstr "在 wxMaxima 中输入的内容可以存为以下三种文件格式之一，以供以后使用："
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:286
-#, fuzzy
-#| msgid ".mac"
-msgid "### .mac"
-msgstr ".mac"
+#. type: Title ###
+#: ../../info/wxmaxima.md:285
+#, no-wrap
+msgid ".mac"
+msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:288
@@ -9284,19 +13657,19 @@ msgstr ""
 msgid "You can be use `.mac` files for writing your own library of macros. But since they don’t contain enough structural information they cannot be read back as a _wxMaxima_ session."
 msgstr "用户可以使用 `.mac` 文件编写自己的程序包。但是由于它们没有包含足够的结构信息，因此不能作为一个 wxMaxima 工作簿来读取。"
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:299
-#, fuzzy
-#| msgid ".wxm"
-msgid "### .wxm"
-msgstr ".wxm"
+#. type: Title ###
+#: ../../info/wxmaxima.md:298
+#, no-wrap
+msgid ".wxm"
+msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:302
-#, fuzzy
-#| msgid ".wxm files contain the worksheet except _Maxima_'s output. On Maxima versions >5.38 they can be read using _Maxima_'s `load()` function just as .mac files can be. With this plain-text format it sometimes is unavoidable that worksheets that use new features are not downwards-compatible with older versions of _wxMaxima_.\n"
-msgid "`.wxm` files contain the worksheet except for _Maxima_’s output. On Maxima versions >5.38 they can be read using _Maxima_’s `load()` function just as .mac files. Well - mostly. Questions (like `asksign(x)`) are problematic, as the answer is written in the `.wxm` file (so that it can be suggested after loading), but that can Maxima not evaluate.  You can prevent Maxima from asking questions by using `assume()` to declare some properties, Maxima wants to know."
-msgstr "`.wxm` 文件包含除 Maxima 输出之外的工作簿内容。在版本号大于 5.38 的 Maxima 上，可以像 `.mac` 文件一样，使用 Maxima 的 `load()` 函数来读取。如果采用这种文本格式，使用含新功能的工作簿时会不可避免地与旧版本的 wxMaxima 不兼容。\n"
+#, no-wrap
+msgid ""
+"`.wxm` files contain the worksheet except for _Maxima_’s output. On Maxima versions >5.38 they can be read using _Maxima_’s `load()` function just as .mac files. Well - mostly. Questions (like `asksign(x)`) are problematic, as the answer is written in the `.wxm` file (so that it can be suggested after loading), but that can Maxima not evaluate.\n"
+"You can prevent Maxima from asking questions by using `assume()` to declare some properties, Maxima wants to know.\n"
+msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:304
@@ -9305,12 +13678,11 @@ msgstr "`.wxm` 文件包含除 Maxima 输出之外的工作簿内容。在版本
 msgid "With this plain-text format, it sometimes is unavoidable that worksheets that use new features are not downwards-compatible with older versions of _wxMaxima_."
 msgstr "`.wxm` 文件包含除 Maxima 输出之外的工作簿内容。在版本号大于 5.38 的 Maxima 上，可以像 `.mac` 文件一样，使用 Maxima 的 `load()` 函数来读取。如果采用这种文本格式，使用含新功能的工作簿时会不可避免地与旧版本的 wxMaxima 不兼容。\n"
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:306
-#, fuzzy
-#| msgid "File Formats"
-msgid "#### File format of wxm files"
-msgstr "文件格式"
+#. type: Title ####
+#: ../../info/wxmaxima.md:305
+#, no-wrap
+msgid "File format of wxm files"
+msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:308
@@ -9322,9 +13694,12 @@ msgstr ""
 msgid "It starts with the following comment:"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:315
-msgid "```maxima /* [wxMaxima batch file version 1] [ DO NOT EDIT BY HAND! ]*/ /* [ Created with wxMaxima version 24.02.2_DevelopmentSnapshot ] */ ```"
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:311
+#, no-wrap
+msgid ""
+"/* [wxMaxima batch file version 1] [ DO NOT EDIT BY HAND! ]*/\n"
+"/* [ Created with wxMaxima version 24.02.2_DevelopmentSnapshot ] */\n"
 msgstr ""
 
 #. type: Plain text
@@ -9332,15 +13707,13 @@ msgstr ""
 msgid "And then the cells follow, encoded as Maxima comments, e.g. a section cell:"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:323
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:318
 #, no-wrap
 msgid ""
-"```maxima\n"
 "/* [wxMaxima: section start ]\n"
 "Title of the section\n"
 "   [wxMaxima: section end   ] */\n"
-"```\n"
 msgstr ""
 
 #. type: Plain text
@@ -9348,16 +13721,14 @@ msgstr ""
 msgid "or (in a Math cell the input is of course *not* commented out (the output is not saved in a `wxm` file)):"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:332
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:326
 #, no-wrap
 msgid ""
-"```maxima\n"
 "/* [wxMaxima: input   start ] */\n"
 "f(x):=x^2+1$\n"
 "f(2);\n"
 "/* [wxMaxima: input   end   ] */\n"
-"```\n"
 msgstr ""
 
 #. type: Plain text
@@ -9365,16 +13736,14 @@ msgstr ""
 msgid "Images are [Base64 encoded](https://en.wikipedia.org/wiki/Base64) with the image type as first line):"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:341
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:335
 #, no-wrap
 msgid ""
-"```maxima\n"
 "/* [wxMaxima: image   start ]\n"
 "jpg\n"
 "[very chaotic looking character sequence]\n"
 "   [wxMaxima: image   end   ] */\n"
-"```\n"
 msgstr ""
 
 #. type: Plain text
@@ -9382,13 +13751,10 @@ msgstr ""
 msgid "A page break is just one line containing:"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:347
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:344
 #, no-wrap
-msgid ""
-"```maxima\n"
-"/* [wxMaxima: page break    ] */\n"
-"```\n"
+msgid "/* [wxMaxima: page break    ] */\n"
 msgstr ""
 
 #. type: Plain text
@@ -9396,35 +13762,31 @@ msgstr ""
 msgid "And folded cells marked by:"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:355
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:350
 #, no-wrap
 msgid ""
-"```maxima\n"
 "/* [wxMaxima: fold    start ] */\n"
 "...\n"
 "/* [wxMaxima: fold    end   ] */\n"
-"```\n"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:357
-#, fuzzy
-#| msgid ".wxmx"
-msgid "### .wxmx"
-msgstr ".wxmx"
+#. type: Title ###
+#: ../../info/wxmaxima.md:356
+#, no-wrap
+msgid ".wxmx"
+msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:359
 msgid "This XML-based file format saves the complete worksheet including things like the zoom factor and the watchlist. It is the preferred file format."
 msgstr "这种基于 XML 的文件格式保存了完整的工作簿内容，包括缩放因子和观察列表等内容。它是首选的文件格式。"
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:361
-#, fuzzy
-#| msgid "File Formats"
-msgid "#### File format of wxmx files"
-msgstr "文件格式"
+#. type: Title ####
+#: ../../info/wxmaxima.md:360
+#, no-wrap
+msgid "File format of wxmx files"
+msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:364
@@ -9461,12 +13823,11 @@ msgstr ""
 msgid "So, if something goes wrong, you can unzip a wxMaxima document (maybe rename it before to a `zip`-file), maybe make changes in the `content.xml` file with a text editor, or replace an broken image, zip the files again, probably rename the `zip` to a `wxmx`-file - and you get another modified `wxmx`-file."
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:375
-#, fuzzy
-#| msgid "Configuration options"
-msgid "## Configuration options"
-msgstr "设置选项"
+#. type: Title ##
+#: ../../info/wxmaxima.md:374
+#, no-wrap
+msgid "Configuration options"
+msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:377
@@ -9490,24 +13851,22 @@ msgstr "对于当前会话，要变更大多数可设置变量的值只能通过
 msgid "![wxMaxima configuration 1](./wxMaxima_configuration_001.png){ id=img_wxMaxima_configuration_001 }"
 msgstr "![wxMaxima 设置对话框](./wxMaxima_configuration_001.png){ id=img_wxMaxima_configuration_001 }"
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:384
-#, fuzzy
-#| msgid "Default animation framerate"
-msgid "### Default animation framerate"
-msgstr "默认动图帧率"
+#. type: Title ###
+#: ../../info/wxmaxima.md:383
+#, no-wrap
+msgid "Default animation framerate"
+msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:386
 msgid "The animation framerate that is used for new animations is kept in the variable `wxanimate_framerate`. The initial value this variable will contain in a new worksheet can be changed using the configuration dialogue."
 msgstr "用于新生成动图的帧率保存在变量 `wxanimate_framerate` 中，可以使用设置对话框更改此变量在新工作簿中的初始值。"
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:388
-#, fuzzy
-#| msgid "Default plot size for new _maxima_ sessions"
-msgid "### Default plot size for new _maxima_ sessions"
-msgstr "新 Maxima 会话的默认绘图尺寸"
+#. type: Title ###
+#: ../../info/wxmaxima.md:387
+#, no-wrap
+msgid "Default plot size for new _maxima_ sessions"
+msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:390
@@ -9523,39 +13882,23 @@ msgstr "如果 `wxplot_size` 的值没有被 Maxima 更改，则使用此大小�
 msgid "In order to set the plot size of a single graph only use the following notation can be used that sets a variable’s value for one command only:"
 msgstr "为了仅对单个绘图命令设置绘制图形的大小，可以使用以下代码："
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:401
-#, fuzzy, no-wrap
-#| msgid ""
-#| "wxdraw2d( \n"
-#| "   explicit(\n"
-#| "       x^2,\n"
-#| "\t   x,-5,5\n"
-#| "   )\n"
-#| "), wxplot_size=[480,480]$\n"
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:393
+#, no-wrap
 msgid ""
-"```maxima\n"
 "wxdraw2d(\n"
 "   explicit(\n"
 "       x^2,\n"
 "       x,-5,5\n"
 "   )\n"
 "), wxplot_size=[480,480]$\n"
-"```\n"
 msgstr ""
-"wxdraw2d( \n"
-"   explicit(\n"
-"       x^2,\n"
-"\t   x,-5,5\n"
-"   )\n"
-"), wxplot_size=[480,480]$\n"
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:403
-#, fuzzy
-#| msgid "Match parenthesis in text controls"
-msgid "### Match parenthesis in text controls"
-msgstr "在文本中匹配括号"
+#. type: Title ###
+#: ../../info/wxmaxima.md:402
+#, no-wrap
+msgid "Match parenthesis in text controls"
+msgstr "在文本控件中匹配括号"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:405
@@ -9574,12 +13917,11 @@ msgstr "如果输入了左括号、左方括号或左双引号，wxMaxima 将自
 msgid "If text is selected if any of these keys is pressed the selected text will be put between the matched signs."
 msgstr "如果在输入前述字符中的任何一个时选择了文本，则所选文本将被放在配对的两个字符之间。"
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:410
-#, fuzzy
-#| msgid "Don't save the worksheet automatically"
-msgid "### Don’t save the worksheet automatically"
-msgstr "不自动保存工作簿"
+#. type: Title ###
+#: ../../info/wxmaxima.md:409
+#, no-wrap
+msgid "Don’t save the worksheet automatically"
+msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:412
@@ -9607,35 +13949,30 @@ msgstr "文件在退出时被自动保存；"
 msgid "And the file will automatically be saved every 3 minutes."
 msgstr "每 3 分钟文件被自动保存一次；"
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:419
-#, fuzzy
-#| msgid "Where is the configuration saved?"
-msgid "### Where is the configuration saved?"
-msgstr "设置信息保存的位置"
+#. type: Title ###
+#: ../../info/wxmaxima.md:418
+#, no-wrap
+msgid "Where is the configuration saved?"
+msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:422
-#, fuzzy
-#| msgid ""
-#| "If you are using Unix/Linux, the configuration information will be saved in a file `.wxMaxima` in your home directory (if you are using wxWidgets < 3.1.1), or `.config/wxMaxima.conf` ((XDG-Standard) if wxWidgets >= 3.1.1 is used). You can retrieve the wxWidgets version from the command `wxbuild_info();` or by using the menu option Help->About. [wxWidgets](https://www.wxwidgets.org/) is the cross-platform GUI library, which is the base for _wxMaxima_ (therefore the `wx` in the name).\n"
-#| "(Since the filename starts with a dot, `.wxMaxima` or `.config` will be hidden).\n"
-msgid "If you are using Unix/Linux, the configuration information will be saved in a file `.wxMaxima` in your home directory (if you are using wxWidgets \\< 3.1.1), or `.config/wxMaxima.conf` ((XDG-Standard) if wxWidgets >= 3.1.1 is used). You can retrieve the wxWidgets version from the command `wxbuild_info();` or by using the menu option Help->About. [wxWidgets](https://www.wxwidgets.org/) is the cross-platform GUI library, which is the base for _wxMaxima_ (therefore the `wx` in the name).  (Since the filename starts with a dot, `.wxMaxima` or `.config` will be hidden)."
+#, no-wrap
+msgid ""
+"If you are using Unix/Linux, the configuration information will be saved in a file `.wxMaxima` in your home directory (if you are using wxWidgets \\< 3.1.1), or `.config/wxMaxima.conf` ((XDG-Standard) if wxWidgets >= 3.1.1 is used). You can retrieve the wxWidgets version from the command `wxbuild_info();` or by using the menu option Help->About. [wxWidgets](https://www.wxwidgets.org/) is the cross-platform GUI library, which is the base for _wxMaxima_ (therefore the `wx` in the name).\n"
+"(Since the filename starts with a dot, `.wxMaxima` or `.config` will be hidden).\n"
 msgstr ""
-"当使用 Unix/Linux 系统时，设置信息将保存在主目录中的 `.wxMaxima` 文件里（如果 wxWidgets 版本号小于 3.1.1）或 `.config/wxMaxima.conf` 文件里（如果 wxWidgets 的版本号大于等于 3.1.1（XDG标准））。用户可以通过命令 `wxbuild_info();` 或使用菜单选项 \"帮助->关于\"（Help->About）来检索 wxWidgets 版本号。[wxWidgets](https://www.wxwidgets.org/) 是跨平台的 GUI 库，也是 wxMaxima 的底层库（因此 wxMaxima 的名称中带“wx”）。\n"
-"（由于文件名以点“.”开头，文件 `.wxMaxima` 或 `.config` 将被隐藏）。\n"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:424
 msgid "If you are using Windows, the configuration will be stored in the registry. You will find the entries for _wxMaxima_ at the following position in the registry: `HKEY_CURRENT_USER\\Software\\wxMaxima`"
 msgstr "当使用 Windows 系统时，配置信息将存储在注册表中。在注册表中的以下位置可以找到 wxMaxima 的相关条目：`HKEY_CURRENT_USER\\Software\\wxMaxima`。"
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:428
-#, fuzzy
-#| msgid "Extensions to _Maxima_"
-msgid "# Extensions to _Maxima_"
-msgstr "对 Maxima 功能的扩充"
+#. type: Title #
+#: ../../info/wxmaxima.md:427
+#, no-wrap
+msgid "Extensions to _Maxima_"
+msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:430
@@ -9644,12 +13981,11 @@ msgstr "对 Maxima 功能的扩充"
 msgid "_WxMaxima_ is primarily a graphical user interface for _Maxima_. As such, its main purpose is to pass along commands to _Maxima_ and to report the results of executing those commands. In some cases, however, _wxMaxima_ adds functionality to _Maxima_. _WxMaxima_’s ability to generate reports by exporting a workbook’s contents to HTML and LaTeX files has been mentioned. This section considers some ways that _wxMaxima_ enhances the inclusion of graphics in a session."
 msgstr "wxMaxima 是 Maxima 的图形用户界面，因此它的主要目的是将命令传递给 Maxima，并输出执行这些命令的结果。但是，在某些情况下，wxMaxima 会为 Maxima 添加新的功能。前面已提到 wxMaxima 可以将工作簿的内容导出为 HTML 和 LaTeX 文件。本节将讨论另外一些增强功能，以及在工作簿中包含图形的方法。"
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:432
-#, fuzzy
-#| msgid "Subscripted variables"
-msgid "## Subscripted variables"
-msgstr "为变量添加下标"
+#. type: Title ##
+#: ../../info/wxmaxima.md:431
+#, no-wrap
+msgid "Subscripted variables"
+msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:434
@@ -9699,15 +14035,15 @@ msgstr "如果变量格式与上述条件不匹配，仍可以使用命令`wxdec
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:449
-msgid "You can use the menu \"View->Autosubscript\" to set these values."
+#, no-wrap
+msgid "You can use the menu \"View->Autosubscript\" to set these values.\n"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:451
-#, fuzzy
-#| msgid "User feedback in the status bar"
-msgid "## User feedback in the status bar"
-msgstr "在状态栏中提供反馈信息"
+#. type: Title ##
+#: ../../info/wxmaxima.md:450
+#, no-wrap
+msgid "User feedback in the status bar"
+msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:453
@@ -9716,20 +14052,10 @@ msgstr "在状态栏中提供反馈信息"
 msgid "Long-running commands can provide user feedback in the status bar. This user feedback is replaced by any new feedback that is placed there (allowing to use it as a progress indicator) and is deleted as soon as the current command sent to _Maxima_ is finished. It is safe to use `wxstatusbar()` even in libraries that might be used with plain _Maxima_ (as opposed to _wxMaxima_): If _wxMaxima_ isn’t present the `wxstatusbar()` command will just be left unevaluated."
 msgstr "长时间运行的命令中可以包含 `wxstatusbar()`，以用于在状态栏中向用户提供反馈信息。此反馈信息将被任何新生成的反馈信息覆盖（从而可以将其用作运行进度指示器），并在发送到 Maxima 的命令运行结束后立即被删除。即使在只与 Maxima（而非 wxMaxima）一起使用的库中包含命令 `wxstatusbar()` 也是可行的：如果没有运行 wxMaxima，那么命令 `wxstatusbar()` 也不会被执行。"
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:464
-#, fuzzy, no-wrap
-#| msgid ""
-#| "for i:1 thru 10 do (\n"
-#| "    /* Tell the user how far we got */\n"
-#| "    wxstatusbar(concat(\"Pass \",i)),\n"
-#| "    /* (sleep n) is a Lisp function, which can be used */\n"
-#| "    /* with the character \"?\" before. It delays the */\n"
-#| "    /* program execution (here: for 3 seconds) */\n"
-#| "    ?sleep(3)\n"
-#| ")$\n"
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:454
+#, no-wrap
 msgid ""
-"```maxima\n"
 "for i:1 thru 10 do (\n"
 "    /* Tell the user how far we got */\n"
 "    wxstatusbar(concat(\"Pass \",i)),\n"
@@ -9738,19 +14064,12 @@ msgid ""
 "    /* program execution (here: for 3 seconds) */\n"
 "    ?sleep(3)\n"
 ")$\n"
-"```\n"
 msgstr ""
-"for i:1 thru 10 do (\n"
-"    /* 告诉用户目前的运行位置 */\n"
-"    wxstatusbar(concat(\"Pass \",i)),\n"
-"    /* (sleep n) 是可接在字符\"?\"后使用的 Lisp 函数 */\n"
-"    /* 它推迟了程序的运行，此处是 3 秒 */\n"
-"    ?sleep(3)\n"
-")$\n"
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:466
-msgid "## Exporting the worksheet from within Maxima"
+#. type: Title ##
+#: ../../info/wxmaxima.md:465
+#, no-wrap
+msgid "Exporting the worksheet from within Maxima"
 msgstr ""
 
 #. type: Plain text
@@ -9758,9 +14077,12 @@ msgstr ""
 msgid "The command `wxworksheettohtml()` exports the current worksheet to an HTML file from within a running _Maxima_ session, which is convenient for scripted or batch export. Like `wxstatusbar()` it is safe to use in code that might also run in plain (console) _Maxima_: if _wxMaxima_ isn’t present the command is simply left unevaluated."
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:473
-msgid "```maxima wxworksheettohtml(\"report.html\")$ wxworksheettohtml(\"report.html\", flavor=\"svg\", wxmx=true)$ ```"
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:469
+#, no-wrap
+msgid ""
+"wxworksheettohtml(\"report.html\")$\n"
+"wxworksheettohtml(\"report.html\", flavor=\"svg\", wxmx=true)$\n"
 msgstr ""
 
 #. type: Plain text
@@ -9788,9 +14110,12 @@ msgstr ""
 msgid "The companion command `wxworksheettotex()` exports to a LaTeX (`.tex`) file the same way:"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:489
-msgid "```maxima wxworksheettotex(\"report.tex\")$ wxworksheettotex(\"report.tex\", documentclass=\"report\", documentclassoptions=\"12pt,a4paper\")$ ```"
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:485
+#, no-wrap
+msgid ""
+"wxworksheettotex(\"report.tex\")$\n"
+"wxworksheettotex(\"report.tex\", documentclass=\"report\", documentclassoptions=\"12pt,a4paper\")$\n"
 msgstr ""
 
 #. type: Plain text
@@ -9808,24 +14133,22 @@ msgstr ""
 msgid "Support for `wxworksheettopdf()` is planned."
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:498
-#, fuzzy
-#| msgid "Plotting"
-msgid "## Plotting"
-msgstr "绘图"
+#. type: Title ##
+#: ../../info/wxmaxima.md:497
+#, no-wrap
+msgid "Plotting"
+msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:500
 msgid "Plotting (having fundamentally to do with graphics) is a place where a graphical user interface will have to provide some extensions to the original program."
 msgstr "因为绘图功能与图形密切相关，所以图形用户界面理应为原始程序的绘图功能提供一些扩充内容。"
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:502
-#, fuzzy
-#| msgid "Embedding a plot into the work sheet"
-msgid "### Embedding a plot into the worksheet"
-msgstr "将绘制的图形嵌入工作簿"
+#. type: Title ###
+#: ../../info/wxmaxima.md:501
+#, no-wrap
+msgid "Embedding a plot into the worksheet"
+msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:504
@@ -9868,12 +14191,11 @@ msgstr ""
 msgid "If you got problems with one of these functions, please check, if the problem exists in the the Maxima function too (e.g. you got an error with `wxplot2d()`, check the same plot in the Maxima command `plot2d()` (which opens the plot in a separate Window)). If the problem does not disappear, it is most likely a Maxima issue and should be reported in the [Maxima bugtracker](https://sourceforge.net/p/maxima/bugs/). Or maybe a Gnuplot issue."
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:526
-#, fuzzy
-#| msgid "Making embedded plots bigger or smaller"
-msgid "### Making embedded plots bigger or smaller"
-msgstr "设置嵌入图形的大小"
+#. type: Title ###
+#: ../../info/wxmaxima.md:525
+#, no-wrap
+msgid "Making embedded plots bigger or smaller"
+msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:528
@@ -9882,19 +14204,10 @@ msgstr "设置嵌入图形的大小"
 msgid "As noted above, the configure dialog provides a way to change the default size plots created which sets the starting value of `wxplot_size`. The plotting routines of _wxMaxima_ respect this variable that specifies the size of a plot in pixels. It can always be queried or used to set the size of the following plots:"
 msgstr "如前面所述，设置对话框提供了一种更改默认绘图大小的方法，该方法设置了 `wxplot_size` 的默认值。绘图时，wxMaxima 将该变量识别为图片尺寸（以像素为单位）。可以查询该变量，或以如下方式设置所绘制图片的大小："
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:538
-#, fuzzy, no-wrap
-#| msgid ""
-#| "wxplot_size:[1200,800]$\n"
-#| "wxdraw2d(\n"
-#| "    explicit(\n"
-#| "        sin(x),\n"
-#| "        x,1,10\n"
-#| "    )\n"
-#| ")$\n"
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:529
+#, no-wrap
 msgid ""
-"```maxima\n"
 "wxplot_size:[1200,800]$\n"
 "wxdraw2d(\n"
 "    explicit(\n"
@@ -9902,59 +14215,35 @@ msgid ""
 "        x,1,10\n"
 "    )\n"
 ")$\n"
-"```\n"
 msgstr ""
-"wxplot_size:[1200,800]$\n"
-"wxdraw2d(\n"
-"    explicit(\n"
-"        sin(x),\n"
-"        x,1,10\n"
-"    )\n"
-")$\n"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:540
 msgid "If the size of only one plot is to be changed _Maxima_ provides a canonical way to change an attribute only for the current cell. In this usage the specification `wxplot_size = [value1, value2]` is appended to the `wxdraw2d( )` command, and is not part of the `wxdraw2d` command."
 msgstr "如果只更改一个绘制图片的大小，wxMaxima 提供了一种只为当前单元格更改属性的方法。具体用法为，将 `wxplot_size=[value1,value2]` 附加到 `wxdraw2d()` 命令结尾，而不是作为该命令的一部分："
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:549
-#, fuzzy, no-wrap
-#| msgid ""
-#| "wxdraw2d(\n"
-#| "    explicit(\n"
-#| "        sin(x),\n"
-#| "        x,1,10\n"
-#| "    )\n"
-#| "),wxplot_size=[1600,800]$\n"
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:541
+#, no-wrap
 msgid ""
-"```maxima\n"
 "wxdraw2d(\n"
 "    explicit(\n"
 "        sin(x),\n"
 "        x,1,10\n"
 "    )\n"
 "),wxplot_size=[1600,800]$\n"
-"```\n"
 msgstr ""
-"wxdraw2d(\n"
-"    explicit(\n"
-"        sin(x),\n"
-"        x,1,10\n"
-"    )\n"
-"),wxplot_size=[1600,800]$\n"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:551
 msgid "Setting the size of embedded plot with `wxplot_size` works for embedded plots using e.g. `wxplot`, `wxdraw`, `wxcontour_plot` and `wximplicit_plot` commands and for embedded animations with `with_slider_draw` and `wxanimate` commands."
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:553
-#, fuzzy
-#| msgid "Better quality plots"
-msgid "### Better quality plots"
-msgstr "更好的绘图质量"
+#. type: Title ###
+#: ../../info/wxmaxima.md:552
+#, no-wrap
+msgid "Better quality plots"
+msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:555
@@ -9963,12 +14252,11 @@ msgstr "更好的绘图质量"
 msgid "_Gnuplot_ doesn’t seem to provide a portable way of determining whether it supports the high-quality bitmap output that the Cairo library provides. On systems where _Gnuplot_ is compiled to use this library the pngCairo option from the configuration menu (that can be overridden by the variable `wxplot_pngcairo`) enables support for antialiasing and additional line styles. If `wxplot_pngCairo` is set without _Gnuplot_ supporting this the result will be error messages instead of graphics."
 msgstr "Gnuplot 似乎没有提供一种通用的方法来确定它是否支持 cairo 库提供的高质量位图输出。如果所编译的 gnuplot 使用了 cairo 库，勾选设置菜单中的 pngcairo 选项（可被变量 `wxplot_pngcairo` 覆盖）可以提供抗锯齿和其他线条样式支持。如果设置了 `wxplot_pngcairo`，而 gnuplot 并未使用 cairo 库，则绘图将会失败并给出错误消息。"
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:557
-#, fuzzy
-#| msgid "Opening embedded plots in interactive _gnuplot_ windows"
-msgid "### Opening embedded plots in interactive _Gnuplot_ windows"
-msgstr "在交互式 gnuplot 窗口中打开嵌入的绘图"
+#. type: Title ###
+#: ../../info/wxmaxima.md:556
+#, no-wrap
+msgid "Opening embedded plots in interactive _Gnuplot_ windows"
+msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:559
@@ -9977,12 +14265,11 @@ msgstr "在交互式 gnuplot 窗口中打开嵌入的绘图"
 msgid "If a plot was generated using the `wxdraw`-type commands (`wxplot2d` and `wxplot3d` isn’t supported by this feature) and the file size of the underlying _Gnuplot_ project isn’t way too high _wxMaxima_ offers a right-click menu that allows to open the plot in an interactive _Gnuplot_ window."
 msgstr "如果绘图时使用 `wxdraw` 类型的命令（不含 `wxplot2d` 和 `wxplot3d`），并且底层的 `gnuplot` 项目文件不是太大，则 wxMaxima 提供了一个右键单击菜单，允许在交互式的 gnuplot 窗口中打开绘制的图形。"
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:561
-#, fuzzy
-#| msgid "Opening gnuplot's command console in `plot` windows"
-msgid "### Opening Gnuplot’s command console in `plot` windows"
-msgstr "在绘图窗口中打开 gnuplot 控制台"
+#. type: Title ###
+#: ../../info/wxmaxima.md:560
+#, no-wrap
+msgid "Opening Gnuplot’s command console in `plot` windows"
+msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:564
@@ -9991,12 +14278,11 @@ msgstr "在绘图窗口中打开 gnuplot 控制台"
 msgid "On MS Windows, there are two Gnuplot programs, `gnuplot.exe` and `wgnuplot.exe`.  You can configure, which command should be used using the configuration menu. `wgnuplot.exe` offers the possibility to open a console window, where _gnuplot_ commands can be entered into, `gnuplot.exe` does not offer this possibility. Unfortunately, `wgnuplot.exe` causes _Gnuplot_ to \"steal\" the keyboard focus for a short time every time a plot is prepared."
 msgstr "在 Windows 系统上，如果 Maxima 的变量 `gnuplot_command` 的值 “gnuplot” 被换为 “wgnuplot”，则 gnuplot 会打开一个控制台窗口，在该窗口中可以输入 gnuplot 的命令。但是，启用此功能会使得每次绘图时 gnuplot 短时间内独占键盘。"
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:566
-#, fuzzy
-#| msgid "Embedding animations into the spreadsheet"
-msgid "### Embedding animations into the spreadsheet"
-msgstr "在工作簿中嵌入动图"
+#. type: Title ###
+#: ../../info/wxmaxima.md:565
+#, no-wrap
+msgid "Embedding animations into the spreadsheet"
+msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:568
@@ -10010,20 +14296,10 @@ msgstr "在三维图形中，点的坐标往往难以读取。一个可行的替
 msgid "The first two arguments for `with_slider_draw` are the name of the variable that is stepped between the plots and a list of the values of these variable. The arguments that follow are the ordinary arguments for `wxdraw2d`:"
 msgstr "`with_slider_draw` 命令的前两个参数是用于控制绘图的变量名称和变量值的列表，接下来的参数与 `wxdraw2d` 命令的参数相同："
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:581
-#, fuzzy, no-wrap
-#| msgid ""
-#| "with_slider_draw(\n"
-#| "    f,[1,2,3,4,5,6,7,10],\n"
-#| "    title=concat(\"f=\",f,\"Hz\"),\n"
-#| "    explicit(\n"
-#| "        sin(2*%pi*f*x),\n"
-#| "        x,0,1\n"
-#| "    ),grid=true\n"
-#| ");\n"
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:571
+#, no-wrap
 msgid ""
-"```maxima\n"
 "with_slider_draw(\n"
 "    f,[1,2,3,4,5,6,7,10],\n"
 "    title=concat(\"f=\",f,\"Hz\"),\n"
@@ -10032,42 +14308,17 @@ msgid ""
 "        x,0,1\n"
 "    ),grid=true\n"
 ");\n"
-"```\n"
 msgstr ""
-"with_slider_draw(\n"
-"    f,[1,2,3,4,5,6,7,10],\n"
-"    title=concat(\"f=\",f,\"Hz\"),\n"
-"    explicit(\n"
-"        sin(2*%pi*f*x),\n"
-"        x,0,1\n"
-"    ),grid=true\n"
-");\n"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:583
 msgid "The same functionality for 3D plots is accessible as `with_slider_draw3d`, which allows for rotating 3d plots:"
 msgstr "对三维绘图而言，类似的功能由命令 `with_slider_draw3d` 提供，可用参数来旋转三维图形："
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:600
-#, fuzzy, no-wrap
-#| msgid ""
-#| "wxanimate_autoplay:true;\n"
-#| "wxanimate_framerate:20;\n"
-#| "with_slider_draw3d(\n"
-#| "    α,makelist(i,i,1,360,3),\n"
-#| "    title=sconcat(\"α=\",α),\n"
-#| "    surface_hide=true,\n"
-#| "    contour=both,\n"
-#| "    view=[60,α],\n"
-#| "    explicit(\n"
-#| "        sin(x)*sin(y),\n"
-#| "        x,-π,π,\n"
-#| "        y,-π,π\n"
-#| "    )\n"
-#| ")$\n"
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:584
+#, no-wrap
 msgid ""
-"```maxima\n"
 "wxanimate_autoplay:true;\n"
 "wxanimate_framerate:20;\n"
 "with_slider_draw3d(\n"
@@ -10082,48 +14333,17 @@ msgid ""
 "        y,-π,π\n"
 "    )\n"
 ")$\n"
-"```\n"
 msgstr ""
-"wxanimate_autoplay:true;\n"
-"wxanimate_framerate:20;\n"
-"with_slider_draw3d(\n"
-"    α,makelist(i,i,1,360,3),\n"
-"    title=sconcat(\"α=\",α),\n"
-"    surface_hide=true,\n"
-"    contour=both,\n"
-"    view=[60,α],\n"
-"    explicit(\n"
-"        sin(x)*sin(y),\n"
-"        x,-π,π,\n"
-"        y,-π,π\n"
-"    )\n"
-")$\n"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:602
 msgid "If the general shape of the plot is what matters it might suffice to move the plot just a little bit in order to make its 3D nature available to the intuition:"
 msgstr "如果重要的是图的大致形状，那么只要稍微移动一点，就可以直观地看出它的三维特征："
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:619
-#, fuzzy, no-wrap
-#| msgid ""
-#| "wxanimate_autoplay:true;\n"
-#| "wxanimate_framerate:20;\n"
-#| "with_slider_draw3d(\n"
-#| "    t,makelist(i,i,0,2*π,.05*π),\n"
-#| "    title=sconcat(\"α=\",α),\n"
-#| "    surface_hide=true,\n"
-#| "    contour=both,\n"
-#| "    view=[60,30+5*sin(t)],\n"
-#| "    explicit(\n"
-#| "        sin(x)*y^2,\n"
-#| "        x,-2*π,2*π,\n"
-#| "        y,-2*π,2*π\n"
-#| "    )\n"
-#| ")$\n"
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:603
+#, no-wrap
 msgid ""
-"```maxima\n"
 "wxanimate_autoplay:true;\n"
 "wxanimate_framerate:20;\n"
 "with_slider_draw3d(\n"
@@ -10138,22 +14358,7 @@ msgid ""
 "        y,-2*π,2*π\n"
 "    )\n"
 ")$\n"
-"```\n"
 msgstr ""
-"wxanimate_autoplay:true;\n"
-"wxanimate_framerate:20;\n"
-"with_slider_draw3d(\n"
-"    t,makelist(i,i,0,2*π,.05*π),\n"
-"    title=sconcat(\"t=\",t),\n"
-"    surface_hide=true,\n"
-"    contour=both,\n"
-"    view=[60,30+5*sin(t)],\n"
-"    explicit(\n"
-"        sin(x)*y^2,\n"
-"        x,-2*π,2*π,\n"
-"        y,-2*π,2*π\n"
-"    )\n"
-")$\n"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:621
@@ -10181,20 +14386,13 @@ msgstr "`wxanimate`。"
 msgid "Normally the animations are played back or exported with the frame rate chosen in the configuration of _wxMaxima_. To set the speed at an individual animation is played back the variable `wxanimate_framerate` can be used:"
 msgstr "在通常情况下，动图会以设置中选择的帧率回放或导出。要设置回放单个动图的速度，可以修改变量 `wxanimate_framerate`："
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:631
-#, fuzzy, no-wrap
-#| msgid ""
-#| "wxanimate(a, 10,\n"
-#| "    sin(a*x), [x,-5,5]), wxanimate_framerate=6$\n"
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:627
+#, no-wrap
 msgid ""
-"```maxima\n"
 "wxanimate(a, 10,\n"
 "    sin(a*x), [x,-5,5]), wxanimate_framerate=6$\n"
-"```\n"
 msgstr ""
-"wxanimate(a, 10, sin(a*x), [x,-5,5]),\n"
-"     wxanimate_framerate=6$\n"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:633
@@ -10203,19 +14401,10 @@ msgstr ""
 msgid "The animation functions use _Maxima_’s `makelist` command and therefore share the pitfall that the slider variable’s value is substituted into the expression only if the variable is directly visible in the expression. Therefore the following example will fail:"
 msgstr "动图函数使用 Maxima 的 `makelist` 命令，因此存在如下缺陷：只有当滑块变量在绘图表达式中直接可见时，才会将该变量的值替换到表达式中。因此，执行以下例子将显示错误信息："
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:643
-#, fuzzy, no-wrap
-#| msgid ""
-#| "f:sin(a*x);\n"
-#| "with_slider_draw(\n"
-#| "    a,makelist(i/2,i,1,10),\n"
-#| "    title=concat(\"a=\",float(a)),\n"
-#| "    grid=true,\n"
-#| "    explicit(f,x,0,10)\n"
-#| ")$\n"
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:634
+#, no-wrap
 msgid ""
-"```maxima\n"
 "f:sin(a*x);\n"
 "with_slider_draw(\n"
 "    a,makelist(i/2,i,1,10),\n"
@@ -10223,15 +14412,7 @@ msgid ""
 "    grid=true,\n"
 "    explicit(f,x,0,10)\n"
 ")$\n"
-"```\n"
 msgstr ""
-"f:sin(a*x);\n"
-"with_slider_draw(\n"
-"    a,makelist(i/2,i,1,10),\n"
-"    title=concat(\"a=\",float(a)),\n"
-"    grid=true,\n"
-"    explicit(f,x,0,10)\n"
-")$\n"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:645
@@ -10240,22 +14421,10 @@ msgstr ""
 msgid "If _Maxima_ is explicitly asked to substitute the slider’s value plotting works fine instead:"
 msgstr "如果修改为明确要求 Maxima 代入滑块变量的值，则修改后的代码可用于绘制动图："
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:658
-#, fuzzy, no-wrap
-#| msgid ""
-#| "f:sin(a*x);\n"
-#| "with_slider_draw(\n"
-#| "    b,makelist(i/2,i,1,10),\n"
-#| "    title=concat(\"a=\",float(b)),\n"
-#| "    grid=true,\n"
-#| "    explicit(\n"
-#| "        subst(a=b,f),\n"
-#| "        x,0,10\n"
-#| "    )\n"
-#| ")$\n"
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:646
+#, no-wrap
 msgid ""
-"```maxima\n"
 "f:sin(a*x);\n"
 "with_slider_draw(\n"
 "    b,makelist(i/2,i,1,10),\n"
@@ -10266,25 +14435,13 @@ msgid ""
 "        x,0,10\n"
 "    )\n"
 ")$\n"
-"```\n"
 msgstr ""
-"f:sin(a*x);\n"
-"with_slider_draw(\n"
-"    b,makelist(i/2,i,1,10),\n"
-"    title=concat(\"a=\",float(b)),\n"
-"    grid=true,\n"
-"    explicit(\n"
-"        subst(a=b,f),\n"
-"        x,0,10\n"
-"    )\n"
-")$\n"
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:660
-#, fuzzy
-#| msgid "Opening multiple plots in contemporaneous windows"
-msgid "### Opening multiple plots in contemporaneous windows"
-msgstr "同时打开多个绘图窗口"
+#. type: Title ###
+#: ../../info/wxmaxima.md:659
+#, no-wrap
+msgid "Opening multiple plots in contemporaneous windows"
+msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:662
@@ -10293,45 +14450,52 @@ msgstr "同时打开多个绘图窗口"
 msgid "While not being provided by _wxMaxima_ this feature of _Maxima_ (on setups that support it) sometimes comes in handily. The following example comes from a post from Mario Rodriguez to the _Maxima_ mailing list:"
 msgstr "虽然这个 Maxima 特性不是由 wxMaxima 提供的，但是（如果安装的 Maxima 支持此特性）有时使用起来会很方便。以下例子来自 Mario Rodriguez 在 Maxima 邮件列表中的一篇帖子："
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:665
-msgid "```maxima load(draw);"
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:663
+#, fuzzy, no-wrap
+#| msgid ""
+#| "    load(draw);\n"
+#| "    \n"
+#| "    /* Parabola in window #1 */\n"
+#| "    draw2d(terminal=[wxt,1],explicit(x^2,x,-1,1));\n"
+#| "    \n"
+#| "    /* Parabola in window #2 */\n"
+#| "    draw2d(terminal=[wxt,2],explicit(x^2,x,-1,1));\n"
+#| "    \n"
+#| "    /* Paraboloid in window #3 */\n"
+#| "    draw3d(terminal=[wxt,3],explicit(x^2+y^2,x,-1,1,y,-1,1));\n"
+msgid ""
+"load(draw);\n"
+"\n"
+"/* Parabola in window #1 */\n"
+"draw2d(terminal=[wxt,1],explicit(x^2,x,-1,1));\n"
+"\n"
+"/* Parabola in window #2 */\n"
+"draw2d(terminal=[wxt,2],explicit(x^2,x,-1,1));\n"
+"\n"
+"/* Paraboloid in window #3 */\n"
+"draw3d(terminal=[wxt,3],explicit(x^2+y^2,x,-1,1,y,-1,1));\n"
 msgstr ""
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:668
-msgid "/* Parabola in window #1 */ draw2d(terminal=[wxt,1],explicit(x^2,x,-1,1));"
-msgstr ""
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:671
-msgid "/* Parabola in window #2 */ draw2d(terminal=[wxt,2],explicit(x^2,x,-1,1));"
-msgstr ""
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:675
-msgid "/* Paraboloid in window #3 */ draw3d(terminal=[wxt,3],explicit(x^2+y^2,x,-1,1,y,-1,1)); ```"
-msgstr ""
+"    load(draw);\n"
+"    \n"
+"    /* 在第一个窗口中绘制抛物线 */\n"
+"    draw2d(terminal=[wxt,1],explicit(x^2,x,-1,1));\n"
+"    \n"
+"    /* 在第二个窗口中绘制抛物线 */\n"
+"    draw2d(terminal=[wxt,2],explicit(x^2,x,-1,1));\n"
+"    \n"
+"    /* 在第三个窗口中绘制旋转抛物面 */\n"
+"    draw3d(terminal=[wxt,3],explicit(x^2+y^2,x,-1,1,y,-1,1));\n"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:677
 msgid "Plotting multiple plots in the same window is possible, too (the same is possible in command line Maxima with the standard `draw()` command):"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:688
-#, fuzzy, no-wrap
-#| msgid ""
-#| "\twxdraw(\n"
-#| "\t\tgr2d(\n"
-#| "\t    \tkey=\"sin (x)\",grid=[2,2],\n"
-#| "\t    \texplicit(sin(x),x,0,2*%pi)),\n"
-#| "\t\tgr2d(\n"
-#| "\t   \tkey=\"cos (x)\",grid=[2,2],\n"
-#| "\t   \texplicit(cos(x),x,0,2*%pi))\n"
-#| "\t );\n"
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:678
+#, no-wrap
 msgid ""
-"```maxima\n"
 "wxdraw(\n"
 "  gr2d(\n"
 "    key=\"sin (x)\",grid=[2,2],\n"
@@ -10340,23 +14504,13 @@ msgid ""
 "    key=\"cos (x)\",grid=[2,2],\n"
 "    explicit(cos(x),x,0,2*%pi))\n"
 ");\n"
-"```\n"
 msgstr ""
-"\twxdraw(\n"
-"\t\tgr2d(\n"
-"\t    \tkey=\"sin (x)\",grid=[2,2],\n"
-"\t    \texplicit(sin(x),x,0,2*%pi)),\n"
-"\t\tgr2d(\n"
-"\t   \tkey=\"cos (x)\",grid=[2,2],\n"
-"\t   \texplicit(cos(x),x,0,2*%pi))\n"
-"\t );\n"
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:690
-#, fuzzy
-#| msgid "The \"Plot using draw\" side pane"
-msgid "### The \"Plot using draw\" side pane"
-msgstr "“用 draw 函数绘图”侧边栏"
+#. type: Title ###
+#: ../../info/wxmaxima.md:689
+#, no-wrap
+msgid "The \"Plot using draw\" side pane"
+msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:692
@@ -10364,11 +14518,6 @@ msgstr "“用 draw 函数绘图”侧边栏"
 #| msgid "The \"Plot using draw\" sidebar hides a simple code generator that allows to generate scenes that make use of some of the flexibility of the _draw_ package _maxima_ comes with."
 msgid "The \"Plot using draw\" sidebar hides a simple code generator that allows generating scenes that make use of some of the flexibility of the _draw_ package _maxima_ comes with."
 msgstr "“用 draw 函数绘图”侧边栏暗含一个简单的代码生成器，使用它可以利用 Maxima 的 draw 程序包方便灵活地生成一些图形绘制命令模板。"
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:694
-msgid "#### 2D"
-msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:696
@@ -10385,11 +14534,6 @@ msgid "One helpful feature of the 2D button is that it allows to set up the scen
 msgstr "“二维图形”按钮的一个有用的功能是，用它可以设置一个生成动画的模板，其中一个变量（默认情况下是 t）在每一帧中都有不同的值。通常动态的二维图形比静态的三维图形中的相同数据更容易理解。"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:700
-msgid "#### 3D"
-msgstr ""
-
-#. type: Plain text
 #: ../../info/wxmaxima.md:702
 #, fuzzy
 #| msgid "Generates the skeleton of a `draw()` command that draws a 3D scene. If neither a 2D or a 3D scene are set up all of the other buttons set up a 2D scene that contains the command the button generates."
@@ -10397,23 +14541,15 @@ msgid "Generates the skeleton of a `draw()` command that draws a 3D scene. If ne
 msgstr "提供绘制三维图形的 `draw()` 命令的简单模板。如果没有主动使用此功能和上一功能，则所有其他按钮都将自动提前调用上一功能中的绘制二维图形模板。"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:704
-#, fuzzy
-#| msgid "Expression"
-msgid "#### Expression"
-msgstr "表达式"
-
-#. type: Plain text
 #: ../../info/wxmaxima.md:706
 msgid "Appends a standard plot of an expression like `sin(x)`, `x*sin(x)` or `x^2+2*x-4` to the `draw()` command the cursor currently is in. If there is no draw command a 2D scene with the plot is generated. Each scene can be filled with any number of plots."
 msgstr "在光标当前所在的 `draw()` 命令中添加绘图函数表达式，如 `sin(x)`, `x*sin(x)` 或者 `x^2+2*x-4` 等 。每个图中可以绘制任意数量的图形。如果没有 `draw()` 命令，将调用绘制二维图形的模板。"
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:708
-#, fuzzy
-#| msgid "Implicit plot"
-msgid "#### Implicit plot"
-msgstr "隐式图形"
+#. type: Title ####
+#: ../../info/wxmaxima.md:707
+#, no-wrap
+msgid "Implicit plot"
+msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:710
@@ -10421,23 +14557,9 @@ msgid "Tries to find all points an expression like `y=sin(x)`, `y*sin(x)=3` or `
 msgstr "尝试寻找满足 `y=sin(x)`，`y*sin(x)=3` 或 `x^2+y^2=4` 之类的表达式的所有解，并在光标当前所在的 `draw()` 命令中绘制对应曲线。如果没有 `draw()` 命令，将调用绘制二维图形的模板。"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:712
-#, fuzzy
-#| msgid "Parametric plot"
-msgid "#### Parametric plot"
-msgstr "参数式图形"
-
-#. type: Plain text
 #: ../../info/wxmaxima.md:714
 msgid "Steps a variable from a lower limit to an upper limit and uses two expressions like `t*sin(t)` and `t*cos(t)` for generating the x, y (and in 3D plots also z) coordinates of a curve that is put into the current draw command."
 msgstr "将变量（如 t）从下限变化到上限，并在当前绘图命令中使用两个表达式（如 `t*sin(t)` 和 `t*cos(t)`），以生成曲线上点的横、纵坐标 (x,y)（在三维图形中，第三个表达式生成竖坐标 z）。"
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:716
-#, fuzzy
-#| msgid "Points"
-msgid "#### Points"
-msgstr "点"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:718
@@ -10445,35 +14567,14 @@ msgid "Draws many points that can optionally be joined. The coordinates of the p
 msgstr "绘制多个点，并且可以选择顺次连接它们。点的坐标取自列表的列表、二维数组或为每个轴指定的一个列表或数组。"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:720
-#, fuzzy
-#| msgid "Diagram title"
-msgid "#### Diagram title"
-msgstr "图形标题"
-
-#. type: Plain text
 #: ../../info/wxmaxima.md:722
 msgid "Draws a title on the upper end of the diagram,"
 msgstr "在图形上方绘制标题。"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:724
-#, fuzzy
-#| msgid "Axis"
-msgid "#### Axis"
-msgstr "坐标轴"
-
-#. type: Plain text
 #: ../../info/wxmaxima.md:726
 msgid "Sets up the axis."
 msgstr "设置坐标轴。"
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:728
-#, fuzzy
-#| msgid "Contour"
-msgid "#### Contour"
-msgstr "等高线"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:730
@@ -10483,37 +14584,28 @@ msgid "(Only for 3D plots): Adds contour lines similar to the ones one can find 
 msgstr "（仅适用于三维绘图）将类似于山地图中的等高线添加到当前 `draw()` 命令绘制的三维图形中，或图形在坐标面的二维投影上。另外，此向导也可以用来不绘制曲面而只显示等高线。"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:732
-#, fuzzy
-#| msgid "Plot name"
-msgid "#### Plot name"
-msgstr "图形名称"
-
-#. type: Plain text
 #: ../../info/wxmaxima.md:734
 #, fuzzy
 #| msgid "Adds a legend entry showing the next plot's name to the legend of the diagram. An empty name disables generating legend entries for the following plots."
 msgid "Adds a legend entry showing the next plot’s name to the legend of the diagram. An empty name disables generating legend entries for the following plots."
 msgstr "在图例中增加下一个图形对应的图例项。空名称将阻止为下一个图形生成图例项。"
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:736
-#, fuzzy
-#| msgid "Line colour"
-msgid "#### Line colour"
-msgstr "线条颜色"
+#. type: Title ####
+#: ../../info/wxmaxima.md:735
+#, no-wrap
+msgid "Line colour"
+msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:738
 msgid "Sets the line colour for the following plots the current draw command contains."
 msgstr "为当前 `draw()` 命令所绘图形设置线条颜色。"
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:740
-#, fuzzy
-#| msgid "Fill colour"
-msgid "#### Fill colour"
-msgstr "填充颜色"
+#. type: Title ####
+#: ../../info/wxmaxima.md:739
+#, no-wrap
+msgid "Fill colour"
+msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:742
@@ -10521,32 +14613,19 @@ msgid "Sets the fill colour for the following plots the current draw command con
 msgstr "为当前 `draw()` 命令所绘图形设置填充颜色。"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:744
-#, fuzzy
-#| msgid "Grid"
-msgid "#### Grid"
-msgstr "网格"
-
-#. type: Plain text
 #: ../../info/wxmaxima.md:746
 msgid "Pops up a wizard that allows to set up grid lines."
 msgstr "弹出设置网格线的向导。"
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:748
-#, fuzzy
-#| msgid "Accuracy"
-msgid "#### Accuracy"
-msgstr "精度"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:750
 msgid "Allows to select an adequate point in the speed vs. accuracy tradeoff that is part of any plot program."
 msgstr "允许选择适当数目的点，以兼顾速度与精度（任何绘图程序都会权衡两者）。"
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:752
-msgid "### Modify font and font size for plots"
+#. type: Title ###
+#: ../../info/wxmaxima.md:751
+#, no-wrap
+msgid "Modify font and font size for plots"
 msgstr ""
 
 #. type: Plain text
@@ -10554,40 +14633,27 @@ msgstr ""
 msgid "Especially when you use a high resolution display, the default font size might be very small. For the `draw`-based commands, you can set the font / font size using options like `font=...`, `font_size=...`, e.g.:"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:761
-#, fuzzy, no-wrap
-#| msgid ""
-#| "wxdraw2d(\n"
-#| "    file_name=\"test\",\n"
-#| "    explicit(sin(x),x,1,10)\n"
-#| ");\n"
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:755
+#, no-wrap
 msgid ""
-"~~~maxima\n"
 "wxdraw2d(\n"
 "     font=\"Helvetica\",\n"
 "     font_size=30,\n"
 "     explicit(sin(x),x,1,10));\n"
-"~~~\n"
 msgstr ""
-"wxdraw2d(\n"
-"    file_name=\"test\",\n"
-"    explicit(sin(x),x,1,10)\n"
-");\n"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:763
 msgid "For the `plot`-commands (e.g. `wxplot2d`, `wxplot3d`) font sizes and fonts can be set using the `gnuplot_preamble` command, e.g.:"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:768
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:764
 #, no-wrap
 msgid ""
-"~~~maxima\n"
 "wxplot2d(sin(x),[x,1,10],\n"
 "         [gnuplot_preamble, \"set tics font \\\"Arial, 30\\\"; set xlabel font \\\",20\\\"; set ylabel font \\\",20\\\";\"]);\n"
-"~~~\n"
 msgstr ""
 
 #. type: Plain text
@@ -10600,12 +14666,11 @@ msgstr ""
 msgid "Read the Maxima and Gnuplot documentation for further information.  Note: Gnuplot seems to have issues with larger font sizes, see [wxMaxima issue 1966](https://github.com/wxMaxima-developers/wxmaxima/issues/1966)."
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:775
-#, fuzzy
-#| msgid "Embedding graphics"
-msgid "## Embedding graphics"
-msgstr "嵌入图片"
+#. type: Title ##
+#: ../../info/wxmaxima.md:774
+#, no-wrap
+msgid "Embedding graphics"
+msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:777
@@ -10614,19 +14679,17 @@ msgstr "嵌入图片"
 msgid "If the `.wxmx` file format is being used embedding files in a _wxMaxima_ project can be done as easily as per drag-and-drop. But sometimes (for example if an image’s contents might change later on in a session) it is better to tell the file to load the image on evaluation:"
 msgstr "如果使用的是 `.wxmx` 文件格式，则可以通过拖放将图片文件嵌入 wxMaxima 文档中。但有时（例如某个图像的内容可能在稍后发生更改）最好指明在计算时加载图像："
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:781
-#, fuzzy
-#| msgid "show_image(\"man.png\");\n"
-msgid "```maxima show_image(\"man.png\"); ```"
-msgstr "show_image(\"man.png\");\n"
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:778
+#, no-wrap
+msgid "show_image(\"man.png\");\n"
+msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:783
-#, fuzzy
-#| msgid "Startup files"
-msgid "## Startup files"
-msgstr "启动时读取的文件"
+#. type: Title ##
+#: ../../info/wxmaxima.md:782
+#, no-wrap
+msgid "Startup files"
+msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:785
@@ -10657,361 +14720,364 @@ msgstr ""
 msgid "These files are in the Maxima user directory (usually `%USERPROFILE%/maxima` in Windows, `$HOME/.maxima` otherwise). The location can be found out with the command: `maxima_userdir;`"
 msgstr "这些文件位于用户的主目录或配置文件目录中的 Maxima 用户目录（在 Windows 系统中通常为 maxima，在其他系统中为 .maxima）。使用命令 `maxima_userdir;` 可以确定该目录。"
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:794
-#, fuzzy
-#| msgid "Special variables wx..."
-msgid "## Special variables wx..."
-msgstr "以 wx 开头的特殊变量"
+#. type: Title ##
+#: ../../info/wxmaxima.md:793
+#, no-wrap
+msgid "Special variables wx..."
+msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:805
+#: ../../info/wxmaxima.md:811
 msgid "`wxsubscripts` tells _Maxima_ if it should convert variable names that contain an underscore (`R_150` or the like) into subscripted variables. See `wxdeclare_subscript` for details which variable names are automatically converted."
 msgstr "`wxsubscripts` ：告诉 Maxima 是否应将包含下划线的变量名（例如 `R_150`）转换为带下标的变量名。有关自动转换哪些变量名的详细信息，请参见 `wxdeclare_subscript`。"
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:805
+#: ../../info/wxmaxima.md:811
 msgid "`wxfilename`: This variable contains the name of the file currently opened in _wxMaxima_."
 msgstr "`wxfilename`：此变量包含当前在 wxMaxima 中打开的文件的名称。"
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:805
+#: ../../info/wxmaxima.md:811
 #, fuzzy
 #| msgid "`wxfilename`: This variable contains the name of the file currently opened in _wxMaxima_."
 msgid "`wxdirname`: This variable contains the name the directory, in which the file currently opened in _wxMaxima_ is."
 msgstr "`wxfilename`：此变量包含当前在 wxMaxima 中打开的文件的名称。"
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:805
+#: ../../info/wxmaxima.md:811
 #, fuzzy
 #| msgid "`wxplot_pngcairo` tells whether _wxMaxima_ tries to use _gnuplot_’s pngcairo terminal that provides more line styles and a better overall graphics quality."
 msgid "`wxplot_pngcairo` tells whether _wxMaxima_ tries to use _Gnuplot_’s pngcairo terminal that provides more line styles and a better overall graphics quality."
 msgstr "`wxplot_pngcairo`：表明 wxMaxima 是否尝试使用 gnuplot 的 pngcairo 功能，以提供更多的线条样式和更好的整体图形质量。"
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:805
+#: ../../info/wxmaxima.md:811
 msgid "`wxplot_size` defines the resolution of embedded plots."
 msgstr "`wxplot_size`：定义嵌入绘图的分辨率。"
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:805
+#: ../../info/wxmaxima.md:811
 #, fuzzy
 #| msgid "`wxchangedir`: On most operating systems _wxMaxima_ automatically sets _Maxima_’s working directory to the directory of the current file. This allows file I/O (e.g. by `read_matrix`) to work without specifying the whole path to the file that has to be read or written. On Windows this feature sometimes causes error messages and therefore can be set to `false` from the config dialogue."
 msgid "`wxchangedir`: On most operating systems _wxMaxima_ automatically sets _Maxima_’s working directory to the directory of the current file. This allows file I/O (e.g. by `read_matrix`) to work without specifying the whole path to the file that has to be read or written. On Windows this feature sometimes causes error messages and therefore can be set to `false` from the config dialogue."
 msgstr "`wxchangedir`：在大多数操作系统上，wxMaxima 自动将 Maxima 的工作目录设置为当前文件的目录。这允许文件 I/O（例如通过 `read_matrix`）工作，而无需指定必须读或写的文件的整个路径。在 Windows 操作系统上，此功能有时会导致错误消息，因此可以在设置对话框中将其设置为 `false`。"
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:805
+#: ../../info/wxmaxima.md:811
 msgid "`wxanimate_framerate`: The number of frames per second the following animations have to be played back with."
 msgstr "`wxanimate_framerate`：下一个动图回放的帧率。"
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:805
+#: ../../info/wxmaxima.md:811
 msgid "`wxanimate_autoplay`: Automatically play animations by default?"
 msgstr "`wxanimate_autoplay`：是否在默认情况下自动播放动图。"
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:805
+#: ../../info/wxmaxima.md:811
 msgid "`wxmaximaversion`: Returns the version number of _wxMaxima_."
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:805
+#: ../../info/wxmaxima.md:811
 msgid "`wxwidgetsversion`: Returns the wxWidgets version _wxMaxima_ is using."
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:807
-#, fuzzy
-#| msgid "Pretty-printing 2D output"
-msgid "## Pretty-printing 2D output"
-msgstr "输出美观的二维公式"
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:811
+msgid "`wxdirs`: A struct holding the paths _wxMaxima_ itself uses, since these differ by maintainer, distribution and operating system:"
+msgstr ""
+
+#. type: Bullet: '  - '
+#: ../../info/wxmaxima.md:811
+msgid "`wxdirs@userconfdir`: The directory the user's configuration is stored in. Same directory as `maxima_userdir` (see above) - both point at the same place, `wxdirs@userconfdir` is only useful if that is more convenient to reach from a `.mac` file than the Maxima-side variable."
+msgstr ""
+
+#. type: Bullet: '  - '
+#: ../../info/wxmaxima.md:811
+msgid "`wxdirs@datadir`: The directory _wxMaxima_'s own data (icons, the built-in autocompletion list, ...) is installed in."
+msgstr ""
+
+#. type: Bullet: '  - '
+#: ../../info/wxmaxima.md:811
+msgid "`wxdirs@helpdir`: The directory the offline copy of this manual is installed in."
+msgstr ""
+
+#. type: Bullet: '  - '
+#: ../../info/wxmaxima.md:811
+msgid "`wxdirs@localedir`: The directory _wxMaxima_'s translation files are installed in."
+msgstr ""
+
+#. type: Bullet: '  - '
+#: ../../info/wxmaxima.md:811
+msgid "`wxdirs@maximalocation`: The path to the _Maxima_ executable _wxMaxima_ is configured to start."
+msgstr ""
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:812
+#, no-wrap
+msgid "Pretty-printing 2D output"
+msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:809
+#: ../../info/wxmaxima.md:815
 #, fuzzy
 #| msgid "The function `table_form()` displays a 2D list in a form that is more readable than the output from _Maxima_’s default output routine. The input is a list of one or more lists. Like the \"print\" command, this command displays output even when ended with a dollar sign. Ending the command with a semicolon results in the same table along with a \"done\" statement."
 msgid "The function `table_form()` displays a 2D list in a form that is more readable than the output from _Maxima_’s default output routine. The input is a list of one or more lists. Like the \"print\" command, this command displays output even when ended with a dollar sign. Ending the command with a semicolon results in the same table along with a \"done\" statement."
 msgstr "函数 `table_form()` 显示的二维列表比 Maxima 的默认输出更具可读性。该函数的输入是一个列表，其中含一个或多个列表。与 `print` 命令类似，此命令即使以符号 `$` 结尾也会显示输出。以分号 `;` 结束命令时，除了得到列表，还会有“done”语句。"
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:818
-#, fuzzy, no-wrap
-#| msgid ""
-#| "table_form(\n"
-#| "    [\n"
-#| "        [1,2],\n"
-#| "        [3,4]\n"
-#| "    ]\n"
-#| ")$\n"
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:816
+#, no-wrap
 msgid ""
-"```maxima\n"
 "table_form(\n"
 "    [\n"
 "        [1,2],\n"
 "        [3,4]\n"
 "    ]\n"
 ")$\n"
-"```\n"
 msgstr ""
-"table_form(\n"
-"    [\n"
-"        [1,2],\n"
-"        [3,4]\n"
-"    ]\n"
-")$\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:820
+#: ../../info/wxmaxima.md:826
 msgid "As the next example shows, the lists that are assembled by the `table_form` command can be created before the command is executed."
 msgstr "正如下一个例子所示，可以在执行 `table_form` 命令之前创建需要显示的列表。"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:822
+#: ../../info/wxmaxima.md:828
 msgid "![A third table example](./MatrixTableExample.png){ id=img_MatrixTableExample }"
 msgstr "![一个三行表的例子](./MatrixTableExample.png){ id=img_MatrixTableExample }"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:824
+#: ../../info/wxmaxima.md:830
 msgid "Also, because a matrix is a list of lists, matrices can be converted to tables in a similar fashion."
 msgstr "此外，由于矩阵是含列表的列表，它也可以用类似的方式转换为表格。"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:826
+#: ../../info/wxmaxima.md:832
 msgid "![Another table_form example](./SecondTableExample.png){ id=img_SecondTableExample }"
 msgstr "![另一个 table_form 的例子](./SecondTableExample.png){ id=img_SecondTableExample }"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:828
+#: ../../info/wxmaxima.md:834
 msgid "The function `wx_matrix()` is a wrapper for Maxima's `matrix()` command that allows for more flexible formatting of matrices in wxMaxima:"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:830
+#: ../../info/wxmaxima.md:836
 #, no-wrap
 msgid "**`wx_matrix( <matrix>, [options] )`**\n"
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:835
+#: ../../info/wxmaxima.md:841
 msgid "**`lines=true`**: Draws internal separator lines between the cells. This is required to visually separate headings from data."
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:835
+#: ../../info/wxmaxima.md:841
 msgid "**`rownames=true`**: Tells wxMaxima that the first column of the matrix contains labels."
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:835
+#: ../../info/wxmaxima.md:841
 msgid "**`colnames=true`**: Tells wxMaxima that the first row of the matrix contains labels."
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:835
+#: ../../info/wxmaxima.md:841
 msgid "**`parenstyle=<style>`**: Sets the type of parenthesis or brackets to draw around the matrix. Supported styles are: `round` `()`, `square` `[]`, `angled` `<>`, `straight` `||`, or `none`."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:837
+#: ../../info/wxmaxima.md:843
 #, fuzzy
 #| msgid "One Example:"
 msgid "Example:"
 msgstr "例如："
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:842
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:844
 #, no-wrap
 msgid ""
-"```maxima\n"
 "wx_matrix(matrix([\"Name\", \"Value\"], [\"X\", 10], [\"Y\", 20]),\n"
 "          lines=true, rownames=true, colnames=true, parenstyle=square);\n"
-"```\n"
+msgstr ""
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:849
+#, no-wrap
+msgid "Bug reporting"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:844
-#, fuzzy
-#| msgid "Bug reporting"
-msgid "## Bug reporting"
-msgstr "错误（bug）报告"
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:846
+#: ../../info/wxmaxima.md:852
 #, fuzzy
 #| msgid "_wxMaxima_ provides a few functions that gather bug reporting information about the current system:"
 msgid "_WxMaxima_ provides a few functions that gather bug reporting information about the current system:"
 msgstr "wxMaxima 提供了一些函数，用于收集当前系统的错误报告信息："
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:849
+#: ../../info/wxmaxima.md:855
 #, fuzzy
 #| msgid "`wxbuild_info()` gathers information about the currently running version of _wxMaxima_"
 msgid "`wxbuild_info()` gathers information about the currently running version of _wxMaxima_"
 msgstr "`wxbuild_info()` 收集当前运行的 wxMaxima 的版本信息；"
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:849
+#: ../../info/wxmaxima.md:855
 msgid "`wxbug_report()` tells how and where to file bugs"
 msgstr "`wxbug_report()` 说明如何以及在何处提交错误报告。"
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:851
-#, fuzzy
-#| msgid "Marking output being drawn in red"
-msgid "## Marking output being drawn in red"
-msgstr "让输出显示为红色"
+#. type: Title ##
+#: ../../info/wxmaxima.md:856
+#, no-wrap
+msgid "Marking output being drawn in red"
+msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:854
+#: ../../info/wxmaxima.md:860
 #, fuzzy
 #| msgid "_Maxima_'s `box()` command causes _wxMaxima_ to print its argument with a red foreground."
 msgid "_Maxima_’s `box()` command causes _wxMaxima_ to print its argument with a red foreground, if the second argument to the command is the text `highlight`."
 msgstr "Maxima 的 `box()` 命令使 wxMaxima 以红色输出其参数。"
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:856
-msgid "## Output rendering."
+#. type: Title ##
+#: ../../info/wxmaxima.md:861
+#, no-wrap
+msgid "Output rendering."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:858
+#: ../../info/wxmaxima.md:864
 msgid "With `set_display()` one can set, how wxMaxima will render the output."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:860
+#: ../../info/wxmaxima.md:866
 msgid "`set_display('xml)` is the default value. Here Maxima speaks to wxMaxima using an (machine readable) XML-dialect (can be seen in the \"Raw XML sidebar\") and outputs the resulting formulas nicely rendered, e.g. pretty Matrices, Square root signs, fractions, etc."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:863
-msgid "<!--- Currently that does not work as it should, the line with the output label is shifted right (issue: #2006) --> `set_display('ascii)` causes wxMaxima to output formulas as in command line Maxima - as ASCII-Art."
-msgstr ""
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:865
-msgid "`set_display('none)` causes 'one-line' ASCII results - the same as the command line Maxima command `display2d:false;` does."
-msgstr ""
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:867
-msgid "# Help menu"
-msgstr ""
-
-#. type: Plain text
 #: ../../info/wxmaxima.md:869
-msgid "WxMaxima’s help menu provides access to the Maxima and wxMaxima manual, tips, some example worksheets and in command line Maxima included demos (the `demo()` command)."
+#, no-wrap
+msgid ""
+"<!--- Currently that does not work as it should, the line with the output label is shifted right (issue: #2006) -->\n"
+"`set_display('ascii)` causes wxMaxima to output formulas as in command line Maxima - as ASCII-Art.\n"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:871
-msgid "Please notice, that the demos write:"
+msgid "`set_display('none)` causes 'one-line' ASCII results - the same as the command line Maxima command `display2d:false;` does."
+msgstr ""
+
+#. type: Title #
+#: ../../info/wxmaxima.md:872
+#, no-wrap
+msgid "Help menu"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:875
-msgid "~~~text At the ’_’ prompt, type ’;’ and <enter> to proceed with the demonstration.  ~~~"
+msgid "WxMaxima’s help menu provides access to the Maxima and wxMaxima manual, tips, some example worksheets and in command line Maxima included demos (the `demo()` command)."
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:877
-msgid "That is valid for command-line Maxima, however in wxMaxima by default it is necessary to continue the demonstration with: <kbd>CTRL</kbd>+<kbd>ENTER</kbd>"
+msgid "Please notice, that the demos write:"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:879
-msgid "(That can be configured in the Configure->Worksheet->\"Hotkeys for sending commands to Maxima\" menu.)"
+#. type: Fenced code block (text)
+#: ../../info/wxmaxima.md:878
+#, no-wrap
+msgid "At the ’_’ prompt, type ’;’ and <enter> to proceed with the demonstration.\n"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:883
-#, fuzzy
-#| msgid "Troubleshooting"
-msgid "# Troubleshooting"
-msgstr "疑难解答"
+#, no-wrap
+msgid "That is valid for command-line Maxima, however in wxMaxima by default it is necessary to continue the demonstration with: <kbd>CTRL</kbd>+<kbd>ENTER</kbd>\n"
+msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:885
-#, fuzzy
-#| msgid "Cannot connect to _Maxima_"
-msgid "## Cannot connect to _Maxima_"
-msgstr "无法连接到 Maxima"
+#, no-wrap
+msgid "(That can be configured in the Configure->Worksheet->\"Hotkeys for sending commands to Maxima\" menu.)\n"
+msgstr ""
+
+#. type: Title #
+#: ../../info/wxmaxima.md:888
+#, no-wrap
+msgid "Troubleshooting"
+msgstr ""
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:890
+#, no-wrap
+msgid "Cannot connect to _Maxima_"
+msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:887
+#: ../../info/wxmaxima.md:893
 #, fuzzy
 #| msgid "Since _Maxima_ (the program that does the actual mathematics) and _wxMaxima_ (providing the easy-to-use user interface) are separate programs that communicate by the means of a local network connection. Therefore the most probable cause is that this connection is somehow not working. For example a firewall could be set up in a way that it doesn’t just prevent unauthorized connections from the internet (and perhaps to intercept some connections to the internet, too), but it also to blocks inter-process-communication inside the same computer. Note that since _Maxima_ is being run by a Lisp processor the process communication that is blocked from does not necessarily have to be named \"maxima\". Common names of the program that opens the network connection would be sbcl, gcl, ccl, lisp.exe or similar names."
 msgid "Since _Maxima_ (the program that does the actual mathematics) and _wxMaxima_ (providing the easy-to-use user interface) are separate programs that communicate by the means of a local network connection. Therefore the most probable cause is that this connection is somehow not working. For example, a firewall could be set up in a way that it doesn’t just prevent unauthorized connections from the internet (and perhaps intercept some connections to the internet, too), but also blocks inter-process-communication inside the same computer. Note that since _Maxima_ is being run by a Lisp processor the process communication that is blocked does not necessarily have to be named \"maxima\". Common names of the program that opens the network connection would be sbcl, gcl, ccl, lisp.exe, or similar names."
 msgstr "由于 Maxima（进行实际数学运算的程序）和 wxMaxima（提供易于使用的用户界面的程序）是通过本地网络连接进行通信的独立程序，因此，最有可能的原因是这种连接不起作用。例如，可能设置了防火墙不仅可以阻止来自互联网的未经授权的连接（也许还会拦截一些通向互联网的连接），而且可以阻止同一台计算机内部的进程间通信。注意，由于 Maxima 由 Lisp 语言处理程序运行，因此被阻止的通信进程不一定命名为“Maxima”。此时打开网络连接的程序名称可能是 sbcl、gcl、ccl、lisp.exe 或者类似的名字。"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:889
+#: ../../info/wxmaxima.md:895
 #, fuzzy
 #| msgid "On Un\\*x computers another possible reason would be that the loopback network that provides network connections between two programs in the same computer isn’t properly configured."
 msgid "On Unix computers another possible reason would be that the loopback network that provides network connections between two programs in the same computer isn’t properly configured."
 msgstr "在 Un\\*x 系统上，另一个可能的原因是在同一台计算机上的两个程序之间提供网络连接的环回（loopback）网络配置不正确。"
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:891
-#, fuzzy
-#| msgid "How to save data from a broken .wxmx file"
-msgid "## How to save data from a broken .wxmx file"
-msgstr "从损坏的 .wxmx 文件中取回信息的方法"
+#. type: Title ##
+#: ../../info/wxmaxima.md:896
+#, no-wrap
+msgid "How to save data from a broken .wxmx file"
+msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:893
+#: ../../info/wxmaxima.md:899
 #, fuzzy
 #| msgid "Internally most modern XML-based formats are ordinary zip-files. _wxMaxima_ doesn't turn on compression, so the contents of .wxmx files can be viewed in any text editor."
 msgid "Internally most modern XML-based formats are ordinary zip files. _WxMaxima_ doesn’t turn on compression, so the contents of `.wxmx` files can be viewed in any text editor."
 msgstr "大多数现代的、基于 XML 格式的文件其实都是普通的压缩（zip）文件。wxMaxima 没有启用压缩，因此可以在任何文本编辑器中查看 `.wxmx` 文件的内容。"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:895
+#: ../../info/wxmaxima.md:901
 #, fuzzy
 #| msgid "If the zip signature at the end of the file is still intact after renaming a broken .wxmx file to .zip most operating systems will provide a way to extract any portion of information that is stored inside it. This can be done when there is the need of recovering the original image files from a text processor document. If the zip signature isn’t intact that does not need to be the end of the world: If _wxMaxima_ during saving detected that something went wrong there will be a `wxmx~` file whose contents might help."
 msgid "If the zip signature at the end of the file is still intact after renaming a broken `.wxmx` file to `.zip` most operating systems will provide a way to extract any portion of the information that is stored inside it. This can be done when there is a need of recovering the original image files from a text processor document. If the zip signature isn’t intact that does not need to be the end of the world: If _wxMaxima_ during saving detected that something went wrong there will be a `.wxmx~` file whose contents might help."
 msgstr "如果文件末尾的 zip 签名仍然完整，那么将损坏的 `.wxmx` 文件重命名为 `.zip` 文件后，大多数操作系统都提供了提取存储在其中的信息的方法。当需要从该文件中恢复原始图像文件时，可以执行此操作。当 zip 签名不完整时，也不是毫无办法：如果 wxMaxima 在保存文件时检测到错误，那么还会有一个 `.wxmx~` 文件，其内容可能会有所帮助。"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:897
-#, fuzzy
-#| msgid "And even if there isn’t such a file: The `.wxmx` file is a container format and the XML portion is stored uncompressed. It it is possible to rename the `.wxmx` file to a `.txt` file and to use a text editor to recover the XML portion of the file's contents (it starts with `<?xml version=\"1.0\" encoding=\"UTF-8\"?>` and ends with `</wxMaximaDocument>`. Before and after that text you will see some unreadable binary contents in the text editor).\n"
-msgid "And even if there isn’t such a file: The `.wxmx` file is a container format and the XML portion is stored uncompressed. It it is possible to rename the `.wxmx` file to a `.txt` file and to use a text editor to recover the XML portion of the file’s contents (it starts with `<?xml version=\"1.0\" encoding=\"UTF-8\"?>` and ends with `</wxMaximaDocument>`. Before and after that text you will see some unreadable binary contents in the text editor)."
-msgstr "即使没有 `.wxmx~` 文件，`.wxmx` 文件中 XML 部分是未压缩的，可以将该文件重命名为 `.txt` 文件，并使用文本编辑器恢复文件中的 XML 部分（以 `<?xml version=\"1.0\" encoding=\"UTF-8\"?>` 开头，并以 `</wxMaximaDocument>` 结尾（在 XML 部分的前后，可在文本编辑器中看到一些不可读的二进制内容）。\n"
+#: ../../info/wxmaxima.md:903
+#, no-wrap
+msgid "And even if there isn’t such a file: The `.wxmx` file is a container format and the XML portion is stored uncompressed. It it is possible to rename the `.wxmx` file to a `.txt` file and to use a text editor to recover the XML portion of the file’s contents (it starts with `<?xml version=\"1.0\" encoding=\"UTF-8\"?>` and ends with `</wxMaximaDocument>`. Before and after that text you will see some unreadable binary contents in the text editor).\n"
+msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:899
+#: ../../info/wxmaxima.md:905
 #, fuzzy
 #| msgid "If a text file containing only this contents (e.g. copy and paste this text into a new file) is saved as a file ending in `.xml`, _wxMaxima_ will know how to recover the text of the document from it."
 msgid "If a text file containing only these contents (e.g. copy and paste this text into a new file) is saved as a file ending in `.xml`, _wxMaxima_ will know how to recover the text from the document."
 msgstr "如果将只包含 XML 部分的文本文件（例如，将这一部分复制并粘贴到新文件中）保存为以 `.xml` 结尾的文件，则 wxMaxima 可以从中恢复原始文档的文本。"
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:901
-#, fuzzy
-#| msgid "I want some debug info to be displayed on the screen before my command has finished"
-msgid "## I want some debug info to be displayed on the screen before my command has finished"
-msgstr "在命令完成前显示一些调试信息"
+#. type: Title ##
+#: ../../info/wxmaxima.md:906
+#, no-wrap
+msgid "I want some debug info to be displayed on the screen before my command has finished"
+msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:903
+#: ../../info/wxmaxima.md:909
 msgid "Normally _wxMaxima_ waits for the whole 2D formula to be transferred before it begins to typeset. This saves time for making many attempts to typeset a only partially completed equation. There is a `disp` command, though, that will provide debug output immediately and without waiting for the current _Maxima_ command to finish:"
 msgstr "通常 wxMaxima 会等待最后的公式形成后才开始输出，这节省了多次尝试输出部分公式的时间。不过， `disp()` 命令可以立即输出调试信息，而不必等待当前的 Maxima 命令完成："
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:913
-#, fuzzy, no-wrap
-#| msgid ""
-#| "for i:1 thru 10 do (\n"
-#| "   disp(i),\n"
-#| "   /* (sleep n) is a Lisp function, which can be used */\n"
-#| "   /* with the character \"?\" before. It delays the */\n"
-#| "   /* program execution (here: for 3 seconds) */\n"
-#| "   ?sleep(3)\n"
-#| ")$\n"
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:910
+#, no-wrap
 msgid ""
-"```maxima\n"
 "for i:1 thru 10 do (\n"
 "   disp(i),\n"
 "   /* (sleep n) is a Lisp function, which can be used */\n"
@@ -11019,380 +15085,315 @@ msgid ""
 "   /* program execution (here: for 3 seconds) */\n"
 "   ?sleep(3)\n"
 ")$\n"
-"```\n"
 msgstr ""
-"for i:1 thru 10 do (\n"
-"   disp(i),\n"
-"   /* (sleep n) 是可接在字符\"?\"后使用的 Lisp 函数 */\n"
-"   /* 它推迟了程序的运行，此处是 3 秒 */\n"
-"   ?sleep(3)\n"
-")$\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:915
+#: ../../info/wxmaxima.md:921
 msgid "Alternatively one can look for the `wxstatusbar()` command above."
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:917
-#, fuzzy
-#| msgid "Plotting only shows a closed empty envelope with an error message"
-msgid "## Plotting only shows a closed empty envelope with an error message"
-msgstr "绘图结果是空的绘图框和错误信息"
+#. type: Title ##
+#: ../../info/wxmaxima.md:922
+#, no-wrap
+msgid "Plotting only shows a closed empty envelope with an error message"
+msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:919
+#: ../../info/wxmaxima.md:925
 #, fuzzy
 #| msgid "This means that _wxMaxima_ could not read the file _Maxima_ that was supposed to instruct _gnuplot_ to create."
 msgid "This means that _wxMaxima_ could not read the file _Maxima_ that was supposed to instruct _Gnuplot_ to create."
 msgstr "这意味着 wxMaxima 无法读取由 Maxima 指示 gnuplot 创建的文件。"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:921
+#: ../../info/wxmaxima.md:927
 msgid "Possible reasons for this error are:"
 msgstr "这个错误的可能原因如下："
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:926
+#: ../../info/wxmaxima.md:932
 #, fuzzy
 #| msgid "The plotting command is part of a third-party package like `implicit_plot` but this package was not loaded by _Maxima_’s `load()` command before trying to plot."
 msgid "The plotting command is part of a third-party package like `implicit_plot` but this package was not loaded by _Maxima_’s `load()` command before trying to plot."
 msgstr "绘图命令是第三方程序包（如 `implicit_plot`）的一部分，但在尝试绘图之前，没有调用 Maxima 的 `load()` 命令加载此包。"
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:926
+#: ../../info/wxmaxima.md:932
 #, fuzzy
 #| msgid "_Maxima_ tried to do something the currently installed version of _gnuplot_ isn’t able to understand. In this case, a file ending in `.gnuplot` located in the directory, which _Maxima_’s variable `maxima_userdir` is pointing, contains the instructions from _Maxima_ to _gnuplot_. Most of the time, this file’s contents therefore are helpful when debugging the problem."
 msgid "_Maxima_ tried to do something the currently installed version of _Gnuplot_ isn’t able to understand. In this case, a file ending in `.gnuplot` located in the directory, which _Maxima_’s variable `maxima_userdir` is pointing, contains the instructions from _Maxima_ to _Gnuplot_. Most of the time, this file’s contents therefore are helpful when debugging the problem."
 msgstr "Maxima 试图做一些当前版本的 gnuplot 无法理解的事情。此时，在由 Maxima 的变量 `maxima_userdir` 确定的目录中，以 `.gnuplot` 结尾的文件包含了 Maxima 给 gnuplot 的指令。在调试问题时，此文件的内容在大多数情况下都是有帮助的。"
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:926
+#: ../../info/wxmaxima.md:932
 #, fuzzy
 #| msgid "Gnuplot was instructed to use the pngcairo library that provides antialiasing and additional line styles, but it was not compiled to support this possibility. Solution: Uncheck the \"Use the cairo terminal for plot\" checkbox in the configuration dialog and don’t set `wxplot_pngcairo` to true from _Maxima_."
 msgid "Gnuplot was instructed to use the pngCairo library that provides antialiasing and additional line styles, but it was not compiled to support this possibility. Solution: Uncheck the \"Use the Cairo terminal for the plot\" checkbox in the configuration dialog and don’t set `wxplot_pngcairo` to true from _Maxima_."
 msgstr "Gnuplot 被设置为使用 pngcairo 库以提供抗锯齿功能和更多线条样式，但是在编译时没有开启此项功能支持。解决方案：取消选中设置对话框中的“使用 cairo 终端进行绘图”复选框，并且不要在 Maxima 中将 `wxplot_pngcairo` 设置为true。"
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:926
+#: ../../info/wxmaxima.md:932
 #, fuzzy
 #| msgid "Gnuplot didn’t output a valid `.png` file."
 msgid "Gnuplot didn’t output a valid `.png` file."
 msgstr "Gnuplot 没有生成有效的 .png 文件。"
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:928
-#, fuzzy
-#| msgid "Plotting an animation results in “error: undefined variable”"
-msgid "## Plotting an animation results in “error: undefined variable”"
-msgstr "绘制动图时得到“error: undefined variable（错误：未定义的变量）”"
+#. type: Title ##
+#: ../../info/wxmaxima.md:933
+#, no-wrap
+msgid "Plotting an animation results in “error: undefined variable”"
+msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:930
+#: ../../info/wxmaxima.md:936
 #, fuzzy
 #| msgid "The value of the slider variable by default is only substituted into the expression that is to be plotted if it is visible there. Using a `subst` command that substitutes the slider variable into the equation to plot resolves this problem. At the end of section [Embedding animations into the spreadsheet](#embedding-animations-into-the-spreadsheet) you can see an example."
 msgid "The value of the slider variable by default is only substituted into the expression that is to be plotted if it is visible there. Using a `subst` command that substitutes the slider variable into the equation to plot resolves this problem. At the end of section [Embedding animations into the spreadsheet](#embedding-animations-into-the-spreadsheet), you can see an example."
 msgstr "在默认情况下，滑块变量的值需要被替换到要绘制图形的表达式中，即该变量在表达式中可见。使用 `subst()` 命令将滑块变量替换到要绘制图形的方程中可以解决此问题。[在工作簿中嵌入动图](#embedding-animations-into-the-spreadsheet)一节的末尾有一个例子。"
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:932
-#, fuzzy
-#| msgid "I lost a cell contents and undo doesn’t remember"
-msgid "## I lost cell content and undo doesn’t remember"
-msgstr "删除了一个单元格，而撤销操作不起作用"
+#. type: Title ##
+#: ../../info/wxmaxima.md:937
+#, no-wrap
+msgid "I lost cell content and undo doesn’t remember"
+msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:934
+#: ../../info/wxmaxima.md:940
 msgid "There are separate undo functions for cell operations and for changes inside of cells so chances are low that this ever happens. If it does there are several methods to recover data:"
 msgstr "对单元格的操作和单元格内部的更改均有单独的撤消函数，因此发生这种情况的可能性很低。如果确实是这样，有如下方法可以恢复数据："
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:939
+#: ../../info/wxmaxima.md:945
 #, fuzzy
 #| msgid "_wxMaxima_ actually has two undo features: The global undo buffer that is active if no cell is selected and a per-cell undo buffer that is active if the cursor is inside a cell. It is worth trying to use both undo options in order to see if an old value can still be accessed."
 msgid "_WxMaxima_ actually has two undo features: The global undo buffer that is active if no cell is selected and a per-cell undo buffer that is active if the cursor is inside a cell. It is worth trying to use both undo options in order to see if an old value can still be accessed."
 msgstr "wxMaxima 实际上有两个撤消功能：全局撤消（如果未选择单元格）和单元格内撤消（如果光标在单元格内）。可以尝试使用这两个撤消选项，以查看是否可以恢复内容。"
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:939
+#: ../../info/wxmaxima.md:945
 #, fuzzy
 #| msgid "If you still have a way to find out what label _Maxima_ has assigned to the cell just type in the cell’s label and its contents will reappear."
 msgid "If you still have a way to find out what label _Maxima_ has assigned to the cell just type in the cell’s label and its contents will reappear."
 msgstr "如果有办法确定 Maxima 分配给该单元格的标签，只需键入此标签，单元格的内容就会重新出现。"
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:939
+#: ../../info/wxmaxima.md:945
 #, fuzzy
 #| msgid "If you don’t: Don’t panic. In the “View” menu there is a way to show a history pane that shows all _Maxima_ commands that have been issued recently."
 msgid "If you don’t: Don’t panic. In the “View” menu there is a way to show a history pane that shows all _Maxima_ commands that have been issued recently."
 msgstr "如果忘了单元格的标签，也无需惊慌。在“查看”菜单中，可以勾选显示“历史命令”侧边栏，其中显示了最近使用的所有 Maxima 命令。"
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:939
+#: ../../info/wxmaxima.md:945
 msgid "If nothing else helps _Maxima_ contains a replay feature:"
 msgstr "如果以上都没有帮助，可以调用 Maxima 的回放功能："
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:943
-msgid "```maxima playback(); ```"
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:946
+#, no-wrap
+msgid "playback();\n"
+msgstr "playback();\n"
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:950
+#, no-wrap
+msgid "_WxMaxima_ starts up with the message “Maxima process terminated.”"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:945
-#, fuzzy
-#| msgid "_wxMaxima_ starts up with the message “Maxima process terminated.”"
-msgid "## _WxMaxima_ starts up with the message “Maxima process terminated.”"
-msgstr "wxMaxima 启动时显示信息“Maxima process terminated（Maxima 进程已终止）。”"
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:947
+#: ../../info/wxmaxima.md:953
 #, fuzzy
 #| msgid "One possible reason is that _Maxima_ cannot be found in the location that is set in the “Maxima” tab of _wxMaxima_’s configuration dialog and therefore won’t run at all. Setting the path to a working _Maxima_ binary should fix this problem."
 msgid "One possible reason is that _Maxima_ cannot be found in the location that is set in the “Maxima” tab of _wxMaxima_’s configuration dialog and therefore won’t run at all. Setting the path to a working _Maxima_ binary should fix this problem."
 msgstr "一个可能的原因是，在设置对话框的“Maxima”选项卡中设置的位置找不到 Maxima 程序，因此根本无法运行 Maxima。将路径设置为有效的 Maxima 二进制文件所在文件夹应该可以解决此问题。"
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:949
-#, fuzzy
-#| msgid "Maxima is forever calculating and not responding to input"
-msgid "## Maxima is forever calculating and not responding to input"
-msgstr "Maxima 永远在计算中而不响应输入"
+#. type: Title ##
+#: ../../info/wxmaxima.md:954
+#, no-wrap
+msgid "Maxima is forever calculating and not responding to input"
+msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:951
+#: ../../info/wxmaxima.md:957
 #, fuzzy
 #| msgid "It is theoretically possible that _wxMaxima_ doesn’t realize that _Maxima_ has finished calculating and therefore never gets informed it can send new data to _Maxima_. If this is the case “Trigger evaluation” might resynchronize the two programs."
 msgid "It is theoretically possible that _wxMaxima_ doesn’t realize that _Maxima_ has finished calculating and therefore never gets informed it can send new data to _Maxima_. If this is the case “Trigger evaluation” might resynchronize the two programs."
 msgstr "理论上讲，有可能是 wxMaxima 没有意识到 Maxima 已经完成了计算，因此没有得到通知，以告知它可以向 Maxima 发送新的数据。如果是这种情况，重新求值可能会使两个程序同步。"
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:953
-#, fuzzy
-#| msgid "My SBCL-based _Maxima_ runs out of memory"
-msgid "## My SBCL-based _Maxima_ runs out of memory"
-msgstr "基于 SBCL 的 Maxima 耗尽内存"
+#. type: Title ##
+#: ../../info/wxmaxima.md:958
+#, no-wrap
+msgid "My SBCL-based _Maxima_ runs out of memory"
+msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:955
+#: ../../info/wxmaxima.md:961
 #, fuzzy
 #| msgid "The Lisp compiler SBCL by default comes with a memory limit that allows it to run even on low-end computers. When compiling a big software package like Lapack or dealing with extremely big lists or equations this limit might be too low. In order to extend the limits SBCL can be provided with the command line parameter `--dynamic-space-size` that tells SBCL how many megabytes it should reserve. A 32bit Windows-SBCL can reserve up to 999 Megabytes. A 64-bit SBCL version running on Windows can be instructed to use more than the about 1280 Megabytes compiling Lapack needs."
 msgid "The Lisp compiler SBCL by default comes with a memory limit that allows it to run even on low-end computers. When compiling a big software package like Lapack or dealing with extremely big lists of equations this limit might be too low. In order to extend the limits, SBCL can be provided with the command line parameter `--dynamic-space-size` that tells SBCL how many megabytes it should reserve. A 32bit Windows-SBCL can reserve up to 999 Megabytes. A 64-bit SBCL version running on Windows can be instructed to use more than the about 1280 Megabytes compiling Lapack needs."
 msgstr "默认情况下，Lisp 编译器 SBCL 有一个内存限制，以使得它能在低端计算机上运行。当编译一个大型软件包（如 Lapack）或处理特别大的列表和方程时，该限制值可能太低。为了扩展内存限制，可以向 SBCL 提供命令行参数 `--dynamic-space-size`，该参数告诉 SBCL 应该使用多少兆字节的内存。32位 Windows 系统版本的 SBCL 最多可使用 999 兆字节，64位 Windows 系统版本的 SBCL 可以被设置为使用更大的内存（例如超过编译 Lapack 所需的约 1280 兆字节）。"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:957
+#: ../../info/wxmaxima.md:963
 #, fuzzy
 #| msgid "One way to provide _Maxima_ (and thus SBCL) with command line parameters is the \"Additional parameters for Maxima\" field of _wxMaxima_’s configuration dialogue."
 msgid "One way to provide _Maxima_ (and thus SBCL) with command line parameters is the \"Additional parameters for Maxima\" field of _wxMaxima_’s configuration dialogue."
 msgstr "为 Maxima（因此也为 SBCL）提供命令行参数的一种方法是利用 wxMaxima 设置对话框的“额外的 Maxima 参数（Additional parameters for Maxima）”字段。"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:959
+#: ../../info/wxmaxima.md:965
 msgid "![sbcl memory](./sbclMemory.png){ id=img_sbclMemory }"
 msgstr "![SBCL 内存](./sbclMemory.png){ id=img_sbclMemory }"
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:961
-#, fuzzy
-#| msgid "Input sometimes is sluggish/ignoring keys on Ubuntu"
-msgid "## Input sometimes is sluggish/ignoring keys on Ubuntu"
-msgstr "在 Ubuntu 系统上，有时输入无响应或响应迟缓"
+#. type: Title ##
+#: ../../info/wxmaxima.md:966
+#, no-wrap
+msgid "Input sometimes is sluggish/ignoring keys on Ubuntu"
+msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:963
+#: ../../info/wxmaxima.md:969
 msgid "Installing the package `ibus-gtk` should resolve this issue. See ([https://bugs.launchpad.net/ubuntu/+source/wxwidgets3.0/+bug/1421558](https://bugs.launchpad.net/ubuntu/+source/wxwidgets3.0/+bug/1421558)) for details."
 msgstr "安装软件包 `ibus-gtk` 应该可以解决此问题. 详情见 [https://bugs.launchpad.net/ubuntu/+source/wxwidgets3.0/+bug/1421558](https://bugs.launchpad.net/ubuntu/+source/wxwidgets3.0/+bug/1421558)。"
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:965
-#, fuzzy
-#| msgid "_wxMaxima_ halts when _Maxima_ processes Greek characters or Umlauts"
-msgid "## _WxMaxima_ halts when _Maxima_ processes Greek characters or Umlauts"
-msgstr "wxMaxima 在处理希腊字符或元音变音符时停止"
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:967
-msgid "If your _Maxima_ is based on SBCL the following lines have to be added to your `.sbclrc`:"
-msgstr "如果所使用的 Maxima 基于SBCL，则必须将以下行添加到 `.sbclrc` 文件中："
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:971
-#, fuzzy
-#| msgid "(setf sb-impl::*default-external-format* :utf-8)\n"
-msgid "```commonlisp (setf sb-impl::*default-external-format* :utf-8)  ```"
-msgstr "(setf sb-impl::*default-external-format* :utf-8)\n"
+#. type: Title ##
+#: ../../info/wxmaxima.md:970
+#, no-wrap
+msgid "_WxMaxima_ halts when _Maxima_ processes Greek characters or Umlauts"
+msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:973
+msgid "If your _Maxima_ is based on SBCL the following lines have to be added to your `.sbclrc`:"
+msgstr "如果所使用的 Maxima 基于SBCL，则必须将以下行添加到 `.sbclrc` 文件中："
+
+#. type: Fenced code block (commonlisp)
+#: ../../info/wxmaxima.md:974
+#, no-wrap
+msgid "(setf sb-impl::*default-external-format* :utf-8)\n"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:979
 #, fuzzy
 #| msgid "The folder this file has to be placed in is system- and installation-specific. But any SBCL-based _Maxima_ that already has evaluated a cell in the current session will happily tell where it can be found after getting the following command:"
 msgid "The folder where this file has to be placed is system- and installation-specific. But any SBCL-based _Maxima_ that already has evaluated a cell in the current session will happily tell where it can be found after getting the following command:"
 msgstr "`.sbclrc` 文件应放入特定的文件夹。任何基于 SBCL 的 Maxima 如果已经在当前会话中计算了一个单元格，那么在获得如下命令后，都会显示该文件的位置："
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:977
-#, fuzzy
-#| msgid "    :lisp (sb-impl::userinit-pathname)\n"
-msgid "```maxima :lisp (sb-impl::userinit-pathname)  ```"
-msgstr "    :lisp (sb-impl::userinit-pathname)\n"
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:979
-msgid "## Note concerning Wayland (recent Linux/BSD distributions)"
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:980
+#, no-wrap
+msgid ":lisp (sb-impl::userinit-pathname)\n"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:982
-msgid "There seem to be issues with the Wayland Display Server and wxWidgets.  WxMaxima may be affected, e.g. that sidebars are not moveable."
-msgstr ""
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:986
-msgid "You can either disable Wayland and use X11 instead (globally)  or just tell, that wxMaxima should use the X Window System by setting: `GDK_BACKEND=x11`"
+#. type: Title ##
+#: ../../info/wxmaxima.md:984
+#, no-wrap
+msgid "Note concerning Wayland (recent Linux/BSD distributions)"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:988
-msgid "E.g. start wxMaxima with:"
-msgstr ""
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:990
-msgid "`GDK_BACKEND=x11 wxmaxima`"
+msgid "There seem to be issues with the Wayland Display Server and wxWidgets.  WxMaxima may be affected, e.g. that sidebars are not moveable."
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:992
-msgid "## The menu bar disappears on KDE Plasma"
+msgid "You can either disable Wayland and use X11 instead (globally)  or just tell, that wxMaxima should use the X Window System by setting: `GDK_BACKEND=x11`"
 msgstr ""
 
 #. type: Plain text
+#: ../../info/wxmaxima.md:994
+msgid "E.g. start wxMaxima with:"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:996
+msgid "`GDK_BACKEND=x11 wxmaxima`"
+msgstr ""
+
+#. type: Title ##
 #: ../../info/wxmaxima.md:997
-msgid "On some KDE Plasma installations the global menu bar disappears when clicked.  As this is a bug in the global menu proxy, the only way to avoid it is to tell that wxMaxima should use its own menu bar instead of the global one.  This is done by setting: `UBUNTU_MENUPROXY=0`"
-msgstr ""
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:1001
-msgid "Starting with version 26.05.0, wxMaxima attempts to set this variable automatically if it detects an affected system (KDE, Unity, or Ubuntu with older wxWidgets versions)."
+#, no-wrap
+msgid "The menu bar disappears on KDE Plasma"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:1003
-msgid "If the automatic fix fails, you can manually start wxMaxima with:"
-msgstr ""
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:1005
-msgid "`UBUNTU_MENUPROXY=0 wxmaxima`"
+msgid "On some KDE Plasma installations the global menu bar disappears when clicked.  As this is a bug in the global menu proxy, the only way to avoid it is to tell that wxMaxima should use its own menu bar instead of the global one.  This is done by setting: `UBUNTU_MENUPROXY=0`"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:1007
-msgid "## Why is the integrated manual browser not offered on my Windows PC?"
+msgid "Starting with version 26.05.0, wxMaxima attempts to set this variable automatically if it detects an affected system (KDE, Unity, or Ubuntu with older wxWidgets versions)."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1010
+#: ../../info/wxmaxima.md:1009
+msgid "If the automatic fix fails, you can manually start wxMaxima with:"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1011
+msgid "`UBUNTU_MENUPROXY=0 wxmaxima`"
+msgstr ""
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:1012
+#, no-wrap
+msgid "Why is the integrated manual browser not offered on my Windows PC?"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1016
 msgid "Either wxWidgets wasn’t compiled with support for Microsoft’s webview2 or Microsoft’s webview2 isn’t installed."
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:1012
-msgid "## Why is the external manual browser not working on my Linux box?"
+#. type: Title ##
+#: ../../info/wxmaxima.md:1017
+#, no-wrap
+msgid "Why is the external manual browser not working on my Linux box?"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1018
+#: ../../info/wxmaxima.md:1024
 msgid "The HTML browser might be a snap, flatpack or appimage version. All of these typically cannot access files that are installed on your local system. Another reason might be that maxima or wxMaxima is installed as a snap, flatpack or something else that doesn’t give the host system access to its contents. A third reason might be that the maxima HTML manual isn’t installed and the online one cannot be accessed."
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:1020
-#, fuzzy
-#| msgid "Can I make _wxMaxima_ output both image files and embedded plots at once?"
-msgid "## Can I make _wxMaxima_ output both image files and embedded plots at once?"
-msgstr "是否可以同时输出和嵌入绘图文件？"
+#. type: Title ##
+#: ../../info/wxmaxima.md:1025
+#, no-wrap
+msgid "Can I make _wxMaxima_ output both image files and embedded plots at once?"
+msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1022
+#: ../../info/wxmaxima.md:1028
 #, fuzzy
 #| msgid "The worksheet embeds .png files. _wxMaxima_ allows the user to specify where they should be generated:"
 msgid "The worksheet embeds `.png files. _WxMaxima_ allows the user to specify where they should be generated:"
 msgstr "工作簿可嵌入 `.png` 文件。wxMaxima 允许用户指定它们的生成位置："
 
-#. type: Plain text
+#. type: Fenced code block (maxima)
 #: ../../info/wxmaxima.md:1029
-#, fuzzy, no-wrap
-#| msgid ""
-#| "wxdraw2d(\n"
-#| "    file_name=\"test\",\n"
-#| "    explicit(sin(x),x,1,10)\n"
-#| ");\n"
+#, no-wrap
 msgid ""
-"```maxima\n"
 "wxdraw2d(\n"
 "    file_name=\"test\",  /* extension .png automatically added */\n"
 "    explicit(sin(x),x,1,10)\n"
 ");\n"
-"```\n"
 msgstr ""
-"wxdraw2d(\n"
-"    file_name=\"test\",\n"
-"    explicit(sin(x),x,1,10)\n"
-");\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1031
+#: ../../info/wxmaxima.md:1037
 #, fuzzy
 #| msgid "If a different format is to be used it is easier to generate the images and then to import them into the worksheet again:"
 msgid "If a different format is to be used, it is easier to generate the images and then import them into the worksheet again:"
 msgstr "如果要使用不同的格式，则可以先生成图像，然后再将其导入工作簿："
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:1050
-#, fuzzy, no-wrap
-#| msgid ""
-#| "load(\"draw\");\n"
-#| "pngdraw(name,[contents]):=\n"
-#| "(\n"
-#| "    draw(\n"
-#| "        append(\n"
-#| "            [\n"
-#| "                terminal=pngcairo,\n"
-#| "                dimensions=wxplot_size,\n"
-#| "                file_name=name\n"
-#| "            ],\n"
-#| "            contents\n"
-#| "        )\n"
-#| "    ),\n"
-#| "    show_image(printf(false,\"~a.png\",name))\n"
-#| ");\n"
-#| "pngdraw2d(name,[contents]):=\n"
-#| "    pngdraw(name,gr2d(contents));\n"
-#| "\n"
-#| "pngdraw2d(\"Test\",\n"
-#| "        explicit(sin(x),x,1,10)\n"
-#| ");\n"
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:1038
+#, no-wrap
 msgid ""
-"```maxima\n"
-"load(\"draw\");\n"
-"pngdraw(name,[contents]):=\n"
-"(\n"
-"    draw(\n"
-"        append(\n"
-"            [\n"
-"                terminal=pngcairo,\n"
-"                dimensions=wxplot_size,\n"
-"                file_name=name\n"
-"            ],\n"
-"            contents\n"
-"        )\n"
-"    ),\n"
-"    show_image(printf(false,\"~a.png\",name))\n"
-");\n"
-"pngdraw2d(name,[contents]):=\n"
-"    pngdraw(name,gr2d(contents));\n"
-msgstr ""
 "load(\"draw\");\n"
 "pngdraw(name,[contents]):=\n"
 "(\n"
@@ -11414,255 +15415,236 @@ msgstr ""
 "pngdraw2d(\"Test\",\n"
 "        explicit(sin(x),x,1,10)\n"
 ");\n"
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:1055
-#, fuzzy, no-wrap
-#| msgid ""
-#| "wxdraw2d(\n"
-#| "    file_name=\"test\",\n"
-#| "    explicit(sin(x),x,1,10)\n"
-#| ");\n"
-msgid ""
-"pngdraw2d(\"Test\",\n"
-"        explicit(sin(x),x,1,10)\n"
-");\n"
-"```\n"
 msgstr ""
-"wxdraw2d(\n"
-"    file_name=\"test\",\n"
-"    explicit(sin(x),x,1,10)\n"
-");\n"
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:1057
-#, fuzzy
-#| msgid "Can I set the aspect ratio of a plot?"
-msgid "## Can I set the aspect ratio of an embedded plot?"
-msgstr "是否可以指定绘制图形的相对比例？"
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:1059
-msgid "Use the variable `wxplot_size`:"
+#. type: Title ##
+#: ../../info/wxmaxima.md:1062
+#, no-wrap
+msgid "Can I set the aspect ratio of an embedded plot?"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:1065
-#, fuzzy, no-wrap
-#| msgid ""
-#| "wxdraw2d(\n"
-#| "    proportional_axis=xy,\n"
-#| "    explicit(sin(x),x,1,10)\n"
-#| "),wxplot_size=[1000,1000];\n"
+msgid "Use the variable `wxplot_size`:"
+msgstr ""
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:1066
+#, no-wrap
 msgid ""
-"```maxima\n"
 "wxdraw2d(\n"
 "    explicit(sin(x),x,1,10)\n"
 "),wxplot_size=[1000,1000];\n"
-"```\n"
-msgstr ""
-"wxdraw2d(\n"
-"    proportional_axis=xy,\n"
-"    explicit(sin(x),x,1,10)\n"
-"),wxplot_size=[1000,1000];\n"
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:1067
-msgid "## After upgrading to MacOS 13.1 plot and/or draw commands output error messages like"
 msgstr ""
 
-#. type: Plain text
+#. type: Title ##
+#: ../../info/wxmaxima.md:1072
+#, no-wrap
+msgid "After upgrading to MacOS 13.1 plot and/or draw commands output error messages like"
+msgstr ""
+
+#. type: Fenced code block (text)
 #: ../../info/wxmaxima.md:1074
-msgid "```text 1 HIToolbox 0x00007ff80cd91726 _ZN15MenuBarInstance22EnsureAutoShowObserverEv + 102 2 HIToolbox 0x00007ff80cd912b8 _ZN15MenuBarInstance14EnableAutoShowEv + 52 3 HIToolbox 0x00007ff80cd35908 SetMenuBarObscured + 408 ...  ```"
-msgstr ""
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:1076
-msgid "This might be an issue with the operating system. Disable the hiding of the menu bar (SystemSettings => Desktop & Dock => Menu Bar) might solve the issue. See [wxMaxima issue #1746](https://github.com/wxMaxima-developers/wxmaxima/issues/1746) for more information."
-msgstr ""
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:1078
-msgid "## Logging"
+#, no-wrap
+msgid ""
+"1 HIToolbox 0x00007ff80cd91726 _ZN15MenuBarInstance22EnsureAutoShowObserverEv + 102\n"
+"2 HIToolbox 0x00007ff80cd912b8 _ZN15MenuBarInstance14EnableAutoShowEv + 52\n"
+"3 HIToolbox 0x00007ff80cd35908 SetMenuBarObscured + 408\n"
+"...\n"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:1082
-msgid "Log messages might be helpful to debug problems. WxMaxima can log many events. Most log entries will be helpful for developers, especially in case of problems or bugs. If you run a \"Release\"-Build, the log windows is not shown by default, if you run a development version, it is shown by default as a second window. You can enable and disable this window using the \"View->Toggle log window\" menu entry."
+#, no-wrap
+msgid "This might be an issue with the operating system. Disable the hiding of the menu bar (SystemSettings => Desktop & Dock => Menu Bar) might solve the issue. See [wxMaxima issue #1746](https://github.com/wxMaxima-developers/wxmaxima/issues/1746) for more information.\n"
+msgstr ""
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:1083
+#, no-wrap
+msgid "Logging"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1084
+#: ../../info/wxmaxima.md:1088
+#, no-wrap
+msgid ""
+"Log messages might be helpful to debug problems. WxMaxima can log many events. Most log entries will be helpful for developers, especially in case of problems or bugs. If you run a \"Release\"-Build,\n"
+"the log windows is not shown by default, if you run a development version, it is shown by default as a second window. You can enable and disable\n"
+"this window using the \"View->Toggle log window\" menu entry.\n"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1090
 msgid "Messages are not 'lost', if the log window is not shown, if you select to show the log window later, you will see past log messages (if you did not clear the messages)."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1086
+#: ../../info/wxmaxima.md:1092
 msgid "Such messages may be helpful, when you create bug reports (or trying to find a bug by yourself)."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1089
+#: ../../info/wxmaxima.md:1095
 msgid "Log messages can (additionally) be printed to STDERR, when using the command line option \"--logtostderr\". On Windows a separate text console will be opened, as a Windows GUI application does not have the standard IO connected."
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:1093
-msgid "# FAQ"
+#. type: Title #
+#: ../../info/wxmaxima.md:1098
+#, no-wrap
+msgid "FAQ"
+msgstr ""
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:1100
+#, no-wrap
+msgid "Is there a way to make more text fit on a LaTeX page?"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1095
-#, fuzzy
-#| msgid "Is there a way to make more text fit on a LaTeX page?"
-msgid "## Is there a way to make more text fit on a LaTeX page?"
-msgstr "有没有办法在 LaTeX 页面中显示更多的文字？"
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:1097
+#: ../../info/wxmaxima.md:1103
 msgid "Yes. Use the [LaTeX package \"geometry\"](https://ctan.org/pkg/geometry) to specify the size of the borders."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1099
-#, fuzzy
-#| msgid "There is: Just add the following lines to the LaTeX preamble (for example by using the respective field in the config dialogue (\"Export\"->\"Additional lines for the TeX preamble\"):\n"
-msgid "You can add the following line to the LaTeX preamble (for example by using the respective field in the config dialogue (\"Export\"->\"Additional lines for the TeX preamble\"), to set borders of 1cm):"
-msgstr "有，只需将以下文字添加到 LaTeX 文件的导言区，例如通过修改设置对话框中的相应字段（导出->在 TeX 导言区中添加额外的内容（Export->Additional lines for the TeX preamble））：\n"
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:1103
-#, fuzzy
-#| msgid "\\usepackage[left=1cm,right=1cm,top=1cm,bottom=1cm]{geometry}\n"
-msgid "```latex \\usepackage[left=1cm,right=1cm,top=1cm,bottom=1cm]{geometry} ```"
-msgstr "\\usepackage[left=1cm,right=1cm,top=1cm,bottom=1cm]{geometry}\n"
-
-#. type: Plain text
 #: ../../info/wxmaxima.md:1105
-#, fuzzy
-#| msgid "Is there a dark mode?"
-msgid "## Is there a dark mode?"
-msgstr "是否有深色模式？"
+#, no-wrap
+msgid "You can add the following line to the LaTeX preamble (for example by using the respective field in the config dialogue (\"Export\"->\"Additional lines for the TeX preamble\"), to set borders of 1cm):\n"
+msgstr ""
+
+#. type: Fenced code block (latex)
+#: ../../info/wxmaxima.md:1106
+#, no-wrap
+msgid "\\usepackage[left=1cm,right=1cm,top=1cm,bottom=1cm]{geometry}\n"
+msgstr ""
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:1110
+#, no-wrap
+msgid "Is there a dark mode?"
+msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1107
+#: ../../info/wxmaxima.md:1113
 #, fuzzy
 #| msgid "If wxWidgets is new enough _wxMaxima_ will automatically be in dark mode if the rest of the operating system is. The worksheet itself is by default equipped with a bright background. But it can be configured otherwise. Alternatively there is a `View/Invert worksheet brightness` menu entry that allows to quickly convert the worksheet from dark to bright and vice versa."
 msgid "If wxWidgets is new enough, _wxMaxima_ will automatically be in dark mode if the rest of the operating system is. The worksheet itself is by default equipped with a bright background. But it can be configured otherwise. Alternatively, there is a `View/Invert worksheet brightness` menu entry that allows to quickly convert the worksheet from dark to bright and vice versa."
 msgstr "如果 wxWidgets 版本足够新，那么当系统设置了深色主题时，wxMaxima 将自动处于深色模式。在默认情况下，工作簿本身具有浅色背景。但也可以进行其他配置：利用菜单“查看->反转工作簿亮度”，可以快速将工作簿在浅色模式和深色模式中转换。"
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:1109
-#, fuzzy
-#| msgid "_wxMaxima_ sometimes hangs for a several seconds once in the first minute"
-msgid "## _WxMaxima_ sometimes hangs for several seconds once in the first minute"
-msgstr "wxMaxima 有时在启动后的一段时间内无响应"
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:1111
-#, fuzzy
-#| msgid "_wxMaxima_ delegates some big tasks like parsing _Maxima_'s >1000-page-manual to background tasks, which normally goes totally unnoticed. In the moment the result of such a task is needed, though, it is possible that _wxMaxima_ needs to wait a couple of seconds before it can continue its work.\n"
-msgid "_WxMaxima_ delegates some big tasks like parsing _Maxima_’s >1000-page-manual to background tasks, which normally goes totally unnoticed. At the moment the result of such a task is needed, though, it is possible that _wxMaxima_ needs to wait a couple of seconds before it can continue its work."
-msgstr "wxMaxima 将一些大型任务（如解析 Maxima 的超过 1000 页的手册）委托给后台任务，而这些任务通常不会被执行。然而，当需要执行这样一个任务时，可能需要等待几秒钟才能继续工作。\n"
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:1113
-msgid "## Especially when testing new locale settings, a message box \"locale ’xx_YY’ can not be set\" occurs"
+#. type: Title ##
+#: ../../info/wxmaxima.md:1114
+#, no-wrap
+msgid "_WxMaxima_ sometimes hangs for several seconds once in the first minute"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1115
+#: ../../info/wxmaxima.md:1117
+#, no-wrap
+msgid "_WxMaxima_ delegates some big tasks like parsing _Maxima_’s >1000-page-manual to background tasks, which normally goes totally unnoticed. At the moment the result of such a task is needed, though, it is possible that _wxMaxima_ needs to wait a couple of seconds before it can continue its work.\n"
+msgstr ""
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:1118
+#, no-wrap
+msgid "Especially when testing new locale settings, a message box \"locale ’xx_YY’ can not be set\" occurs"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1121
 msgid "![Locale warning](./locale-warning.png){ id=img_locale_warning}"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1119
+#: ../../info/wxmaxima.md:1125
 msgid "(The same problem can occur with other applications too). The translations seem okay after you click on ’OK’. WxMaxima does not only use its own translations but the translations of the wxWidgets framework too."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1122
+#: ../../info/wxmaxima.md:1128
 msgid "These locales maybe not present in the system. On Ubuntu/Debian systems they can be generated using: `dpkg-reconfigure locales`"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:1124
-msgid "## How can I use symbols for real numbers, natural numbers (ℝ, ℕ), etc.?"
-msgstr ""
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:1126
-msgid "You can find these symbols in the Unicode sidebar (search for ’double-struck capital’). But the selected font must also support these symbols. If they do not display properly, select another font."
-msgstr ""
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:1128
-msgid "## How can a Maxima script determine, if it is running under wxMaxima or command line Maxima?"
-msgstr ""
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:1130
-msgid "If wxMaxima is used, the Maxima variable `maxima_frontend` is set to `wxmaxima`. The Maxima variable `maxima_frontend_version` contains the wxMaxima version in this case."
+#. type: Title ##
+#: ../../info/wxmaxima.md:1129
+#, no-wrap
+msgid "How can I use symbols for real numbers, natural numbers (ℝ, ℕ), etc.?"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:1132
-msgid "If no frontend is used (you are using command line Maxima), these variables are `false`."
+msgid "You can find these symbols in the Unicode sidebar (search for ’double-struck capital’). But the selected font must also support these symbols. If they do not display properly, select another font."
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:1134
-msgid "## Help! I can not save my document!"
+#. type: Title ##
+#: ../../info/wxmaxima.md:1133
+#, no-wrap
+msgid "How can a Maxima script determine, if it is running under wxMaxima or command line Maxima?"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:1136
-msgid "If saving as wxmx file does not work, try saving the document as wxm file (and vice versa). And you can also try to remove all output (Menu Cell->Remove all output) and save that file, maybe some unexpected output causes issues during the save process."
+msgid "If wxMaxima is used, the Maxima variable `maxima_frontend` is set to `wxmaxima`. The Maxima variable `maxima_frontend_version` contains the wxMaxima version in this case."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1140
-#, fuzzy
-#| msgid "Command-line arguments"
-msgid "# Command-line arguments"
-msgstr "命令行参数"
+#: ../../info/wxmaxima.md:1138
+msgid "If no frontend is used (you are using command line Maxima), these variables are `false`."
+msgstr ""
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:1139
+#, no-wrap
+msgid "Help! I can not save my document!"
+msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:1142
+#, no-wrap
+msgid "If saving as wxmx file does not work, try saving the document as wxm file (and vice versa). And you can also try to remove all output (Menu Cell->Remove all output) and save that file, maybe some unexpected output causes issues during the save process.\n"
+msgstr ""
+
+#. type: Title #
+#: ../../info/wxmaxima.md:1145
+#, no-wrap
+msgid "Command-line arguments"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1148
 msgid "Usually you can start programs with a graphical user interface just by clicking on a desktop icon or desktop menu entry. WxMaxima - if started from the command line - still provides some command-line switches, though."
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:1158
+#: ../../info/wxmaxima.md:1164
 msgid "`-v` or `--version`: Output the version information"
 msgstr "`-v` 或 `--version`：输出版本信息。"
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:1158
+#: ../../info/wxmaxima.md:1164
 msgid "`-h` or `--help`: Output a short help text"
 msgstr "`-h` 或 `--help`: 输出简短的帮助文本。"
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:1158
+#: ../../info/wxmaxima.md:1164
 #, fuzzy
 #| msgid "`-o` or `--open=<str>`: Open the filename given as argument to this command-line switch"
 msgid "`-o` or `--open=<str>`: Open the filename given as an argument to this command-line switch"
 msgstr "`-o` 或 `--open=<str>`：打开作为此命令行参数的文件名。"
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:1158
+#: ../../info/wxmaxima.md:1164
 msgid "`-e` or `--eval`: Evaluate the file after opening it."
 msgstr "`-e` 或 `--eval`：打开文件后对公式单元格求值。"
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:1158
+#: ../../info/wxmaxima.md:1164
 #, fuzzy
 #| msgid "`-b` or `--batch`: If the command-line opens a file all cells in this file are evaluated and the file is saved afterwards. This is for example useful if the session described in the file makes _Maxima_ generate output files. Batch-processing will be stopped if _wxMaxima_ detects that _Maxima_ has output an error and will pause if _Maxima_ has a question: Mathematics is somewhat interactive by nature so a completely interaction-free batch processing cannot always be guaranteed."
 msgid "`-b` or `--batch`: If the command-line opens a file all cells in this file are evaluated and the file is saved afterward. This is for example useful if the session described in the file makes _Maxima_ generate output files. Batch-processing will be stopped if _wxMaxima_ detects that _Maxima_ has output an error and will pause if _Maxima_ has a question: Mathematics is somewhat interactive by nature so a completely interaction-free batch processing cannot always be guaranteed."
 msgstr "`-b` 或 `--batch`：如果用命令行打开一个文件，则计算该文件中的所有单元格，然后保存文件。例如，如果文件中描述的会话使 Maxima 生成输出文件，则这一参数会很有用。如果 wxMaxima 检测到 Maxima 输出了错误信息，则批处理将停止；如果检测到 Maxima 有疑问，则批处理将暂停。Maxima 的计算过程有一定的交互性，因此无法保证完全无交互的批处理。"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1158
+#: ../../info/wxmaxima.md:1164
 #, fuzzy, no-wrap
 #| msgid ""
 #| "* `--logtostdout`:                 Log all \"debug messages\" sidebar messages to stderr, too.\n"
@@ -11698,46 +15680,1217 @@ msgstr ""
 "\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1160
+#: ../../info/wxmaxima.md:1166
 #, fuzzy
 #| msgid "Instead of a minus some operating systems might use a dash in front of the command-line switches."
 msgid "Instead of a minus, some operating systems might use a dash in front of the command-line switches."
 msgstr "一些操作系统可能在命令行选项前面使用连字符（-，dash），而不是减号。"
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:1164
-msgid "# About the program, contributing to wxMaxima"
-msgstr ""
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:1166
-msgid "wxMaxima is mainly developed using the programming language C++ using the [wxWidgets framework](https://www.wxwidgets.org), as build system we use [CMake](https://www.cmake.org), a small part is written in Lisp. You can contribute to wxMaxima, join the wxMaxima project at <https://github.com/wxMaxima-developers/wxmaxima>, if you have knowledge of these programming languages and want to help and contribute to the open source project wxMaxima."
-msgstr ""
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:1168
-msgid "But not only programmers are necessary! You can also contribute to wxMaxima, if you help to improve the documentation, find and report bugs (and maybe bugfixes), suggest new features, help to translate wxMaxima or the manual to your language (read the README.md in the [locale subdirectory](https://github.com/wxMaxima-developers/wxmaxima/tree/main/locales) how wxMaxima and the manual can be translated)."
-msgstr ""
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:1170
-msgid "Or answer questions of other users in the discussion forum."
+#. type: Title #
+#: ../../info/wxmaxima.md:1169
+#, no-wrap
+msgid "About the program, contributing to wxMaxima"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:1172
-msgid "The source code of wxMaxima is documented using Doxygen [here](https://wxmaxima-developers.github.io/wxmaxima/Doxygen-documentation/)."
+msgid "wxMaxima is mainly developed using the programming language C++ using the [wxWidgets framework](https://www.wxwidgets.org), as build system we use [CMake](https://www.cmake.org), a small part is written in Lisp. You can contribute to wxMaxima, join the wxMaxima project at <https://github.com/wxMaxima-developers/wxmaxima>, if you have knowledge of these programming languages and want to help and contribute to the open source project wxMaxima."
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:1174
+msgid "But not only programmers are necessary! You can also contribute to wxMaxima, if you help to improve the documentation, find and report bugs (and maybe bugfixes), suggest new features, help to translate wxMaxima or the manual to your language (read the README.md in the [locale subdirectory](https://github.com/wxMaxima-developers/wxmaxima/tree/main/locales) how wxMaxima and the manual can be translated)."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1176
+msgid "Or answer questions of other users in the discussion forum."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1178
+msgid "The source code of wxMaxima is documented using Doxygen [here](https://wxmaxima-developers.github.io/wxmaxima/Doxygen-documentation/)."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1180
 msgid "The program is nearly self-contained, so except for system libraries (and the wxWidgets library), no external dependencies (like graphic files or the Lisp part (the `wxmathML.lisp`-file) is needed, these files are included in the executable."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1175
-msgid "If you are a developer, you might want to try out a modified `wxmathML.lisp`-file without recompiling everything, one can use the command line option `--wxmathml-lisp=<str>` to use another Lisp file, not the included one."
+#: ../../info/wxmaxima.md:1181
+#, no-wrap
+msgid "If you are a developer, you might want to try out a modified `wxmathML.lisp`-file without recompiling everything, one can use the command line option `--wxmathml-lisp=<str>` to use another Lisp file, not the included one.\n"
 msgstr ""
+
+#, fuzzy
+#~ msgid "1×n Matrix b:"
+#~ msgstr "矩阵 #1："
+
+#~ msgid "After clicking on animations created with with_slider_draw() or similar this slider allows to change the current frame."
+#~ msgstr "在单击由 with_slider_draw() 等命令创建的动图后，使用此滑块可以更改当前帧。"
+
+#~ msgid "Bug: Got a request to change the contents of the cell above the beginning of the worksheet."
+#~ msgstr "Bug: Got a request to change the contents of the cell above the beginning of the worksheet."
+
+#~ msgid "Bug: Undo request for cell outside worksheet."
+#~ msgstr "Bug: Undo request for cell outside worksheet."
+
+#, fuzzy
+#~ msgid "Calculate variation"
+#~ msgstr "计算乘积"
+
+#~ msgid "Exit wxMaxima"
+#~ msgstr "退出 wxMaxima"
+
+#~ msgid "GTK_IM_MODULE is set to \"xim\". Expect the program to hideously flicker and hotkeys to be broken, see for example https://trac.wxwidgets.org/ticket/18462."
+#~ msgstr "GTK_IM_MODULE 被设置为“xim”。输入时界面会闪烁，且快捷键会失效，见 https://trac.wxwidgets.org/ticket/18462。"
+
+#~ msgid "Hide All Toolbars\tAlt+Shift+-"
+#~ msgstr "隐藏所有工具栏\tAlt+Shift+-"
+
+#~ msgid "Image files (*.png, *.jpg, *.bmp, *.xpm, *.gif, *.svg, *.svgz)|*.png;*.jpg;*.bmp;*.xpm;*.gif;*.svg;*.svgz"
+#~ msgstr "图片文件 (*.png, *.jpg, *.bmp, *.xpm, *.gif, *.svg, *.svgz)|*.png;*.jpg;*.bmp;*.xpm;*.gif;*.svg;*.svgz"
+
+#, fuzzy
+#~ msgid "Integrate numerically"
+#~ msgstr "Risch 积分"
+
+#~ msgid "Invert worksheet brightness"
+#~ msgstr "反转工作簿亮度"
+
+#~ msgid "Jump to first error"
+#~ msgstr "跳转至第一处错误"
+
+#~ msgid "Jump to the first cell Maxima has reported an error in."
+#~ msgstr "跳转至 Maxima 报错的第一个单元格。"
+
+#~ msgid "Load a list from a csv file"
+#~ msgstr "从 csv 文件载入列表"
+
+#~ msgid "Main Toolbar\tAlt+Shift+B"
+#~ msgstr "主工具栏\tAlt+Shift+B"
+
+#, fuzzy
+#~ msgid "Multivariate linear regression"
+#~ msgstr "线性回归..."
+
+#~ msgid "PNG image (*.png)|*.png|JPEG image (*.jpg)|*.jpg|GIF image (*.gif)|*.gif|Scaleable vector graphics (*.svg)|*.svg|Windows bitmap (*.bmp)|*.bmp|Portable anymap (*.pnm)|*.pnm|Tagged image file format (*.tif)|*.tif|X pixmap (*.xpm)|*.xpm"
+#~ msgstr "PNG 图像 (*.png)|*.png|JPEG 图像 (*.jpg)|*.jpg|GIF 图像 (*.gif)|*.gif|可缩放矢量图像 (*.svg)|*.svg|Windows 位图 (*.bmp)|*.bmp|Portable anymap (*.pnm)|*.pnm|带标记图像文件 (*.tif)|*.tif|X pixmap (*.xpm)|*.xpm"
+
+#~ msgid "PNG image (*.png)|*.png|JPEG image (*.jpg)|*.jpg|Windows bitmap (*.bmp)|*.bmp|GIF image (*.gif)|*.gif|Portable anymap (*.pnm)|*.pnm|Tagged image file format (*.tif)|*.tif|X pixmap (*.xpm)|*.xpm"
+#~ msgstr "PNG 图像 (*.png)|*.png|JPEG 图像 (*.jpg)|*.jpg|Windows 位图 (*.bmp)|*.bmp|GIF 图像 (*.gif)|*.gif|Portable anymap (*.pnm)|*.pnm|带标记图像文件 (*.tif)|*.tif|X pixmap (*.xpm)|*.xpm"
+
+#~ msgid "Parts of the document will not be loaded correctly!"
+#~ msgstr "文档的某些部分无法正确载入！"
+
+#~ msgid "Produced invalid XML. The erroneous XML data has therefore not been saved but has been put on the clipboard in order to allow to debug it."
+#~ msgstr "生成了无效的 XML。因此，错误的 XML 数据没有保存，而是放在剪贴板上，以便进行调试。"
+
+#, fuzzy
+#~ msgid "Read List from csv file..."
+#~ msgstr "从 csv 文件读取列表"
+
+#, fuzzy
+#~ msgid "Remove Rows or Columns..."
+#~ msgstr "移除行或列"
+
+#, fuzzy
+#~ msgid "Remove rows and/or columns"
+#~ msgstr "移除行或列"
+
+#~ msgid "Remove rows and/or columns from the matrix"
+#~ msgstr "从矩阵中移除行或列"
+
+#~ msgid "Scalable Vector image (*.svg)|*.svg|Compressed Scalable Vector Image (*.svgz)|*.svgz|PNG image (*.png)|*.png|JPEG image (*.jpg)|*.jpg|GIF image (*.gif)|*.gif|Windows bitmap (*.bmp)|*.bmp|Portable anymap (*.pnm)|*.pnm|Tagged image file format (*.tif)|*.tif|X pixmap (*.xpm)|*.xpm"
+#~ msgstr "可缩放矢量图像 (*.svg)|*.svg|压缩后的可缩放矢量图像 (*.svgz)|*.svgz|PNG 图像 (*.png)|*.png|JPEG 图像 (*.jpg)|*.jpg|GIF 图像 (*.gif)|*.gif|Windows 位图 (*.bmp)|*.bmp|Portable anymap (*.pnm)|*.pnm|带标签的图像文件 (*.tif)|*.tif|X pixmap (*.xpm)|*.xpm"
+
+#~ msgid "Starting to save the worksheet as .wxmx"
+#~ msgstr "开始保存工作簿为 wxmx 文件"
+
+#~ msgid "Unable to interpret the version info I got from http://wxMaxima-developers.github.io/wxmaxima/version.txt: "
+#~ msgstr "无法解释来自 http://wxMaxima-developers.github.io/wxMaxima/version.txt 的版本信息："
+
+#, fuzzy, c-format
+#~ msgid ""
+#~ "You have version %s. The newest version source code is available for is %s.\n"
+#~ "\n"
+#~ "Select OK to visit the wxMaxima webpage."
+#~ msgstr ""
+#~ "当前的版本是：%s. 最新版本是：%s。\n"
+#~ "\n"
+#~ "按“确认”后，会访问 wxMaxima 网页。"
+
+#, fuzzy, c-format
+#~ msgid "_%d.gif\"  alt=\"Animated Diagram\" loading=\"lazy\" style=\"max-width:90%%;\">\n"
+#~ msgstr "_%d.gif\"  alt=\"动态图表\" loading=\"lazy\" style=\"max-width:90%%;\" />\n"
+
+#, fuzzy, c-format
+#~ msgid "_%d.gif\" alt=\"Animated Diagram\" style=\"max-width:90%%;\" loading=\"lazy\">"
+#~ msgstr "_%d.gif\" alt=\"动态图表\" style=\"max-width:90%%;\" loading=\"lazy\" />"
+
+#, fuzzy
+#~| msgid "The wxMaxima user manual {-}"
+#~ msgid "# The wxMaxima user manual"
+#~ msgstr "wxMaxima 用户手册 {-}"
+
+#, fuzzy
+#~| msgid "Introduction to wxMaxima"
+#~ msgid "# Introduction to wxMaxima"
+#~ msgstr "wxMaxima 简介"
+
+#, fuzzy
+#~| msgid "_Maxima_ and wxMaxima"
+#~ msgid "## _Maxima_ and wxMaxima"
+#~ msgstr "Maxima 和 wxMaxima"
+
+#, fuzzy
+#~| msgid "_Maxima_"
+#~ msgid "### _Maxima_"
+#~ msgstr "Maxima"
+
+#, fuzzy
+#~| msgid "Extensive documentation for _Maxima_ is [available in the internet](http://maxima.sourceforge.net/documentation.html). Part of this documentation is also available in wxMaxima’s help menu. Pressing the Help key (on most systems the F1 key) causes _wxMaxima_’s context-sensitive help feature to automatically jump to _Maxima_’s manual page for the command at the cursor."
+#~ msgid "Extensive documentation for _Maxima_ is [available in the internet](https://maxima.sourceforge.io/documentation.html). Part of this documentation is also available in wxMaxima’s help menu. Pressing the Help key (on most systems the <kbd>F1</kbd> key) causes _wxMaxima_’s context-sensitive help feature to automatically jump to _Maxima_’s manual page for the command at the cursor."
+#~ msgstr "大量关于 Maxima 的文档[可在互联网上获得](https://maxima.sourceforge.io/documentation.html)。wxMaxima 的“帮助”菜单中也提供了部分文档。按下帮助键（在大多数系统上是按 F1 键）后，wxMaxima 的上下文相关帮助功能会自动打开 Maxima 的手册页，并跳转到光标处命令对应的内容。"
+
+#, fuzzy
+#~| msgid "wxMaxima"
+#~ msgid "### WxMaxima"
+#~ msgstr "wxMaxima"
+
+#, fuzzy
+#~| msgid "Workbook basics"
+#~ msgid "## Workbook basics"
+#~ msgstr "工作簿（Workbook）基础"
+
+#, fuzzy
+#~| msgid "The workbook approach"
+#~ msgid "### The workbook approach"
+#~ msgstr "工作簿的使用"
+
+#, fuzzy
+#~| msgid "Cells"
+#~ msgid "### Cells"
+#~ msgstr "单元格"
+
+#, fuzzy
+#~| msgid "Horizontal and vertical cursors"
+#~ msgid "### Horizontal and vertical cursors"
+#~ msgstr "水平光标和竖直光标"
+
+#, fuzzy
+#~| msgid "Sending cells to Maxima"
+#~ msgid "### Sending cells to Maxima"
+#~ msgstr "向 Maxima 发送单元格"
+
+#, fuzzy
+#~| msgid "The command in a code cell are executed once <kbd>CTRL</kbd>+<kbd>ENTER</kbd>, <kbd>SHIFT</kbd>+<kbd>ENTER</kbd> or the <kbd>ENTER</kbd> key on the keypad is pressed. The _wxMaxima_ default is to enter commands when either <kbd>CTRL+ENTER</kbd> or <kbd>SHIFT+ENTER</kbd> is entered, but _wxMaxima_ can be configured to execute commands in response to <kbd>ENTER</kbd>.\n"
+#~ msgid "The command in a code cell is executed once by pressing <kbd>CTRL</kbd>+<kbd>ENTER</kbd>, <kbd>SHIFT</kbd>+<kbd>ENTER</kbd> or the <kbd>ENTER</kbd> key on the keypad. The _wxMaxima_ default is to enter commands when either <kbd>CTRL</kbd>+<kbd>ENTER</kbd> or <kbd>SHIFT</kbd>+<kbd>ENTER</kbd> is entered, but _wxMaxima_ can be configured to execute commands in response to <kbd>ENTER</kbd>."
+#~ msgstr "只要按下键盘上的 <kbd>CTRL</kbd>+<kbd>ENTER</kbd>、<kbd>SHIFT</kbd>+<kbd>ENTER</kbd> 或 <kbd>ENTER</kbd> 键，（数学）代码单元格中的命令就会执行。wxMaxima 的默认设置是 <kbd>CTRL</kbd>+<kbd>ENTER</kbd> 或 <kbd>SHIFT</kbd>+ENTER</kbd> 键会使得命令由 Maxima 执行，但也可以设置为按下 <kbd>ENTER</kbd> 键执行命令。\n"
+
+#, fuzzy
+#~| msgid "Command autocompletion"
+#~ msgid "### Command autocompletion"
+#~ msgstr "命令自动补全"
+
+#, fuzzy
+#~| msgid "_wxMaxima_ contains an autocompletion feature that is triggered via the menu (Cell/Complete Word) or alternatively by pressing the key combination <kbd>CTRL</kbd>+<kbd>SPACE</kbd>. The autocompletion is context-sensitive. For example if activated within an unit specification for ezUnits it will offer a list of applicable units.\n"
+#~ msgid "_WxMaxima_ contains an autocompletion feature that is triggered via the menu (Cell/Complete Word) or alternatively by pressing the key combination <kbd>CTRL</kbd>+<kbd>SPACE</kbd>. The autocompletion is context-sensitive. For example, if activated within a unit specification for ezUnits it will offer a list of applicable units."
+#~ msgstr "wxMaxima 包含自动补全功能，该功能可以通过菜单“单元格->自动补全”（Cell->Complete Word）或按组合键 <kbd>CTRL</kbd>+<kbd>K</kbd> 来触发。自动补全是上下文相关的。例如，如果在使用 ezUnits （单位换算包）的单元格中激活，它将提供适用的单位列表。\n"
+
+#, fuzzy
+#~| msgid "Besides completing a file name, a unit name or the current command’s or variable’s name the autocompletion is able to show a template for most of the commands indicating the type (and meaning) of the parameters this program expects. To activate this feature press <kbd>SHIFT</kbd>+<kbd>CTRL</kbd>+<kbd>SPACE</kbd> or select the respective menu item (Cell/Show Template).\n"
+#~ msgid "Besides completing a file name, a unit name, or the current command or variable name, the autocompletion is able to show a template for most of the commands indicating the type (and meaning) of the parameters this program expects. To activate this feature press <kbd>SHIFT</kbd>+<kbd>CTRL</kbd>+<kbd>SPACE</kbd> or select the respective menu item (Cell/Show Template)."
+#~ msgstr "除了补全文件名、单位名、当前命令或变量的名称之外，自动补全功能还可以显示大多数命令的模板，指示该命令所需参数的类型（和含义）。要激活此功能，可按下 <kbd>SHIFT</kbd> +<kbd>CTRL</kbd> +<kbd>K</kbd> 或选择相应的菜单项（“单元格->显示模板”，Cell->Show Template）。\n"
+
+#, fuzzy
+#~| msgid "Greek characters"
+#~ msgid "#### Greek characters"
+#~ msgstr "希腊字母"
+
+#, fuzzy
+#~| msgid "If a special symbol isn’t in the list it is possible to input arbitrary Unicode characters by pressing <kbd>ESC</kbd> [number of the character (hexadecimal)] <kbd>ESC</kbd>.\n"
+#~ msgid "If a special symbol isn’t in the list, it is possible to input arbitrary Unicode characters by pressing <kbd>ESC</kbd> \\[number of the character (hexadecimal)\\] <kbd>ESC</kbd>. Additionally the \"symbols\" sidebar has a right-click menu that allow to display a list of all available Unicode symbols one can add to this toolbar or to the worksheet."
+#~ msgstr "如果某个特殊的 Unicode 字符不在上表中，则可以用如下方式输入：按下 <kbd>ESC</kbd> 后，输入该字符的 16 进制编码，再按下 <kbd>ESC</kbd>。\n"
+
+#, fuzzy
+#~| msgid "<kbd>ESC</kbd> <kbd>61</kbd> <kbd>ESC</kbd> therefore results in an `a`.\n"
+#~ msgid "<kbd>ESC</kbd><kbd>6</kbd><kbd>1</kbd><kbd>ESC</kbd> therefore results in an `a`."
+#~ msgstr "因此 <kbd>ESC</kbd> <kbd>61</kbd> <kbd>ESC</kbd> 输入了字符 `a`.\n"
+
+#, fuzzy
+#~| msgid "Side Panes"
+#~ msgid "### Side Panes"
+#~ msgstr "侧边栏"
+
+#, fuzzy
+#~| msgid "MathML output"
+#~ msgid "### MathML output"
+#~ msgstr "MathML 输出"
+
+#, fuzzy
+#~| msgid "Markdown support"
+#~ msgid "### Markdown support"
+#~ msgstr "标记语言（Markdown）支持"
+
+#, fuzzy, no-wrap
+#~| msgid ""
+#~| "Ordinary text\n"
+#~| " * One item, indentation level 1\n"
+#~| " * Another item at indentation level 1\n"
+#~| "   * An item at a second indentation level\n"
+#~| "   * A second item at the second indentation level\n"
+#~| " * A third item at the first indentation level\n"
+#~| "Ordinary text\n"
+#~ msgid ""
+#~ "```text\n"
+#~ "Ordinary text\n"
+#~ " * One item, indentation level 1\n"
+#~ " * Another item at indentation level 1\n"
+#~ "   * An item at a second indentation level\n"
+#~ "   * A second item at the second indentation level\n"
+#~ " * A third item at the first indentation level\n"
+#~ "Ordinary text\n"
+#~ "```\n"
+#~ msgstr ""
+#~ "普通文本\n"
+#~ " *一个条目，缩进级别为 1\n"
+#~ " *另一个条目，缩进级别为 1\n"
+#~ "   *一个条目，缩进级别为 2\n"
+#~ "   *另一个条目，缩进级别为 2\n"
+#~ "*第三个条目，缩进级别为 1\n"
+#~ "普通文本\n"
+
+#, fuzzy
+#~| msgid "_wxMaxima_ will recognize text starting with `>` chars as block quotes:\n"
+#~ msgid "_WxMaxima_ will recognize text starting with `>` chars as block quotes:"
+#~ msgstr "wxMaxima 也能将以 `>` 字符开头的文本识别为引用块：\n"
+
+#, fuzzy
+#~| msgid ""
+#~| "Ordinary text\n"
+#~| "> quote quote quote quote\n"
+#~| "> quote quote quote quote\n"
+#~| "> quote quote quote quote\n"
+#~| "Ordinary text\n"
+#~ msgid "```text Ordinary text > quote quote quote quote > quote quote quote quote > quote quote quote quote Ordinary text ```"
+#~ msgstr ""
+#~ "普通文本\n"
+#~ ">引用文字\n"
+#~ ">引用文字\n"
+#~ ">引用文字\n"
+#~ "普通文本\n"
+
+#, fuzzy
+#~| msgid "_wxMaxima_'s TeX and HTML output will also recognize `=>` and replace it by the corresponding Unicode sign:\n"
+#~ msgid "_WxMaxima_’s TeX and HTML output will also recognize `=>` and replace it by the corresponding Unicode sign:"
+#~ msgstr "wxMaxima 的 TeX 和 HTML 输出也能识别 `=>`，并将其替换为相应的 Unicode 符号：\n"
+
+#, fuzzy
+#~| msgid "cogito => sum.\n"
+#~ msgid "```text cogito => sum.  ```"
+#~ msgstr "cogito => sum.\n"
+
+#, fuzzy
+#~| msgid "Other symbols the HTML and TeX export will recognize are `<=` and `>=` for comparisons, a double-pointed double arrow (`<=>`), single- headed arrows (`<->`, `->` and `<-`) and `+/-` as the respective sign. For TeX output also `<<` and `>>` are recognized.\n"
+#~ msgid "Other symbols the HTML and TeX export will recognize are `<=` and `>=` for comparisons, a double-pointed double arrow (`<=>`), single-headed arrows (`<->`, `->` and `<-`) and `+/-` as the respective sign. For TeX output also `<<` and `>>` are recognized."
+#~ msgstr "导出 TeX 和 HTML 文件时将识别的其他符号还有不等号（`<=` 和 `>=`）、双线箭头（`<=>`）、单线箭头（`<->`、`->` 和 `<-`）以及 `+/-`。对于 TeX 输出，还可以识别 `<<` 和 `>>`。\n"
+
+#, fuzzy
+#~| msgid "Hotkeys"
+#~ msgid "### Hotkeys"
+#~ msgstr "快捷键"
+
+#, fuzzy
+#~| msgid "Raw TeX in the TeX export"
+#~ msgid "### Raw TeX in the TeX export"
+#~ msgstr "导出 TeX 时的原始 TeX 代码"
+
+#, fuzzy
+#~| msgid "File Formats"
+#~ msgid "## File Formats"
+#~ msgstr "文件格式"
+
+#, fuzzy
+#~| msgid ".mac"
+#~ msgid "### .mac"
+#~ msgstr ".mac"
+
+#, fuzzy
+#~| msgid ".wxm"
+#~ msgid "### .wxm"
+#~ msgstr ".wxm"
+
+#, fuzzy
+#~| msgid ".wxm files contain the worksheet except _Maxima_'s output. On Maxima versions >5.38 they can be read using _Maxima_'s `load()` function just as .mac files can be. With this plain-text format it sometimes is unavoidable that worksheets that use new features are not downwards-compatible with older versions of _wxMaxima_.\n"
+#~ msgid "`.wxm` files contain the worksheet except for _Maxima_’s output. On Maxima versions >5.38 they can be read using _Maxima_’s `load()` function just as .mac files. Well - mostly. Questions (like `asksign(x)`) are problematic, as the answer is written in the `.wxm` file (so that it can be suggested after loading), but that can Maxima not evaluate.  You can prevent Maxima from asking questions by using `assume()` to declare some properties, Maxima wants to know."
+#~ msgstr "`.wxm` 文件包含除 Maxima 输出之外的工作簿内容。在版本号大于 5.38 的 Maxima 上，可以像 `.mac` 文件一样，使用 Maxima 的 `load()` 函数来读取。如果采用这种文本格式，使用含新功能的工作簿时会不可避免地与旧版本的 wxMaxima 不兼容。\n"
+
+#, fuzzy
+#~| msgid "File Formats"
+#~ msgid "#### File format of wxm files"
+#~ msgstr "文件格式"
+
+#, fuzzy
+#~| msgid ".wxmx"
+#~ msgid "### .wxmx"
+#~ msgstr ".wxmx"
+
+#, fuzzy
+#~| msgid "File Formats"
+#~ msgid "#### File format of wxmx files"
+#~ msgstr "文件格式"
+
+#, fuzzy
+#~| msgid "Configuration options"
+#~ msgid "## Configuration options"
+#~ msgstr "设置选项"
+
+#, fuzzy
+#~| msgid "Default animation framerate"
+#~ msgid "### Default animation framerate"
+#~ msgstr "默认动图帧率"
+
+#, fuzzy
+#~| msgid "Default plot size for new _maxima_ sessions"
+#~ msgid "### Default plot size for new _maxima_ sessions"
+#~ msgstr "新 Maxima 会话的默认绘图尺寸"
+
+#, fuzzy, no-wrap
+#~| msgid ""
+#~| "wxdraw2d( \n"
+#~| "   explicit(\n"
+#~| "       x^2,\n"
+#~| "\t   x,-5,5\n"
+#~| "   )\n"
+#~| "), wxplot_size=[480,480]$\n"
+#~ msgid ""
+#~ "```maxima\n"
+#~ "wxdraw2d(\n"
+#~ "   explicit(\n"
+#~ "       x^2,\n"
+#~ "       x,-5,5\n"
+#~ "   )\n"
+#~ "), wxplot_size=[480,480]$\n"
+#~ "```\n"
+#~ msgstr ""
+#~ "wxdraw2d( \n"
+#~ "   explicit(\n"
+#~ "       x^2,\n"
+#~ "\t   x,-5,5\n"
+#~ "   )\n"
+#~ "), wxplot_size=[480,480]$\n"
+
+#, fuzzy
+#~| msgid "Match parenthesis in text controls"
+#~ msgid "### Match parenthesis in text controls"
+#~ msgstr "在文本中匹配括号"
+
+#, fuzzy
+#~| msgid "Don't save the worksheet automatically"
+#~ msgid "### Don’t save the worksheet automatically"
+#~ msgstr "不自动保存工作簿"
+
+#, fuzzy
+#~| msgid "Where is the configuration saved?"
+#~ msgid "### Where is the configuration saved?"
+#~ msgstr "设置信息保存的位置"
+
+#, fuzzy
+#~| msgid ""
+#~| "If you are using Unix/Linux, the configuration information will be saved in a file `.wxMaxima` in your home directory (if you are using wxWidgets < 3.1.1), or `.config/wxMaxima.conf` ((XDG-Standard) if wxWidgets >= 3.1.1 is used). You can retrieve the wxWidgets version from the command `wxbuild_info();` or by using the menu option Help->About. [wxWidgets](https://www.wxwidgets.org/) is the cross-platform GUI library, which is the base for _wxMaxima_ (therefore the `wx` in the name).\n"
+#~| "(Since the filename starts with a dot, `.wxMaxima` or `.config` will be hidden).\n"
+#~ msgid "If you are using Unix/Linux, the configuration information will be saved in a file `.wxMaxima` in your home directory (if you are using wxWidgets \\< 3.1.1), or `.config/wxMaxima.conf` ((XDG-Standard) if wxWidgets >= 3.1.1 is used). You can retrieve the wxWidgets version from the command `wxbuild_info();` or by using the menu option Help->About. [wxWidgets](https://www.wxwidgets.org/) is the cross-platform GUI library, which is the base for _wxMaxima_ (therefore the `wx` in the name).  (Since the filename starts with a dot, `.wxMaxima` or `.config` will be hidden)."
+#~ msgstr ""
+#~ "当使用 Unix/Linux 系统时，设置信息将保存在主目录中的 `.wxMaxima` 文件里（如果 wxWidgets 版本号小于 3.1.1）或 `.config/wxMaxima.conf` 文件里（如果 wxWidgets 的版本号大于等于 3.1.1（XDG标准））。用户可以通过命令 `wxbuild_info();` 或使用菜单选项 \"帮助->关于\"（Help->About）来检索 wxWidgets 版本号。[wxWidgets](https://www.wxwidgets.org/) 是跨平台的 GUI 库，也是 wxMaxima 的底层库（因此 wxMaxima 的名称中带“wx”）。\n"
+#~ "（由于文件名以点“.”开头，文件 `.wxMaxima` 或 `.config` 将被隐藏）。\n"
+
+#, fuzzy
+#~| msgid "Extensions to _Maxima_"
+#~ msgid "# Extensions to _Maxima_"
+#~ msgstr "对 Maxima 功能的扩充"
+
+#, fuzzy
+#~| msgid "Subscripted variables"
+#~ msgid "## Subscripted variables"
+#~ msgstr "为变量添加下标"
+
+#, fuzzy
+#~| msgid "User feedback in the status bar"
+#~ msgid "## User feedback in the status bar"
+#~ msgstr "在状态栏中提供反馈信息"
+
+#, fuzzy, no-wrap
+#~| msgid ""
+#~| "for i:1 thru 10 do (\n"
+#~| "    /* Tell the user how far we got */\n"
+#~| "    wxstatusbar(concat(\"Pass \",i)),\n"
+#~| "    /* (sleep n) is a Lisp function, which can be used */\n"
+#~| "    /* with the character \"?\" before. It delays the */\n"
+#~| "    /* program execution (here: for 3 seconds) */\n"
+#~| "    ?sleep(3)\n"
+#~| ")$\n"
+#~ msgid ""
+#~ "```maxima\n"
+#~ "for i:1 thru 10 do (\n"
+#~ "    /* Tell the user how far we got */\n"
+#~ "    wxstatusbar(concat(\"Pass \",i)),\n"
+#~ "    /* (sleep n) is a Lisp function, which can be used */\n"
+#~ "    /* with the character \"?\" before. It delays the */\n"
+#~ "    /* program execution (here: for 3 seconds) */\n"
+#~ "    ?sleep(3)\n"
+#~ ")$\n"
+#~ "```\n"
+#~ msgstr ""
+#~ "for i:1 thru 10 do (\n"
+#~ "    /* 告诉用户目前的运行位置 */\n"
+#~ "    wxstatusbar(concat(\"Pass \",i)),\n"
+#~ "    /* (sleep n) 是可接在字符\"?\"后使用的 Lisp 函数 */\n"
+#~ "    /* 它推迟了程序的运行，此处是 3 秒 */\n"
+#~ "    ?sleep(3)\n"
+#~ ")$\n"
+
+#, fuzzy
+#~| msgid "Plotting"
+#~ msgid "## Plotting"
+#~ msgstr "绘图"
+
+#, fuzzy
+#~| msgid "Embedding a plot into the work sheet"
+#~ msgid "### Embedding a plot into the worksheet"
+#~ msgstr "将绘制的图形嵌入工作簿"
+
+#, fuzzy
+#~| msgid "Making embedded plots bigger or smaller"
+#~ msgid "### Making embedded plots bigger or smaller"
+#~ msgstr "设置嵌入图形的大小"
+
+#, fuzzy, no-wrap
+#~| msgid ""
+#~| "wxplot_size:[1200,800]$\n"
+#~| "wxdraw2d(\n"
+#~| "    explicit(\n"
+#~| "        sin(x),\n"
+#~| "        x,1,10\n"
+#~| "    )\n"
+#~| ")$\n"
+#~ msgid ""
+#~ "```maxima\n"
+#~ "wxplot_size:[1200,800]$\n"
+#~ "wxdraw2d(\n"
+#~ "    explicit(\n"
+#~ "        sin(x),\n"
+#~ "        x,1,10\n"
+#~ "    )\n"
+#~ ")$\n"
+#~ "```\n"
+#~ msgstr ""
+#~ "wxplot_size:[1200,800]$\n"
+#~ "wxdraw2d(\n"
+#~ "    explicit(\n"
+#~ "        sin(x),\n"
+#~ "        x,1,10\n"
+#~ "    )\n"
+#~ ")$\n"
+
+#, fuzzy, no-wrap
+#~| msgid ""
+#~| "wxdraw2d(\n"
+#~| "    explicit(\n"
+#~| "        sin(x),\n"
+#~| "        x,1,10\n"
+#~| "    )\n"
+#~| "),wxplot_size=[1600,800]$\n"
+#~ msgid ""
+#~ "```maxima\n"
+#~ "wxdraw2d(\n"
+#~ "    explicit(\n"
+#~ "        sin(x),\n"
+#~ "        x,1,10\n"
+#~ "    )\n"
+#~ "),wxplot_size=[1600,800]$\n"
+#~ "```\n"
+#~ msgstr ""
+#~ "wxdraw2d(\n"
+#~ "    explicit(\n"
+#~ "        sin(x),\n"
+#~ "        x,1,10\n"
+#~ "    )\n"
+#~ "),wxplot_size=[1600,800]$\n"
+
+#, fuzzy
+#~| msgid "Better quality plots"
+#~ msgid "### Better quality plots"
+#~ msgstr "更好的绘图质量"
+
+#, fuzzy
+#~| msgid "Opening embedded plots in interactive _gnuplot_ windows"
+#~ msgid "### Opening embedded plots in interactive _Gnuplot_ windows"
+#~ msgstr "在交互式 gnuplot 窗口中打开嵌入的绘图"
+
+#, fuzzy
+#~| msgid "Opening gnuplot's command console in `plot` windows"
+#~ msgid "### Opening Gnuplot’s command console in `plot` windows"
+#~ msgstr "在绘图窗口中打开 gnuplot 控制台"
+
+#, fuzzy
+#~| msgid "Embedding animations into the spreadsheet"
+#~ msgid "### Embedding animations into the spreadsheet"
+#~ msgstr "在工作簿中嵌入动图"
+
+#, fuzzy, no-wrap
+#~| msgid ""
+#~| "with_slider_draw(\n"
+#~| "    f,[1,2,3,4,5,6,7,10],\n"
+#~| "    title=concat(\"f=\",f,\"Hz\"),\n"
+#~| "    explicit(\n"
+#~| "        sin(2*%pi*f*x),\n"
+#~| "        x,0,1\n"
+#~| "    ),grid=true\n"
+#~| ");\n"
+#~ msgid ""
+#~ "```maxima\n"
+#~ "with_slider_draw(\n"
+#~ "    f,[1,2,3,4,5,6,7,10],\n"
+#~ "    title=concat(\"f=\",f,\"Hz\"),\n"
+#~ "    explicit(\n"
+#~ "        sin(2*%pi*f*x),\n"
+#~ "        x,0,1\n"
+#~ "    ),grid=true\n"
+#~ ");\n"
+#~ "```\n"
+#~ msgstr ""
+#~ "with_slider_draw(\n"
+#~ "    f,[1,2,3,4,5,6,7,10],\n"
+#~ "    title=concat(\"f=\",f,\"Hz\"),\n"
+#~ "    explicit(\n"
+#~ "        sin(2*%pi*f*x),\n"
+#~ "        x,0,1\n"
+#~ "    ),grid=true\n"
+#~ ");\n"
+
+#, fuzzy, no-wrap
+#~| msgid ""
+#~| "wxanimate_autoplay:true;\n"
+#~| "wxanimate_framerate:20;\n"
+#~| "with_slider_draw3d(\n"
+#~| "    α,makelist(i,i,1,360,3),\n"
+#~| "    title=sconcat(\"α=\",α),\n"
+#~| "    surface_hide=true,\n"
+#~| "    contour=both,\n"
+#~| "    view=[60,α],\n"
+#~| "    explicit(\n"
+#~| "        sin(x)*sin(y),\n"
+#~| "        x,-π,π,\n"
+#~| "        y,-π,π\n"
+#~| "    )\n"
+#~| ")$\n"
+#~ msgid ""
+#~ "```maxima\n"
+#~ "wxanimate_autoplay:true;\n"
+#~ "wxanimate_framerate:20;\n"
+#~ "with_slider_draw3d(\n"
+#~ "    α,makelist(i,i,1,360,3),\n"
+#~ "    title=sconcat(\"α=\",α),\n"
+#~ "    surface_hide=true,\n"
+#~ "    contour=both,\n"
+#~ "    view=[60,α],\n"
+#~ "    explicit(\n"
+#~ "        sin(x)*sin(y),\n"
+#~ "        x,-π,π,\n"
+#~ "        y,-π,π\n"
+#~ "    )\n"
+#~ ")$\n"
+#~ "```\n"
+#~ msgstr ""
+#~ "wxanimate_autoplay:true;\n"
+#~ "wxanimate_framerate:20;\n"
+#~ "with_slider_draw3d(\n"
+#~ "    α,makelist(i,i,1,360,3),\n"
+#~ "    title=sconcat(\"α=\",α),\n"
+#~ "    surface_hide=true,\n"
+#~ "    contour=both,\n"
+#~ "    view=[60,α],\n"
+#~ "    explicit(\n"
+#~ "        sin(x)*sin(y),\n"
+#~ "        x,-π,π,\n"
+#~ "        y,-π,π\n"
+#~ "    )\n"
+#~ ")$\n"
+
+#, fuzzy, no-wrap
+#~| msgid ""
+#~| "wxanimate_autoplay:true;\n"
+#~| "wxanimate_framerate:20;\n"
+#~| "with_slider_draw3d(\n"
+#~| "    t,makelist(i,i,0,2*π,.05*π),\n"
+#~| "    title=sconcat(\"α=\",α),\n"
+#~| "    surface_hide=true,\n"
+#~| "    contour=both,\n"
+#~| "    view=[60,30+5*sin(t)],\n"
+#~| "    explicit(\n"
+#~| "        sin(x)*y^2,\n"
+#~| "        x,-2*π,2*π,\n"
+#~| "        y,-2*π,2*π\n"
+#~| "    )\n"
+#~| ")$\n"
+#~ msgid ""
+#~ "```maxima\n"
+#~ "wxanimate_autoplay:true;\n"
+#~ "wxanimate_framerate:20;\n"
+#~ "with_slider_draw3d(\n"
+#~ "    t,makelist(i,i,0,2*π,.05*π),\n"
+#~ "    title=sconcat(\"α=\",α),\n"
+#~ "    surface_hide=true,\n"
+#~ "    contour=both,\n"
+#~ "    view=[60,30+5*sin(t)],\n"
+#~ "    explicit(\n"
+#~ "        sin(x)*y^2,\n"
+#~ "        x,-2*π,2*π,\n"
+#~ "        y,-2*π,2*π\n"
+#~ "    )\n"
+#~ ")$\n"
+#~ "```\n"
+#~ msgstr ""
+#~ "wxanimate_autoplay:true;\n"
+#~ "wxanimate_framerate:20;\n"
+#~ "with_slider_draw3d(\n"
+#~ "    t,makelist(i,i,0,2*π,.05*π),\n"
+#~ "    title=sconcat(\"t=\",t),\n"
+#~ "    surface_hide=true,\n"
+#~ "    contour=both,\n"
+#~ "    view=[60,30+5*sin(t)],\n"
+#~ "    explicit(\n"
+#~ "        sin(x)*y^2,\n"
+#~ "        x,-2*π,2*π,\n"
+#~ "        y,-2*π,2*π\n"
+#~ "    )\n"
+#~ ")$\n"
+
+#, fuzzy, no-wrap
+#~| msgid ""
+#~| "wxanimate(a, 10,\n"
+#~| "    sin(a*x), [x,-5,5]), wxanimate_framerate=6$\n"
+#~ msgid ""
+#~ "```maxima\n"
+#~ "wxanimate(a, 10,\n"
+#~ "    sin(a*x), [x,-5,5]), wxanimate_framerate=6$\n"
+#~ "```\n"
+#~ msgstr ""
+#~ "wxanimate(a, 10, sin(a*x), [x,-5,5]),\n"
+#~ "     wxanimate_framerate=6$\n"
+
+#, fuzzy, no-wrap
+#~| msgid ""
+#~| "f:sin(a*x);\n"
+#~| "with_slider_draw(\n"
+#~| "    a,makelist(i/2,i,1,10),\n"
+#~| "    title=concat(\"a=\",float(a)),\n"
+#~| "    grid=true,\n"
+#~| "    explicit(f,x,0,10)\n"
+#~| ")$\n"
+#~ msgid ""
+#~ "```maxima\n"
+#~ "f:sin(a*x);\n"
+#~ "with_slider_draw(\n"
+#~ "    a,makelist(i/2,i,1,10),\n"
+#~ "    title=concat(\"a=\",float(a)),\n"
+#~ "    grid=true,\n"
+#~ "    explicit(f,x,0,10)\n"
+#~ ")$\n"
+#~ "```\n"
+#~ msgstr ""
+#~ "f:sin(a*x);\n"
+#~ "with_slider_draw(\n"
+#~ "    a,makelist(i/2,i,1,10),\n"
+#~ "    title=concat(\"a=\",float(a)),\n"
+#~ "    grid=true,\n"
+#~ "    explicit(f,x,0,10)\n"
+#~ ")$\n"
+
+#, fuzzy, no-wrap
+#~| msgid ""
+#~| "f:sin(a*x);\n"
+#~| "with_slider_draw(\n"
+#~| "    b,makelist(i/2,i,1,10),\n"
+#~| "    title=concat(\"a=\",float(b)),\n"
+#~| "    grid=true,\n"
+#~| "    explicit(\n"
+#~| "        subst(a=b,f),\n"
+#~| "        x,0,10\n"
+#~| "    )\n"
+#~| ")$\n"
+#~ msgid ""
+#~ "```maxima\n"
+#~ "f:sin(a*x);\n"
+#~ "with_slider_draw(\n"
+#~ "    b,makelist(i/2,i,1,10),\n"
+#~ "    title=concat(\"a=\",float(b)),\n"
+#~ "    grid=true,\n"
+#~ "    explicit(\n"
+#~ "        subst(a=b,f),\n"
+#~ "        x,0,10\n"
+#~ "    )\n"
+#~ ")$\n"
+#~ "```\n"
+#~ msgstr ""
+#~ "f:sin(a*x);\n"
+#~ "with_slider_draw(\n"
+#~ "    b,makelist(i/2,i,1,10),\n"
+#~ "    title=concat(\"a=\",float(b)),\n"
+#~ "    grid=true,\n"
+#~ "    explicit(\n"
+#~ "        subst(a=b,f),\n"
+#~ "        x,0,10\n"
+#~ "    )\n"
+#~ ")$\n"
+
+#, fuzzy
+#~| msgid "Opening multiple plots in contemporaneous windows"
+#~ msgid "### Opening multiple plots in contemporaneous windows"
+#~ msgstr "同时打开多个绘图窗口"
+
+#, fuzzy, no-wrap
+#~| msgid ""
+#~| "\twxdraw(\n"
+#~| "\t\tgr2d(\n"
+#~| "\t    \tkey=\"sin (x)\",grid=[2,2],\n"
+#~| "\t    \texplicit(sin(x),x,0,2*%pi)),\n"
+#~| "\t\tgr2d(\n"
+#~| "\t   \tkey=\"cos (x)\",grid=[2,2],\n"
+#~| "\t   \texplicit(cos(x),x,0,2*%pi))\n"
+#~| "\t );\n"
+#~ msgid ""
+#~ "```maxima\n"
+#~ "wxdraw(\n"
+#~ "  gr2d(\n"
+#~ "    key=\"sin (x)\",grid=[2,2],\n"
+#~ "    explicit(sin(x),x,0,2*%pi)),\n"
+#~ "  gr2d(\n"
+#~ "    key=\"cos (x)\",grid=[2,2],\n"
+#~ "    explicit(cos(x),x,0,2*%pi))\n"
+#~ ");\n"
+#~ "```\n"
+#~ msgstr ""
+#~ "\twxdraw(\n"
+#~ "\t\tgr2d(\n"
+#~ "\t    \tkey=\"sin (x)\",grid=[2,2],\n"
+#~ "\t    \texplicit(sin(x),x,0,2*%pi)),\n"
+#~ "\t\tgr2d(\n"
+#~ "\t   \tkey=\"cos (x)\",grid=[2,2],\n"
+#~ "\t   \texplicit(cos(x),x,0,2*%pi))\n"
+#~ "\t );\n"
+
+#, fuzzy
+#~| msgid "The \"Plot using draw\" side pane"
+#~ msgid "### The \"Plot using draw\" side pane"
+#~ msgstr "“用 draw 函数绘图”侧边栏"
+
+#, fuzzy
+#~| msgid "Expression"
+#~ msgid "#### Expression"
+#~ msgstr "表达式"
+
+#, fuzzy
+#~| msgid "Implicit plot"
+#~ msgid "#### Implicit plot"
+#~ msgstr "隐式图形"
+
+#, fuzzy
+#~| msgid "Parametric plot"
+#~ msgid "#### Parametric plot"
+#~ msgstr "参数式图形"
+
+#, fuzzy
+#~| msgid "Points"
+#~ msgid "#### Points"
+#~ msgstr "点"
+
+#, fuzzy
+#~| msgid "Diagram title"
+#~ msgid "#### Diagram title"
+#~ msgstr "图形标题"
+
+#, fuzzy
+#~| msgid "Axis"
+#~ msgid "#### Axis"
+#~ msgstr "坐标轴"
+
+#, fuzzy
+#~| msgid "Contour"
+#~ msgid "#### Contour"
+#~ msgstr "等高线"
+
+#, fuzzy
+#~| msgid "Plot name"
+#~ msgid "#### Plot name"
+#~ msgstr "图形名称"
+
+#, fuzzy
+#~| msgid "Line colour"
+#~ msgid "#### Line colour"
+#~ msgstr "线条颜色"
+
+#, fuzzy
+#~| msgid "Fill colour"
+#~ msgid "#### Fill colour"
+#~ msgstr "填充颜色"
+
+#, fuzzy
+#~| msgid "Grid"
+#~ msgid "#### Grid"
+#~ msgstr "网格"
+
+#, fuzzy
+#~| msgid "Accuracy"
+#~ msgid "#### Accuracy"
+#~ msgstr "精度"
+
+#, fuzzy, no-wrap
+#~| msgid ""
+#~| "wxdraw2d(\n"
+#~| "    file_name=\"test\",\n"
+#~| "    explicit(sin(x),x,1,10)\n"
+#~| ");\n"
+#~ msgid ""
+#~ "~~~maxima\n"
+#~ "wxdraw2d(\n"
+#~ "     font=\"Helvetica\",\n"
+#~ "     font_size=30,\n"
+#~ "     explicit(sin(x),x,1,10));\n"
+#~ "~~~\n"
+#~ msgstr ""
+#~ "wxdraw2d(\n"
+#~ "    file_name=\"test\",\n"
+#~ "    explicit(sin(x),x,1,10)\n"
+#~ ");\n"
+
+#, fuzzy
+#~| msgid "Embedding graphics"
+#~ msgid "## Embedding graphics"
+#~ msgstr "嵌入图片"
+
+#, fuzzy
+#~| msgid "show_image(\"man.png\");\n"
+#~ msgid "```maxima show_image(\"man.png\"); ```"
+#~ msgstr "show_image(\"man.png\");\n"
+
+#, fuzzy
+#~| msgid "Startup files"
+#~ msgid "## Startup files"
+#~ msgstr "启动时读取的文件"
+
+#, fuzzy
+#~| msgid "Special variables wx..."
+#~ msgid "## Special variables wx..."
+#~ msgstr "以 wx 开头的特殊变量"
+
+#, fuzzy
+#~| msgid "Pretty-printing 2D output"
+#~ msgid "## Pretty-printing 2D output"
+#~ msgstr "输出美观的二维公式"
+
+#, fuzzy, no-wrap
+#~| msgid ""
+#~| "table_form(\n"
+#~| "    [\n"
+#~| "        [1,2],\n"
+#~| "        [3,4]\n"
+#~| "    ]\n"
+#~| ")$\n"
+#~ msgid ""
+#~ "```maxima\n"
+#~ "table_form(\n"
+#~ "    [\n"
+#~ "        [1,2],\n"
+#~ "        [3,4]\n"
+#~ "    ]\n"
+#~ ")$\n"
+#~ "```\n"
+#~ msgstr ""
+#~ "table_form(\n"
+#~ "    [\n"
+#~ "        [1,2],\n"
+#~ "        [3,4]\n"
+#~ "    ]\n"
+#~ ")$\n"
+
+#, fuzzy
+#~| msgid "Bug reporting"
+#~ msgid "## Bug reporting"
+#~ msgstr "错误（bug）报告"
+
+#, fuzzy
+#~| msgid "Marking output being drawn in red"
+#~ msgid "## Marking output being drawn in red"
+#~ msgstr "让输出显示为红色"
+
+#, fuzzy
+#~| msgid "Troubleshooting"
+#~ msgid "# Troubleshooting"
+#~ msgstr "疑难解答"
+
+#, fuzzy
+#~| msgid "Cannot connect to _Maxima_"
+#~ msgid "## Cannot connect to _Maxima_"
+#~ msgstr "无法连接到 Maxima"
+
+#, fuzzy
+#~| msgid "How to save data from a broken .wxmx file"
+#~ msgid "## How to save data from a broken .wxmx file"
+#~ msgstr "从损坏的 .wxmx 文件中取回信息的方法"
+
+#, fuzzy
+#~| msgid "And even if there isn’t such a file: The `.wxmx` file is a container format and the XML portion is stored uncompressed. It it is possible to rename the `.wxmx` file to a `.txt` file and to use a text editor to recover the XML portion of the file's contents (it starts with `<?xml version=\"1.0\" encoding=\"UTF-8\"?>` and ends with `</wxMaximaDocument>`. Before and after that text you will see some unreadable binary contents in the text editor).\n"
+#~ msgid "And even if there isn’t such a file: The `.wxmx` file is a container format and the XML portion is stored uncompressed. It it is possible to rename the `.wxmx` file to a `.txt` file and to use a text editor to recover the XML portion of the file’s contents (it starts with `<?xml version=\"1.0\" encoding=\"UTF-8\"?>` and ends with `</wxMaximaDocument>`. Before and after that text you will see some unreadable binary contents in the text editor)."
+#~ msgstr "即使没有 `.wxmx~` 文件，`.wxmx` 文件中 XML 部分是未压缩的，可以将该文件重命名为 `.txt` 文件，并使用文本编辑器恢复文件中的 XML 部分（以 `<?xml version=\"1.0\" encoding=\"UTF-8\"?>` 开头，并以 `</wxMaximaDocument>` 结尾（在 XML 部分的前后，可在文本编辑器中看到一些不可读的二进制内容）。\n"
+
+#, fuzzy
+#~| msgid "I want some debug info to be displayed on the screen before my command has finished"
+#~ msgid "## I want some debug info to be displayed on the screen before my command has finished"
+#~ msgstr "在命令完成前显示一些调试信息"
+
+#, fuzzy, no-wrap
+#~| msgid ""
+#~| "for i:1 thru 10 do (\n"
+#~| "   disp(i),\n"
+#~| "   /* (sleep n) is a Lisp function, which can be used */\n"
+#~| "   /* with the character \"?\" before. It delays the */\n"
+#~| "   /* program execution (here: for 3 seconds) */\n"
+#~| "   ?sleep(3)\n"
+#~| ")$\n"
+#~ msgid ""
+#~ "```maxima\n"
+#~ "for i:1 thru 10 do (\n"
+#~ "   disp(i),\n"
+#~ "   /* (sleep n) is a Lisp function, which can be used */\n"
+#~ "   /* with the character \"?\" before. It delays the */\n"
+#~ "   /* program execution (here: for 3 seconds) */\n"
+#~ "   ?sleep(3)\n"
+#~ ")$\n"
+#~ "```\n"
+#~ msgstr ""
+#~ "for i:1 thru 10 do (\n"
+#~ "   disp(i),\n"
+#~ "   /* (sleep n) 是可接在字符\"?\"后使用的 Lisp 函数 */\n"
+#~ "   /* 它推迟了程序的运行，此处是 3 秒 */\n"
+#~ "   ?sleep(3)\n"
+#~ ")$\n"
+
+#, fuzzy
+#~| msgid "Plotting only shows a closed empty envelope with an error message"
+#~ msgid "## Plotting only shows a closed empty envelope with an error message"
+#~ msgstr "绘图结果是空的绘图框和错误信息"
+
+#, fuzzy
+#~| msgid "Plotting an animation results in “error: undefined variable”"
+#~ msgid "## Plotting an animation results in “error: undefined variable”"
+#~ msgstr "绘制动图时得到“error: undefined variable（错误：未定义的变量）”"
+
+#, fuzzy
+#~| msgid "I lost a cell contents and undo doesn’t remember"
+#~ msgid "## I lost cell content and undo doesn’t remember"
+#~ msgstr "删除了一个单元格，而撤销操作不起作用"
+
+#, fuzzy
+#~| msgid "_wxMaxima_ starts up with the message “Maxima process terminated.”"
+#~ msgid "## _WxMaxima_ starts up with the message “Maxima process terminated.”"
+#~ msgstr "wxMaxima 启动时显示信息“Maxima process terminated（Maxima 进程已终止）。”"
+
+#, fuzzy
+#~| msgid "Maxima is forever calculating and not responding to input"
+#~ msgid "## Maxima is forever calculating and not responding to input"
+#~ msgstr "Maxima 永远在计算中而不响应输入"
+
+#, fuzzy
+#~| msgid "My SBCL-based _Maxima_ runs out of memory"
+#~ msgid "## My SBCL-based _Maxima_ runs out of memory"
+#~ msgstr "基于 SBCL 的 Maxima 耗尽内存"
+
+#, fuzzy
+#~| msgid "Input sometimes is sluggish/ignoring keys on Ubuntu"
+#~ msgid "## Input sometimes is sluggish/ignoring keys on Ubuntu"
+#~ msgstr "在 Ubuntu 系统上，有时输入无响应或响应迟缓"
+
+#, fuzzy
+#~| msgid "_wxMaxima_ halts when _Maxima_ processes Greek characters or Umlauts"
+#~ msgid "## _WxMaxima_ halts when _Maxima_ processes Greek characters or Umlauts"
+#~ msgstr "wxMaxima 在处理希腊字符或元音变音符时停止"
+
+#, fuzzy
+#~| msgid "(setf sb-impl::*default-external-format* :utf-8)\n"
+#~ msgid "```commonlisp (setf sb-impl::*default-external-format* :utf-8)  ```"
+#~ msgstr "(setf sb-impl::*default-external-format* :utf-8)\n"
+
+#, fuzzy
+#~| msgid "    :lisp (sb-impl::userinit-pathname)\n"
+#~ msgid "```maxima :lisp (sb-impl::userinit-pathname)  ```"
+#~ msgstr "    :lisp (sb-impl::userinit-pathname)\n"
+
+#, fuzzy
+#~| msgid "Can I make _wxMaxima_ output both image files and embedded plots at once?"
+#~ msgid "## Can I make _wxMaxima_ output both image files and embedded plots at once?"
+#~ msgstr "是否可以同时输出和嵌入绘图文件？"
+
+#, fuzzy, no-wrap
+#~| msgid ""
+#~| "wxdraw2d(\n"
+#~| "    file_name=\"test\",\n"
+#~| "    explicit(sin(x),x,1,10)\n"
+#~| ");\n"
+#~ msgid ""
+#~ "```maxima\n"
+#~ "wxdraw2d(\n"
+#~ "    file_name=\"test\",  /* extension .png automatically added */\n"
+#~ "    explicit(sin(x),x,1,10)\n"
+#~ ");\n"
+#~ "```\n"
+#~ msgstr ""
+#~ "wxdraw2d(\n"
+#~ "    file_name=\"test\",\n"
+#~ "    explicit(sin(x),x,1,10)\n"
+#~ ");\n"
+
+#, fuzzy, no-wrap
+#~| msgid ""
+#~| "load(\"draw\");\n"
+#~| "pngdraw(name,[contents]):=\n"
+#~| "(\n"
+#~| "    draw(\n"
+#~| "        append(\n"
+#~| "            [\n"
+#~| "                terminal=pngcairo,\n"
+#~| "                dimensions=wxplot_size,\n"
+#~| "                file_name=name\n"
+#~| "            ],\n"
+#~| "            contents\n"
+#~| "        )\n"
+#~| "    ),\n"
+#~| "    show_image(printf(false,\"~a.png\",name))\n"
+#~| ");\n"
+#~| "pngdraw2d(name,[contents]):=\n"
+#~| "    pngdraw(name,gr2d(contents));\n"
+#~| "\n"
+#~| "pngdraw2d(\"Test\",\n"
+#~| "        explicit(sin(x),x,1,10)\n"
+#~| ");\n"
+#~ msgid ""
+#~ "```maxima\n"
+#~ "load(\"draw\");\n"
+#~ "pngdraw(name,[contents]):=\n"
+#~ "(\n"
+#~ "    draw(\n"
+#~ "        append(\n"
+#~ "            [\n"
+#~ "                terminal=pngcairo,\n"
+#~ "                dimensions=wxplot_size,\n"
+#~ "                file_name=name\n"
+#~ "            ],\n"
+#~ "            contents\n"
+#~ "        )\n"
+#~ "    ),\n"
+#~ "    show_image(printf(false,\"~a.png\",name))\n"
+#~ ");\n"
+#~ "pngdraw2d(name,[contents]):=\n"
+#~ "    pngdraw(name,gr2d(contents));\n"
+#~ msgstr ""
+#~ "load(\"draw\");\n"
+#~ "pngdraw(name,[contents]):=\n"
+#~ "(\n"
+#~ "    draw(\n"
+#~ "        append(\n"
+#~ "            [\n"
+#~ "                terminal=pngcairo,\n"
+#~ "                dimensions=wxplot_size,\n"
+#~ "                file_name=name\n"
+#~ "            ],\n"
+#~ "            contents\n"
+#~ "        )\n"
+#~ "    ),\n"
+#~ "    show_image(printf(false,\"~a.png\",name))\n"
+#~ ");\n"
+#~ "pngdraw2d(name,[contents]):=\n"
+#~ "    pngdraw(name,gr2d(contents));\n"
+#~ "\n"
+#~ "pngdraw2d(\"Test\",\n"
+#~ "        explicit(sin(x),x,1,10)\n"
+#~ ");\n"
+
+#, fuzzy, no-wrap
+#~| msgid ""
+#~| "wxdraw2d(\n"
+#~| "    file_name=\"test\",\n"
+#~| "    explicit(sin(x),x,1,10)\n"
+#~| ");\n"
+#~ msgid ""
+#~ "pngdraw2d(\"Test\",\n"
+#~ "        explicit(sin(x),x,1,10)\n"
+#~ ");\n"
+#~ "```\n"
+#~ msgstr ""
+#~ "wxdraw2d(\n"
+#~ "    file_name=\"test\",\n"
+#~ "    explicit(sin(x),x,1,10)\n"
+#~ ");\n"
+
+#, fuzzy
+#~| msgid "Can I set the aspect ratio of a plot?"
+#~ msgid "## Can I set the aspect ratio of an embedded plot?"
+#~ msgstr "是否可以指定绘制图形的相对比例？"
+
+#, fuzzy, no-wrap
+#~| msgid ""
+#~| "wxdraw2d(\n"
+#~| "    proportional_axis=xy,\n"
+#~| "    explicit(sin(x),x,1,10)\n"
+#~| "),wxplot_size=[1000,1000];\n"
+#~ msgid ""
+#~ "```maxima\n"
+#~ "wxdraw2d(\n"
+#~ "    explicit(sin(x),x,1,10)\n"
+#~ "),wxplot_size=[1000,1000];\n"
+#~ "```\n"
+#~ msgstr ""
+#~ "wxdraw2d(\n"
+#~ "    proportional_axis=xy,\n"
+#~ "    explicit(sin(x),x,1,10)\n"
+#~ "),wxplot_size=[1000,1000];\n"
+
+#, fuzzy
+#~| msgid "Is there a way to make more text fit on a LaTeX page?"
+#~ msgid "## Is there a way to make more text fit on a LaTeX page?"
+#~ msgstr "有没有办法在 LaTeX 页面中显示更多的文字？"
+
+#, fuzzy
+#~| msgid "There is: Just add the following lines to the LaTeX preamble (for example by using the respective field in the config dialogue (\"Export\"->\"Additional lines for the TeX preamble\"):\n"
+#~ msgid "You can add the following line to the LaTeX preamble (for example by using the respective field in the config dialogue (\"Export\"->\"Additional lines for the TeX preamble\"), to set borders of 1cm):"
+#~ msgstr "有，只需将以下文字添加到 LaTeX 文件的导言区，例如通过修改设置对话框中的相应字段（导出->在 TeX 导言区中添加额外的内容（Export->Additional lines for the TeX preamble））：\n"
+
+#, fuzzy
+#~| msgid "\\usepackage[left=1cm,right=1cm,top=1cm,bottom=1cm]{geometry}\n"
+#~ msgid "```latex \\usepackage[left=1cm,right=1cm,top=1cm,bottom=1cm]{geometry} ```"
+#~ msgstr "\\usepackage[left=1cm,right=1cm,top=1cm,bottom=1cm]{geometry}\n"
+
+#, fuzzy
+#~| msgid "Is there a dark mode?"
+#~ msgid "## Is there a dark mode?"
+#~ msgstr "是否有深色模式？"
+
+#, fuzzy
+#~| msgid "_wxMaxima_ sometimes hangs for a several seconds once in the first minute"
+#~ msgid "## _WxMaxima_ sometimes hangs for several seconds once in the first minute"
+#~ msgstr "wxMaxima 有时在启动后的一段时间内无响应"
+
+#, fuzzy
+#~| msgid "_wxMaxima_ delegates some big tasks like parsing _Maxima_'s >1000-page-manual to background tasks, which normally goes totally unnoticed. In the moment the result of such a task is needed, though, it is possible that _wxMaxima_ needs to wait a couple of seconds before it can continue its work.\n"
+#~ msgid "_WxMaxima_ delegates some big tasks like parsing _Maxima_’s >1000-page-manual to background tasks, which normally goes totally unnoticed. At the moment the result of such a task is needed, though, it is possible that _wxMaxima_ needs to wait a couple of seconds before it can continue its work."
+#~ msgstr "wxMaxima 将一些大型任务（如解析 Maxima 的超过 1000 页的手册）委托给后台任务，而这些任务通常不会被执行。然而，当需要执行这样一个任务时，可能需要等待几秒钟才能继续工作。\n"
+
+#, fuzzy
+#~| msgid "Command-line arguments"
+#~ msgid "# Command-line arguments"
+#~ msgstr "命令行参数"
 
 #~ msgid "Debug messages"
 #~ msgstr "调试信息"
@@ -11790,30 +16943,6 @@ msgstr ""
 #~ "\n"
 #~ "请检查网络是否已连接并再次尝试。"
 
-#, fuzzy
-#~ msgid ""
-#~ "\n"
-#~ "Not connected to Maxima."
-#~ msgstr "没有连接至 Maxima"
-
-#, fuzzy
-#~ msgid "Build from Git version: %s\n"
-#~ msgstr "Maxima 版本：%s"
-
-#, fuzzy
-#~ msgid "Maxima version: "
-#~ msgstr ""
-#~ "\n"
-#~ "Maxima 版本："
-
-#, fuzzy
-#~ msgid "Maxima was compiled using: "
-#~ msgstr "Maxima 使用 %s 编译"
-
-#, fuzzy
-#~ msgid "wxMaxima is a cross-platform graphical user interface for the computer algebra system Maxima based on wxWidgets.\n"
-#~ msgstr "wxMaxima 是计算机代数系统 Maxima 的图形用户界面，基于 wxWidgets。"
-
 #~ msgid ""
 #~ "\n"
 #~ "\n"
@@ -11851,131 +16980,14 @@ msgstr ""
 #~ "\n"
 #~ "未连接。"
 
-#~ msgid "      -X \"--control-stack-size <int>\""
-#~ msgstr "      -X \"--control-stack-size <int>\""
-
-#~ msgid "      -X \"--dynamic-space-size <int>\""
-#~ msgstr "      -X \"--dynamic-space-size <int>\""
-
-#~ msgid "      -X '--control-stack-size <int>'"
-#~ msgstr "      -X '--control-stack-size <int>'"
-
-#~ msgid "      -X '--dynamic-space-size <int>'"
-#~ msgstr "      -X '--dynamic-space-size <int>'"
-
-#~ msgid "      -l <name>"
-#~ msgstr "      -l <name>"
-
 #~ msgid "      -u <number>"
 #~ msgstr "      -u <number>"
-
-#~ msgid "\"Copy LaTeX\" adds equation markers"
-#~ msgstr "\"复制为 LaTeX\" 添加公式环境标志"
-
-#~ msgid "\"Numpad Enter\" always evaluates cells"
-#~ msgstr "按下回车键时，对单元格求值"
-
-#~ msgid "\"implies\" symbol"
-#~ msgstr "可推出"
-
-#~ msgid "(Not a valid variable name)"
-#~ msgstr "（非可用变量名）"
-
-#~ msgid "(Use default language)"
-#~ msgstr "（使用默认语言）"
-
-#~ msgid "1/2"
-#~ msgstr "1/2"
-
-#, fuzzy, no-wrap
-#~ msgid "2D"
-#~ msgstr ""
-#~ "#-#-#-#-#  zh_CN.po (wxMaxima HEAD)  #-#-#-#-#\n"
-#~ "二维绘图\n"
-#~ "#-#-#-#-#  zh_CN.po (wxMaxima-manual)  #-#-#-#-#\n"
-#~ "二维图形"
-
-#, fuzzy, no-wrap
-#~ msgid "3D"
-#~ msgstr ""
-#~ "#-#-#-#-#  zh_CN.po (wxMaxima HEAD)  #-#-#-#-#\n"
-#~ "三维绘图\n"
-#~ "#-#-#-#-#  zh_CN.po (wxMaxima-manual)  #-#-#-#-#\n"
-#~ "三维图形"
-
-#~ msgid "A 'horizontal cursor' was introduced in wxMaxima 0.8.0. It looks like a horizontal line between cells. It indicates where a new cell will appear if you type or paste text or execute a menu command."
-#~ msgstr "wxMaxima 0.8.0 引入了“水平光标”，其外观是单元格之间的水平线。在键入、粘贴文本或执行菜单命令时，水平光标用于指示新单元格出现的位置。"
-
-#, fuzzy
-#~ msgid "A new document format has been introduced in wxMaxima 0.8.2 that saves not only your input and text commentaries, but also the outputs of your calculations. When saving your document, select 'Whole document (*.wxmx)' format."
-#~ msgstr "wxMaxima 0.8.2 引入了一种新的文档格式，这种格式的文档不仅可以保存用户输入的命令和注释文本，还可以保存计算结果。在保存文档时，选择“整个文档（*.wxmx）”即可使用该格式。"
-
-#~ msgid "A plot to be embedded into the work sheet by preceding its name with a \"wx\". \"draw\" can be replaced by \"wxdraw\", plot by \"wxplot\" etc."
-#~ msgstr "通过在 Maxima 绘图命令的名称前面加上“wx”，例如将“draw”替换为“wxdraw”，“plot”替换为“wxplot”等，可以将生成的图片嵌入当前工作簿。"
-
-#~ msgid "A scale factor for the printout. Helpful for printing big equations on small pdf pages."
-#~ msgstr "打印输出的比例因子。有助于在小的 pdf 页面上打印大的公式。"
-
-#~ msgid "A symbol from the configuration dialogue"
-#~ msgstr "来自设置对话框中的符号"
-
-#~ msgid "Abort evaluation on error"
-#~ msgstr "发生错误时中止计算"
-
-#~ msgid "Accuracy"
-#~ msgstr "精度"
-
-#~ msgid "Add all"
-#~ msgstr "添加所有"
-
-#~ msgid "Add more symbols"
-#~ msgstr "添加更多符号"
-
-#~ msgid "Add the .wxmx file to the HTML export"
-#~ msgstr "为导出的 HTML 文件添加 .wxmx 文件"
-
-#~ msgid "Add to symbols Sidebar"
-#~ msgstr "添加至符号侧边栏"
-
-#~ msgid "Added much text (%li chars) to the XML inspector."
-#~ msgstr "向 XML 检查器添加了大量文本（%li 个字符）。"
-
-#~ msgid "Additional clipboard formats to put on the clipboard on ordinary copy"
-#~ msgstr "在复制到剪贴板时，附加剪贴板格式"
-
-#~ msgid "Additional commands to be added to the preamble of LaTeX output for pdftex."
-#~ msgstr "输出 LaTeX 文件时，添加额外的命令到导言区。"
-
-#~ msgid "Additional lines for the TeX preamble:"
-#~ msgstr "LaTeX 导言区的附加内容："
-
-#~ msgid "Additional parameters for Maxima (e.g. -l clisp)."
-#~ msgstr "Maxima 的附加参数（例如： -l clisp）。"
 
 #~ msgid "Additional parameters for maxima"
 #~ msgstr "Maxima 的附加参数"
 
-#~ msgid "Additional symbols for the \"symbols\" sidebar:"
-#~ msgstr "为符号侧边栏添加额外的符号："
-
-#~ msgid "All variable names"
-#~ msgstr "所有变量名"
-
 #~ msgid "Allows to specify which not-builtin unicode symbols should be displayed in the symbols sidebar along with the built-in symbols."
 #~ msgstr "指定未内置的 Unicode 符号，以便将其与内置符号一起显示在符号侧边栏。"
-
-#~ msgid "All|*"
-#~ msgstr "所有类型|*"
-
-#~ msgid "Ask to save untitled documents"
-#~ msgstr "询问是否保存未命名文档"
-
-#~ msgid "Auto-indent new lines"
-#~ msgstr "自动缩进新行"
-
-#, fuzzy
-#~ msgid "Auto-insert closing parenthesis"
-#~ msgstr "未配对的括号"
 
 #~ msgid "Autocompletion: Scanning %s for loadable demo files."
 #~ msgstr "自动补全：在 %s 中扫描可载入的示例（demo）文件。"
@@ -11986,305 +16998,14 @@ msgstr ""
 #~ msgid "Autocompletion: Scanning %s recursively for loadable lisp files."
 #~ msgstr "自动补全：在 %s 中递归地扫描可载入的 Lisp 文件。"
 
-#~ msgid "Autodetect"
-#~ msgstr "自动检测"
-
-#~ msgid "Automatic"
-#~ msgstr "自动"
-
-#~ msgid "Automatic labels (%i1, %o1,...)"
-#~ msgstr "自动设置标签（%i1, %o1, ...）"
-
-#~ msgid "Autowrap long lines:"
-#~ msgstr "对较长的行自动换行："
-
-#~ msgid "Axis"
-#~ msgstr "坐标轴"
-
-#~ msgid "Barsplot..."
-#~ msgstr "直方图..."
-
 #~ msgid "Bat files (*.bat)|*.bat|All|*"
 #~ msgstr "批处理文件 (*.bat)|*.bat|所有类型|*"
 
 #~ msgid "Bat files (*.bat)|*.bat|Exe files (*.exe)||All|*"
 #~ msgstr "批处理文件 (*.bat)|*.bat|程序文件 (*.exe)|*.exe|所有类型|*"
 
-#~ msgid "Besides the global undo functionality that is active when the cursor is between cells, wxMaxima has a per-cell undo function that is active if the cursor is inside a cell. Pressing Ctrl+Z inside a cell can therefore been used for a fine-pitch undo that doesn't affect latter changes made in other cells."
-#~ msgstr "当光标处于在单元格之间（即显示为水平光标）时，wxMaxima 将激活全局撤销功能。当光标处于在单元格内部（即显示为竖直光标）时，wxMaxima 将激活单元格撤消功能。因此，可以定位到单元格内，按 Ctrl+Z 键撤销该单元格内部的改动，而不会影响之前在其他单元格中所做的更改。"
-
-#~ msgid "Beta"
-#~ msgstr "Beta"
-
-#~ msgid "Bitmap"
-#~ msgstr "位图"
-
-#~ msgid "Bitmap scale for export:"
-#~ msgstr "导出位图的比例："
-
-#~ msgid "Bitmaps"
-#~ msgstr "位图"
-
-#~ msgid "Bold"
-#~ msgstr "黑体"
-
-#~ msgid "Boxplot..."
-#~ msgstr "箱线图..."
-
-#~ msgid "By default, Shift-Enter is used to evaluate commands, while Enter is used for multiline input. This behaviour can be changed in 'Edit->Configure' dialog by checking 'Enter evaluates cells'. This switches the roles of these two key commands."
-#~ msgstr "在默认情况下，使用 Shift+Enter 键执行命令，而使用 Enter 键输入多行命令。可以在“编辑->设置”对话框中更改此行为。选中“按下 Enter 键执行命令”，将切换这两种键位的功能。"
-
-#~ msgid "Canonical (tr)"
-#~ msgstr "标准形式（三角）"
-
-#~ msgid "Catalan"
-#~ msgstr "加泰罗尼亚语"
-
-#~ msgid "Change names of greek letters to greek letters"
-#~ msgstr "修改希腊字母的名称为希腊字母"
-
-#~ msgid "Change the text \"alpha\" and \"beta\" to the corresponding greek letter?"
-#~ msgstr "修改文本“alpha”和“beta”为相应的希腊字母？"
-
-#, fuzzy
-#~ msgid "ChangeLog"
-#~ msgstr "修改变量"
-
-#~ msgid "Chi"
-#~ msgstr "Chi"
-
-#~ msgid "Chinese (Simplified)"
-#~ msgstr "简体中文"
-
-#~ msgid "Chinese (traditional)"
-#~ msgstr "繁体中文"
-
-#~ msgid "Choose font"
-#~ msgstr "选择字体"
-
-#~ msgid "Choose the %s Font"
-#~ msgstr "选择 %s 字体"
-
-#~ msgid "Clear the selection"
-#~ msgstr "删除所选单元格"
-
-#~ msgid "Clipboard format parameters"
-#~ msgstr "剪贴板格式参数"
-
-#~ msgid "Commands that are executed at every start of maxima."
-#~ msgstr "每次启动 Maxima 时执行的命令。"
-
-#~ msgid "Config file (*.ini)|*.ini"
-#~ msgstr "设置文件 (*.ini)|*.ini"
-
-#~ msgid "Config item \"%s\" was of an unknown type"
-#~ msgstr "设置项“%s”为未知类型"
-
-#~ msgid "Configuration warning"
-#~ msgstr "设置警告"
-
-#~ msgid "Contents"
-#~ msgstr "内容"
-
-#~ msgid "Contour"
-#~ msgstr "等高线"
-
-#~ msgid "Contour lines for 3d plots"
-#~ msgstr "三维图形的等高线"
-
-#, fuzzy
-#~ msgid "Convert to Heading 5"
-#~ msgstr "显示五级标题"
-
-#, fuzzy
-#~ msgid "Convert to Heading 6"
-#~ msgstr "显示六级标题"
-
-#, fuzzy
-#~ msgid "Convert to Section"
-#~ msgstr "转换为直角坐标形式(&R)"
-
-#, fuzzy
-#~ msgid "Convert to Sub-Subsection"
-#~ msgstr "插入小小节单元格"
-
-#, fuzzy
-#~ msgid "Convert to Subsection"
-#~ msgstr "转换为直角坐标形式(&R)"
-
-#, fuzzy
-#~ msgid "Convert to Title"
-#~ msgstr "将一行转换为列表"
-
-#~ msgid "Copying config bool \"%s\""
-#~ msgstr "正在复制设置布尔变量“%s”"
-
-#~ msgid "Copying config float \"%s\""
-#~ msgstr "正在复制设置浮点数变量“%s”"
-
-#~ msgid "Copying config int \"%s\""
-#~ msgstr "正在复制设置整数变量“%s”"
-
-#~ msgid "Copying config string \"%s\""
-#~ msgstr "正在复制设置字符串变量“%s”"
-
-#~ msgid "Create scalable plots."
-#~ msgstr "创建可缩放图形"
-
-#~ msgid "Czech"
-#~ msgstr "捷克语"
-
-#~ msgid "Danish"
-#~ msgstr "丹麦语"
-
-#~ msgid "Default animation framerate:"
-#~ msgstr "默认动画帧率："
-
-#~ msgid "Default plot size for new maxima sessions:"
-#~ msgstr "新 Maxima 会话的默认绘图大小"
-
-#~ msgid "Default port for communication with wxMaxima:"
-#~ msgstr "与 wxMaxima 通信的默认端口："
-
-#~ msgid "Define the default speed (in frames per second) animations are played back with."
-#~ msgstr "定义动图回放的默认速度（帧率）。"
-
-#~ msgid "Delta"
-#~ msgstr "Delta"
-
-#~ msgid "Deviation..."
-#~ msgstr "偏差..."
-
-#~ msgid "Diagram title"
-#~ msgstr "图表标题"
-
 #~ msgid "Did you know?"
 #~ msgstr "你知道吗？"
-
-#~ msgid "Diff..."
-#~ msgstr "求导..."
-
-#~ msgid "Display"
-#~ msgstr "显示"
-
-#, fuzzy
-#~ msgid "Display all digits"
-#~ msgstr "显示算法"
-
-#, fuzzy
-#~ msgid "Display of long numbers"
-#~ msgstr "显示三维图形"
-
-#~ msgid "Documentclass for TeX export:"
-#~ msgstr "导出 Tex 时所用的文档类型（documentclass）："
-
-#~ msgid "Documentclass options:"
-#~ msgstr "文档类型（documentclass）选项："
-
-#~ msgid "Down"
-#~ msgstr "下"
-
-#~ msgid "Drag-and-drop unicode symbols here"
-#~ msgstr "拖动 unicode 符号到此处"
-
-#~ msgid "End of proof"
-#~ msgstr "证毕"
-
-#~ msgid "English"
-#~ msgstr "英语"
-
-#~ msgid "Enhanced meta file (emf)"
-#~ msgstr "增强图元文件（emf）"
-
-#~ msgid "Enter Matrix..."
-#~ msgstr "输入矩阵..."
-
-#~ msgid "Enter adds newlines, Ctrl+Enter evaluates cells"
-#~ msgstr "按下 Enter 键新增一行，按下 Ctrl+Enter 键对单元格求值"
-
-#~ msgid "Enter evaluates cells, Ctrl+Enter adds newlines"
-#~ msgstr "按下 Enter 键对单元格求值，按下 Ctrl+Enter 键新增一行"
-
-#~ msgid "Enter the path to the Maxima executable."
-#~ msgstr "输入 Maxima 程序（可执行文件）的路径。"
-
-#~ msgid "Environment variables for maxima"
-#~ msgstr "Maxima 的环境变量（附加参数）"
-
-#~ msgid "Epsilon"
-#~ msgstr "Epsilon"
-
-#~ msgid "Equations have several advantages over functions. For example they can be manipulated with factor(), expand() and similar functions. They can easily be introduced one into another. Also they are always printed out as 2D maths."
-#~ msgstr "相比函数而言，方程有一些优点。例如，factor()，expand() 等命令可以对直接方程使用；方程很容易互相代入，也总是以 2D 式子的形式输出。"
-
-#~ msgid "Eta"
-#~ msgstr "Eta"
-
-#~ msgid "Evaluate"
-#~ msgstr "计算"
-
-#~ msgid "Example text"
-#~ msgstr "示例文本"
-
-#~ msgid "Examples:"
-#~ msgstr "示例："
-
-#~ msgid "Expand"
-#~ msgstr "展开"
-
-#~ msgid "Expand (tr)"
-#~ msgstr "展开（三角）"
-
-#~ msgid "Export As"
-#~ msgstr "导出为"
-
-#~ msgid "Export all history to a .mac file"
-#~ msgstr "将所有历史记录导出为 .mac 文件"
-
-#~ msgid "Export all settings"
-#~ msgstr "导出所有设置"
-
-#~ msgid "Export commands from the current maxima session to a .mac file"
-#~ msgstr "将本次 Maxima 会话的所有命令导出为 .mac 文件"
-
-#~ msgid "Export equations to HTML as:"
-#~ msgstr "将式子导出到 HTML 为："
-
-#~ msgid "Export selected commands to a .mac file"
-#~ msgstr "将选中的命令导出为 .mac 文件"
-
-#~ msgid "Export the style settings"
-#~ msgstr "导出样式设置"
-
-#~ msgid "Export visible commands to a .mac file"
-#~ msgstr "将可见的命令导出为 .mac 文件"
-
-#~ msgid "Exporting to .mac file failed!"
-#~ msgstr "导出到 .mac 文件失败！"
-
-#~ msgid "Factor"
-#~ msgstr "因式分解"
-
-#~ msgid "Fill color"
-#~ msgstr "填充色"
-
-#~ msgid "Find:"
-#~ msgstr "查找："
-
-#~ msgid "Finnish"
-#~ msgstr "芬兰语"
-
-#~ msgid "Fix reordered reference indices (of %i, %o) before saving"
-#~ msgstr "在保存前整理公式引用（%i，%o）序号"
-
-#~ msgid "Fixed font in text controls"
-#~ msgstr "文本控件中使用等宽字体"
-
-#~ msgid "Fonts"
-#~ msgstr "字体"
-
-#~ msgid "For each Text-, Sectioning or code cell wxMaxima can display a bracket showing the extend of the cell and allowing to fold it. This setting now tells if this bracket is to be printed, as well."
-#~ msgstr "对于每个文本、节或代码单元格，wxMaxima 可以显示一个括号，用于表示单元格的范围和折叠单元格。此设置指示是否要打印该括号。"
 
 #, fuzzy
 #~ msgid "Found %li anchors, %li anchors total."
@@ -12298,199 +17019,8 @@ msgstr ""
 #~ msgid "Found %li loadable files."
 #~ msgstr "找到 %i 个可载入文件。"
 
-#~ msgid "French"
-#~ msgstr "法语"
-
-#~ msgid "Galician"
-#~ msgstr "加里西亚语"
-
-#~ msgid "Gamma"
-#~ msgstr "Gamma"
-
-#~ msgid "German"
-#~ msgstr "德语"
-
-#~ msgid "Greek"
-#~ msgstr "希腊语"
-
-#~ msgid "Grid"
-#~ msgstr "网格"
-
-#~ msgid "HTML"
-#~ msgstr "HTML"
-
-#~ msgid "Help browser:"
-#~ msgstr "帮助浏览器："
-
-#~ msgid "Hide"
-#~ msgstr "隐藏"
-
-#~ msgid "Hide all multiplication signs that aren't really necessary for understanding the equation"
-#~ msgstr "隐藏理解公式时所有不必要的乘号"
-
-#~ msgid "Hide multiplication signs, if possible"
-#~ msgstr "隐藏乘号（如可能）"
-
-#~ msgid "Hide the brackets that mark the extend of the worksheet cells at the worksheet's right side and that contain the \"hide\" button of the cell if the cells aren't active."
-#~ msgstr "如果单元格未处于活动状态，隐藏工作簿左侧标记单元格范围的方括号及其包含的“隐藏”按钮。"
-
-#, fuzzy
-#~ msgid "Highlight the matching parenthesis"
-#~ msgstr "括号不匹配"
-
-#~ msgid "Histogram..."
-#~ msgstr "柱状图..."
-
-#~ msgid "Horizontal cursor works like a normal cursor, but it operates on cells: press up or down arrow to move it, holding down Shift while moving will select cells, pressing backspace or delete twice will delete a cell next to it."
-#~ msgstr "水平光标的工作方式与普通光标类似，但它是对单元格操作的：按向上或向下箭头移动光标，在移动光标时按住 Shift 键将选择单元格，按 Backspace 键或 Delete 键两次将删除与水平光标相邻的单元格。"
-
-#~ msgid "Hotkeys for sending commands to maxima"
-#~ msgstr "将命令发送至 Maxima 的快捷键"
-
-#~ msgid "Hungarian"
-#~ msgstr "匈牙利语"
-
-#~ msgid "Identical to"
-#~ msgstr "等价于"
-
-#~ msgid "If maxima versions compiled with different lisps are installed: The name of the lisp to use by default"
-#~ msgstr "如果安装了由不同 Lisp 编译器得到的 Maxima 版本：默认情况下要使用的 Lisp 的名称"
-
-#~ msgid "If maxima was compiled by GCL: Garbage Collect at minimum allocation past this heapsize"
-#~ msgstr "If maxima was compiled by GCL: Garbage Collect at minimum allocation past this heapsize"
-
-#~ msgid "If maxima was compiled by GCL: Minimum allocation fraction between Garbage Collects"
-#~ msgstr "If maxima was compiled by GCL: Minimum allocation fraction between Garbage Collects"
-
-#~ msgid "If maxima was compiled by GCL: Only garbage collect past this heapsize fraction of working mem"
-#~ msgstr "If maxima was compiled by GCL: Only garbage collect past this heapsize fraction of working mem"
-
-#~ msgid "If maxima was compiled by GCL: Share the allocated memory between gcl processes. Allows more than one gcl-compiled maxima to run at the same time, but might provoke crashes."
-#~ msgstr "If maxima was compiled by GCL: Share the allocated memory between gcl processes. Allows more than one gcl-compiled maxima to run at the same time, but might provoke crashes."
-
-#~ msgid "If maxima was compiled by GCL: The fraction of the total installed RAM to reserve for maxima"
-#~ msgstr "If maxima was compiled by GCL: The fraction of the total installed RAM to reserve for maxima"
-
-#~ msgid "If multiple cells are evaluated in one go: Abort evaluation if wxMaxima detects that maxima has encountered any error."
-#~ msgstr "如果一次计算多个单元格：当 wxMaxima 检测到 Maxima 遇到任何错误时，中止计算。"
-
-#~ msgid "If not extremely long"
-#~ msgstr "如果不是特别长"
-
-#~ msgid "If not very long"
-#~ msgstr "如果不是很长"
-
-#~ msgid "If numbers are getting longer than this number of digits they will be displayed abbreviated by an ellipsis."
-#~ msgstr "如果数值的长度超过这个数，超出的部分将显示为省略号。"
-
-#~ msgid "If the \"Autosave\" functionality is enabled in the configuration dialogue wxMaxima acts like mobile apps that backup the file every few minutes and save it on closing."
-#~ msgstr "如果在配置对话框中启用了“自动保存（autosave）”功能，那么 wxMaxima 会像手机上的应用程序一样，每隔几分钟备份文档，并在退出时保存文档。"
-
-#~ msgid "If the font provides big parenthesis symbols: Use them when big parenthesis are needed for maths display."
-#~ msgstr "如果字体提供大型括号符号：当显示式子需要大型括号时使用它们。"
-
-#~ msgid "If this checkbox is checked wxMaxima automatically saves the file closing and every few minutes giving wxMaxima a more cellphone-app-like feel as the file is virtually always saved. If this checkbox is unchecked from time to time a backup is made in the temp folder instead."
-#~ msgstr "如果选中此复选框，wxMaxima 会每隔几分钟自动保存文件，表现得类似于手机应用程序，即文件实际上总是被保存。如果取消选中此复选框，则会不定期在临时文件夹中进行备份。"
-
-#~ msgid "If this checkbox is set a new code cell is opened as soon as maxima requests data. If it isn't set a new code cell is opened in this case as soon as the user starts typing in code."
-#~ msgstr "如果设置了此复选框，则在 Maxima 请求数据时将打开一个新的代码单元格。如果没有设置，只有在用户开始输入代码时，才会打开一个新的代码单元格。"
-
-#~ msgid "If this checkbox isn't checked the current command is sent to maxima only on pressing Ctrl+Enter"
-#~ msgstr "如果未选中此复选框，则仅当按下 Ctrl+Enter 时当前命令才发送到 Maxima。"
-
-#~ msgid "If this option is set the .wxmx source of the current file is copied to a place a link to is put into the result of an export."
-#~ msgstr "如果设置了此选项，则当前的 .wxmx 文件将复制到相关文件夹，且导出的文件将包含对应的链接。"
-
-#~ msgid "If you type an operator (one of +*/^=,) as the first symbol in an input cell, % will be automatically inserted before the operator, as on a graphing calculator. You can disable this feature from the 'Edit->Configure' dialog."
-#~ msgstr "如在图形计算器中一样，如果键入六个运算符 +*/^=，中的一个作为（数学）输入单元格中的第一个符号，wxMaxima 将自动在该运算符之前插入 %（表示上一个输出结果）。可以在“编辑->设置”对话框开启（禁用）此功能。"
-
-#~ msgid "If your calculation is taking too long to evaluate, you can try 'Maxima->Interrupt' or 'Maxima->Restart Maxima' menu commands."
-#~ msgstr "如果计算时花费了太长时间仍无结果，可以尝试用菜单命令“Maxima->中断”或“Maxima->重新启动”来中止计算。"
-
-#~ msgid "Image"
-#~ msgstr "图片"
-
-#~ msgid "Implicit Plot"
-#~ msgstr "隐式图形"
-
-#~ msgid "Import settings"
-#~ msgstr "导入设置"
-
-#~ msgid "Import+Export"
-#~ msgstr "导入和导出"
-
-#, fuzzy
-#~ msgid ""
-#~ "In order to visualize how a parameter affects an equation wxMaxima provides commands that start with \"with_slider_\" and that create animations. One example would be:\n"
-#~ "\n"
-#~ "    with_slider_draw(\n"
-#~ "        a,[-16,-9,-4,-2,0,1,2,3,4,5,6,7],\n"
-#~ "        title=concat(\"a=\",a),\n"
-#~ "        grid=true,\n"
-#~ "        explicit(\n"
-#~ "            x^2-a*x,\n"
-#~ "            x,-10,10\n"
-#~ "        )\n"
-#~ "    );"
-#~ msgstr ""
-#~ "为了将参数对方程的影响可视化，wxMaxima 提供了以“with_slider_”开头的命令，以生成动图。一个例子是：\n"
-#~ "\n"
-#~ "    with_slider_draw(\n"
-#~ "        a,[-16,-9,-4,-2,0,1,2,3,4,5,6,7],\n"
-#~ "        title=concat(\"a=\",a),\n"
-#~ "        grid=true,\n"
-#~ "        explicit(\n"
-#~ "            x^2-a*x,\n"
-#~ "            x,-10,10\n"
-#~ "        )\n"
-#~ "    );"
-
-#, fuzzy
-#~ msgid "In text cells bullet lists can be created by beginning a line with \" * \". The number of spaces in front of the \"*\" determines the indentation level; Indentation can be continued in the next line by indenting the line using spaces."
-#~ msgstr "在文本单元格中，可以通过以“*”开头的行来创建项目列表：“*”前面的空格数决定了缩进级别；在下一行继续使用空格可以维持缩进级别。"
-
-#~ msgid "In the LaTeX output: Put exponents after an eventual subscript instead of above it. Might increase readability for some fonts and short subscripts."
-#~ msgstr "在 LaTeX 输出中，将上标文字放在下标文字之后，而不是之前；可能会增加某些字体和短下标的可读性。"
-
-#~ msgid "Incremental Search"
-#~ msgstr "增量搜索"
-
-#~ msgid "Indent equations by the label width"
-#~ msgstr "按标签的宽度缩进式子"
-
-#~ msgid "Indent maths so all lines are in par with the first line that starts after the label."
-#~ msgstr "缩进式子，使所有行与标签后的第一行一致。"
-
-#~ msgid "Infinity"
-#~ msgstr "无穷大"
-
 #~ msgid "Input a RegEx here to filter the results"
 #~ msgstr "在此处输入正则表达式（RegEx）来筛选结果"
-
-#~ msgid "Insert % before an operator at the beginning of a cell"
-#~ msgstr "在单元格开头的运算符前插入 %"
-
-#~ msgid "Integers and single letters"
-#~ msgstr "整数和单个字母"
-
-#~ msgid "Integral sign"
-#~ msgstr "积分号"
-
-#~ msgid "Intelligently hide cell brackets"
-#~ msgstr "智能隐藏单元格左侧括号"
-
-#~ msgid "Interaction"
-#~ msgstr "相互作用"
-
-#~ msgid "Interactive popup memory limit [MB/plot]:"
-#~ msgstr "交互式弹出图形的内存限制 [MB/幅]："
-
-#, fuzzy
-#~ msgid "Internal"
-#~ msgstr "积分"
-
-#~ msgid "Invalid RegEx!"
-#~ msgstr "不正确的正则表达式！"
 
 #~ msgid ""
 #~ "Invalid entry for Maxima program.\n"
@@ -12500,131 +17030,6 @@ msgstr ""
 #~ "无效的 Maxima 程序路径。\n"
 #~ "\n"
 #~ "请再次输入 Maxima 程序所在路径。"
-
-#~ msgid "Iota"
-#~ msgstr "Iota"
-
-#~ msgid "Issue a notification if maxima finishes calculating while the wxMaxima window isn't in focus."
-#~ msgstr "如果当 wxMaxima 窗口未处于激活状态时 Maxima 完成计算，则发出通知。"
-
-#~ msgid "It is possible to add custom symbols to the \"symbols\" sidebar by copying them into the respective field in the configuration dialogue."
-#~ msgstr "只需复制各种符号到配置对话框的相应字段（见菜单“设置->选项”）内，就可以将这些符号添加到“符号”侧边栏。"
-
-#, fuzzy
-#~ msgid "It is possible to define reusable Maxima libraries with wxMaxima that can be later loaded by using the load() function. All that has to be done is to export a file in the .mac or to save it in the .wxm format. Note, though, that a few special characters like the \"not equal\" symbol for \"#\" are handled by wxMaxima, not by Maxima and therefore cannot be recognized on load()."
-#~ msgstr "使用 wxMaxima 能定义可重用的 Maxima 程序库，只需以 .mac 格式导出文件或以 .wxm 格式保存文件，该程序库随后可以使用 load() 命令加载。不过，应注意一些特殊字符，如表示“不相等”符号的“#”，是由 wxMaxima 而非 Maxima 处理的，因此用 load() 命令无法顺利识别。"
-
-#~ msgid "Italian"
-#~ msgstr "意大利语"
-
-#~ msgid "Italic"
-#~ msgstr "斜体"
-
-#~ msgid "Japanese"
-#~ msgstr "日本语"
-
-#~ msgid "Kabyle"
-#~ msgstr "卡拜尔语"
-
-#~ msgid "Kappa"
-#~ msgstr "Kappa"
-
-#~ msgid "Keep percent sign with special symbols: %e, %i, etc."
-#~ msgstr "保留特殊符号前的百分号，如 %e，%i 等。"
-
-#~ msgid "LaTeX"
-#~ msgstr "LaTeX"
-
-#~ msgid "LaTeX: Place exponents after, instead above subscripts"
-#~ msgstr "LaTeX：将上标文字放在下标文字之后， 而不是之前"
-
-#~ msgid "LaTeX: Use the \"partial derivative\" symbol to represent diff()"
-#~ msgstr "LaTeX：使用偏导数符号表示 diff()"
-
-#~ msgid "Label width:"
-#~ msgstr "标签宽度："
-
-#~ msgid "Language used for wxMaxima GUI."
-#~ msgstr "wxMaxima 图形界面使用的语言。"
-
-#~ msgid "Language:"
-#~ msgstr "语言："
-
-#~ msgid "Leads to"
-#~ msgstr "导出"
-
-#~ msgid "Least Squares Fit..."
-#~ msgstr "最小二乘拟合..."
-
-#, fuzzy
-#~ msgid "Libraries can be accessed by any wxMaxima process regardless of which directory it runs in, if they are placed in the user directory. This directory can be found by typing maxima_userdir;"
-#~ msgstr "只要将程序库放在特定用户目录中，那么不管当前 wxMaxima 进程运行的目录是什么，wxMaxima 进程都可以直接访问这些程序库。通过变量 maxima_userdir 的值能确定该特定目录。"
-
-#~ msgid "License"
-#~ msgstr "许可证"
-
-#~ msgid "Limit..."
-#~ msgstr "极限..."
-
-#~ msgid "Line color"
-#~ msgstr "线条颜色"
-
-#~ msgid "Linear Regression..."
-#~ msgstr "线性回归..."
-
-#~ msgid "List of arrays"
-#~ msgstr "数组的列表"
-
-#~ msgid "List of changed options"
-#~ msgstr "变更选项的列表"
-
-#, fuzzy
-#~ msgid "List of functional dependencies"
-#~ msgstr "用户函数列表"
-
-#, fuzzy
-#~ msgid "List of labels"
-#~ msgstr "数组的列表"
-
-#~ msgid "List of structs"
-#~ msgstr "结构列表"
-
-#~ msgid "List of user aliases"
-#~ msgstr "用户别名列表"
-
-#~ msgid "List of user functions"
-#~ msgstr "用户函数列表"
-
-#~ msgid "List of user rules"
-#~ msgstr "用户规则列表"
-
-#~ msgid "List of user variables"
-#~ msgstr "用户变量列表"
-
-#~ msgid "List of user-defined derivatives"
-#~ msgstr "用户定义的导数列表"
-
-#, fuzzy
-#~ msgid "List of user-defined macros"
-#~ msgstr "用户定义的性质列表"
-
-#~ msgid "List of user-defined properties"
-#~ msgstr "用户定义的性质列表"
-
-#~ msgid "Load"
-#~ msgstr "载入"
-
-#~ msgid "Load style from file"
-#~ msgstr "从文件载入样式"
-
-#~ msgid "Long Right arrow"
-#~ msgstr "长右箭头"
-
-#~ msgid "MAXIMA RESPONSE:"
-#~ msgstr "Maxima 回应："
-
-#~ msgid "Match Case"
-#~ msgstr "区分大小写"
 
 #~ msgid ""
 #~ "MathJAX creates scalable High-Quality representations of 2D Maths that can be used for Drag-And-Drop and provides accessibility options. The disadvantage of MathJAX is that it needs JavaScript and a little bit of time in order to typeset equations.\n"
@@ -12638,54 +17043,9 @@ msgstr ""
 #~ msgid "MathML + MathJaX as Fill-In"
 #~ msgstr "MathML，以 MathJaX 做替补"
 
-#~ msgid "MathML as HTML"
-#~ msgstr "MathML 的 HTML 代码"
-
-#~ msgid "MathML description"
-#~ msgstr "MathML 描述"
-
-#~ msgid "Maxima"
-#~ msgstr "Maxima"
-
-#~ msgid "Maxima Location"
-#~ msgstr "Maxima 位置"
-
 #, fuzzy
 #~ msgid "Maxima assigns each command/equation an automatic label (which looks like %i1 or %o1). If a command begins with a descriptive name followed by a : wxMaxima will call the descriptive name a \"user-defined label\" instead. This selection now allows to tell wxMaxima if to show only automatic labels, automatic labels if there aren't user-defined ones or no label at all until a user-defined label can be found by wxMaxima's heuristics. If automatic labels are suppressed extra vertical space is added between equations in order to ease discerning which line starts a new equation and which one only continues the one from the last line."
 #~ msgstr "Maxima 给每个式子或命令分配自动标签（形如 %i1 或 %o1）。如果命令以描述性文字开头，后跟“:”，那么 wxMaxima 将把描述性文字称为“用户定义的标签”。这个选项用于告诉wxMaxima 是否只显示自动标签；或仅在没有用户定义的标签时，显示自动标签；或者仅显示 wxMaxima 找到用户定义的标签。如果取消分配自动标签，在两行式子之间会增加额外的垂直空格，以便于区分哪一行开始了一个新的式子，哪一行只是延续上一行的式子。"
-
-#~ msgid "Maxima commands to be executed at every start of Maxima"
-#~ msgstr "Maxima 每次启动时执行的 Maxima 命令"
-
-#~ msgid "Maxima commands to be executed every time wxMaxima starts Maxima"
-#~ msgstr "wxMaxima 每次启动 Maxima 时执行的 Maxima 命令"
-
-#~ msgid "Maxima configuration"
-#~ msgstr "Maxima 设置"
-
-#~ msgid "Maxima program:"
-#~ msgstr "Maxima 程序："
-
-#~ msgid "Maxima provides no \"forget all\" command that flushes all settings a maxima session could make. wxMaxima therefore normally defaults to starting a fresh maxima process every time the worksheet is to be re-evaluated. As this needs a little bit of time this switch allows to disable this behavior."
-#~ msgstr "Maxima 没有提供“忘记所有内容”命令来刷新当前 Maxima 会话已有的所有设置。因此，每次重新计算工作簿中的所有式子时，wxMaxima 默认启动一个新的 Maxima 进程。这个过程通常需要一点时间，而此选项可以禁用该过程。"
-
-#~ msgid "Maxima session (*.mac)|*.mac"
-#~ msgstr "Maxima 会话 (*.mac)|*.mac"
-
-#~ msgid "Maxima startup file location: "
-#~ msgstr "Maxima 启动文件位置："
-
-#~ msgid "Maxima supports three types of numbers: exact fractions (which can be generated for example by typing 1/10), IEEE floating-point numbers (0.2) and arbitrary precision big floats (1b-1). Note that, owing to their nature as binary (not decimal) numbers, there is for example no way to generate an IEEE floating-point number that exactly equals 0.1. If floating-point numbers are used instead of fractions, Maxima will therefore sometimes have to introduce a (very small) error and use things like 3602879701896397/36028797018963968 for 0.1."
-#~ msgstr "Maxima 支持的数值类型有三种：表示准确数值的分数（如 1/10）、IEEE 浮点数（如 0.2）和任意精度大浮点数（如 1b-1）。注意，由于 IEEE 浮点数是由二进制（而非十进制）表示的，所以无法生成恰好等于 0.1 的 IEEE 浮点数。如果强制使用此种浮点数，如 0.1，Maxima 在计算时将使用类似于3602879701896397/36028797018963968 的分数来表示它，因此会引入一个（非常小的）误差。"
-
-#~ msgid "Maxima usage"
-#~ msgstr "Maxima 用法"
-
-#, fuzzy
-#~ msgid ""
-#~ "Maxima uses ':=' to define functions, e.g.:\n"
-#~ "f(x) := x^2;"
-#~ msgstr "Maxima 使用“:”来赋值（如“a : 3;”) ，使用“:=”来定义函数（如“f(x) := x^2;”）。"
 
 #~ msgid ""
 #~ "Maxima's \"at\" function allows to access to arbitrary variables in a list of results:\n"
@@ -12704,246 +17064,12 @@ msgstr ""
 #~ "    %[1];\n"
 #~ "    result_b:b=at(b,%);"
 
-#~ msgid ""
-#~ "Maxima's strengths are manipulating equations and in symbolic calculations. It therefore makes sense to use functions (as opposed to equations with labels) sparingly and to keep the actual values of variables in a list, instead of directly assigning them values. An example session that does do so would be:\n"
-#~ "\n"
-#~ "/* We keep the actual values in a list so we can use them later on */\n"
-#~ "    Values:[a=10,c=100];\n"
-#~ "    Pyth:a^2+b^2=c^2;\n"
-#~ "    solve(%,b);\n"
-#~ "    result:%[2];\n"
-#~ "    at(result,Values);\n"
-#~ "    float(%);"
-#~ msgstr ""
-#~ "Maxima 的优势在于对方程变形和进行符号计算，因此与其使用函数，不如使用带（名称）标签的方程，以及储存变量的实际值为一个列表，而不是直接对变量赋值。一个例子如下：\n"
-#~ "\n"
-#~ "/* 将实际数值储存在列表中，以便于将来使用 */\n"
-#~ "    Values:[a=10,c=100];\n"
-#~ "    Pyth:a^2+b^2=c^2;\n"
-#~ "    solve(%,b);\n"
-#~ "    result:%[2];\n"
-#~ "    at(result,Values);\n"
-#~ "    float(%);"
-
-#~ msgid "Maximum bitmap size on clipboard [Mb]:"
-#~ msgstr "剪贴板上的最大位图大小 [Mb]："
-
-#, fuzzy
-#~ msgid "Maximum number of displayed digits:"
-#~ msgstr "显示数值时的最大位数："
-
-#~ msgid "Mean Difference Test..."
-#~ msgstr "均值差检验..."
-
-#~ msgid "Mean Test..."
-#~ msgstr "均值检验..."
-
-#~ msgid "Mean..."
-#~ msgstr "均值..."
-
-#~ msgid "Median..."
-#~ msgstr "中值..."
-
-#~ msgid "Misc"
-#~ msgstr "其他"
-
-#, fuzzy
-#~ msgid "Misc settings"
-#~ msgstr "导入设置"
-
-#~ msgid "Mu"
-#~ msgstr "Mu"
-
-#~ msgid "New lines: Jump to text"
-#~ msgstr "新行：跳转到文本"
-
-#~ msgid "Non-builtin symbols"
-#~ msgstr "非内置符号"
-
-#~ msgid "Normality Test..."
-#~ msgstr "正态分布检验..."
-
-#~ msgid "Normally html expects images to be rather low-res but space saving. These images tend to look rather blurry when viewed on modern screens. Therefore this setting was introduces that selects the factor by which the HTML export increases the resolution in respect to the default value."
-#~ msgstr "通常，HTML 使用的图片文件分辨率较低以节省储存空间。但是在现在的屏幕上查看时，这些图片往往显得相当模糊。因此引入此设置，用于选择当导出 HTML 文件时，相对于默认值分辨率而提高的因子。"
-
-#~ msgid "Norwegian"
-#~ msgstr "挪威语"
-
-#~ msgid "Nu"
-#~ msgstr "Nu"
-
-#~ msgid "Offer answers for questions known from previous runs"
-#~ msgstr "提供上次运行后得到的问题的答案"
-
-#~ msgid "Omega"
-#~ msgstr "Omega"
-
-#~ msgid "Omicron"
-#~ msgstr "Omicron"
-
-#~ msgid "Only user-defined labels"
-#~ msgstr "仅限用户定义的标签"
-
-#~ msgid "Open a cell when Maxima expects input"
-#~ msgstr "当 Maxima 等待输入时打开一个新单元格"
-
-#~ msgid "PNG images can be read by old wxMaxima versions - but aren't really scalable."
-#~ msgstr "PNG 图像可以被旧版本的 wxMaxima 读取，但是不具有真正的可放缩性。"
-
-#~ msgid "Pagebreak"
-#~ msgstr "换页符"
-
-#~ msgid "Parallel to"
-#~ msgstr "平行于"
-
-#~ msgid "Parametric Plot"
-#~ msgstr "参数式绘图"
-
-#~ msgid "Perpendicular to"
-#~ msgstr "垂直于"
-
-#~ msgid "Phi"
-#~ msgstr "Phi"
-
-#~ msgid "Pi"
-#~ msgstr "Pi"
-
-#~ msgid "Piechart..."
-#~ msgstr "饼图..."
-
-#~ msgid "Please restart wxMaxima for changes to take effect!"
-#~ msgstr "请重启 wxMaxima 以使变更生效！"
-
 #, fuzzy
 #~ msgid "Please wait while wxMaxima parses the maxima manual"
 #~ msgstr "正在编译 Maxima 用户手册提供的锚列表"
 
-#~ msgid "Plot name"
-#~ msgstr "图形名称"
-
-#~ msgid "Points"
-#~ msgstr "点"
-
-#~ msgid "Polish"
-#~ msgstr "波兰语"
-
-#~ msgid "Portuguese (Brazilian)"
-#~ msgstr "葡萄牙语（巴西）"
-
-#~ msgid "Pressing Ctrl+Space or Ctrl+Tab starts an autocomplete function that can not only complete all functions that are integrated into the Maxima core and their parameters: It also knows about parameters from currently loaded packages and from functions that are defined in the current file."
-#~ msgstr "按 Ctrl+K 或 Ctrl+Tab 组合键可以启动自动补全功能，该功能不仅可以补全所有集成到 Maxima 核心的函数，还可以补全当前文档内已加载程序包中的函数以及新定义的函数。"
-
-#, fuzzy
-#~ msgid "Print Margins"
-#~ msgstr "正在输出"
-
-#~ msgid "Print scale:"
-#~ msgstr "输出范围："
-
-#~ msgid "Print the cell brackets [drawn to their left]"
-#~ msgstr "输出单元格左侧的括号"
-
-#, fuzzy
-#~ msgid "Printout settings"
-#~ msgstr "导入设置"
-
-#, fuzzy
-#~ msgid "Privacy settings"
-#~ msgstr "导入设置"
-
-#~ msgid "Product sign"
-#~ msgstr "乘积符号"
-
-#~ msgid "Psi"
-#~ msgstr "Psi"
-
-#~ msgid "RTF with OMML maths"
-#~ msgstr "带 OMML 的 RTF"
-
-#~ msgid "Read Matrix..."
-#~ msgstr "读取矩阵..."
-
-#~ msgid "Read config to file"
-#~ msgstr "从文件读取设置"
-
-#~ msgid "Recent files list length:"
-#~ msgstr "最近的文件列表长度："
-
-#~ msgid "Rectform"
-#~ msgstr "直角坐标形式"
-
-#~ msgid "Reduce (tr)"
-#~ msgstr "化简（三角）"
-
-#~ msgid "Reload all GUI settings from disc"
-#~ msgstr "从硬盘重新载入所有 GUI 设置"
-
-#~ msgid "Reload the style settings from disc"
-#~ msgstr "从硬盘重新载入所有样式设置"
-
-#~ msgid "Reloading the configuration from disc"
-#~ msgstr "从硬盘重新载入设置"
-
-#~ msgid "Reloading the styles from disc"
-#~ msgstr "从硬盘重新载入样式"
-
-#~ msgid "Remove"
-#~ msgstr "移除"
-
-#~ msgid "Remove all"
-#~ msgstr "移除所有"
-
-#~ msgid "Replace All"
-#~ msgstr "全部替换"
-
-#~ msgid "Replacement:"
-#~ msgstr "替换："
-
-#~ msgid "Reset all GUI settings"
-#~ msgstr "重置所有 GUI 设置"
-
-#~ msgid "Reset the Style settings"
-#~ msgstr "重置所有样式设置"
-
-#~ msgid "Resetting all configuration settings"
-#~ msgstr "重置所有设置"
-
-#~ msgid "Revert all to defaults"
-#~ msgstr "还原为默认值"
-
-#~ msgid "Revert changes"
-#~ msgstr "撤销修改"
-
-#~ msgid "Rho"
-#~ msgstr "Rho"
-
-#, fuzzy
-#~ msgid "Right"
-#~ msgstr "右"
-
-#~ msgid "Right arrow"
-#~ msgstr "右箭头"
-
-#~ msgid "Russian"
-#~ msgstr "俄语"
-
-#~ msgid "SENT TO MAXIMA:"
-#~ msgstr "发送至 Maxima："
-
-#~ msgid "SVG graphics"
-#~ msgstr "SVG 图片"
-
-#~ msgid "Save config to file"
-#~ msgstr "保存设置到文件"
-
 #~ msgid "Save only this number of actions in the undo buffer. 0 means: save an infinite number of actions."
 #~ msgstr "在撤消缓冲区中只保存此数量的操作。0 表示：保存无限数量的操作。"
-
-#~ msgid "Save style to file"
-#~ msgstr "保存样式到文件"
-
-#~ msgid "Save the worksheet automatically"
-#~ msgstr "自动保存工作簿"
 
 #~ msgid "Saving successful."
 #~ msgstr "保存成功。"
@@ -12951,18 +17077,9 @@ msgstr ""
 #~ msgid "Saving..."
 #~ msgstr "保存中……"
 
-#~ msgid "Scalable Vector Graphics (svg)"
-#~ msgstr "可缩放矢量图像（svg）"
-
 #, fuzzy
 #~ msgid "Scanning help file %s for anchors"
 #~ msgstr "正在打开帮助文件 %s"
-
-#~ msgid "Scatterplot..."
-#~ msgstr "散点图..."
-
-#~ msgid "Select"
-#~ msgstr "选择"
 
 #~ msgid "Select Maxima program"
 #~ msgstr "选择 Maxima 程序"
@@ -12970,130 +17087,14 @@ msgstr ""
 #~ msgid "Select help browser"
 #~ msgstr "选择帮助浏览器"
 
-#~ msgid "Selecting a part of an output and right-clicking on the selection will bring up a menu with convenient functions that will operate on the selection."
-#~ msgstr "选择输出结果（或其一部分）并右键单击，将打开一个菜单，以对所选部分进行更多操作。"
-
-#~ msgid "Set fixed font in text controls."
-#~ msgstr "设置文本控件中使用固定字体"
-
-#, fuzzy
-#~ msgid "Set image resolution [in ppi]"
-#~ msgstr "重复使用所得的解\n"
-
-#~ msgid "Set maximum image size [in mm]"
-#~ msgstr "设置图片最大尺寸（单位：mm）"
-
-#~ msgid "Sets the language, line ending type and charset encoding programs will use"
-#~ msgstr "设置程序使用的语言、行结束符和字符集编码"
-
-#~ msgid "Setting this to \"cat\" causes gnuplot not to halt if there is much output"
-#~ msgstr "将此变量设置为“cat”可使 gnuplot 不会因为要输出的数据太多而停止。"
-
-#~ msgid "Setup a 2D plot"
-#~ msgstr "设置二维绘图"
-
-#~ msgid "Setup a 3D plot"
-#~ msgstr "设置三维绘图"
-
-#~ msgid "Setup the axis"
-#~ msgstr "设置坐标轴"
-
-#~ msgid "Show all unicode symbols"
-#~ msgstr "显示所有 Unicode 符号"
-
-#~ msgid "Show commands from current session only"
-#~ msgstr "只显示当前会话的命令"
-
-#~ msgid "Show labels:"
-#~ msgstr "显示标签："
-
-#~ msgid "Show long expressions in wxMaxima document."
-#~ msgstr "在 wxMaxima 文档中显示长表达式"
-
-#~ msgid "Show long expressions:"
-#~ msgstr "显示长表达式："
-
 #~ msgid "Show section numbers"
 #~ msgstr "显示节编号"
-
-#~ msgid "Show tips at Startup"
-#~ msgstr "启动时显示提示"
-
-#~ msgid "Sigma"
-#~ msgstr "Sigma"
-
-#, fuzzy
-#~ msgid "Simple"
-#~ msgstr "样本："
-
-#~ msgid "Simplify"
-#~ msgstr "化简"
-
-#~ msgid "Simplify (r)"
-#~ msgstr "化简根式"
-
-#~ msgid "Simplify (tr)"
-#~ msgstr "化简三角式"
-
-#, fuzzy
-#~ msgid "Since wxMaxima 0.8.2 you can also insert images into your documents. Use 'Cell->Insert Image...' menu command."
-#~ msgstr "从 wxMmaxima 0.8.2 起，用户可以在文档中插入图像，方法是使用“单元格->插入图像…”菜单命令。注意，如果希望保存文档时也保存插入的图像，必须使用（默认的）“.wxmx”格式。"
-
-#~ msgid "Solve ODE..."
-#~ msgstr "求解常微分方程..."
-
-#~ msgid "Spanish"
-#~ msgstr "西班牙语"
-
-#, fuzzy
-#~ msgid "Standard Options"
-#~ msgstr "标准曲面\n"
-
-#~ msgid "Start a new maxima for each re-evaluation"
-#~ msgstr "每次重新计算时启动新的 Maxima 进程"
-
-#~ msgid "Start searching while the phrase to search for is still being typed."
-#~ msgstr "要查询的内容仍在键入中时，立即开始查询。"
-
-#~ msgid "Startup commands"
-#~ msgstr "启动命令"
 
 #~ msgid "String from maxima apparently didn't end in a newline"
 #~ msgstr "来自 Maxima 的字符串很明显不以换行符结尾"
 
-#~ msgid "Style"
-#~ msgstr "样式"
-
-#~ msgid "Styles"
-#~ msgstr "样式"
-
-#~ msgid "Subsample..."
-#~ msgstr "子样本..."
-
-#~ msgid "Subst..."
-#~ msgstr "代入..."
-
-#~ msgid "Sum sign"
-#~ msgstr "求和符号"
-
-#~ msgid "Symbols that are entered or copied here will appear in the symbols sidebar so they can be entered into the worksheet easily."
-#~ msgstr "输入或复制到此处的符号将显示在符号侧边栏中，以便可以轻松地将它们输入工作簿。"
-
-#~ msgid "Tau"
-#~ msgstr "Tau"
-
 #~ msgid "TeX, interpreted by MathJaX"
 #~ msgstr "TeX，由 MathJaX 解析"
-
-#~ msgid "Tells maxima where to store the result of compiling libraries"
-#~ msgstr "告诉 Maxima 编译库的结果存储的位置"
-
-#~ msgid "Text Only"
-#~ msgstr "仅为文本"
-
-#, fuzzy
-#~ msgid "Text cells can hold citations that as marked as such by beginning a line with \" > \". The number of spaces in front of the \">\" determines the indentation level, as it does with bullet lists."
-#~ msgstr "文本单元格中以“>”开始的行将显示为引用，而“>”前面的空格数决定了缩进级别。这一功能类似于对项目列表的支持。"
 
 #~ msgid ""
 #~ "The \"at\" function allows to introduce one equation into another:\n"
@@ -13107,79 +17108,6 @@ msgstr ""
 #~ "    ohm:U=R*I;\n"
 #~ "    r_parallel:R=R_1*R_2/(R_1+R_2);\n"
 #~ "    result:at(ohm,r_parallel);"
-
-#~ msgid "The URL MathJaX.js should be downloaded from by our HTML export."
-#~ msgstr "包含在导出的 HTML 文件中的 URL，用于自动下载 MathJaX.js。"
-
-#~ msgid "The accuracy versus speed tradeoff"
-#~ msgstr "精度与速度的权衡"
-
-#~ msgid "The color of the next line to draw"
-#~ msgstr "用于绘制下一条线的颜色"
-
-#~ msgid "The default height for embedded plots. Can be read out or overridden by the maxima variable wxplot_size."
-#~ msgstr "嵌入绘图的默认高度，可以被 Maxima 变量 wxplot_size 读取或改写。"
-
-#~ msgid "The default port used for communication between Maxima and wxMaxima."
-#~ msgstr "Maxima 和 wxMaxima 之间用于通信的默认端口。"
-
-#~ msgid "The default width for embedded plots. Can be read out or overridden by the maxima variable wxplot_size"
-#~ msgstr "嵌入绘图的默认宽度，可以被 Maxima 变量 wxplot_size 读取或改写。"
-
-#~ msgid "The diagram title"
-#~ msgstr "图表标题"
-
-#~ msgid "The directory %s with maxima's startup file doesn't exist. Trying to create it..."
-#~ msgstr "包含 Maxima 启动文件的目录 %s 不存在。尝试新建此目录..."
-
-#~ msgid "The directory containing the startup files, any user libraries and, if MAXIMA_OBJDIR isn't set the subdirectory with the results from compiling maxima libraries."
-#~ msgstr "包含启动文件、任何用户库的目录，以及含 Maxima 库的编译结果的子目录（如果没有设置变量 MAXIMA_OBJDIR）。"
-
-#~ msgid "The directory maxima places temporary files in, for example plots that are to be included in the worksheet."
-#~ msgstr "Maxima 放置临时文件（例如要嵌入工作簿的绘图）的目录。"
-
-#~ msgid "The directory the compiled versions of maxima are placed in"
-#~ msgstr "已编译的 Maxima 所在的目录"
-
-#~ msgid "The directory the maxima manual can be found in"
-#~ msgstr "Maxima 用户手册所在的目录"
-
-#~ msgid "The directory the user's home directory is in"
-#~ msgstr "用户家（home）目录"
-
-#~ msgid "The document class LaTeX is instructed to use for our documents."
-#~ msgstr "导出 LaTeX 文档所用的文档类（document class）。"
-
-#~ msgid "The fill color for the next objects"
-#~ msgstr "下一个对象的填充颜色"
-
-#~ msgid "The grid in the background of the diagram"
-#~ msgstr "图表背景的网格"
-
-#~ msgid "The key combination Shift+Space results in a non-breakable space."
-#~ msgstr "使用 Shift+Space 组合键可以生成不可断开（换行）的空格。"
-
-#~ msgid "The list of directories the operating system looks for programs in"
-#~ msgstr "操作系统用来寻找程序的一组目录"
-
-#, fuzzy
-#~ msgid "The load() command of Maxima versions >5.38 is able to load .wxm files as library of Maxima's commands."
-#~ msgstr "Maxima 5.38 及更新的版本中，load() 命令可以载入 .wxm 文件作为 Maxima 的程序库。"
-
-#~ msgid "The maximum size for this image. Values <= 0 mean: Unspecified."
-#~ msgstr "此图片的最小尺寸，小于等于零的值对应“未指定”。"
-
-#~ msgid "The next plot's title"
-#~ msgstr "下一个绘图的标题"
-
-#~ msgid "The number of recently opened files that is to be remembered."
-#~ msgstr "记录的最近打开的文件数量。"
-
-#~ msgid "The options the document class LaTeX is instructed to use for our documents gets."
-#~ msgstr "指示导出的 LaTeX 文档所用文档类（document class）的选项。"
-
-#~ msgid "The part of the output of these commands that isn't declared as \"math\" might be suppressed by wxMaxima. As always maxima commands are required to end in a \";\" or a \"$\""
-#~ msgstr "这些命令的输出中没有声明为“math”的部分可能被 wxMaxima 抑制。Maxima 命令必须以“;”或“$”结尾。"
 
 #~ msgid ""
 #~ "The rhs() (\"right hand side\") command allows to retrieve the result of an equation in exactly the format a function would have:\n"
@@ -13206,152 +17134,18 @@ msgstr ""
 #~ "    at(Energy,Values);\n"
 #~ "    W_mech:rhs(%);"
 
-#~ msgid "The standard plot command: Plot an equation as a curve"
-#~ msgstr "标准绘图命令：绘制方程对应的曲线"
-
-#~ msgid "There are many resources about Maxima and wxMaxima on the internet. Visit https://wxMaxima-developers.github.io/wxmaxima/help.html for more information and to find tutorials on using wxMaxima and Maxima."
-#~ msgstr "互联网上有很多关于 Maxima 和 wxMaxima 的资源。访问 https://wxMaxima-developers.github.io/wxMaxima/help.html 可以了解更多信息，以及查找 wxMaxima 和Maxima 的相关教程。"
-
-#~ msgid "Theta"
-#~ msgstr "Theta"
-
-#~ msgid "This file won't be read by maxima if maxima is used without wxMaxima. In order to add startup commands that are executed in this case, too, please add them to maxima-init.mac, instead."
-#~ msgstr "如果未通过 wxMaxima 使用 Maxima，后者将不会读取此文件。为了在这种情况下添加启动时执行的命令，请将这些命令写入 Maxima 会读取的 init.mac 文件。"
-
-#~ msgid "Tip of the day"
-#~ msgstr "每日提示"
-
-#~ msgid "Title, section and subsection cells can be folded to hide their contents. To fold or unfold, click in the square next to the cell. If you shift-click, all sublevels of that cell will also fold/unfold."
-#~ msgstr "标题、节和小节单元格可以折叠以隐藏其内容。要折叠或展开，请单击单元格左侧的正方形。如果按住 Shift 键并单击，该单元格的所有子单元格也将折叠或展开。"
-
-#~ msgid "To plot in polar coordinates, select 'set polar' in the Options entry for Plot2d dialog. You can also plot in spherical and cylindrical coordinates in 3D."
-#~ msgstr "要按极坐标绘图，可以在菜单“绘图->二维绘图”的“选项”中选择“设置极轴（set polar）”。在菜单“绘图->三维绘图”中则可以选择按球面坐标或柱面坐标绘图。"
-
-#~ msgid "To put parentheses around an expression, select it, and press '(' or ')' depending on where you want the cursor to appear afterwards."
-#~ msgstr "若要对表达式整体加括号，可以先选择该表达式，然后按“(”或“)”（括号类型决定了光标随后出现的位置）。"
-
-#~ msgid "To save the size and position of wxMaxima windows between session, use 'Edit->Configure' dialog."
-#~ msgstr "要在不同会话之间使用相同的 wxMaxima 窗口的大小和位置，可使用“编辑->配置”对话框。"
-
-#~ msgid "To start using wxMaxima right away, start typing your command. An input cell should appear. Then press Shift-Enter to evaluate your command."
-#~ msgstr "开始使用 wxMaxima 时，键入的命令会出现在（数学）输入单元格中，输入完成后按 Shift+Enter 键执行命令（开始计算）。"
-
-#, fuzzy
-#~ msgid "Top"
-#~ msgstr "弹出（pop）"
-
 #~ msgid "Trying to load a list of autocompletable symbols from file %s"
 #~ msgstr "尝试从文件 %s 加载自动完成符号列表"
-
-#~ msgid "Turkish"
-#~ msgstr "土耳其语"
 
 #~ msgid "URL MathJaX.js lies at:"
 #~ msgstr "MathJaX.js 的 URL 是："
 
-#~ msgid "Ukrainian"
-#~ msgstr "乌克兰语"
-
-#~ msgid "Underlined"
-#~ msgstr "下划线"
-
-#~ msgid "Underscore converts to subscripts:"
-#~ msgstr "下划线转换为下标："
-
 #~ msgid "Undo limit (0 for none):"
 #~ msgstr "撤销限制（0 为无限制）："
-
-#~ msgid "Unhide"
-#~ msgstr "显示"
-
-#~ msgid "Unicode symbols:"
-#~ msgstr "Unicode 符号："
-
-#~ msgid "Up"
-#~ msgstr "上"
 
 #, fuzzy
 #~ msgid "Updating the configuration from the system's configuration memory"
 #~ msgstr "正在从默认位置读取设置。"
-
-#~ msgid "Upsilon"
-#~ msgstr "Upsilon"
-
-#~ msgid "Use centered dot and Minus, not Star and Hyphen"
-#~ msgstr "使用居中的点和减号，而不是星号和连字符"
-
-#~ msgid "Use centered dot character for multiplication"
-#~ msgstr "使用居中的点（∙）表示乘法"
-
-#~ msgid "Use the \"partial derivative\" symbol to represent the fraction that represents a diff() when exporting LaTeX"
-#~ msgstr "导出为 LaTeX 文件时，使用偏导数符号表示 diff() 命令的结果"
-
-#~ msgid "Use unicode Math Symbols, if available"
-#~ msgstr "尽可能使用 Unicode 数学符号"
-
-#~ msgid "User specified"
-#~ msgstr "用户指定"
-
-#~ msgid "User-defined labels if available"
-#~ msgstr "尽可能使用用户定义的标签"
-
-#~ msgid "Value"
-#~ msgstr "值"
-
-#~ msgid "Variance..."
-#~ msgstr "方差..."
-
-#~ msgid "Warn if an inactive window is idle"
-#~ msgstr "非活动窗口空闲时发出警告"
-
-#~ msgid "When applying functions with one argument from menus, the default argument is '%'. To apply the function to some other value, select it in the document before executing a menu command."
-#~ msgstr "从菜单中选择带一个参数的函数时，默认值参数为“%”。若要将该函数应用于其他式子，可在执行菜单命令前，先选择对应的式子。"
-
-#~ msgid "Worksheet"
-#~ msgstr "工作簿"
-
-#~ msgid "Wrap equations exported by the \"copy as LaTeX\" feature between \\[ and \\] as equation markers"
-#~ msgstr "对由“复制为 LaTeX”功能导出的式子，使用 \\[ 和 \\] 作为公式环境标志"
-
-#~ msgid "Xi"
-#~ msgstr "Xi"
-
-#~ msgid "Yes"
-#~ msgstr "是"
-
-#~ msgid "You can access the last output using the variable '%'. You can access the output of previous commands using variables '%on' where n is the number of output."
-#~ msgstr "可以使用变量“%”访问上一个输出结果，也可以访问使用变量“%on”访问任意输出结果，其中 n 是输出结果的编号。"
-
-#~ msgid "You can evaluate your whole document by using 'Cell->Evaluate All Cells' menu command or the appropriate key shortcut. The cells will be evaluated in the order they appear in the document."
-#~ msgstr "可以使用菜单命令“单元格->计算所有单元格”或相应的快捷键来计算整个文档中的数学单元格，计算顺序为单元格在文档中出现的顺序。"
-
-#, fuzzy
-#~ msgid "You can get help on a Maxima function by selecting or clicking on the function name and pressing F1. wxMaxima will search the help index for the selection or the word under the cursor."
-#~ msgstr "选择或单击输入的函数（命令）名称并按下 F1 键后，wxMaxima 将在帮助文档中搜索该函数相关的内容。"
-
-#~ msgid "You can hide output part of cells by clicking in the triangle on the left side of cells. This works on text cells also."
-#~ msgstr "可以通过单击（数学）输入单元格左侧的三角形来隐藏该单元格的输出结果。文本单元格也提供了类似的功能。"
-
-#~ msgid "You can insert different types of 'cells' in wxMaxima documents using the 'Cell' menu. Note that only 'input cells' can be evaluated, while others are used for commenting and structuring your calculations."
-#~ msgstr "可以使用“单元格”菜单在 wxMaxima 文档中插入不同类型的“单元格”。注意，只有“（数学）输入单元格”可以用于计算，而其他单元格则用于组织文档内容。"
-
-#~ msgid "You can select multiple cells either with a mouse - click'n'drag from between cells or from a cell bracket on the left - or with a keyboard - hold down Shift while moving the horizontal cursor - and then operate on selection. This comes in handy when you want to delete or evaluate multiple cells."
-#~ msgstr "有两种方法可以选择连续的多个单元格：按住鼠标左键并在单元格之间（或其左侧）拖动，或者移动水平光标时按住 Shift 键。接着可以对所选内容进行操作。当需要删除或计算多个单元格时，使用这两种方法会更方便。"
-
-#~ msgid "Zeta"
-#~ msgstr "Zeta"
-
-#~ msgid "alpha"
-#~ msgstr "alpha"
-
-#~ msgid "and"
-#~ msgstr "且"
-
-#~ msgid "beta"
-#~ msgstr "beta"
-
-#~ msgid "chi"
-#~ msgstr "chi"
 
 #~ msgid "choose a lisp maxima was compiled with"
 #~ msgstr "选择编译 Maxima 的 Lisp 类型"
@@ -13359,204 +17153,11 @@ msgstr ""
 #~ msgid "choose between installed maxima versions"
 #~ msgstr "选择已安装的 Maxima 版本"
 
-#~ msgid "delta"
-#~ msgstr "delta"
-
-#~ msgid "empty"
-#~ msgstr "空集"
-
-#~ msgid "epsilon"
-#~ msgstr "epsilon"
-
-#~ msgid "equivalent"
-#~ msgstr "等价于"
-
-#~ msgid "eta"
-#~ msgstr "eta"
-
-#~ msgid "exists"
-#~ msgstr "存在"
-
-#~ msgid ""
-#~ "false=Don't generate subscripts\n"
-#~ "true=Automatically convert underscores to subscript markers if the would-be subscript is a number or a single letter\n"
-#~ "all=_ marks subscripts."
-#~ msgstr ""
-#~ "false = 不生成下标\n"
-#~ "true = 如果下划线后是数字或单个字母，则自动将其转换为下标\n"
-#~ "all = 符号“_”后文本均为下标"
-
-#~ msgid "gamma"
-#~ msgstr "gamma"
-
-#~ msgid "greater than or equal"
-#~ msgstr "大于等于"
-
-#~ msgid "in"
-#~ msgstr "属于"
-
-#~ msgid "intersection"
-#~ msgstr "交集"
-
-#~ msgid "iota"
-#~ msgstr "iota"
-
-#~ msgid "kappa"
-#~ msgstr "kappa"
-
-#~ msgid "lambda"
-#~ msgstr "lambda"
-
-#~ msgid "less or equal"
-#~ msgstr "小于等于"
-
-#~ msgid "mu"
-#~ msgstr "mu"
-
-#~ msgid "much greater than"
-#~ msgstr "远大于"
-
-#~ msgid "much less than"
-#~ msgstr "远小于"
-
-#~ msgid "nabla sign"
-#~ msgstr "nabla 符号"
-
-#~ msgid "nand"
-#~ msgstr "且非"
-
-#~ msgid "nor"
-#~ msgstr "或非"
-
-#~ msgid "not"
-#~ msgstr "非"
-
-#~ msgid "not bytewise identical"
-#~ msgstr "不全等"
-
-#~ msgid "not subset"
-#~ msgstr "非子集"
-
-#~ msgid "not subset or equal"
-#~ msgstr "非子集（可相等）"
-
-#~ msgid "nu"
-#~ msgstr "nu"
-
-#~ msgid "omega"
-#~ msgstr "omega"
-
-#~ msgid "omicron"
-#~ msgstr "omicron"
-
-#~ msgid "or"
-#~ msgstr "或"
-
-#~ msgid "partial sign"
-#~ msgstr "偏导数"
-
-#~ msgid "phi"
-#~ msgstr "phi"
-
-#~ msgid "pi"
-#~ msgstr "pi"
-
-#~ msgid "plus or minus"
-#~ msgstr "加减"
-
-#~ msgid "proportional to"
-#~ msgstr "成比例"
-
-#~ msgid "psi"
-#~ msgstr "psi"
-
-#~ msgid "rho"
-#~ msgstr "rho"
-
 #~ msgid "sbcl: use <int>Mbytes of heap"
 #~ msgstr "sbcl: 使用了堆的 <int>Mb 空间"
 
 #~ msgid "sbcl: use <int>Mbytes of stack for function calls"
 #~ msgstr "sbcl: 函数调用使用了堆栈的 <int>Mb 空间"
-
-#~ msgid "sigma"
-#~ msgstr "sigma"
-
-#~ msgid "sqrt (needs parenthesis for its argument to work as a Maxima command)"
-#~ msgstr "开平方（需要将被开方数放入括号，以生成正确的 Maxima 命令）"
-
-#~ msgid "subset"
-#~ msgstr "子集"
-
-#~ msgid "subset or equal"
-#~ msgstr "子集（可相等）"
-
-#~ msgid "tau"
-#~ msgstr "tau"
-
-#~ msgid "there is no"
-#~ msgstr "不存在"
-
-#~ msgid "theta"
-#~ msgstr "theta"
-
-#~ msgid "to the power of 2"
-#~ msgstr "2 次幂"
-
-#~ msgid "to the power of 3"
-#~ msgstr "3 次幂"
-
-#~ msgid "union"
-#~ msgstr "并"
-
-#~ msgid "upsilon"
-#~ msgstr "upsilon"
-
-#, fuzzy
-#~ msgid "wxMaxima can be made to execute commands at every start-up by placing them in a text file with the name wxmaxima.rc in the user directory. This directory can be found by typing maxima_userdir;"
-#~ msgstr "可以设置 wxMaxima 在每次启动时自动执行一些命令，这些命令应保存在特定用户目录下名为 wxMaxima.rc 的文本文件中。通过变量 maxima_userdir 的值能确定该目录。"
-
-#~ msgid "wxMaxima configuration"
-#~ msgstr "wxMaxima 设置"
-
-#~ msgid "wxMaxima dialogs set default values for inputs entries, one of which is '%'. If you have made a selection in your document, the selection will be used instead of '%'."
-#~ msgstr "wxMaxima 对话框为输入项设置了默认值，其中之一是“%”。但如果提前在文档中选择表达式，则对话框中将使用该表达式而不是“%”。"
-
-#~ msgid "wxMaxima needs more developers. It is an open source project where you can contribute. Join the wxMaxima development at: https://github.com/wxMaxima-developers/wxmaxima"
-#~ msgstr "wxMaxima 需要更多的开发者。它是一个开源项目，每个人都可以对其做出贡献。如果想加入 wxMaxima 的开发工作，可访问网页：https://github.com/wxMaxima-developers/wxMaxima。"
-
-#~ msgid "wxMaxima needs more translators. We do not speak every language. Help us to translate wxMaxima and the manual to your language. Join the wxMaxima development at: https://github.com/wxMaxima-developers/wxmaxima"
-#~ msgstr "wxMaxima 需要更多的翻译者，因为开发者并没有掌握所有的语言。帮助我们将 wxMaxima 的文本和用户手册翻译成本地语言。如果想加入 wxMaxima 的开发工作，可访问网页：https://github.com/wxMaxima-developers/wxMaxima。"
-
-#~ msgid "wxMaxima normally stores the gnuplot sources for every plot made using draw() in order to be able to open plots interactively in gnuplot later. This setting defines the limit [in Megabytes per plot] for this feature."
-#~ msgstr "wxMaxima 通常会储存由 draw() 命令得到的每个绘图的 gnuplot 源文件，以便以后能在 gnuplot 中交互式打开绘图。此设置定义了该功能的储存限制（单位：MB/图）。"
-
-#~ msgid ""
-#~ "wxMaxima provides the \"table_form\" command that shows lists in an alternative form. One example would be:\n"
-#~ "\n"
-#~ "table_form([1,2,3,4,5]);"
-#~ msgstr ""
-#~ "wxMaxima 提供“table_form”命令以竖向显示列表。例如：\n"
-#~ "\n"
-#~ "table_form([1,2,3,4,5]);"
-
-#~ msgid "wxMaxima remembers the answers to maxima's questions. If this checkbox is set it automatically offers to enter the last answer to this question the user has input."
-#~ msgstr "wxMaxima 记得 Maxima 所提问题的答案。如果设置了此复选框，它将自动输入用户对此问题的最后一个答案。"
-
-#~ msgid "wxMaxima startup file location: "
-#~ msgstr "wxMaxima 启动文件位置："
-
-#~ msgid "x"
-#~ msgstr "x"
-
-#~ msgid "xi"
-#~ msgstr "xi"
-
-#~ msgid "xor"
-#~ msgstr "异或"
-
-#~ msgid "zeta"
-#~ msgstr "zeta"
 
 #~ msgid "Sending an interactive Interrupt signal (Ctrl+C) to Maxima."
 #~ msgstr "发送交互式中断信号（Ctrl+C）至 Maxima。"
@@ -13569,9 +17170,6 @@ msgstr ""
 
 #~ msgid "Antialias lines."
 #~ msgstr "线条抗锯齿"
-
-#~ msgid "Direction:"
-#~ msgstr "方向："
 
 #~ msgid "Gnuplot Data File Name: "
 #~ msgstr "Gnuplot 数据文件名："
@@ -13723,9 +17321,6 @@ msgstr ""
 #~ msgid "At value"
 #~ msgstr "设定值"
 
-#~ msgid "BC2"
-#~ msgstr "两个边界条件"
-
 #~ msgid "Char poly"
 #~ msgstr "特征多项式"
 
@@ -13819,9 +17414,6 @@ msgstr ""
 
 #~ msgid "Automatically insert matching parenthesis in text controls. Automatic highlighting of matching parenthesis can be suppressed by setting the respective color to match the background of ordinary text."
 #~ msgstr "自动在文本控件中插入匹配的括号。通过设置相应的颜色以匹配普通文本的背景，可以淡化匹配括号的高亮显示。"
-
-#~ msgid "Match parenthesis in text controls"
-#~ msgstr "在文本控件中匹配括号"
 
 #~ msgid "Searching for maxima help file %s"
 #~ msgstr "查询 Maxima 帮助文档 %s"
@@ -14843,223 +18435,11 @@ msgstr ""
 #~ msgid "Save panes layout between sessions."
 #~ msgstr "保存会话间的面板布局。"
 
-#~ msgid " samples"
-#~ msgstr "样本"
-
-#~ msgid " times"
-#~ msgstr "微分次数"
-
-#~ msgid "&Definite integration"
-#~ msgstr "定积分(&D)"
-
-#~ msgid "&Nusum"
-#~ msgstr "使用 Nusum(&N)"
-
-#~ msgid "&Rational"
-#~ msgstr "有理式(&R)"
-
-#~ msgid "&Special"
-#~ msgstr "特殊(&S)"
-
-#~ msgid "&Taylor series"
-#~ msgstr "泰勒级数(&T)"
-
-#~ msgid "&pm3d"
-#~ msgstr "&pm3d"
-
-#~ msgid "- Infinity"
-#~ msgstr "负无穷"
-
-#~ msgid "A function f(a,b), named"
-#~ msgstr "一个函数 f(a,b) 名"
-
-#~ msgid "A page break"
-#~ msgstr "换页"
-
-#, fuzzy
-#~ msgid "A static plot"
-#~ msgstr "参数式绘图"
-
-#~ msgid "A sub-subsection heading"
-#~ msgstr "小小节单元"
-
-#~ msgid "A subsection heading"
-#~ msgstr "小节头文件"
-
-#~ msgid "Browse"
-#~ msgstr "浏览"
-
-#~ msgid "Bug: Unknown type of text"
-#~ msgstr "错误：未知文本类型"
-
-#~ msgid "Cannot remove the file %s"
-#~ msgstr "无法移除文件 %s"
-
-#~ msgid "Choose new plot format:"
-#~ msgstr "选择新的绘图格式："
-
-#~ msgid "Comma separated x coordinates"
-#~ msgstr "x坐标，以逗号分割"
-
-#~ msgid "Comma separated y coordinates"
-#~ msgstr "y 坐标，以逗号分割"
-
-#~ msgid "Constant"
-#~ msgstr "常量"
-
-#~ msgid "Data format"
-#~ msgstr "数据格式"
-
-#~ msgid "Depth:"
-#~ msgstr "深度："
-
-#~ msgid "Discrete plot"
-#~ msgstr "离散绘图"
-
-#~ msgid "Draw points"
-#~ msgstr "画点"
-
-#~ msgid "Enhanced 3D settings:"
-#~ msgstr "增强三维设置："
-
 #~ msgid "Equation %d:"
 #~ msgstr "方程 %d："
 
-#~ msgid "Figure %d:"
-#~ msgstr "图 %d："
-
 #~ msgid "File:"
 #~ msgstr "文件："
-
-#~ msgid "Format:"
-#~ msgstr "格式："
-
-#~ msgid "Frame counter"
-#~ msgstr "帧计数"
-
-#~ msgid "Frame counter end"
-#~ msgstr "帧计数结束"
-
-#~ msgid "Frame counter start"
-#~ msgstr "开始帧计数"
-
-#~ msgid "Grid:"
-#~ msgstr "网格："
-
-#~ msgid "Math output"
-#~ msgstr "数学输出"
-
-#~ msgid "Method:"
-#~ msgstr "方法："
-
-#~ msgid "New value:"
-#~ msgstr "新值："
-
-#~ msgid "Old value:"
-#~ msgstr "旧值："
-
-#~ msgid "Options:"
-#~ msgstr "选项："
-
-#~ msgid "Parametric plot"
-#~ msgstr "参数式绘图"
-
-#~ msgid "Plot an explicit expression"
-#~ msgstr "绘制显式表达式"
-
-#~ msgid "Plot to file:"
-#~ msgstr "绘图至文件："
-
-#~ msgid "Point type:"
-#~ msgstr "点类型："
-
-#~ msgid "Save plot to file"
-#~ msgstr "保存绘图到文件"
-
-#~ msgid "Sort Criterion:"
-#~ msgstr "排序标准："
-
-#~ msgid "Special"
-#~ msgstr "特殊"
-
-#~ msgid "Start of the y value"
-#~ msgstr "y 的初始值"
-
-#~ msgid "Start of the z value"
-#~ msgstr "z 的初始值"
-
-#~ msgid "Start value of the parameter"
-#~ msgstr "参数的起始值"
-
-#~ msgid "Ticks:"
-#~ msgstr "坐标刻度："
-
-#~ msgid "Type in text"
-#~ msgstr "文本类型"
-
-#~ msgid "Use Gosper algorithm"
-#~ msgstr "使用 Gosper 算法"
-
-#~ msgid "antisymmetric"
-#~ msgstr "非对称"
-
-#~ msgid "both sides"
-#~ msgstr "两边"
-
-#~ msgid "default"
-#~ msgstr "默认"
-
-#~ msgid "diagonal"
-#~ msgstr "对角"
-
-#~ msgid "general"
-#~ msgstr "通用"
-
-#~ msgid "left"
-#~ msgstr "左"
-
-#~ msgid "logscale"
-#~ msgstr "对数尺度"
-
-#~ msgid "secondary x axis label"
-#~ msgstr "二级 x 轴标签"
-
-#~ msgid "secondary y axis label"
-#~ msgstr "二级 y 轴标签"
-
-#~ msgid "symmetric"
-#~ msgstr "对称"
-
-#~ msgid "the x and the y coordinate."
-#~ msgstr "x 轴和y 轴"
-
-#~ msgid "the x, the y and the z coordinate."
-#~ msgstr "x 轴、y 轴和 z 轴"
-
-#~ msgid "x axis label"
-#~ msgstr "x 轴标签"
-
-#~ msgid "y axis label"
-#~ msgstr "y 轴标签"
-
-#~ msgid "z axis label"
-#~ msgstr "z 轴标签"
-
-#~ msgid "An integration constant."
-#~ msgstr "积分常量"
-
-#~ msgid "Complex infinity."
-#~ msgstr "负无穷"
-
-#~ msgid "Division by 0."
-#~ msgstr "除以 0 。"
-
-#, fuzzy
-#~ msgid "Missing contents. Bug?"
-#~ msgstr "漏洞：缺少内容"
-
-#~ msgid "The inverse laplace transform."
-#~ msgstr "Laplace 逆变换"
 
 #~ msgid "Greek constants"
 #~ msgstr "希腊字母常量"
@@ -15122,9 +18502,6 @@ msgstr ""
 #~ msgid "wxMaxima's locale is set to to %s"
 #~ msgstr "设置 wxMaxima 的语言为 %s"
 
-#~ msgid "wxMaxima document (*.wxm, *.wxmx)|*.wxm;*.wxmx"
-#~ msgstr "wxMaxima 文档 (*.wxm, *.wxmx)|*.wxm;*.wxmx"
-
 #~ msgid "&Interrupt\tCtrl+."
 #~ msgstr "中断(&I)\tCtrl+."
 
@@ -15142,45 +18519,6 @@ msgstr ""
 
 #~ msgid "Save wxMaxima window size/position between sessions."
 #~ msgstr "保存会话间的 wxMaxima 窗口的大小和位置。"
-
-#, fuzzy, no-wrap
-#~| msgid ""
-#~| "    load(draw);\n"
-#~| "    \n"
-#~| "    /* Parabola in window #1 */\n"
-#~| "    draw2d(terminal=[wxt,1],explicit(x^2,x,-1,1));\n"
-#~| "    \n"
-#~| "    /* Parabola in window #2 */\n"
-#~| "    draw2d(terminal=[wxt,2],explicit(x^2,x,-1,1));\n"
-#~| "    \n"
-#~| "    /* Paraboloid in window #3 */\n"
-#~| "    draw3d(terminal=[wxt,3],explicit(x^2+y^2,x,-1,1,y,-1,1));\n"
-#~ msgid ""
-#~ "load(draw);\n"
-#~ "\n"
-#~ "/* Parabola in window #1 */\n"
-#~ "draw2d(terminal=[wxt,1],explicit(x^2,x,-1,1));\n"
-#~ "\n"
-#~ "/* Parabola in window #2 */\n"
-#~ "draw2d(terminal=[wxt,2],explicit(x^2,x,-1,1));\n"
-#~ "\n"
-#~ "/* Paraboloid in window #3 */\n"
-#~ "draw3d(terminal=[wxt,3],explicit(x^2+y^2,x,-1,1,y,-1,1));\n"
-#~ msgstr ""
-#~ "    load(draw);\n"
-#~ "    \n"
-#~ "    /* 在第一个窗口中绘制抛物线 */\n"
-#~ "    draw2d(terminal=[wxt,1],explicit(x^2,x,-1,1));\n"
-#~ "    \n"
-#~ "    /* 在第二个窗口中绘制抛物线 */\n"
-#~ "    draw2d(terminal=[wxt,2],explicit(x^2,x,-1,1));\n"
-#~ "    \n"
-#~ "    /* 在第三个窗口中绘制旋转抛物面 */\n"
-#~ "    draw3d(terminal=[wxt,3],explicit(x^2+y^2,x,-1,1,y,-1,1));\n"
-
-#, no-wrap
-#~ msgid "playback();\n"
-#~ msgstr "playback();\n"
 
 #, fuzzy
 #~| msgid "<kbd>CTRL</kbd>+<kbd>TAB</kbd> or <kbd>CTRL</kbd>+<kbd>SHIFT</kbd>+<kbd>TAB</kbd> triggers the auto-completion mechanism."

--- a/locales/wxMaxima/zh_TW.po
+++ b/locales/wxMaxima/zh_TW.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: wxMaxima 0.8.6\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-30 11:38+0200\n"
+"POT-Creation-Date: 2026-08-10 03:42+0000\n"
 "PO-Revision-Date: 2012-03-14 10:23+0800\n"
 "Last-Translator: cw.ahbong <cwahbong@users.sourceforge.net>\n"
 "Language-Team: American English <kde-i18n-doc@kde.org>\n"
@@ -18,7 +18,7 @@ msgstr ""
 "X-Generator: Lokalize 1.2\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: ../../src/StatusBar.cpp:328
+#: ../../src/StatusBar.cpp:447
 #, c-format
 msgid ""
 "\n"
@@ -26,1474 +26,2393 @@ msgid ""
 "Maxima is currently using %3.3f%% of all available CPUs."
 msgstr ""
 
-#: ../../src/Image.cpp:690
+#: ../../src/dialogs/AboutDialog.cpp:59
+#, c-format
+msgid ""
+"\n"
+"\n"
+"Operating System: %s\n"
+msgstr ""
+
+#: ../../src/Image.cpp:773
 msgid ""
 "\n"
 "Image was loaded from a .wxmx file"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:5153
+#: ../../src/dialogs/AboutDialog.cpp:57
+msgid ""
+"\n"
+"Not connected to Maxima."
+msgstr ""
+
+#: ../../src/MaximaEvaluator.cpp:398
+msgid ""
+"\n"
+"Now reads: "
+msgstr ""
+
+#: ../../src/wxMaxima.cpp:1981
 msgid ""
 "\n"
 "Use the menu \"View->Toggle log window\" to show/hide a log window with all debug messages."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:4230
+#: ../../src/dialogs/ConfigDialogue.cpp:1569
+msgid "      -X \"--control-stack-size <int>\""
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1568
+msgid "      -X \"--dynamic-space-size <int>\""
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1572
+msgid "      -X '--control-stack-size <int>'"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1571
+msgid "      -X '--dynamic-space-size <int>'"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1551
+msgid "      -l <name>"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1557
+msgid "      -u <versionnumber>"
+msgstr ""
+
+#: ../../src/Configuration.cpp:1397
+#, c-format
+msgid "  Cells converted to 2D: %ld"
+msgstr ""
+
+#: ../../src/Configuration.cpp:1396
+#, c-format
+msgid "  Cells converted to linear: %ld"
+msgstr ""
+
+#: ../../src/Configuration.cpp:1398
+#, c-format
+msgid "  Cells drawn at the wrong font size: %ld"
+msgstr ""
+
+#: ../../src/Configuration.cpp:1388
+#, c-format
+msgid "  Font cache hits: %ld"
+msgstr ""
+
+#: ../../src/Configuration.cpp:1389
+#, c-format
+msgid "  Font cache misses: %ld"
+msgstr ""
+
+#: ../../src/Configuration.cpp:1400
+#, c-format
+msgid "  Full-window worksheet repaints: %ld"
+msgstr ""
+
+#: ../../src/Configuration.cpp:1384
+#, c-format
+msgid "  Manual anchors from built-in: %ld"
+msgstr ""
+
+#: ../../src/Configuration.cpp:1385
+#, c-format
+msgid "  Manual anchors from cache: %ld"
+msgstr ""
+
+#: ../../src/Configuration.cpp:1386
+#, c-format
+msgid "  Manual anchors self-compiled: %ld"
+msgstr ""
+
+#: ../../src/Configuration.cpp:1387
+#, c-format
+msgid "  Maxima processes spawned: %ld"
+msgstr ""
+
+#: ../../src/Configuration.cpp:1394
+#, c-format
+msgid "  Recalculation needed - Cells appended: %ld"
+msgstr ""
+
+#: ../../src/Configuration.cpp:1393
+#, c-format
+msgid "  Recalculation needed - Config changed: %ld"
+msgstr ""
+
+#: ../../src/Configuration.cpp:1395
+#, c-format
+msgid "  Recalculation needed - Editor dirty: %ld"
+msgstr ""
+
+#: ../../src/Configuration.cpp:1390
+#, c-format
+msgid "  Recalculation needed - Font invalid: %ld"
+msgstr ""
+
+#: ../../src/Configuration.cpp:1392
+#, c-format
+msgid "  Recalculation needed - Font mismatch: %ld"
+msgstr ""
+
+#: ../../src/Configuration.cpp:1391
+#, c-format
+msgid "  Recalculation needed - Size invalid: %ld"
+msgstr ""
+
+#: ../../src/Configuration.cpp:1399
+#, c-format
+msgid "  Worksheet repaints: %ld"
+msgstr ""
+
+#: ../../src/MaximaFileIO.cpp:129
 msgid " (File format (WXM version 1, first line of the file) not recognized)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1559
+#: ../../src/cells/ImgCell.cpp:212 ../../src/cells/ImgCell.cpp:214
+#: ../../src/cells/ImgCell.cpp:216
+msgid " (Graphics) "
+msgstr ""
+
+#: ../../src/cells/EditorCell.cpp:3551 ../../src/cells/EditorCell.cpp:3820
+#: ../../src/cells/EditorCell.cpp:3945
+#, c-format
+msgid " ... + %li hidden lines"
+msgstr ""
+
+#: ../../src/cells/EditorCell.cpp:3553
+msgid " ... + 1 hidden line"
+msgstr ""
+
+#: ../../src/dialogs/TipOfTheDay.cpp:273
+msgid " Did you know? "
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:1607
+msgid " Returns the unique elements of the list"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1596
 msgid " Wrong, if a is complex"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7601
+#: ../../src/wizards/DrawWiz.cpp:964 ../../src/wizards/DrawWiz.cpp:980
+#, fuzzy
+msgid " samples"
+msgstr "範例"
+
+#: ../../src/wizards/DrawWiz.cpp:929 ../../src/wizards/DrawWiz.cpp:945
+msgid " samples, on demand split "
+msgstr ""
+
+#: ../../src/wizards/DrawWiz.cpp:933 ../../src/wizards/DrawWiz.cpp:952
+#, fuzzy
+msgid " times"
+msgstr "次數："
+
+#: ../../src/MaximaCommandMenus.cpp:4473
 msgid ""
 "\".\" = \"The current directory\"\n"
 "\"..\" = \"One directory up\""
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7557 ../../src/wxMaxima.cpp:7563
-#: ../../src/wxMaxima.cpp:7568
+#: ../../src/MaximaCommandMenus.cpp:4429 ../../src/MaximaCommandMenus.cpp:4435
+#: ../../src/MaximaCommandMenus.cpp:4440
 msgid "\"..\" means \"one directory up\"."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:5053
+#: ../../src/dialogs/ConfigDialogue.cpp:1208
+msgid "\"Copy LaTeX\" adds equation markers"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:446
+msgid ""
+"\"MathML (rendered by the browser)\" is the recommended choice: every current browser renders MathML natively and instantly, and the exported page needs no JavaScript and makes no requests to any external server.\n"
+"\"MathML + MathJaX fall-back for old browsers\" behaves the same on current browsers, but additionally downloads MathJaX from an external server (a CDN) as a fall-back on browsers too old to support MathML. Only choose this if you need to support such browsers and accept the external dependency.\n"
+"Bitmaps tend to need more band width than the other options. They lack support for advanced features like drag-and-drop or accessibility. Also they have problems aligning and scaling with the rest of the text and might use fonts that don't match the rest of the document."
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:930
+#, fuzzy
+msgid "\"Numpad Enter\" always evaluates cells"
+msgstr "按 Enter 評算單元"
+
+#: ../../src/sidebars/SymbolsSidebar.cpp:90
+msgid "\"implies\" symbol"
+msgstr ""
+
+#: ../../src/dialogs/DiffFrame.cpp:306
+#, c-format
+msgid "%d differences"
+msgstr ""
+
+#: ../../src/wxMaxima.cpp:1831
 #, c-format
 msgid "%i cells in evaluation queue"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:330
+#: ../../src/sidebars/TableOfContents.cpp:570
+#, c-format
+msgid "%li Levels"
+msgstr ""
+
+#: ../../src/worksheet/Worksheet.cpp:423
 #, c-format
 msgid "%s image, %li×%li, %li ppi"
 msgstr ""
 
-#: ../../src/Autocomplete.cpp:319
+#: ../../src/Autocomplete.cpp:405
 #, c-format
 msgid "%s: Can't interpret line: %s"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1655
+#: ../../src/wxMaxima.cpp:2859
+#, c-format
+msgid ""
+"%sCould not write the setting for:%s\n"
+"(Is the client installed?)"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1692
 #, fuzzy
 msgid "&Algebraic Mode"
 msgstr "代數(&A)"
 
-#: ../../src/wxMaximaFrame.cpp:1884
+#: ../../src/wxMaximaFrame.cpp:1921
 msgid "&Apropos..."
 msgstr "Apropos 指令(&A)..."
 
-#: ../../src/wxMaximaFrame.cpp:615
+#: ../../src/wxMaximaFrame.cpp:646
 msgid "&Batch File...\tCtrl+B"
 msgstr "以批次檔載入(&B)...\tCtrl+B"
 
-#: ../../src/wxMaximaFrame.cpp:1278
+#: ../../src/wxMaximaFrame.cpp:1312
 msgid "&Boundary Value Problem..."
 msgstr "邊界值問題(&B)..."
 
-#: ../../src/wxMaximaFrame.cpp:1950
+#: ../../src/wxMaximaFrame.cpp:1987
 msgid "&Bug Report"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1505
+#: ../../src/wxMaximaFrame.cpp:1542
 msgid "&Calculus"
 msgstr "微積分(&C)"
 
-#: ../../src/wxMaximaFrame.cpp:1601
+#: ../../src/wxMaximaFrame.cpp:1638
 msgid "&Canonical Form"
 msgstr "標準形式(&C)"
 
-#: ../../src/wxMaximaFrame.cpp:1358
+#: ../../src/wxMaximaFrame.cpp:1392
 msgid "&Characteristic Polynomial..."
 msgstr "特徵多項式(&C)..."
 
-#: ../../src/wxMaximaFrame.cpp:990
+#: ../../src/wxMaximaFrame.cpp:1024
 msgid "&Clear Memory"
 msgstr "清除記憶體(&C)"
 
-#: ../../src/wxMaximaFrame.cpp:1583
+#: ../../src/wxMaximaFrame.cpp:1620
 msgid "&Combine Factorials"
 msgstr "合併階乘(&C)"
 
-#: ../../src/wxMaximaFrame.cpp:1628
+#: ../../src/wxMaximaFrame.cpp:1665
 msgid "&Complex Simplification"
 msgstr "複數化簡(&C)"
 
-#: ../../src/wxMaximaFrame.cpp:1502
+#: ../../src/wxMaximaFrame.cpp:1539
 msgid "&Continued Fraction"
 msgstr "連分數(&C)"
 
-#: ../../src/wxMaximaFrame.cpp:638
+#: ../../src/wxMaximaFrame.cpp:675
 msgid "&Copy\tCtrl+C"
 msgstr "複製(&C)\tCtrl+C"
 
-#: ../../src/wxMaximaFrame.cpp:1621
+#: ../../src/wizards/IntegrateWiz.cpp:39
+msgid "&Definite integration"
+msgstr "定積分(&D)"
+
+#: ../../src/wxMaximaFrame.cpp:1658
 msgid "&Demoivre"
 msgstr "Demoivre(&D)"
 
-#: ../../src/wxMaximaFrame.cpp:1362
+#: ../../src/wxMaximaFrame.cpp:1396
 msgid "&Determinant"
 msgstr "行列式(&D)"
 
-#: ../../src/wxMaximaFrame.cpp:1466
+#: ../../src/wxMaximaFrame.cpp:1503
 msgid "&Differentiate..."
 msgstr "微分(&D)..."
 
-#: ../../src/wxMaximaFrame.cpp:689
+#: ../../src/wxMaximaFrame.cpp:726
 msgid "&Edit"
 msgstr "編輯(&E)"
 
-#: ../../src/wxMaximaFrame.cpp:1246
+#: ../../src/wxMaximaFrame.cpp:1280
 msgid "&Eliminate Variable..."
 msgstr "消去變數(&E)..."
 
-#: ../../src/wxMaximaFrame.cpp:1318
+#: ../../src/wxMaximaFrame.cpp:1352
 msgid "&Enter Matrix..."
 msgstr "輸入矩陣(&E)..."
 
-#: ../../src/wxMaximaFrame.cpp:1883
+#: ../../src/wxMaximaFrame.cpp:1920
 msgid "&Example..."
 msgstr "範例(&E)..."
 
-#: ../../src/wxMaximaFrame.cpp:1524
+#: ../../src/wxMaximaFrame.cpp:1561
 msgid "&Expand Expression"
 msgstr "展開數式(&E)"
 
-#: ../../src/wxMaximaFrame.cpp:1597
+#: ../../src/wxMaximaFrame.cpp:1634
 msgid "&Expand Trigonometric"
 msgstr "展開三角函數(&E)"
 
-#: ../../src/wxMaximaFrame.cpp:1626
+#: ../../src/wxMaximaFrame.cpp:1663
 msgid "&Exponentialize"
 msgstr "指數化(&E)"
 
-#: ../../src/wxMaximaFrame.cpp:618
+#: ../../src/wxMaximaFrame.cpp:651
 msgid "&Export..."
 msgstr "匯出(&E)..."
 
-#: ../../src/wxMaximaFrame.cpp:1516
+#: ../../src/wxMaximaFrame.cpp:1553
 msgid "&Factor Expression"
 msgstr "因式分解數式(&F)"
 
-#: ../../src/wxMaximaFrame.cpp:626
+#: ../../src/wxMaximaFrame.cpp:663
 msgid "&File"
 msgstr "檔案(&F)"
 
-#: ../../src/wxMaximaFrame.cpp:1019
+#: ../../src/wxMaximaFrame.cpp:1053
 #, fuzzy
 msgid "&Functions"
 msgstr "函數："
 
-#: ../../src/wxMaximaFrame.cpp:1490
+#: ../../src/wxMaximaFrame.cpp:1527
 msgid "&Greatest Common Divisor..."
 msgstr "最大公因式(&G)..."
 
-#: ../../src/wxMaximaFrame.cpp:1968
+#: ../../src/wxMaximaFrame.cpp:2021
 msgid "&Help"
 msgstr "說明(&H)"
 
-#: ../../src/wxMaximaFrame.cpp:1453
+#: ../../src/wxMaximaFrame.cpp:1490
 msgid "&Integrate..."
 msgstr "積分(&I)..."
 
-#: ../../src/wxMaximaFrame.cpp:964
+#: ../../src/wxMaximaFrame.cpp:998
 msgid "&Interrupt\tCtrl+G"
 msgstr "中斷(&I)\tCtrl+G"
 
-#: ../../src/wxMaximaFrame.cpp:1355
+#: ../../src/wxMaximaFrame.cpp:1389
 msgid "&Invert Matrix"
 msgstr "反矩陣(&I)"
 
-#: ../../src/wxMaximaFrame.cpp:1952
+#: ../../src/wxMaximaFrame.cpp:1995
 msgid "&License"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1763
+#: ../../src/wxMaximaFrame.cpp:1800
 #, fuzzy
 msgid "&List"
 msgstr "串列："
 
-#: ../../src/wxMaximaFrame.cpp:610
+#: ../../src/wxMaximaFrame.cpp:641
 msgid "&Load Package...\tCtrl+L"
 msgstr "載入 Package(&L)...\tCtrl+L"
 
-#: ../../src/wxMaximaFrame.cpp:1232
+#: ../../src/wxMaximaFrame.cpp:1266
 msgid "&Maxima"
 msgstr "Maxima(&M)"
 
-#: ../../src/wxMaximaFrame.cpp:1882
+#: ../../src/wxMaximaFrame.cpp:1919
 #, fuzzy
 msgid "&Maxima help"
 msgstr "顯示 Maxima 說明"
 
-#: ../../src/wxMaximaFrame.cpp:1660
+#: ../../src/wxMaximaFrame.cpp:1697
 msgid "&Modulus Computation..."
 msgstr "設定模運算(&M)..."
 
-#: ../../src/main.cpp:435
+#: ../../src/main.cpp:674
 #, fuzzy
 msgid "&New\tCtrl+N"
 msgstr "新增\tCtrl+N"
 
-#: ../../src/wxMaximaFrame.cpp:1870
+#: ../../src/wxMaximaFrame.cpp:1907
 msgid "&Numeric"
 msgstr "數值(&N)"
 
-#: ../../src/wxMaximaFrame.cpp:1785
+#: ../../src/wxMaximaFrame.cpp:1822
 #, fuzzy
 msgid "&Numeric Output"
 msgstr "切換數值輸出(&N)"
 
-#: ../../src/main.cpp:436
+#: ../../src/wizards/IntegrateWiz.cpp:52
+msgid "&Numerical integration"
+msgstr "數值積分(&N)"
+
+#: ../../src/wizards/SumWiz.cpp:44
+msgid "&Nusum"
+msgstr "使用 Nusum(&N)"
+
+#: ../../src/main.cpp:675
 #, fuzzy
 msgid "&Open\tCtrl+O"
 msgstr "開啟(&O)\tCtrl+O"
 
-#: ../../src/wxMaximaFrame.cpp:598
+#: ../../src/wxMaximaFrame.cpp:629
 msgid "&Open...\tCtrl+O"
 msgstr "開啟(&O)...\tCtrl+O"
 
-#: ../../src/wxMaximaFrame.cpp:1780
+#: ../../src/wxMaximaFrame.cpp:1817
 msgid "&Plot"
 msgstr "繪圖(&P)"
 
-#: ../../src/wxMaximaFrame.cpp:622
+#: ../../src/wizards/SeriesWiz.cpp:45
+msgid "&Power series"
+msgstr "冪級數(&P)"
+
+#: ../../src/wxMaximaFrame.cpp:655
 msgid "&Print...\tCtrl+P"
 msgstr "列印(&P)...\tCtrl+P"
 
-#: ../../src/wxMaximaFrame.cpp:1594
+#: ../../src/wizards/SubstituteWiz.cpp:38
+msgid "&Rational"
+msgstr "有理式(&R)"
+
+#: ../../src/wxMaximaFrame.cpp:1631
 msgid "&Reduce Trigonometric"
 msgstr "縮併三角函數(&R)"
 
-#: ../../src/wxMaximaFrame.cpp:974
+#: ../../src/wxMaximaFrame.cpp:1008
 #, fuzzy
 msgid "&Restart Maxima\tCtrl+Alt+R"
 msgstr "重新啟動 Maxima(&R)"
 
-#: ../../src/wxMaximaFrame.cpp:608
+#: ../../src/wxMaximaFrame.cpp:639
 msgid "&Save\tCtrl+S"
 msgstr "儲存(&S)\tCtrl+S"
 
-#: ../../src/wxMaximaFrame.cpp:1662
+#: ../../src/wizards/SumWiz.cpp:43 ../../src/wxMaximaFrame.cpp:1699
 msgid "&Simplify"
 msgstr "化簡(&S)"
 
-#: ../../src/wxMaximaFrame.cpp:1581
+#: ../../src/wxMaximaFrame.cpp:1618
 msgid "&Simplify Factorials"
 msgstr "化簡階乘(&S)"
 
-#: ../../src/wxMaximaFrame.cpp:1591
+#: ../../src/wxMaximaFrame.cpp:1628
 msgid "&Simplify Trigonometric"
 msgstr "化簡三角函數(&S)"
 
-#: ../../src/wxMaximaFrame.cpp:1238
+#: ../../src/wxMaximaFrame.cpp:1272
 msgid "&Solve..."
 msgstr "求解(&S)..."
 
-#: ../../src/wxMaximaFrame.cpp:1035
+#: ../../src/wizards/Plot2dWiz.cpp:42
+msgid "&Special"
+msgstr "特殊(&S)"
+
+#: ../../src/wizards/LimitWiz.cpp:45
+msgid "&Taylor series"
+msgstr "Taylor 級數(&T)"
+
+#: ../../src/wxMaximaFrame.cpp:1069
 #, fuzzy
 msgid "&Time Display"
 msgstr "切換計算時間顯示(&T)"
 
-#: ../../src/wxMaximaFrame.cpp:1375
+#: ../../src/wxMaximaFrame.cpp:1409
 msgid "&Transpose Matrix"
 msgstr "轉置矩陣(&T)"
 
-#: ../../src/wxMaximaFrame.cpp:1605
+#: ../../src/wxMaximaFrame.cpp:1642
 msgid "&Trigonometric Simplification"
 msgstr "三角化簡(&T)"
 
-#: ../../src/wxMaximaFrame.cpp:1021
+#: ../../src/wxMaximaFrame.cpp:1055
 #, fuzzy
 msgid "&Variables"
 msgstr "變數"
 
-#: ../../src/wxMaxima.cpp:2443
+#: ../../src/wizards/Plot3dWiz.cpp:79
+msgid "&pm3d"
+msgstr "pm3d(&P)"
+
+#: ../../src/cells/AnimationCell.cpp:475
+msgid "(Animation)"
+msgstr ""
+
+#: ../../src/MaximaProcessManager.cpp:771
 msgid "(Config tells to suppress the output of long cells)"
 msgstr ""
 
-#: ../../src/MathParser.cpp:1288
+#: ../../src/cells/ImgCell.cpp:284
+msgid "(Image)"
+msgstr ""
+
+#: ../../src/MathParser.cpp:1418
 msgid "(Invalid XML from maxima)"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:4221
+#: ../../src/cells/GroupCell.cpp:652
+msgid "(Layout took too long and was suppressed)"
+msgstr ""
+
+#: ../../src/MaximaFileIO.cpp:120
 msgid "(Maybe a permission problem?)"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:9248
+#: ../../src/sidebars/CharButton.cpp:211
+msgid "(Might not be displayed correctly in at least one of the worksheet fonts)"
+msgstr ""
+
+#: ../../src/sidebars/VariablesPane.cpp:254
+msgid "(Not a valid variable name)"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:183
+msgid "(Use default language)"
+msgstr "( 使用預設語言 )"
+
+#: ../../src/MaximaCommandMenus.cpp:440
 msgid "(f(x),x,a,b)), Epsilon algorithm"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:9235
+#: ../../src/MaximaCommandMenus.cpp:426
 msgid "(f(x),x,a,b)), Strategy of Aind"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:9258
+#: ../../src/MaximaCommandMenus.cpp:453
 msgid "(f(x),x,a,b), (semi-) infinite interval"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1841
+#: ../../src/wxMaximaFrame.cpp:1878
 msgid "(f(x),x,a,b), Epsilon algorithm"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1843
+#: ../../src/wxMaximaFrame.cpp:1880
 msgid "(f(x),x,a,b), infinite interval"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1839
+#: ../../src/wxMaximaFrame.cpp:1876
 msgid "(f(x),x,a,b), strategy of Aind"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:9361 ../../src/wxMaximaFrame.cpp:1867
+#: ../../src/MaximaCommandMenus.cpp:596 ../../src/wxMaximaFrame.cpp:1904
 msgid "(f(x),x,y) with singularities+discontinuities"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2065
+#: ../../src/wizards/DrawWiz.cpp:274 ../../src/wizards/DrawWiz.cpp:287
+#: ../../src/wizards/DrawWiz.cpp:303 ../../src/wizards/DrawWiz.cpp:320
+#: ../../src/wizards/DrawWiz.cpp:335
+msgid "-"
+msgstr ""
+
+#: ../../src/wizards/IntegrateWiz.cpp:192
+#: ../../src/wizards/IntegrateWiz.cpp:202
+#: ../../src/wizards/IntegrateWiz.cpp:207
+#: ../../src/wizards/IntegrateWiz.cpp:217 ../../src/wizards/LimitWiz.cpp:132
+#: ../../src/wizards/LimitWiz.cpp:142
+msgid "- Infinity"
+msgstr "負無限大"
+
+#: ../../src/MaximaOutputAppender.cpp:116
 msgid "... [suppressed additional lines as the output is longer than allowed in the wxMaxima configuration] "
 msgstr ""
 
-#: ../../src/Worksheet.cpp:6666
+#: ../../src/worksheet/Worksheet.cpp:4657
 msgid ".wxm clipboard data with unusual header"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8047
-#, fuzzy
-msgid "1×n Matrix b:"
-msgstr "矩陣："
+#: ../../src/sidebars/TableOfContents.cpp:567
+msgid "1 Level"
+msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1312
+#: ../../src/sidebars/SymbolsSidebar.cpp:77
+msgid "1/2"
+msgstr ""
+
+#: ../../src/sidebars/DrawSidebar.cpp:45
+msgid "2D"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1346
 #, fuzzy
 msgid "2D Array to Matrix..."
 msgstr "映射至整個矩陣(&P)..."
 
-#: ../../src/wxMaximaFrame.cpp:743
+#: ../../src/wxMaximaFrame.cpp:780
 msgid "2D equations using ASCII Art"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:746
+#: ../../src/wxMaximaFrame.cpp:783
 msgid "2D equations using ASCII Art with unicode characters, if available"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:5057
+#: ../../src/dialogs/ConfigDialogue.cpp:786
+msgid "2D if it fits on the page width"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:785
+msgid "2D, whenever possible"
+msgstr ""
+
+#: ../../src/sidebars/DrawSidebar.cpp:49
+msgid "3D"
+msgstr ""
+
+#: ../../src/wxMaxima.cpp:1835
 #, c-format
 msgid "; %i commands left in the current cell"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:10617
+#: ../../src/MaximaEvaluator.cpp:500
 msgid "A \":lisp\" as the first command might fail to send a \"finished\" signal."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:6585
+#: ../../src/dialogs/TipOfTheDay.cpp:102
+msgid "A 'horizontal cursor' was introduced in wxMaxima 0.8.0. It looks like a horizontal line between cells. It indicates where a new cell will appear if you type or paste text or execute a menu command."
+msgstr "自 wxMaxima 0.8.0 版開始引進「水平游標」。它的外觀為單元之間的水平線，代表您輸入或貼上文字或執行標能表命令時新單元出現的位置。"
+
+#: ../../src/MaximaCommandMenus.cpp:3099
 msgid "A Ctrl-F event"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1973
+#: ../../src/cells/GroupCell.cpp:2178
+msgid "A Maxima input cell with its output"
+msgstr ""
+
+#: ../../src/worksheet/WorksheetContextMenu.cpp:745
 msgid "A Scalar"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:6653
+#: ../../src/cells/TextCell.cpp:239
+msgid ""
+"A command or number wasn't preceded by a \":\", a \"$\", a \";\" or a \",\".\n"
+"Most probable cause: A missing comma between two list items."
+msgstr ""
+
+#: ../../src/wxMaxima.cpp:2642
 #, c-format
 msgid "A find event, %s"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:2012
+#: ../../src/wizards/ListSortWiz.cpp:63
+#, fuzzy
+msgid "A function f(a,b), named"
+msgstr "函數名"
+
+#: ../../src/worksheet/WorksheetContextMenu.cpp:784
 msgid "A function returning integers"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:2014
+#: ../../src/worksheet/WorksheetContextMenu.cpp:786
 msgid "A function returning positive numbers"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1965
+#: ../../src/wizards/DrawWiz.cpp:164
+msgid "A good example equation would be x^2+y^2=1"
+msgstr ""
+
+#: ../../src/cells/GroupCell.cpp:2193 ../../src/cells/GroupCell.cpp:2196
+msgid "A heading"
+msgstr ""
+
+#: ../../src/worksheet/WorksheetContextMenu.cpp:737
 #, fuzzy
 msgid "A irrational variable"
 msgstr "變數變換"
 
-#: ../../src/Worksheet.cpp:2016
+#: ../../src/worksheet/WorksheetContextMenu.cpp:788
 msgid "A left-associative function"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:2019
+#: ../../src/worksheet/WorksheetContextMenu.cpp:791
 #, fuzzy
 msgid "A linear function"
 msgstr "刪除函數"
 
-#: ../../src/wxMaxima.cpp:9590
+#: ../../src/MaximaCommandMenus.cpp:1830
 msgid "A matrix in which each row is a set of variables"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1963
+#: ../../src/dialogs/TipOfTheDay.cpp:84
+#, fuzzy
+msgid "A new document format has been introduced in wxMaxima 0.8.2 that saves not only your input and text commentaries, but also the outputs of your calculations. When saving your document, select 'Whole document (*.wxmx)' format."
+msgstr "從 wxMaxima 0.8.2 版開始有新的文件格式。這種格式除了儲存您的輸入和文字註解以外，也一起儲存您的計算的輸出。請在儲存您的文件時，選擇「wxMaxima XML 文件」。"
+
+#: ../../src/cells/GroupCell.cpp:2175
+#, fuzzy
+msgid "A page break"
+msgstr "換頁符號"
+
+#: ../../src/dialogs/TipOfTheDay.cpp:168
+msgid "A plot to be embedded into the work sheet by preceding its name with a \"wx\". \"draw\" can be replaced by \"wxdraw\", plot by \"wxplot\" etc."
+msgstr ""
+
+#: ../../src/worksheet/WorksheetContextMenu.cpp:735
 #, fuzzy
 msgid "A rational variable"
 msgstr "變數變換"
 
-#: ../../src/Worksheet.cpp:2018
+#: ../../src/worksheet/WorksheetContextMenu.cpp:790
 msgid "A right-associative function"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1634
+#: ../../src/dialogs/ConfigDialogue.cpp:436
+msgid "A scale factor for the printout. Helpful for printing big equations on small pdf pages."
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1671
 msgid "A search-and-replace for equations"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1636
+#: ../../src/cells/EditorCell.cpp:4522 ../../src/cells/GroupCell.cpp:2184
+msgid "A section heading"
+msgstr ""
+
+#: ../../src/wizards/DrawWiz.cpp:479
+#, fuzzy
+msgid "A static plot"
+msgstr "參數式繪圖"
+
+#: ../../src/cells/EditorCell.cpp:4534
+msgid "A sub-sub-sub-subsection heading"
+msgstr ""
+
+#: ../../src/cells/EditorCell.cpp:4531
+msgid "A sub-sub-subsection heading"
+msgstr ""
+
+#: ../../src/cells/EditorCell.cpp:4528 ../../src/cells/GroupCell.cpp:2190
+#, fuzzy
+msgid "A sub-subsection heading"
+msgstr "子章節單元"
+
+#: ../../src/cells/EditorCell.cpp:4525 ../../src/cells/GroupCell.cpp:2187
+#, fuzzy
+msgid "A subsection heading"
+msgstr "子章節單元"
+
+#: ../../src/wxMaximaFrame.cpp:1673
 msgid "A subst with basic maths knowledge"
 msgstr ""
 
-#: ../../src/BTextCtrl.cpp:64
+#: ../../src/sidebars/SymbolsSidebar.cpp:239
+msgid "A symbol from the configuration dialogue"
+msgstr ""
+
+#: ../../src/cells/GroupCell.cpp:2181
+msgid "A text cell"
+msgstr ""
+
+#: ../../src/BTextCtrl.cpp:66
 msgid "A text control got the mouse focus"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1442
+#: ../../src/cells/GroupCell.cpp:2199
+msgid "A title"
+msgstr ""
+
+#: ../../src/cells/TextCell.cpp:197
+msgid ""
+"A variable that can be assigned a number to.\n"
+"Often used by solve() and algsys(), if there is an infinite number of results."
+msgstr ""
+
+#: ../../src/cells/GroupCell.cpp:2205
+msgid "A worksheet cell"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1479
 #, fuzzy
 msgid "A&pply function to each Matrix element..."
 msgstr "套用函數至串列"
 
-#: ../../src/wxMaximaFrame.cpp:1291
+#: ../../src/wxMaximaFrame.cpp:1325
 msgid "A&t Value..."
 msgstr "定點設值(T)..."
 
-#: ../../src/Configuration.cpp:85
+#: ../../src/Styles.cpp:114
 msgid "ASCII maths"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1963
+#: ../../src/dialogs/ConfigDialogue.cpp:1618
+msgid "Abort evaluation on error"
+msgstr ""
+
+#: ../../src/MaximaEvaluator.cpp:214
+#, c-format
+msgid "Aborting due to --exit-on-error (exit code 1). Cell: %s"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:2016
 msgid "About"
 msgstr "關於"
 
-#: ../../src/wxMaximaFrame.cpp:1963 ../../src/wxMaximaFrame.cpp:1965
+#: ../../src/wxMaximaFrame.cpp:2016 ../../src/wxMaximaFrame.cpp:2018
 msgid "About wxMaxima"
 msgstr "關於 wxMaxima"
 
-#: ../../src/wxMaxima.cpp:7837
+#: ../../src/MaximaCommandMenus.cpp:1018
 msgid "Accepts one expression or a list in the format [ode1,ode2,...]"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7841
+#: ../../src/MaximaCommandMenus.cpp:1022
 msgid "Accepts one variable or a list in the format [1,4,...]"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7839
+#: ../../src/MaximaCommandMenus.cpp:1020
 msgid "Accepts one variable or a list in the format [var1,var2,...]"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1371
+#: ../../src/dialogs/ConfigDialogue.cpp:292
+msgid "Accessibility"
+msgstr ""
+
+#: ../../src/sidebars/DrawSidebar.cpp:103
+msgid "Accuracy"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1405
 msgid "Ad&joint Matrix"
 msgstr "伴隨矩陣(&J)"
 
-#: ../../src/wxMaximaFrame.cpp:1657
+#: ../../src/wxMaximaFrame.cpp:1694
 msgid "Add Algebraic E&quality..."
 msgstr "新增代數"
 
-#: ../../src/wxMaximaFrame.cpp:1015
+#: ../../src/wxMaximaFrame.cpp:1049
 msgid "Add a directory to search path"
 msgstr "將目錄加入搜尋路徑"
 
-#: ../../src/wxMaximaFrame.cpp:1752
+#: ../../src/wxMaximaFrame.cpp:1789
 msgid "Add a new item to the beginning of the list. Useful for creating stacks."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8602
+#: ../../src/sidebars/VariablesPane.cpp:228
+msgid "Add all"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:1621
 #, fuzzy
 msgid "Add an element to the end of a list"
 msgstr "開啟文件"
 
-#: ../../src/wxMaxima.cpp:8597
+#: ../../src/MaximaCommandMenus.cpp:1616
 #, fuzzy
 msgid "Add an element to the start of a list"
 msgstr "開啟文件"
 
-#: ../../src/wxMaxima.cpp:7625
+#: ../../src/MaximaCommandMenus.cpp:4497
 msgid "Add dir to path:"
 msgstr "將目錄加入搜尋路徑："
 
-#: ../../src/wxMaximaFrame.cpp:1658
+#: ../../src/wxMaximaFrame.cpp:1695
 msgid "Add equality to the rational simplifier"
 msgstr "新增有理數式化簡所使用的等式"
 
-#: ../../src/wxMaximaFrame.cpp:1015
+#: ../../src/sidebars/SymbolsSidebar.cpp:204
+msgid "Add more symbols"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1262
+msgid "Add the .wxmx file to the HTML export"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1049
 msgid "Add to &Path..."
 msgstr "加入搜尋路徑(&P)..."
 
-#: ../../src/Worksheet.cpp:1531 ../../src/Worksheet.cpp:1564
-#: ../../src/Worksheet.cpp:1704
+#: ../../src/sidebars/UnicodeSidebar.cpp:105
+msgid "Add to symbols Sidebar"
+msgstr ""
+
+#: ../../src/worksheet/WorksheetContextMenu.cpp:304
+#: ../../src/worksheet/WorksheetContextMenu.cpp:337
+#: ../../src/worksheet/WorksheetContextMenu.cpp:477
 msgid "Add to watchlist"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1562
+#: ../../src/sidebars/XmlInspector.cpp:147
+#, c-format
+msgid "Added much text (%li chars) to the XML inspector."
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1896
+msgid "Additional clipboard formats to put on the clipboard on ordinary copy"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:393
+msgid "Additional commands to be added to the preamble of LaTeX output for pdftex."
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1187
+msgid "Additional lines for the TeX preamble:"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:389
+msgid "Additional parameters for Maxima (e.g. -l clisp)."
+msgstr "Maxima 的附加參數 (例： -l clisp)"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1543
+msgid "Additional parameters for Maxima (restart Maxima after changes)"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1318
+msgid "Additional symbols for the \"symbols\" sidebar:"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1599
 msgid "Additionally: log(a*b)=log(a)+log(b)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1566
+#: ../../src/wxMaximaFrame.cpp:1603
 msgid "Additionally: log(a/b)=log(a)-log(b), a and b positive integers"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1996
+#: ../../src/worksheet/WorksheetContextMenu.cpp:768
 msgid "Additive function: f(a+b)=f(a)+f(b)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1911
+#: ../../src/wxMaximaFrame.cpp:1948
 msgid "Advanced 2d plotting"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1809
+#: ../../src/wxMaximaFrame.cpp:1846
 msgid "Advanced guess (PSLQ algorithm)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1920
+#: ../../src/wxMaximaFrame.cpp:1957
 msgid "Advanced variable names"
 msgstr ""
 
-#: ../../src/ToolBar.cpp:321 ../../src/ToolBar.cpp:589
-msgid "After clicking on animations created with with_slider_draw() or similar this slider allows to change the current frame."
+#: ../../src/dialogs/ConfigDialogue.cpp:184
+msgid "Afrikaans"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1028
+#: ../../src/ToolBar.cpp:536 ../../src/ToolBar.cpp:789
+msgid "After clicking on animations created with with_slider_draw() or similar, this slider allows changing the current frame."
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:185
+msgid "Albanian"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1062
 msgid "Aliases"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1714
+#: ../../src/sidebars/TableOfContents.cpp:572
+msgid "All Levels"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1751
 #, fuzzy
 msgid "All but the 1st n elements"
 msgstr "套用函數至串列"
 
-#: ../../src/wxMaximaFrame.cpp:1716
+#: ../../src/wxMaximaFrame.cpp:1753
 #, fuzzy
 msgid "All but the last n elements"
 msgstr "套用函數至串列"
 
-#: ../../src/main.cpp:594 ../../src/wxMaxima.cpp:6075
+#: ../../src/MaximaCommandMenus.cpp:2198 ../../src/main.cpp:883
 msgid "All openable types (*.wxm, *.wxmx, *.mac, *.out, *.xml)|*.wxm;*.wxmx;*.mac;*.out;*.xml|wxMaxima document (*.wxm, *.wxmx)|*.wxm;*.wxmx|Maxima session (*.mac)|*.mac|Xmaxima session (*.out)|*.out|xml from broken .wxmx (*.xml)|*.xml"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:733
+#: ../../src/dialogs/ConfigDialogue.cpp:750
+#, fuzzy
+msgid "All variable names"
+msgstr "舊變數："
+
+#: ../../src/wxMaximaFrame.cpp:770
 #, fuzzy
 msgid "All visible sidebars"
 msgstr "舊變數："
 
-#: ../../src/wxMaximaFrame.cpp:1650
-msgid "Allow to substitute operators"
+#: ../../src/sidebars/HelpBrowser.cpp:48
+msgid "Allow access to an online manual?"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:9040
-msgid "Allows to vary the parameters of a function until it fits experimental data."
+#: ../../src/wxMaximaFrame.cpp:1687
+msgid "Allow substituting operators"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:763
+#: ../../src/wizards/DrawWiz.cpp:722
+msgid "Allows providing separate expressions for calculating"
+msgstr ""
+
+#: ../../src/sidebars/SymbolsSidebar.cpp:182
+msgid "Allows specifying which non-builtin unicode symbols should be displayed in the symbols sidebar along with the built-in symbols."
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:294
+msgid "Allows varying the parameters of a function until it fits experimental data."
+msgstr ""
+
+#: ../../src/dialogs/BinaryNameCtrl.cpp:69
+msgid "All|*"
+msgstr "所有類型|*"
+
+#: ../../src/wxMaximaFrame.cpp:800
 msgid "Always after underscores"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:764
+#: ../../src/wxMaximaFrame.cpp:801
 msgid "Always autosubscript after an underscore"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:774
+#: ../../src/wxMaximaFrame.cpp:811
 msgid "Always display this variable with subscript"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1605
+#: ../../src/worksheet/WorksheetContextMenu.cpp:378
 msgid "Always show all digits"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:9241
+#: ../../src/wizards/DrawWiz.cpp:484
+msgid "An animation with multiple frames"
+msgstr ""
+
+#: ../../src/cells/GroupCell.cpp:2202
+msgid "An image cell"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:433
 msgid "An integer between 1..6; Higher numbers work better for oscillating integrands"
 msgstr ""
 
-#: ../../src/MaximaManual.cpp:385
+#: ../../src/cells/TextCell.cpp:202
+msgid "An integration constant."
+msgstr ""
+
+#: ../../src/MaximaManual.cpp:402
 msgid "Anchors file has no top node."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:791
+#: ../../src/wxMaximaFrame.cpp:828
 msgid "Angles"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1775
+#: ../../src/worksheet/WorksheetExport.cpp:1122
+#: ../../src/worksheet/WorksheetExport.cpp:1387
+msgid "Animated Diagram"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1812
 #, fuzzy
 msgid "Animation autoplay"
 msgstr "儲存動畫至檔案"
 
-#: ../../src/wxMaximaFrame.cpp:1778
+#: ../../src/wxMaximaFrame.cpp:1815
 msgid "Animation framerate..."
 msgstr ""
 
-#: ../../src/Worksheet.cpp:2002
+#: ../../src/dialogs/ConfigDialogue.cpp:1871
+msgid "Announce Maxima's output as MathML"
+msgstr ""
+
+#: ../../src/worksheet/Worksheet.cpp:5467 ../../src/wxMaximaFrame.cpp:1989
+msgid "Anonymize Code for Bug Report"
+msgstr ""
+
+#: ../../src/worksheet/WorksheetContextMenu.cpp:774
 msgid "Antisymmetric function: f(x)=-f(-x)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1739
+#: ../../src/dialogs/ConfigDialogue.cpp:2064
+msgid "Appearance:"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1776
 msgid "Append"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1735
+#: ../../src/wxMaximaFrame.cpp:1772
 msgid "Append a list"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1736
+#: ../../src/wxMaximaFrame.cpp:1773
 #, fuzzy
 msgid "Append a list to an existing list"
 msgstr "求數式的極限"
 
-#: ../../src/wxMaxima.cpp:8607
+#: ../../src/MaximaCommandMenus.cpp:1626
 #, fuzzy
 msgid "Append a list to another list"
 msgstr "求數式的極限"
 
-#: ../../src/wxMaximaFrame.cpp:1729
+#: ../../src/wxMaximaFrame.cpp:1766
 #, fuzzy
 msgid "Append an element"
 msgstr "開啟文件"
 
-#: ../../src/wxMaximaFrame.cpp:1734
+#: ../../src/wxMaximaFrame.cpp:1771
 #, fuzzy
 msgid "Append an element to the beginning an existing list"
 msgstr "求數式的極限"
 
-#: ../../src/wxMaximaFrame.cpp:1730
+#: ../../src/wxMaximaFrame.cpp:1767
 #, fuzzy
 msgid "Append an element to the end of an existing list"
 msgstr "求數式的極限"
 
-#: ../../src/wxMaxima.cpp:8552
+#: ../../src/MaximaCommandMenus.cpp:1565
 #, fuzzy
 msgid "Apply a function to each list element"
 msgstr "套用函數至串列"
 
-#: ../../src/wxMaximaFrame.cpp:1810
+#: ../../src/wxMaximaFrame.cpp:1847
 #, c-format
 msgid "Approximate by a fraction using log(), sqrt() and %pi, when needed. Only available in maxima > 5.46.0"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1806
+#: ../../src/wxMaximaFrame.cpp:1843
 msgid "Approximate by nice fraction"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8931
+#: ../../src/MaximaCommandMenus.cpp:182
 msgid ""
 "Approximates a expression around a point as a polynom\n"
 "The trailing \"...\" can be removed by using ratdisrep()"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8939
+#: ../../src/MaximaCommandMenus.cpp:190
 msgid "Approximates a expression as a polynom"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:9474
+#: ../../src/MaximaCommandMenus.cpp:2117
 msgid "Apropos"
 msgstr "Apropos 指令"
 
-#: ../../src/wxMaxima.cpp:7317
+#: ../../src/dialogs/ConfigDialogue.cpp:186
+msgid "Arabic"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:4189
 msgid "Are the chars equal, if case is ignored?"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7312
+#: ../../src/MaximaCommandMenus.cpp:4184
 #, fuzzy
 msgid "Are the chars equal?"
 msgstr "子章節單元"
 
-#: ../../src/wxMaxima.cpp:7349
+#: ../../src/MaximaCommandMenus.cpp:4221
 msgid "Are these strings equal if case is ignored?"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7344
+#: ../../src/MaximaCommandMenus.cpp:4216
 msgid "Are these strings equal?"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7259
+#: ../../src/MaximaCommandMenus.cpp:4131
 msgid "Arguments:"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8189
+#: ../../src/MaximaCommandMenus.cpp:1379
 #, fuzzy
 msgid "Array"
 msgstr "陣列："
 
-#: ../../src/wxMaximaFrame.cpp:1023
+#: ../../src/wxMaximaFrame.cpp:1057
 #, fuzzy
 msgid "Arrays"
 msgstr "陣列："
 
-#: ../../src/wxMaxima.cpp:7308 ../../src/wxMaxima.cpp:7354
+#: ../../src/cells/TextCell.cpp:212
+msgid ""
+"As calculating 0.1^12 demonstrates maxima by default doesn't tend to hide what looks like being the small error using floating-point numbers introduces.\n"
+"If this seems to be the case here the error can be avoided by using exact numbers like 1/10, 1*10^-1 or rat(.1).\n"
+"It also can be hidden by setting fpprintprec to an appropriate value. But be aware in this case that even small errors can add up."
+msgstr ""
+
+#: ../../src/wizards/ListSortWiz.cpp:51
+msgid "Ascending by magnitude (numeric only)"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:4180 ../../src/MaximaCommandMenus.cpp:4226
 msgid "Ascii code to char"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1138
+#: ../../src/wxMaximaFrame.cpp:1172
 msgid "Ascii code to char..."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:10063
+#: ../../src/dialogs/ConfigDialogue.cpp:1397
+msgid "Ask to save untitled documents"
+msgstr "詢問是否儲存未命名文件"
+
+#: ../../src/dialogs/MaximaNotStartingDialog.cpp:36
+msgid "Asking the user for the location of a working maxima binary"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:3552
 msgid "Assignment(s):"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:10064
+#: ../../src/MaximaCommandMenus.cpp:3553
 msgid "Assignments of the format a=10,b=20"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:6851
+#: ../../src/MaximaCommandMenus.cpp:1754
 msgid "Assume a value range for a variable"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8545
+#: ../../src/MaximaCommandMenus.cpp:1558
 msgid "Attention: Extracting a random list element isn't efficient for long lists.Iterating over lists using makelist() or for loops is way faster."
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1618
+#: ../../src/dialogs/ConfigDialogue.cpp:897
+msgid "Auto-indent new lines"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:893
+#, fuzzy
+msgid "Auto-insert closing parenthesis"
+msgstr "在文字控制項中輸入時匹配括弧"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1441
+#: ../../src/dialogs/ConfigDialogue.cpp:1472
+#: ../../src/dialogs/MaximaNotStartingDialog.cpp:43
+msgid "Autodetect"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1236
+msgid "Automatic"
+msgstr ""
+
+#: ../../src/worksheet/WorksheetContextMenu.cpp:391
 msgid "Automatic labels"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:952
+#: ../../src/dialogs/ConfigDialogue.cpp:769
+#, c-format
+msgid "Automatic labels (%i1, %o1,...)"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:986
 msgid "Automatically answer questions"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:953
+#: ../../src/wxMaximaFrame.cpp:987
 msgid "Automatically fill in answers known from the last run"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1464 ../../src/Worksheet.cpp:1838
+#: ../../src/dialogs/ConfigDialogue.cpp:460
+msgid "Automatically insert a closing parenthesis the moment the user enters an opening one."
+msgstr ""
+
+#: ../../src/worksheet/WorksheetContextMenu.cpp:235
+#: ../../src/worksheet/WorksheetContextMenu.cpp:610
 msgid "Automatically send known answers"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:6021
+#: ../../src/MaximaFileIO.cpp:902
 #, c-format
 msgid "Autosaving as temp file %s"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:6033
+#: ../../src/MaximaFileIO.cpp:914
 #, c-format
 msgid "Autosaving the .wxmx file as %s"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:781
+#: ../../src/wxMaximaFrame.cpp:818
 msgid "Autosubscript"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:782
+#: ../../src/wxMaximaFrame.cpp:819
 msgid "Autosubscript chars after an underscore"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:767
+#: ../../src/wxMaximaFrame.cpp:804
 msgid "Autosubscript numbers and text following single letters"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:6529
+#: ../../src/MaximaCommandMenus.cpp:3049
 msgid "Autosubscript this variable"
 msgstr ""
 
-#: ../../src/MaximaManual.cpp:536
+#: ../../src/dialogs/ConfigDialogue.cpp:734
+msgid "Autowrap long lines:"
+msgstr ""
+
+#: ../../src/sidebars/DrawSidebar.cpp:75
+msgid "Axis"
+msgstr ""
+
+#: ../../src/wizards/BC2Wiz.cpp:59
+msgid "BC2"
+msgstr "邊界條件(二階)"
+
+#: ../../src/MaximaManual.cpp:559
 msgid "Background task that compiles the Manual anchors scheduled."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1350
+#: ../../src/sidebars/StatSidebar.cpp:91
+msgid "Barsplot..."
+msgstr "長條圖..."
+
+#: ../../src/wxMaximaFrame.cpp:1384
 msgid "Basic matrix operations"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:6210
+#: ../../src/dialogs/ConfigDialogue.cpp:187
+msgid "Basque"
+msgstr ""
+
+#: ../../src/dialogs/BinaryNameCtrl.cpp:67
+msgid "Bat files (*.bat)|*.bat|Exe files (*.exe)|*.exe|All|*"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:2366
 msgid "Batch File"
 msgstr "以批次檔載入"
 
-#: ../../src/wxMaxima.cpp:5318
+#: ../../src/wxMaxima.cpp:2079
+#, c-format
+msgid "Batch mode: %d image(s) could not be loaded at all."
+msgstr ""
+
+#: ../../src/wxMaxima.cpp:2084
+#, c-format
+msgid "Batch mode: %d image(s) failed to decode/render (--debug)."
+msgstr ""
+
+#: ../../src/MaximaResponseReader.cpp:523
+#, c-format
+msgid "Batch mode: Maxima asked a question with no scripted answer available (\"%s\"). Halting, as documented for --batch."
+msgstr ""
+
+#: ../../src/cells/TextCell.cpp:305
+msgid "Besides a division by 0 the reason for this error message can be a calculation that returns +/-infinity."
+msgstr ""
+
+#: ../../src/dialogs/TipOfTheDay.cpp:141
+msgid "Besides the global undo functionality that is active when the cursor is between cells, wxMaxima has a per-cell undo function that is active if the cursor is inside a cell. Pressing Ctrl+Z inside a cell can therefore been used for a fine-pitch undo that doesn't affect latter changes made in other cells."
+msgstr ""
+
+#: ../../src/sidebars/GreekSidebar.cpp:179
+msgid "Beta"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1898
+msgid "Bitmap"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1273
+msgid "Bitmap scale for export:"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1223
+msgid "Bitmaps"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:2109
+msgid "Bold"
+msgstr "粗體"
+
+#: ../../src/wxMaxima.cpp:2261
 msgid "Both horizontal and vertical cursor active at the same time"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8191
+#: ../../src/dialogs/ConfigDialogue.cpp:1999
+msgid "Bottom"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:1381
 msgid "Bottom end"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7817
+#: ../../src/MaximaCommandMenus.cpp:998
 #, fuzzy
 msgid "Boundary value problem"
 msgstr "邊界值問題(&B)..."
+
+#: ../../src/MaximaCommandMenus.cpp:1780
+msgid "Boxplot"
+msgstr ""
+
+#: ../../src/sidebars/StatSidebar.cpp:97
+msgid "Boxplot..."
+msgstr "箱形圖..."
+
+#: ../../src/dialogs/BinaryNameCtrl.cpp:42 ../../src/wizards/CsvWiz.cpp:57
+#: ../../src/wizards/CsvWiz.cpp:131 ../../src/wizards/Plot2dWiz.cpp:114
+#: ../../src/wizards/Plot3dWiz.cpp:109
+msgid "Browse"
+msgstr "瀏覽"
 
 #: ../../src/wxMathml.cpp:101
 msgid "Bug: After removing the whitespace wxMathml.lisp is shorter than expected!"
 msgstr ""
 
-#: ../../src/Autocomplete.cpp:509
+#: ../../src/cells/Cell.cpp:498
+#, c-format
+msgid "Bug: AltCopyTexts not implemented for %s cell"
+msgstr ""
+
+#: ../../src/Autocomplete.cpp:642
 msgid "Bug: Autocompletion requested for unknown type of item."
 msgstr ""
 
-#: ../../src/Worksheet.cpp:2992
+#: ../../src/TreeUndoManager.h:138
 msgid "Bug: Cell left but not entered."
 msgstr ""
 
-#: ../../src/Worksheet.cpp:6203
+#: ../../src/worksheet/Worksheet.cpp:4193
 msgid "Bug: Cell with negative y position!"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:7723
+#: ../../src/worksheet/Worksheet.cpp:5905
 msgid "Bug: Encountered a heading I don't know how to move in one sectioning unit"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:7766
+#: ../../src/worksheet/Worksheet.cpp:5952
 msgid "Bug: Encountered a heading I don't know how to move out one sectioning unit"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:3112
+#: ../../src/worksheet/Worksheet.cpp:2244
 msgid "Bug: Got a question but no cell to answer it in"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:6378
-msgid "Bug: Got a request to change the contents of the cell above the beginning of the worksheet."
-msgstr ""
-
-#: ../../src/Worksheet.cpp:6346
+#: ../../src/worksheet/Worksheet.cpp:4293
 msgid "Bug: Got a request to delete the cell above the beginning of the worksheet."
 msgstr ""
 
-#: ../../src/Worksheet.cpp:6415
+#: ../../src/worksheet/WorksheetDocument.cpp:239
 msgid "Bug: Got a request to first change the contents of a cell and to then undelete it."
 msgstr ""
 
-#: ../../src/Worksheet.cpp:5578
+#: ../../src/worksheet/WorksheetExport.cpp:1576
 msgid "Bug: HTML output is no valid XML"
 msgstr ""
 
-#: ../../src/Configuration.h:615
+#: ../../src/cells/Cell.cpp:289
+msgid "Bug: Math Cell that claims to have no group Cell it belongs to"
+msgstr ""
+
+#: ../../src/Configuration.h:741
 msgid "Bug: Maximum number of digits that is to be displayed is too low!"
 msgstr ""
 
-#: ../../src/MathParser.cpp:523
+#: ../../src/MathParser.cpp:575
 msgid "Bug: Missing contents"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:2597 ../../src/Worksheet.cpp:2711
-#: ../../src/Worksheet.cpp:2753 ../../src/Worksheet.cpp:2787
-#: ../../src/Worksheet.cpp:2816 ../../src/Worksheet.cpp:2828
-#: ../../src/Worksheet.cpp:4442 ../../src/Worksheet.cpp:6650
-#: ../../src/Worksheet.cpp:6863
+#: ../../src/cells/GroupCell.cpp:1498
+msgid "Bug: No image counter to write to!"
+msgstr ""
+
+#: ../../src/cells/AnimationCell.cpp:543 ../../src/cells/EditorCell.cpp:2968
+#: ../../src/cells/ImgCell.cpp:353 ../../src/graphical_io/BitmapOut.cpp:161
+#: ../../src/graphical_io/OutCommon.cpp:264
+#: ../../src/worksheet/Worksheet.cpp:1764
+#: ../../src/worksheet/Worksheet.cpp:1901
+#: ../../src/worksheet/Worksheet.cpp:1943
+#: ../../src/worksheet/Worksheet.cpp:1977
+#: ../../src/worksheet/Worksheet.cpp:2006
+#: ../../src/worksheet/Worksheet.cpp:2018
+#: ../../src/worksheet/Worksheet.cpp:3512
+#: ../../src/worksheet/Worksheet.cpp:4641
+#: ../../src/worksheet/Worksheet.cpp:4866
 msgid "Bug: The clipboard is already opened"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:7763
+#: ../../src/cells/EditorCell.cpp:3051
+msgid "Bug: The clipboard isn't open on pasting into an editor cell"
+msgstr ""
+
+#: ../../src/cells/GroupCell.cpp:2288
+msgid "Bug: The predecessor to a GroupCell is not a GroupCell."
+msgstr ""
+
+#: ../../src/cells/GroupCell.cpp:2286
+msgid "Bug: The successor to a GroupCell is not a GroupCell."
+msgstr ""
+
+#: ../../src/cells/GroupCell.cpp:340
+msgid "Bug: Trying to append NULL to a group cell."
+msgstr ""
+
+#: ../../src/worksheet/Worksheet.cpp:5949
 msgid "Bug: Trying to move a title out by one sectioning unit"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:6934
+#: ../../src/worksheet/Worksheet.cpp:4925
 msgid "Bug: Trying to move the horizontally-drawn cursor to a place inside a GroupCell."
 msgstr ""
 
-#: ../../src/Worksheet.h:247 ../../src/Worksheet.h:252
+#: ../../src/TreeUndoAction.h:52 ../../src/TreeUndoAction.h:57
 msgid "Bug: Trying to record a cell contents change for undo without a cell."
 msgstr ""
 
-#: ../../src/Worksheet.cpp:6417
+#: ../../src/TreeUndoAction.h:73
+msgid "Bug: Trying to record a fold/unfold for undo without a cell."
+msgstr ""
+
+#: ../../src/worksheet/WorksheetDocument.cpp:241
 msgid "Bug: Undo action with both cell contents change and cell addition."
 msgstr ""
 
-#: ../../src/Worksheet.cpp:6383
-msgid "Bug: Undo request for cell outside worksheet."
+#: ../../src/cells/EditorCell.cpp:4541
+msgid "Bug: Unknown type of text"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1948
+#: ../../src/cells/EditorCell.cpp:3981 ../../src/cells/TextCell.cpp:479
+msgid "Bug: dc == NULL"
+msgstr ""
+
+#: ../../src/cells/EditorCell.cpp:2637
+msgid "Bug: x position of cell is unknown!"
+msgstr ""
+
+#: ../../src/cells/EditorCell.cpp:2638
+msgid "Bug: y position of cell is unknown!"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1985
 msgid "Build &Info"
 msgstr "建置資訊(&I)"
 
-#: ../../src/wxMaxima.cpp:7275
+#: ../../src/dialogs/AboutDialog.cpp:45
+#, c-format
+msgid "Build from Git version: %s\n"
+msgstr ""
+
+#: ../../src/dialogs/TipOfTheDay.cpp:54
+#, fuzzy
+msgid "By default, Shift-Enter is used to evaluate commands, while Enter is used for multiline input. This behaviour can be changed in 'Edit->Configure' dialog by checking 'Enter evaluates cells'. This switches the roles of these two key commands."
+msgstr "預設值使用 Shift+Enter 來開始評算，Enter 則是用來做多行輸入。這個操作方式可透過「編輯(E)」->「設定(O)」對話框中勾選「按 Enter 鍵評算單元」變更。這會交換這兩組按鍵的功能。"
+
+#: ../../src/MaximaCommandMenus.cpp:4147
 msgid "Byte:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1458
+#: ../../src/wxMaximaFrame.cpp:1495
 #, fuzzy
 msgid "C&hange Variable in Integrate..."
 msgstr "變數變換(&H)..."
 
-#: ../../src/wxMaximaFrame.cpp:687
+#: ../../src/wxMaximaFrame.cpp:724
 msgid "C&onfigure"
 msgstr "設定(&O)"
 
-#: ../../src/wxMaximaFrame.cpp:1482
+#: ../../src/wizards/CsvWiz.cpp:105
+msgid "CSV export"
+msgstr ""
+
+#: ../../src/wizards/CsvWiz.cpp:34
+msgid "CSV import"
+msgstr ""
+
+#: ../../src/cells/FontVariantCache.cpp:96
+#, c-format
+msgid "Caching font variant: %s"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1519
 msgid "Calculate &Product..."
 msgstr "計算乘積(&P)..."
 
-#: ../../src/wxMaxima.cpp:8057
+#: ../../src/MaximaCommandMenus.cpp:1243
 msgid "Calculate Singular Value Decomposition of a matrix numerically"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8050
+#: ../../src/MaximaCommandMenus.cpp:1236
 msgid "Calculate Singular Value Decomposition, left and right singular vectors numerically"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1480
+#: ../../src/wxMaximaFrame.cpp:1517
 msgid "Calculate Su&m..."
 msgstr "計算加總(&M)..."
 
-#: ../../src/wxMaximaFrame.cpp:1795
+#: ../../src/wxMaximaFrame.cpp:1832
 msgid "Calculate bigfloat value of the last result"
 msgstr "將最後的計算結果以長浮點數 (bigfloat) 表示"
 
-#: ../../src/wxMaximaFrame.cpp:1792
+#: ../../src/wxMaximaFrame.cpp:1829
 msgid "Calculate float value of the last result"
 msgstr "將最後的計算結果以浮點數 (float) 表示"
 
-#: ../../src/wxMaxima.cpp:9550
+#: ../../src/MaximaCommandMenus.cpp:1788
 #, fuzzy
 msgid "Calculate mean value"
 msgstr "模運算："
 
-#: ../../src/wxMaxima.cpp:9554
+#: ../../src/MaximaCommandMenus.cpp:1792
 #, fuzzy
 msgid "Calculate median value"
 msgstr "模運算："
 
-#: ../../src/wxMaxima.cpp:8871
+#: ../../src/MaximaCommandMenus.cpp:878
 msgid "Calculate modulus:"
 msgstr "模運算："
 
-#: ../../src/wxMaximaFrame.cpp:1798
+#: ../../src/wxMaximaFrame.cpp:1835
 #, fuzzy
 msgid "Calculate numeric value of the last result"
 msgstr "將最後的計算結果以浮點數 (float) 表示"
 
-#: ../../src/wxMaximaFrame.cpp:1483
+#: ../../src/wxMaximaFrame.cpp:1520
 msgid "Calculate products"
 msgstr "計算乘積"
 
-#: ../../src/wxMaxima.cpp:9562
+#: ../../src/MaximaCommandMenus.cpp:1800
 msgid "Calculate standard deviation"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1480
+#: ../../src/wxMaximaFrame.cpp:1517
 msgid "Calculate sums"
 msgstr "計算加總"
 
-#: ../../src/wxMaxima.cpp:8025 ../../src/wxMaxima.cpp:8035
+#: ../../src/MaximaCommandMenus.cpp:1209 ../../src/MaximaCommandMenus.cpp:1219
 msgid "Calculate the eigenvalues and eigenvectors numerically"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8020 ../../src/wxMaxima.cpp:8030
+#: ../../src/MaximaCommandMenus.cpp:1204 ../../src/MaximaCommandMenus.cpp:1214
 #, fuzzy
 msgid "Calculate the eigenvalues of a matrix numerically"
 msgstr "計算矩陣的反矩陣"
 
-#: ../../src/wxMaxima.cpp:8078 ../../src/wxMaxima.cpp:8099
+#: ../../src/MaximaCommandMenus.cpp:1264 ../../src/MaximaCommandMenus.cpp:1287
 msgid "Calculate the root of the sum of squares of matrix entries"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:9558
-#, fuzzy
-msgid "Calculate variation"
-msgstr "計算乘積"
+#: ../../src/MaximaCommandMenus.cpp:1796
+msgid "Calculate variance"
+msgstr ""
 
-#: ../../src/wxMaxima.cpp:8949
+#: ../../src/MaximaCommandMenus.cpp:203
 msgid "Calculates the fourier coefficients for the expression from -p to p"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1968
+#: ../../src/worksheet/WorksheetContextMenu.cpp:740
 msgid "Calls assume() in order to tell maxima about the variable's range"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:2031
+#: ../../src/worksheet/WorksheetContextMenu.cpp:803
 msgid "Can be specified as flag in ev(exp, flag)"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:11125
+#: ../../src/wxMaxima.cpp:3438
 msgid "Can not connect to the web server."
 msgstr "無法連線至網路伺服器。"
 
-#: ../../src/wxMaxima.cpp:11166
+#: ../../src/wxMaxima.cpp:3384 ../../src/wxMaxima.cpp:3420
+#: ../../src/wxMaxima.cpp:3472
 msgid "Can not download version info."
 msgstr "無法下載版本資訊。"
 
-#: ../../src/wxMaxima.cpp:3016 ../../src/wxMaxima.cpp:4836
+#: ../../src/MaximaProcessManager.cpp:577 ../../src/wxMaxima.cpp:1581
 msgid "Can not start Maxima. The most probable cause is that Maxima isn't installed (it can be downloaded from https://maxima.sourceforge.io) or in wxMaxima's config dialogue the setting for Maxima's location is wrong."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:11203
+#: ../../src/dialogs/MaxSizeChooser.cpp:46
+#: ../../src/dialogs/MaxSizeChooser.cpp:48
+#: ../../src/dialogs/MaximaNotStartingDialog.cpp:71
+#: ../../src/dialogs/MaximaNotStartingDialog.cpp:73
+#: ../../src/dialogs/ResolutionChooser.cpp:41
+#: ../../src/dialogs/ResolutionChooser.cpp:43
+#: ../../src/wizards/ActualValuesStorageWiz.cpp:61
+#: ../../src/wizards/ActualValuesStorageWiz.cpp:63
+#: ../../src/wizards/BC2Wiz.cpp:48 ../../src/wizards/BC2Wiz.cpp:50
+#: ../../src/wizards/CsvWiz.cpp:65 ../../src/wizards/CsvWiz.cpp:139
+#: ../../src/wizards/DrawWiz.cpp:111 ../../src/wizards/DrawWiz.cpp:222
+#: ../../src/wizards/DrawWiz.cpp:354 ../../src/wizards/DrawWiz.cpp:509
+#: ../../src/wizards/DrawWiz.cpp:568 ../../src/wizards/DrawWiz.cpp:665
+#: ../../src/wizards/DrawWiz.cpp:773 ../../src/wizards/DrawWiz.cpp:849
+#: ../../src/wizards/DrawWiz.cpp:987 ../../src/wizards/Gen1Wiz.cpp:44
+#: ../../src/wizards/Gen1Wiz.cpp:46 ../../src/wizards/Gen2Wiz.cpp:47
+#: ../../src/wizards/Gen2Wiz.cpp:49 ../../src/wizards/Gen3Wiz.cpp:55
+#: ../../src/wizards/Gen3Wiz.cpp:57 ../../src/wizards/Gen4Wiz.cpp:62
+#: ../../src/wizards/Gen4Wiz.cpp:64 ../../src/wizards/Gen5Wiz.cpp:70
+#: ../../src/wizards/Gen5Wiz.cpp:72 ../../src/wizards/GenWizPanel.cpp:111
+#: ../../src/wizards/GenWizPanel.cpp:113 ../../src/wizards/IntegrateWiz.cpp:62
+#: ../../src/wizards/IntegrateWiz.cpp:64 ../../src/wizards/LimitWiz.cpp:50
+#: ../../src/wizards/LimitWiz.cpp:52 ../../src/wizards/ListSortWiz.cpp:77
+#: ../../src/wizards/ListSortWiz.cpp:79 ../../src/wizards/MatWiz.cpp:40
+#: ../../src/wizards/MatWiz.cpp:42 ../../src/wizards/MatWiz.cpp:169
+#: ../../src/wizards/MatWiz.cpp:171 ../../src/wizards/Plot2dWiz.cpp:95
+#: ../../src/wizards/Plot2dWiz.cpp:97 ../../src/wizards/Plot2dWiz.cpp:512
+#: ../../src/wizards/Plot2dWiz.cpp:514 ../../src/wizards/Plot2dWiz.cpp:608
+#: ../../src/wizards/Plot2dWiz.cpp:610 ../../src/wizards/Plot3dWiz.cpp:90
+#: ../../src/wizards/Plot3dWiz.cpp:92 ../../src/wizards/PlotFormatWiz.cpp:48
+#: ../../src/wizards/PlotFormatWiz.cpp:50 ../../src/wizards/SeriesWiz.cpp:50
+#: ../../src/wizards/SeriesWiz.cpp:52 ../../src/wizards/SubstituteWiz.cpp:42
+#: ../../src/wizards/SubstituteWiz.cpp:44 ../../src/wizards/SumWiz.cpp:48
+#: ../../src/wizards/SumWiz.cpp:50 ../../src/wizards/SystemWiz.cpp:39
+#: ../../src/wizards/SystemWiz.cpp:41 ../../src/wxMaxima.cpp:3509
 msgid "Cancel"
 msgstr "取消"
 
-#: ../../src/wxMaxima.cpp:3292
+#: ../../src/MaximaResponseReader.cpp:344
 msgid "Cannot authenticate Maxima!"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2677
+#: ../../src/wxMaxima.cpp:1283
+#, c-format
+msgid "Cannot cache the list of known symbols to %s"
+msgstr ""
+
+#: ../../src/cells/FontVariantCache.cpp:85
+#, c-format
+msgid "Cannot create a font based on %s. Falling back to a default font."
+msgstr ""
+
+#: ../../src/MaximaProcessManager.cpp:370
 msgid "Cannot find a maxima binary and no binary chosen in the config dialogue."
 msgstr ""
 
-#: ../../src/Autocomplete.cpp:583
+#: ../../src/Autocomplete.cpp:719
 #, c-format
 msgid "Cannot interpret template %s"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3082
+#: ../../src/MaximaResponseReader.cpp:221
 #, c-format
 msgid "Cannot interpret the numeric value of pid %s"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:11066 ../../src/wxMaxima.cpp:11073
-#: ../../src/wxMaxima.cpp:11080
+#: ../../src/wxMaxima.cpp:3347 ../../src/wxMaxima.cpp:3354
+#: ../../src/wxMaxima.cpp:3361
 #, c-format
 msgid "Cannot interpret version number component %s"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2530
+#: ../../src/cells/EditorCell.cpp:2991
+msgid "Cannot put the copied text on the clipboard"
+msgstr ""
+
+#: ../../src/cells/EditorCell.cpp:2984
+msgid "Cannot put the copied text on the clipboard (1st try)"
+msgstr ""
+
+#: ../../src/cells/EditorCell.cpp:2988
+msgid "Cannot put the copied text on the clipboard (2nd try)"
+msgstr ""
+
+#: ../../src/graphical_io/OutCommon.cpp:98
+#, c-format
+msgid "Cannot remove the file %s"
+msgstr ""
+
+#: ../../src/sidebars/History.cpp:258
+#, c-format
+msgid "Cannot save the command history to %s"
+msgstr ""
+
+#: ../../src/MaximaManual.cpp:386
+#, c-format
+msgid "Cannot save the list of subjects manual contains to the file %s."
+msgstr ""
+
+#: ../../src/MaximaProcessManager.cpp:191
 msgid "Cannot set the communication address to localhost."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2532
+#: ../../src/MaximaProcessManager.cpp:193
 #, c-format
 msgid "Cannot set the communication port to %i."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3656 ../../src/wxMaxima.cpp:6359
+#: ../../src/MaximaCommandMenus.cpp:2795 ../../src/MaximaResponseReader.cpp:880
 #, fuzzy
 msgid "Cannot start gnuplot"
 msgstr "參數式繪圖"
 
-#: ../../src/StatusBar.cpp:216 ../../src/wxMaxima.cpp:2662
+#: ../../src/MaximaCommandMenus.cpp:2844
+msgid "Cannot start the headless gnuplot warnings check"
+msgstr ""
+
+#: ../../src/MaximaProcessManager.cpp:341 ../../src/StatusBar.cpp:254
 msgid "Cannot start the maxima binary"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:9268
+#: ../../src/sidebars/MathSidebar.cpp:62
+msgid "Canonical (tr)"
+msgstr "標準型式 (三角)"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:188
+msgid "Catalan"
+msgstr "Catalan"
+
+#: ../../src/MaximaCommandMenus.cpp:466
 msgid "Cauchy principal value of f(x)/(x-c), finite interval"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1845
+#: ../../src/wxMaximaFrame.cpp:1882
 msgid "Cauchy principal value, finite interval"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:955
+#: ../../src/wxMaximaFrame.cpp:989
 msgid "Ce&ll"
 msgstr "單元(&L)"
 
-#: ../../src/Configuration.cpp:96
+#: ../../src/Styles.cpp:125
 #, fuzzy
 msgid "Cell bracket fill, Active"
 msgstr "單元框"
 
-#: ../../src/Configuration.cpp:95
+#: ../../src/Styles.cpp:124
 #, fuzzy
 msgid "Cell bracket fill, Inactive"
 msgstr "單元框"
 
-#: ../../src/wxMaxima.cpp:10395
+#: ../../src/wxMaxima.cpp:3082
 msgid "Cell ends in a backslash"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1038
+#: ../../src/MaximaCommandMenus.cpp:2262
+#, c-format
+msgid "Cell with UUID %s not found!"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1072
 msgid "Change &2d Display"
 msgstr "變更顯示方式(&2)"
 
-#: ../../src/wxMaxima.cpp:10146
+#: ../../src/MaximaCommandMenus.cpp:3641
 #, fuzzy
 msgid "Change Image"
 msgstr "變數變換"
 
-#: ../../src/Worksheet.cpp:1324
+#: ../../src/worksheet/WorksheetContextMenu.cpp:86
 #, fuzzy
 msgid "Change Image..."
 msgstr "儲存圖片..."
 
-#: ../../src/wxMaximaFrame.cpp:1954
+#: ../../src/wxMaximaFrame.cpp:1997
 #, fuzzy
 msgid "Change Log"
 msgstr "變數變換"
 
-#: ../../src/wxMaxima.cpp:7555
+#: ../../src/MaximaCommandMenus.cpp:4427
 msgid "Change directory"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1202
+#: ../../src/wxMaximaFrame.cpp:1236
 #, fuzzy
 msgid "Change directory..."
 msgstr "儲存圖片..."
 
-#: ../../src/wxMaximaFrame.cpp:1039
+#: ../../src/dialogs/ConfigDialogue.cpp:859
+msgid "Change names of greek letters to greek letters"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1073
 msgid "Change the 2d display algorithm used to display math output"
 msgstr "變更顯示數學輸出的演算法"
 
-#: ../../src/wxMaxima.cpp:8885
+#: ../../src/dialogs/ConfigDialogue.cpp:489
+msgid "Change the text \"alpha\" and \"beta\" to the corresponding greek letter?"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:136
 msgid "Change variable"
 msgstr "變數變換"
 
-#: ../../src/wxMaxima.cpp:8905
+#: ../../src/MaximaCommandMenus.cpp:156
 #, fuzzy
 msgid "Change variable and evaluate"
 msgstr "對積分數式或加總數式作變數變換"
 
-#: ../../src/wxMaximaFrame.cpp:1459
+#: ../../src/wxMaximaFrame.cpp:1496
 msgid "Change variable in integral or sum"
 msgstr "對積分數式或加總數式作變數變換"
 
-#: ../../src/wxMaximaFrame.cpp:1463
+#: ../../src/wxMaximaFrame.cpp:1500
 #, fuzzy
 msgid "Change variable in integral or sum and evaluate the result"
 msgstr "對積分數式或加總數式作變數變換"
 
-#: ../../src/wxMaximaFrame.cpp:1026
+#: ../../src/dialogs/ChangeLogDialog.cpp:37
+#, fuzzy
+msgid "ChangeLog"
+msgstr "變數變換"
+
+#: ../../src/wxMaximaFrame.cpp:1060
 #, fuzzy
 msgid "Changed option variables"
 msgstr "變數變換"
 
-#: ../../src/wxMaxima.cpp:10170
+#: ../../src/MaximaCommandMenus.cpp:3699
 #, c-format
 msgid "Changing image originally loaded from file %s to %s."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7313 ../../src/wxMaxima.cpp:7318
-#: ../../src/wxMaxima.cpp:7323 ../../src/wxMaxima.cpp:7329
-#: ../../src/wxMaxima.cpp:7334 ../../src/wxMaxima.cpp:7340
+#: ../../src/MaximaCommandMenus.cpp:4185 ../../src/MaximaCommandMenus.cpp:4190
+#: ../../src/MaximaCommandMenus.cpp:4195 ../../src/MaximaCommandMenus.cpp:4201
+#: ../../src/MaximaCommandMenus.cpp:4206 ../../src/MaximaCommandMenus.cpp:4212
 msgid "Char #1:"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7314 ../../src/wxMaxima.cpp:7319
-#: ../../src/wxMaxima.cpp:7324 ../../src/wxMaxima.cpp:7329
-#: ../../src/wxMaxima.cpp:7335 ../../src/wxMaxima.cpp:7340
+#: ../../src/MaximaCommandMenus.cpp:4186 ../../src/MaximaCommandMenus.cpp:4191
+#: ../../src/MaximaCommandMenus.cpp:4196 ../../src/MaximaCommandMenus.cpp:4201
+#: ../../src/MaximaCommandMenus.cpp:4207 ../../src/MaximaCommandMenus.cpp:4212
 #, fuzzy
 msgid "Char #2:"
 msgstr "矩陣："
 
-#: ../../src/wxMaximaFrame.cpp:1140
+#: ../../src/wxMaximaFrame.cpp:1174
 msgid "Char to Unicode code point..."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7358 ../../src/wxMaxima.cpp:7362
+#: ../../src/MaximaCommandMenus.cpp:4230 ../../src/MaximaCommandMenus.cpp:4234
 msgid "Char to unicode code point"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7285 ../../src/wxMaxima.cpp:7289
-#: ../../src/wxMaxima.cpp:7293 ../../src/wxMaxima.cpp:7297
-#: ../../src/wxMaxima.cpp:7301 ../../src/wxMaxima.cpp:7305
-#: ../../src/wxMaxima.cpp:7359 ../../src/wxMaxima.cpp:7363
-#: ../../src/wxMaxima.cpp:7435
+#: ../../src/MaximaCommandMenus.cpp:4157 ../../src/MaximaCommandMenus.cpp:4161
+#: ../../src/MaximaCommandMenus.cpp:4165 ../../src/MaximaCommandMenus.cpp:4169
+#: ../../src/MaximaCommandMenus.cpp:4173 ../../src/MaximaCommandMenus.cpp:4177
+#: ../../src/MaximaCommandMenus.cpp:4231 ../../src/MaximaCommandMenus.cpp:4235
+#: ../../src/MaximaCommandMenus.cpp:4307
 msgid "Char:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1131
+#: ../../src/wxMaximaFrame.cpp:1165
 msgid "Character Tests"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8181
+#: ../../src/MaximaCommandMenus.cpp:1369
 #, fuzzy
 msgid "Characteristic polynom"
 msgstr "特徵多項式(&C)..."
 
-#: ../../src/wxMaxima.cpp:7280
+#: ../../src/MaximaCommandMenus.cpp:4152
 msgid "Chars are strings that are one character long"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1957
+#: ../../src/wxMaximaFrame.cpp:2000
 msgid "Check for Updates"
 msgstr "檢查更新"
 
-#: ../../src/wxMaximaFrame.cpp:1958
+#: ../../src/wxMaximaFrame.cpp:2001
 #, fuzzy
 msgid "Check if a newer version of wxMaxima is available."
 msgstr "檢查是否存在新版的 wxMaxima 或 Maxima"
 
-#: ../../src/wxMaximaFrame.cpp:800
+#: ../../src/sidebars/GreekSidebar.cpp:199
+msgid "Chi"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:189
+msgid "Chinese (Simplified)"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:190
+msgid "Chinese (traditional)"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1554
+msgid "Choose a Lisp Maxima was compiled with"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1560
+msgid "Choose between installed Maxima versions"
+msgstr ""
+
+#: ../../src/sidebars/HelpBrowser.cpp:204
+msgid "Choose between the following help topics:"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:2100
+msgid "Choose font"
+msgstr "選擇字型"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:793
+msgid ""
+"Choose how mathematical output is formatted:\n"
+"\"2D, whenever possible\" keeps all expressions in two-dimensional form (fractions stacked, matrices drawn as boxes), even if they overflow the page width.\n"
+"\"2D if it fits on the page width\" (default) switches wide objects to linear notation.\n"
+"\"Prefer 1D\" always uses linear notation."
+msgstr ""
+
+#: ../../src/wizards/PlotFormatWiz.cpp:31
+msgid "Choose new plot format:"
+msgstr "選擇新的繪圖格式："
+
+#: ../../src/dialogs/ConfigDialogue.cpp:2432
+#, fuzzy, c-format
+msgid "Choose the %s Font"
+msgstr "選擇字型"
+
+#: ../../src/wxMaximaFrame.cpp:837
 msgid "Choose the parenthesis type for Matrices"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:9530 ../../src/wxMaxima.cpp:9535
+#: ../../src/MaximaCommandMenus.cpp:1768 ../../src/MaximaCommandMenus.cpp:1773
 msgid "Classes:"
 msgstr "種類數："
 
-#: ../../src/wxMaximaFrame.cpp:1378
+#: ../../src/wxMaximaFrame.cpp:1412
 msgid "Classic matrix operations"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:998
+#: ../../src/wxMaximaFrame.cpp:1032
 #, fuzzy
 msgid "Clear all aliases"
 msgstr "清除記憶體(&C)"
 
-#: ../../src/wxMaximaFrame.cpp:995
+#: ../../src/wxMaximaFrame.cpp:1029
 #, fuzzy
 msgid "Clear all arrays"
 msgstr "清除記憶體(&C)"
 
-#: ../../src/wxMaximaFrame.cpp:992
+#: ../../src/wxMaximaFrame.cpp:1026
 #, fuzzy
 msgid "Clear all dependencies"
 msgstr "清除記憶體(&C)"
 
-#: ../../src/wxMaximaFrame.cpp:994
+#: ../../src/wxMaximaFrame.cpp:1028
 #, fuzzy
 msgid "Clear all functions"
 msgstr "刪除函數"
 
-#: ../../src/wxMaximaFrame.cpp:1001
+#: ../../src/wxMaximaFrame.cpp:1035
 #, fuzzy
 msgid "Clear all gradefs"
 msgstr "清除記憶體(&C)"
 
-#: ../../src/wxMaximaFrame.cpp:1000
+#: ../../src/sidebars/History.cpp:116
+msgid "Clear all history"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1034
 #, fuzzy
 msgid "Clear all labels"
 msgstr "清除記憶體(&C)"
 
-#: ../../src/wxMaximaFrame.cpp:1004
+#: ../../src/wxMaximaFrame.cpp:1038
 msgid "Clear all let rule packages"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1003
+#: ../../src/wxMaximaFrame.cpp:1037
 #, fuzzy
 msgid "Clear all macros"
 msgstr "清除記憶體(&C)"
 
-#: ../../src/wxMaximaFrame.cpp:1002
+#: ../../src/wxMaximaFrame.cpp:1036
 #, fuzzy
 msgid "Clear all props"
 msgstr "清除記憶體(&C)"
 
-#: ../../src/wxMaximaFrame.cpp:997
+#: ../../src/wxMaximaFrame.cpp:1031
 #, fuzzy
 msgid "Clear all rules"
 msgstr "清除記憶體(&C)"
 
-#: ../../src/wxMaximaFrame.cpp:999
+#: ../../src/wxMaximaFrame.cpp:1033
 #, fuzzy
 msgid "Clear all structures"
 msgstr "清除記憶體(&C)"
 
-#: ../../src/wxMaximaFrame.cpp:993
+#: ../../src/wxMaximaFrame.cpp:1027
 #, fuzzy
 msgid "Clear all variables"
 msgstr "刪除變數"
 
-#: ../../src/wxMaximaFrame.cpp:606
+#: ../../src/sidebars/History.cpp:115
+#, fuzzy
+msgid "Clear the selection"
+msgstr "剪下所選區域"
+
+#: ../../src/cells/FontVariantCache.cpp:44
+#, c-format
+msgid "Cleared font cache for font %s"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1926
+msgid "Clipboard format parameters"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:637
 msgid "Close\tCtrl+W"
 msgstr "關閉\tCtrl+W"
 
-#: ../../src/wxMaxima.cpp:7235
+#: ../../src/MaximaCommandMenus.cpp:4107
 msgid "Close Stream"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:606
+#: ../../src/wxMaximaFrame.cpp:637
 msgid "Close window"
 msgstr "關閉視窗"
 
-#: ../../src/wxMaximaFrame.cpp:1105
+#: ../../src/wxMaximaFrame.cpp:1139
 #, fuzzy
 msgid "Close..."
 msgstr "求解..."
 
-#: ../../src/WXMXformat.cpp:301
+#: ../../src/WXMXformat.cpp:303
 msgid "Closed the zip archive"
 msgstr ""
 
-#: ../../src/Configuration.cpp:77
+#: ../../src/Styles.cpp:106
 #, fuzzy
 msgid "Code Default (Maxima input)"
 msgstr "Maxima 輸入"
 
-#: ../../src/Configuration.cpp:103
+#: ../../src/Styles.cpp:133
 msgid "Code highlighting: Comments"
 msgstr ""
 
-#: ../../src/Configuration.cpp:108
+#: ../../src/Styles.cpp:138
 msgid "Code highlighting: End of line markers"
 msgstr ""
 
-#: ../../src/Configuration.cpp:102
+#: ../../src/Styles.cpp:132
 msgid "Code highlighting: Functions"
 msgstr ""
 
-#: ../../src/Configuration.cpp:107
+#: ../../src/Styles.cpp:137
 msgid "Code highlighting: Lisp"
 msgstr ""
 
-#: ../../src/Configuration.cpp:104
+#: ../../src/Styles.cpp:134
 msgid "Code highlighting: Numbers"
 msgstr ""
 
-#: ../../src/Configuration.cpp:106
+#: ../../src/Styles.cpp:136
 msgid "Code highlighting: Operators"
 msgstr ""
 
-#: ../../src/Configuration.cpp:105
+#: ../../src/Styles.cpp:135
 msgid "Code highlighting: Strings"
 msgstr ""
 
-#: ../../src/Configuration.cpp:101
+#: ../../src/Styles.cpp:131
 msgid "Code highlighting: Variables"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7309 ../../src/wxMaxima.cpp:7355
+#: ../../src/MaximaCommandMenus.cpp:4181 ../../src/MaximaCommandMenus.cpp:4227
 #, fuzzy
 msgid "Code number:"
 msgstr "欄："
 
-#: ../../src/wxMaxima.cpp:7367 ../../src/wxMaxima.cpp:7373
+#: ../../src/MaximaCommandMenus.cpp:4239 ../../src/MaximaCommandMenus.cpp:4245
 #, fuzzy
 msgid "Codepoint number:"
 msgstr "欄："
 
-#: ../../src/wxMaxima.cpp:9590
+#: ../../src/MaximaCommandMenus.cpp:1830
 msgid "Col. names:"
 msgstr "欄位名："
 
-#: ../../src/Configuration.cpp:100
+#: ../../src/Styles.cpp:130
 #, fuzzy
 msgid "Color of Outdated cells"
 msgstr "過時的單元"
 
-#: ../../src/Configuration.cpp:99
+#: ../../src/Styles.cpp:128
 #, fuzzy
 msgid "Color of text equal to selection"
 msgstr "剪下所選區域"
 
-#: ../../src/wxMaxima.cpp:7962
+#: ../../src/MaximaCommandMenus.cpp:1142 ../../src/MaximaCommandMenus.cpp:1152
 #, fuzzy
 msgid "Column number:"
 msgstr "欄："
 
-#: ../../src/wxMaxima.cpp:7978
+#: ../../src/MaximaCommandMenus.cpp:1157
 #, fuzzy
 msgid "Column numbers:"
 msgstr "欄："
 
-#: ../../src/wxMaxima.cpp:8202
+#: ../../src/MaximaCommandMenus.cpp:1392
 #, fuzzy
 msgid "Columns"
 msgstr "欄："
 
-#: ../../src/wxMaximaFrame.cpp:1584
+#: ../../src/wizards/MatWiz.cpp:155
+msgid "Columns:"
+msgstr "欄："
+
+#: ../../src/wxMaximaFrame.cpp:1621
 msgid "Combine factorials in an expression"
 msgstr "合併數式中的階乘"
 
-#: ../../src/wxMaxima.cpp:10454
+#: ../../src/wizards/CsvWiz.cpp:41 ../../src/wizards/CsvWiz.cpp:112
+msgid "Comma"
+msgstr ""
+
+#: ../../src/wxMaxima.cpp:3141
 msgid "Comma directly followed by a closing parenthesis"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7259
+#: ../../src/wizards/Plot2dWiz.cpp:626
+msgid "Comma separated x coordinates"
+msgstr "x 座標，以逗號分隔"
+
+#: ../../src/wizards/Plot2dWiz.cpp:627
+msgid "Comma separated y coordinates"
+msgstr "y 座標，以逗號分隔"
+
+#: ../../src/MaximaCommandMenus.cpp:4131
 #, fuzzy
 msgid "Comma-separated arguments"
 msgstr "x 座標，以逗號分隔"
 
-#: ../../src/wxMaxima.cpp:7057 ../../src/wxMaxima.cpp:7066
+#: ../../src/MaximaCommandMenus.cpp:3929 ../../src/MaximaCommandMenus.cpp:3938
 #, fuzzy
 msgid "Comma-separated commands"
 msgstr "x 座標，以逗號分隔"
 
-#: ../../src/wxMaxima.cpp:8458
+#: ../../src/MaximaCommandMenus.cpp:1461
 #, fuzzy
 msgid "Comma-separated elements"
 msgstr "x 座標，以逗號分隔"
 
-#: ../../src/wxMaxima.cpp:7752 ../../src/wxMaxima.cpp:7766
-#: ../../src/wxMaxima.cpp:10031
+#: ../../src/MaximaCommandMenus.cpp:933 ../../src/MaximaCommandMenus.cpp:947
+#: ../../src/MaximaCommandMenus.cpp:3520
 #, fuzzy
 msgid "Comma-separated equations"
 msgstr "x 座標，以逗號分隔"
 
-#: ../../src/wxMaxima.cpp:8727 ../../src/wxMaxima.cpp:8735
-#: ../../src/wxMaxima.cpp:8743 ../../src/wxMaxima.cpp:8751
-#: ../../src/wxMaxima.cpp:8760 ../../src/wxMaxima.cpp:8768
+#: ../../src/MaximaCommandMenus.cpp:722 ../../src/MaximaCommandMenus.cpp:732
+#: ../../src/MaximaCommandMenus.cpp:741 ../../src/MaximaCommandMenus.cpp:752
+#: ../../src/MaximaCommandMenus.cpp:764
 #, fuzzy
 msgid "Comma-separated expressions"
 msgstr "x 座標，以逗號分隔"
 
-#: ../../src/wxMaxima.cpp:7215
+#: ../../src/MaximaCommandMenus.cpp:4087
 #, fuzzy
 msgid "Comma-separated expressions that shall be converted to a string"
 msgstr "x 座標，以逗號分隔"
 
-#: ../../src/wxMaxima.cpp:7100 ../../src/wxMaxima.cpp:7114
+#: ../../src/MaximaCommandMenus.cpp:3972 ../../src/MaximaCommandMenus.cpp:3986
 #, fuzzy
 msgid "Comma-separated expressions."
 msgstr "x 座標，以逗號分隔"
 
-#: ../../src/wxMaxima.cpp:7073 ../../src/wxMaxima.cpp:7168
+#: ../../src/MaximaCommandMenus.cpp:3945 ../../src/MaximaCommandMenus.cpp:4040
 #, fuzzy
 msgid "Comma-separated function names"
 msgstr "x 座標，以逗號分隔"
 
-#: ../../src/wxMaxima.cpp:7086
+#: ../../src/MaximaCommandMenus.cpp:3958
 #, fuzzy
 msgid "Comma-separated function names."
 msgstr "x 座標，以逗號分隔"
 
-#: ../../src/wxMaxima.cpp:8560 ../../src/wxMaxima.cpp:8567
-#: ../../src/wxMaxima.cpp:8573 ../../src/wxMaxima.cpp:8580
+#: ../../src/MaximaCommandMenus.cpp:1576 ../../src/MaximaCommandMenus.cpp:1585
+#: ../../src/MaximaCommandMenus.cpp:1591 ../../src/MaximaCommandMenus.cpp:1598
 msgid "Comma-separated list entry in the format val1=1,val2=2"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7205
+#: ../../src/MaximaCommandMenus.cpp:4077
 msgid "Comma-separated names of the elements that shall be written"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7099
+#: ../../src/MaximaCommandMenus.cpp:3971
 msgid "Comma-separated names the parameters will be referenced by later."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7488 ../../src/wxMaxima.cpp:7493
+#: ../../src/MaximaCommandMenus.cpp:4360 ../../src/MaximaCommandMenus.cpp:4365
 #, fuzzy
 msgid "Comma-separated numbers from 0 to 255"
 msgstr "x 座標，以逗號分隔"
 
-#: ../../src/wxMaxima.cpp:8770
-msgid "Comma-separated numbers of the terms to substitute in"
-msgstr ""
-
-#: ../../src/wxMaxima.cpp:7137 ../../src/wxMaxima.cpp:7150
+#: ../../src/MaximaCommandMenus.cpp:4009 ../../src/MaximaCommandMenus.cpp:4022
 msgid "Comma-separated parameter names. A parameter in square brackets [] will be filled with the list of any additional arguments the function gets."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7054
+#: ../../src/MaximaCommandMenus.cpp:776
+msgid "Comma-separated part numbers selecting the subexpression to replace (as in part())"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:3926
 msgid "Comma-separated variable names, can be initialized by the \":\" operator."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7753 ../../src/wxMaxima.cpp:7767
-#: ../../src/wxMaxima.cpp:8719 ../../src/wxMaxima.cpp:8785
-#: ../../src/wxMaxima.cpp:10032
+#: ../../src/MaximaCommandMenus.cpp:711 ../../src/MaximaCommandMenus.cpp:792
+#: ../../src/MaximaCommandMenus.cpp:934 ../../src/MaximaCommandMenus.cpp:948
+#: ../../src/MaximaCommandMenus.cpp:3521
 msgid "Comma-separated variables"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:9469
+#: ../../src/wizards/GenWizPanel.cpp:226
+msgid "Command"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:2112
 msgid "Command:"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1692
+#: ../../src/dialogs/ConfigDialogue.cpp:1145
+msgid "Commands that are executed at every start of maxima."
+msgstr ""
+
+#: ../../src/cells/EditorCell.cpp:4538
+msgid "Comment (ordinary worksheet text that isn't fed to maxima)"
+msgstr ""
+
+#: ../../src/worksheet/WorksheetContextMenu.cpp:465
 msgid "Comment Selection"
 msgstr "將所選區域變成註解"
 
-#: ../../src/wxMaximaFrame.cpp:681
+#: ../../src/wxMaximaFrame.cpp:718
 msgid "Comment out the currently selected text"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:680
+#: ../../src/wxMaximaFrame.cpp:717
 #, fuzzy
 msgid "Comment selection\tCtrl+/"
 msgstr "將所選區域變成註解"
 
-#: ../../src/Worksheet.cpp:2004
+#: ../../src/worksheet/WorksheetContextMenu.cpp:776
 msgid "Commutative function"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1396
+#: ../../src/wxMaximaFrame.cpp:649
+msgid "Compare files..."
+msgstr ""
+
+#: ../../src/main.cpp:723
+msgid "Comparing worksheets (the --diff option or the wxmxdiff command) needs 2 or 3 files to compare."
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1430
 msgid "Compile a QR decomposition using dgeqrf"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7162
+#: ../../src/MaximaCommandMenus.cpp:4034
 #, fuzzy
 msgid "Compile a function"
 msgstr "刪除函數"
 
-#: ../../src/wxMaximaFrame.cpp:1188
+#: ../../src/wxMaximaFrame.cpp:1222
 #, fuzzy
 msgid "Compile a regular expression"
 msgstr "刪除函數"
 
-#: ../../src/wxMaximaFrame.cpp:1385
+#: ../../src/wxMaximaFrame.cpp:1419
 msgid "Compile eigenvalues using dgeev"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1388
+#: ../../src/wxMaximaFrame.cpp:1422
 msgid "Compile eigenvalues using zgeev"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1391
+#: ../../src/wxMaximaFrame.cpp:1425
 msgid "Compile eigenvalues+eigenvectors using dgeev"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1394
+#: ../../src/wxMaximaFrame.cpp:1428
 msgid "Compile eigenvalues+eigenvectors using zgeev"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1076
+#: ../../src/wxMaximaFrame.cpp:1110
 #, fuzzy
 msgid "Compile function..."
 msgstr "刪除函數(&U)..."
 
-#: ../../src/wxMaxima.cpp:7511
+#: ../../src/MaximaCommandMenus.cpp:4383
 #, fuzzy
 msgid "Compile regex"
 msgstr "自動完成"
@@ -1502,1773 +2421,2407 @@ msgstr "自動完成"
 msgid "Compiler-Bug? wxMathml.lisp is shorter than expected!"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2234
+#: ../../src/MaximaOutputAppender.cpp:286
 #, c-format
 msgid "Compiling %s"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7163
+#: ../../src/MaximaCommandMenus.cpp:4035
 msgid "Compiling a function can generate a considerable speed boost if the types of the function parameters are made known to the function before it is compiled. Else the generated code has to be hideously generic."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:892
+#: ../../src/wxMaximaFrame.cpp:926
 #, fuzzy
 msgid "Complete Word\tCtrl+Space"
 msgstr "自動完成\tCtrl+K"
 
-#: ../../src/wxMaximaFrame.cpp:893
+#: ../../src/wxMaximaFrame.cpp:927
 msgid "Complete word"
 msgstr "自動完成"
 
-#: ../../src/ToolBar.cpp:230
+#: ../../src/ToolBar.cpp:412 ../../src/ToolBar.cpp:418
 msgid "Completely stop maxima and restart it"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1503
+#: ../../src/cells/TextCell.cpp:192
+#, fuzzy
+msgid "Complex infinity."
+msgstr "複數化簡(&C)"
+
+#: ../../src/graphical_io/Printout.cpp:184
+msgid "Composing a list of the line starts we can use as page starts"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1540
 msgid "Compute continued fraction of a value"
 msgstr "計算數值的連分數表示"
 
-#: ../../src/wxMaximaFrame.cpp:1372
+#: ../../src/wxMaximaFrame.cpp:1406
 msgid "Compute the adjoint matrix"
 msgstr "計算伴隨矩陣"
 
-#: ../../src/wxMaximaFrame.cpp:1359
+#: ../../src/wxMaximaFrame.cpp:1393
 msgid "Compute the characteristic polynomial of a matrix"
 msgstr "計算矩陣的特徵多項式"
 
-#: ../../src/wxMaximaFrame.cpp:1363
+#: ../../src/wxMaximaFrame.cpp:1397
 msgid "Compute the determinant of a matrix"
 msgstr "計算矩陣的行列式的值"
 
-#: ../../src/wxMaximaFrame.cpp:1491
+#: ../../src/wxMaximaFrame.cpp:1528
 msgid "Compute the greatest common divisor"
 msgstr "計算最大公因式"
 
-#: ../../src/wxMaximaFrame.cpp:1356
+#: ../../src/wxMaximaFrame.cpp:1390
 msgid "Compute the inverse of a matrix"
 msgstr "計算矩陣的反矩陣"
 
-#: ../../src/wxMaximaFrame.cpp:1494
+#: ../../src/wxMaximaFrame.cpp:1531
 msgid "Compute the least common multiple (do load(functs) before using)"
 msgstr "計算最小公倍式 (在使用前會先執行 load(functs) )"
 
-#: ../../src/wxMaximaFrame.cpp:1374
+#: ../../src/wxMaximaFrame.cpp:1408
 #, fuzzy
 msgid "Compute the rank of a matrix"
 msgstr "計算矩陣的行列式的值"
 
-#: ../../src/wxMaxima.cpp:9629
+#: ../../src/MaximaCommandMenus.cpp:1869
 msgid "Condition:"
 msgstr "條件："
 
-#: ../../src/ToolBar.cpp:200 ../../src/wxMaximaFrame.cpp:685
-#: ../../src/wxMaximaFrame.cpp:687
+#: ../../src/dialogs/ConfigDialogue.cpp:2479
+#: ../../src/dialogs/ConfigDialogue.cpp:2489
+#: ../../src/dialogs/ConfigDialogue.cpp:2641
+#: ../../src/dialogs/ConfigDialogue.cpp:2647
+msgid "Config file (*.ini)|*.ini"
+msgstr "設定檔 (*.ini)|*.ini"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:2539
+#, c-format
+msgid "Config item \"%s\" was of an unknown type"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:2607
+msgid "Configuration warning"
+msgstr ""
+
+#: ../../src/ToolBar.cpp:367 ../../src/ToolBar.cpp:369
+#: ../../src/wxMaximaFrame.cpp:722 ../../src/wxMaximaFrame.cpp:724
 msgid "Configure wxMaxima"
 msgstr "設定 wxMaxima"
 
-#: ../../src/wxMaxima.cpp:2504
+#: ../../src/wizards/DrawWiz.cpp:829
+msgid "Connect the dots"
+msgstr ""
+
+#: ../../src/MaximaProcessManager.cpp:165
 msgid "Connection attempt, but connection failed."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2459
+#: ../../src/MaximaProcessManager.cpp:792
 msgid "Connection to Maxima lost."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7921
+#: ../../src/wizards/IntegrateWiz.cpp:193
+#: ../../src/wizards/IntegrateWiz.cpp:208 ../../src/wizards/LimitWiz.cpp:133
+#: ../../src/wizards/SeriesWiz.cpp:105
+msgid "Constant"
+msgstr "常數"
+
+#: ../../src/MaximaCommandMenus.cpp:1102
 #, fuzzy
 msgid "Construct a fraction"
 msgstr "連分數(&C)"
 
-#: ../../src/wxMaximaFrame.cpp:1305
+#: ../../src/wxMaximaFrame.cpp:1339
 #, fuzzy
 msgid "Construct fraction..."
 msgstr "連分數(&C)"
 
-#: ../../src/wxMaxima.cpp:7158
+#: ../../src/sidebars/VariablesPane.cpp:58
+msgid "Contents"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:4030
 #, fuzzy
 msgid "Contents:"
 msgstr "希臘字母"
 
-#: ../../src/wxMaximaFrame.cpp:1877
+#: ../../src/wxMaximaFrame.cpp:1914
 msgid "Context-sensitive &Help\tCtrl+?"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1879
+#: ../../src/wxMaximaFrame.cpp:1916
 msgid "Context-sensitive &Help\tF1"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1542
+#: ../../src/sidebars/DrawSidebar.cpp:80
+msgid "Contour"
+msgstr ""
+
+#: ../../src/sidebars/DrawSidebar.cpp:101
+msgid "Contour lines for 3d plots"
+msgstr ""
+
+#: ../../src/wizards/DrawWiz.cpp:648
+msgid "Contour lines on surface and Bottom"
+msgstr ""
+
+#: ../../src/wizards/DrawWiz.cpp:644
+msgid "Contour lines on the Bottom"
+msgstr ""
+
+#: ../../src/wizards/DrawWiz.cpp:641
+msgid "Contour lines on the Surface"
+msgstr ""
+
+#: ../../src/wizards/DrawWiz.cpp:629
+msgid "Contour lines settings for the following 3d plots"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1579
 msgid "Contract Logarithms"
 msgstr "合併對數數式"
 
-#: ../../src/wxMaximaFrame.cpp:1161
+#: ../../src/wxMaximaFrame.cpp:1195
 #, fuzzy
 msgid "Conversions"
 msgstr "轉換為直角座標形式(&R)"
 
-#: ../../src/wxMaximaFrame.cpp:1229
+#: ../../src/wxMaximaFrame.cpp:1263
 #, fuzzy
 msgid "Convert"
 msgstr "轉換為直角座標形式(&R)"
 
-#: ../../src/wxMaximaFrame.cpp:1230
+#: ../../src/wxMaximaFrame.cpp:1264
 #, fuzzy
 msgid "Convert + Write to file"
 msgstr "轉換為階乘(&F)"
 
-#: ../../src/wxMaximaFrame.cpp:1434
+#: ../../src/wxMaximaFrame.cpp:1471
 #, fuzzy
 msgid "Convert Column to list..."
 msgstr "轉換為階乘(&F)"
 
-#: ../../src/wxMaximaFrame.cpp:1430
+#: ../../src/wxMaximaFrame.cpp:1467
 #, fuzzy
 msgid "Convert Row to list..."
 msgstr "轉換為階乘(&F)"
 
-#: ../../src/wxMaximaFrame.cpp:1044
+#: ../../src/wxMaximaFrame.cpp:1078
 msgid "Convert a command to maxima code"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1321
+#: ../../src/wxMaximaFrame.cpp:1355
 msgid "Convert a list of lists to a matrix"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1574
+#: ../../src/wxMaximaFrame.cpp:1611
 msgid "Convert binomials, beta and gamma function to factorials"
 msgstr "轉換二項式、beta、及 gamma 函數為階乘數式"
 
-#: ../../src/wxMaximaFrame.cpp:1578
+#: ../../src/wxMaximaFrame.cpp:1615
 msgid "Convert binomials, factorials and beta function to gamma function"
 msgstr "轉換二項式、階乘和 beta 函數為 gamma 函數"
 
-#: ../../src/wxMaximaFrame.cpp:1613
+#: ../../src/wxMaximaFrame.cpp:1650
 msgid "Convert complex expression to polar form"
 msgstr "轉換複數數式為極座標形式"
 
-#: ../../src/wxMaximaFrame.cpp:1610
+#: ../../src/wxMaximaFrame.cpp:1647
 msgid "Convert complex expression to rect form"
 msgstr "轉換複數數式為直角座標形式"
 
-#: ../../src/wxMaximaFrame.cpp:1622
+#: ../../src/wxMaximaFrame.cpp:1659
 msgid "Convert exponential function of imaginary argument to trigonometric form"
 msgstr "轉換虛數的指數函數為三角函數形式"
 
-#: ../../src/wxMaxima.cpp:7411
+#: ../../src/MaximaCommandMenus.cpp:4283
 #, fuzzy
 msgid "Convert string to lowercase"
 msgstr "轉換為階乘(&F)"
 
-#: ../../src/wxMaxima.cpp:7543
+#: ../../src/MaximaCommandMenus.cpp:4415
 #, fuzzy
 msgid "Convert string to matching regex"
 msgstr "轉換為 Gamma 函數(&G)"
 
-#: ../../src/wxMaximaFrame.cpp:1543
+#: ../../src/wxMaximaFrame.cpp:1580
 msgid "Convert sum of logarithms to logarithm of product"
 msgstr "將數項相加的對數轉換為對數內的乘積"
 
-#: ../../src/wxMaximaFrame.cpp:1573
+#: ../../src/wxMaximaFrame.cpp:1610
 msgid "Convert to &Factorials"
 msgstr "轉換為階乘(&F)"
 
-#: ../../src/wxMaximaFrame.cpp:1577
+#: ../../src/wxMaximaFrame.cpp:1614
 msgid "Convert to &Gamma"
 msgstr "轉換為 Gamma 函數(&G)"
 
-#: ../../src/wxMaximaFrame.cpp:1612
+#: ../../src/wxMaximaFrame.cpp:1649
 msgid "Convert to &Polarform"
 msgstr "轉換為極座標形式(&P)"
 
-#: ../../src/wxMaximaFrame.cpp:1609
+#: ../../src/wxMaximaFrame.cpp:1646
 msgid "Convert to &Rectform"
 msgstr "轉換為直角座標形式(&R)"
 
-#: ../../src/wxMaximaFrame.cpp:1166
+#: ../../src/sidebars/TableOfContents.cpp:522
+#: ../../src/sidebars/TableOfContents.cpp:543
+#, fuzzy
+msgid "Convert to Heading 5"
+msgstr "轉換為 Gamma 函數(&G)"
+
+#: ../../src/sidebars/TableOfContents.cpp:519
+#, fuzzy
+msgid "Convert to Heading 6"
+msgstr "轉換為 Gamma 函數(&G)"
+
+#: ../../src/sidebars/TableOfContents.cpp:531
+#: ../../src/sidebars/TableOfContents.cpp:552
+#, fuzzy
+msgid "Convert to Section"
+msgstr "轉換為直角座標形式(&R)"
+
+#: ../../src/sidebars/TableOfContents.cpp:525
+#: ../../src/sidebars/TableOfContents.cpp:546
+#, fuzzy
+msgid "Convert to Sub-Subsection"
+msgstr "插入子章節單元"
+
+#: ../../src/sidebars/TableOfContents.cpp:528
+#: ../../src/sidebars/TableOfContents.cpp:549
+#, fuzzy
+msgid "Convert to Subsection"
+msgstr "轉換為直角座標形式(&R)"
+
+#: ../../src/sidebars/TableOfContents.cpp:555
+#, fuzzy
+msgid "Convert to Title"
+msgstr "轉換為階乘(&F)"
+
+#: ../../src/wxMaximaFrame.cpp:1200
 #, fuzzy
 msgid "Convert to downcase..."
 msgstr "轉換為階乘(&F)"
 
-#: ../../src/wxMaxima.cpp:7016
+#: ../../src/MaximaCommandMenus.cpp:3888
 #, fuzzy
 msgid "Convert to programming language"
 msgstr "轉換為 Gamma 函數(&G)"
 
-#: ../../src/wxMaxima.cpp:7022
+#: ../../src/MaximaCommandMenus.cpp:3894
 msgid "Convert to programming language file"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1602
+#: ../../src/wxMaximaFrame.cpp:1639
 msgid "Convert trigonometric expression to canonical quasilinear form"
 msgstr "轉換三角函數數式為標準準線性形式"
 
-#: ../../src/wxMaximaFrame.cpp:1627
+#: ../../src/wxMaximaFrame.cpp:1664
 msgid "Convert trigonometric functions to exponential form"
 msgstr "轉換三角函數數式為指數形式"
 
-#: ../../src/wxMaximaFrame.cpp:1762
+#: ../../src/sidebars/PerformanceSidebar.cpp:46
+msgid "Converted to 2D:"
+msgstr ""
+
+#: ../../src/sidebars/PerformanceSidebar.cpp:45
+msgid "Converted to linear:"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1799
 msgid "Converts a matrix to a list of lists"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1760
+#: ../../src/wxMaximaFrame.cpp:1797
 msgid "Converts a nested list like [[1,2],[3,4]] to a matrix"
 msgstr ""
 
-#: ../../src/ToolBar.cpp:209 ../../src/Worksheet.cpp:1290
-#: ../../src/Worksheet.cpp:1359 ../../src/Worksheet.cpp:1498
-#: ../../src/Worksheet.cpp:1684
+#: ../../src/ToolBar.cpp:380 ../../src/ToolBar.cpp:384
+#: ../../src/dialogs/ConfigDialogue.cpp:285
+#: ../../src/worksheet/WorksheetContextMenu.cpp:48
+#: ../../src/worksheet/WorksheetContextMenu.cpp:122
+#: ../../src/worksheet/WorksheetContextMenu.cpp:269
+#: ../../src/worksheet/WorksheetContextMenu.cpp:457
 msgid "Copy"
 msgstr "複製"
 
-#: ../../src/Worksheet.cpp:1296 ../../src/Worksheet.cpp:1375
-#: ../../src/Worksheet.cpp:1514
+#: ../../src/worksheet/WorksheetContextMenu.cpp:58
+#: ../../src/worksheet/WorksheetContextMenu.cpp:140
+#: ../../src/worksheet/WorksheetContextMenu.cpp:287
 #, fuzzy
 msgid "Copy Animation"
 msgstr "停止動畫"
 
-#: ../../src/wxMaximaFrame.cpp:887
+#: ../../src/wxMaximaFrame.cpp:921
 msgid "Copy Previous Input\tCtrl+I"
 msgstr "複製上一個輸入\tCtrl+I"
 
-#: ../../src/wxMaximaFrame.cpp:890
+#: ../../src/wxMaximaFrame.cpp:924
 #, fuzzy
 msgid "Copy Previous Output\tCtrl+U"
 msgstr "複製上一個輸入\tCtrl+I"
 
-#: ../../src/wxMaxima.cpp:7992
+#: ../../src/MaximaCommandMenus.cpp:1176
 #, fuzzy
 msgid "Copy a matrix"
 msgstr "複製為圖片"
 
-#: ../../src/Worksheet.cpp:1380 ../../src/Worksheet.cpp:1519
-#: ../../src/wxMaximaFrame.cpp:663
+#: ../../src/worksheet/WorksheetContextMenu.cpp:145
+#: ../../src/worksheet/WorksheetContextMenu.cpp:292
+#: ../../src/wxMaximaFrame.cpp:700
 msgid "Copy as EMF"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1370 ../../src/Worksheet.cpp:1509
-#: ../../src/wxMaximaFrame.cpp:652
+#: ../../src/worksheet/WorksheetContextMenu.cpp:135
+#: ../../src/worksheet/WorksheetContextMenu.cpp:282
+#: ../../src/wxMaximaFrame.cpp:689
 msgid "Copy as Image"
 msgstr "複製為圖片"
 
-#: ../../src/Worksheet.cpp:1362 ../../src/Worksheet.cpp:1501
-#: ../../src/wxMaximaFrame.cpp:645
+#: ../../src/worksheet/WorksheetContextMenu.cpp:126
+#: ../../src/worksheet/WorksheetContextMenu.cpp:273
+#: ../../src/wxMaximaFrame.cpp:682
 msgid "Copy as LaTeX"
 msgstr "複製為 LaTeX 格式"
 
-#: ../../src/wxMaximaFrame.cpp:648
+#: ../../src/wxMaximaFrame.cpp:685
 #, fuzzy
 msgid "Copy as MathML"
 msgstr "複製為圖片"
 
-#: ../../src/Worksheet.cpp:1368 ../../src/Worksheet.cpp:1506
+#: ../../src/worksheet/WorksheetContextMenu.cpp:133
+#: ../../src/worksheet/WorksheetContextMenu.cpp:279
 msgid "Copy as MathML (e.g. to word processor)"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1383 ../../src/Worksheet.cpp:1522
-#: ../../src/wxMaximaFrame.cpp:658
+#: ../../src/worksheet/WorksheetContextMenu.cpp:148
+#: ../../src/worksheet/WorksheetContextMenu.cpp:295
+#: ../../src/wxMaximaFrame.cpp:695
 #, fuzzy
 msgid "Copy as RTF"
 msgstr "複製為 LaTeX 格式"
 
-#: ../../src/Worksheet.cpp:1377 ../../src/Worksheet.cpp:1516
-#: ../../src/wxMaximaFrame.cpp:655
+#: ../../src/worksheet/WorksheetContextMenu.cpp:142
+#: ../../src/worksheet/WorksheetContextMenu.cpp:289
+#: ../../src/wxMaximaFrame.cpp:692
 #, fuzzy
 msgid "Copy as SVG"
 msgstr "複製為 LaTeX 格式"
 
-#: ../../src/wxMaximaFrame.cpp:640
+#: ../../src/wxMaximaFrame.cpp:677
 msgid "Copy as Text\tCtrl+Shift+C"
 msgstr "複製為純文字\tCtrl+Shift+C"
 
-#: ../../src/Worksheet.cpp:1364 ../../src/Worksheet.cpp:1503
+#: ../../src/worksheet/WorksheetContextMenu.cpp:128
+#: ../../src/worksheet/WorksheetContextMenu.cpp:275
 #, fuzzy
 msgid "Copy as plain text"
 msgstr "複製為圖片"
 
-#: ../../src/wxMaxima.cpp:7576
+#: ../../src/MaximaCommandMenus.cpp:4448
 #, fuzzy
 msgid "Copy file"
 msgstr "複製"
 
-#: ../../src/wxMaximaFrame.cpp:1214
+#: ../../src/wxMaximaFrame.cpp:1248
 #, fuzzy
 msgid "Copy file..."
 msgstr "求解..."
 
-#: ../../src/Worksheet.cpp:1360 ../../src/Worksheet.cpp:1499
-#: ../../src/wxMaximaFrame.cpp:643
+#: ../../src/worksheet/WorksheetContextMenu.cpp:124
+#: ../../src/worksheet/WorksheetContextMenu.cpp:271
+#: ../../src/wxMaximaFrame.cpp:680
 msgid "Copy for Octave/Matlab"
 msgstr ""
 
-#: ../../src/ToolBar.cpp:209 ../../src/wxMaximaFrame.cpp:638
+#: ../../src/worksheet/WorksheetContextMenu.cpp:49
+#: ../../src/worksheet/WorksheetContextMenu.cpp:105
+#: ../../src/worksheet/WorksheetContextMenu.cpp:123
+#: ../../src/worksheet/WorksheetContextMenu.cpp:270
+msgid "Copy position (UUID)"
+msgstr ""
+
+#: ../../src/ToolBar.cpp:380 ../../src/ToolBar.cpp:384
+#: ../../src/wxMaximaFrame.cpp:675
 msgid "Copy selection"
 msgstr "複製所選區域"
 
-#: ../../src/wxMaximaFrame.cpp:664
+#: ../../src/wxMaximaFrame.cpp:701
 msgid "Copy selection from document as an Enhanced Metafile"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:656
+#: ../../src/wxMaximaFrame.cpp:693
 #, fuzzy
 msgid "Copy selection from document as an SVG image"
 msgstr "複製所選區域為圖片"
 
-#: ../../src/wxMaximaFrame.cpp:653
+#: ../../src/wxMaximaFrame.cpp:690
 msgid "Copy selection from document as an image"
 msgstr "複製所選區域為圖片"
 
-#: ../../src/wxMaximaFrame.cpp:659
+#: ../../src/wxMaximaFrame.cpp:696
 #, fuzzy
 msgid "Copy selection from document as rtf that a word processor might understand"
 msgstr "複製所選區域為圖片"
 
-#: ../../src/wxMaximaFrame.cpp:641
+#: ../../src/wxMaximaFrame.cpp:678
 msgid "Copy selection from document as text"
 msgstr "複製所選區域為純文字"
 
-#: ../../src/wxMaximaFrame.cpp:646
+#: ../../src/wxMaximaFrame.cpp:683
 msgid "Copy selection from document in LaTeX format"
 msgstr "複製所選區域為 LaTeX 格式"
 
-#: ../../src/wxMaximaFrame.cpp:644
+#: ../../src/wxMaximaFrame.cpp:681
 msgid "Copy selection from document in Matlab format"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:649
+#: ../../src/wxMaximaFrame.cpp:686
 msgid "Copy selection from document in a MathML format many word processors can display as 2d equation"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7403
+#: ../../src/MaximaCommandMenus.cpp:4275
 #, fuzzy
 msgid "Copy string"
 msgstr "複製所選區域"
 
-#: ../../src/wxMaximaFrame.cpp:1165
+#: ../../src/wxMaximaFrame.cpp:1199
 #, fuzzy
 msgid "Copy string..."
 msgstr "輸入矩陣..."
 
-#: ../../src/ToolBar.cpp:623
+#: ../../src/ToolBar.cpp:823
 msgid "Copy, Cut and Paste button"
 msgstr ""
 
-#: ../../src/WXMXformat.cpp:295
+#: ../../src/dialogs/ConfigDialogue.cpp:2523
+#, c-format
+msgid "Copying config bool \"%s\""
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:2533
+#, c-format
+msgid "Copying config float \"%s\""
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:2528
+#, c-format
+msgid "Copying config int \"%s\""
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:2518
+#, c-format
+msgid "Copying config string \"%s\""
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:191
+msgid "Corsican"
+msgstr ""
+
+#: ../../src/WXMXformat.cpp:297
 msgid "Could not create the backup file during saving => aborting."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3294 ../../src/wxMaxima.cpp:3306
+#: ../../src/MaximaResponseReader.cpp:359
 msgid "Could not make sure that we talk to the maxima we started => discarding all data it sends."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2783
+#: ../../src/MaximaProcessManager.cpp:893
 msgid "Could not map view of the file needed in order to send an interrupt signal to maxima."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2763 ../../src/wxMaxima.cpp:2805
+#: ../../src/Image.cpp:1000
+msgid "Could not parse the SVG image data."
+msgstr ""
+
+#: ../../src/MaximaProcessManager.cpp:873
+#: ../../src/MaximaProcessManager.cpp:916
 msgid "Could not send an interrupt signal to maxima."
 msgstr ""
 
-#: ../../src/WXMXformat.cpp:287
+#: ../../src/WXMXformat.cpp:289
 msgid "Could not write the file's contents during saving => aborting."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1325
+#: ../../src/wxMaximaFrame.cpp:1359
 #, fuzzy
 msgid "Create Matrix"
 msgstr "產生矩陣"
 
-#: ../../src/wxMaximaFrame.cpp:1688
+#: ../../src/wxMaximaFrame.cpp:1725
 #, fuzzy
 msgid "Create a list"
 msgstr "產生串列"
 
-#: ../../src/wxMaxima.cpp:8487
+#: ../../src/MaximaCommandMenus.cpp:1491
 msgid "Create a list as a storage for the values of variables"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8463 ../../src/wxMaxima.cpp:8476
+#: ../../src/MaximaCommandMenus.cpp:1479
+msgid "Create a list from a list"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:1466
 #, fuzzy
 msgid "Create a list from a rule"
 msgstr "從數式產生串列"
 
-#: ../../src/wxMaximaFrame.cpp:1670
+#: ../../src/wxMaximaFrame.cpp:1707
 msgid "Create a list from comma-separated elements"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:888
+#: ../../src/wxMaximaFrame.cpp:922
 msgid "Create a new cell with previous input"
 msgstr "以上一個輸入建立一個新的單元"
 
-#: ../../src/wxMaximaFrame.cpp:891
+#: ../../src/wxMaximaFrame.cpp:925
 #, fuzzy
 msgid "Create a new cell with previous output"
 msgstr "以上一個輸入建立一個新的單元"
 
-#: ../../src/wxMaximaFrame.cpp:1348
+#: ../../src/wxMaximaFrame.cpp:1382
 msgid "Create copy, not clone..."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7561
+#: ../../src/MaximaCommandMenus.cpp:4433
 #, fuzzy
 msgid "Create directory"
 msgstr "產生串列"
 
-#: ../../src/wxMaximaFrame.cpp:1203
+#: ../../src/wxMaximaFrame.cpp:1237
 #, fuzzy
 msgid "Create directory..."
 msgstr "產生串列"
 
-#: ../../src/wxMaxima.cpp:7419
+#: ../../src/MaximaCommandMenus.cpp:4291
 #, fuzzy
 msgid "Create empty string"
 msgstr "產生矩陣"
 
-#: ../../src/wxMaximaFrame.cpp:1168
+#: ../../src/wxMaximaFrame.cpp:1202
 #, fuzzy
 msgid "Create empty string..."
 msgstr "產生串列"
 
-#: ../../src/wxMaximaFrame.cpp:1687
+#: ../../src/wxMaximaFrame.cpp:1724
 #, fuzzy
 msgid "Create list"
 msgstr "產生串列"
 
-#: ../../src/wxMaxima.cpp:8457
+#: ../../src/MaximaCommandMenus.cpp:1460
 msgid "Create list from comma-separated elements"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1082
+#: ../../src/dialogs/ConfigDialogue.cpp:1389
+msgid "Create scalable plots."
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1116
 #, fuzzy
 msgid "Create struct..."
 msgstr "產生串列"
 
-#: ../../src/WXMXformat.cpp:80
+#: ../../src/WXMXformat.cpp:81
 msgid "Created a .zip archive (the .wxmx file technically is a .zip file)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1349
+#: ../../src/wxMaximaFrame.cpp:1383
 msgid "Creates an independent matrix with the same contents"
 msgstr ""
 
-#: ../../src/Configuration.cpp:97
+#: ../../src/dialogs/ConfigDialogue.cpp:192
+msgid "Croatian"
+msgstr ""
+
+#: ../../src/wizards/CsvWiz.cpp:93 ../../src/wizards/CsvWiz.cpp:167
+msgid "Csv files (*.csv)|*.csv|Text files (*.txt)|*.txt|All|*"
+msgstr ""
+
+#: ../../src/worksheet/Worksheet.cpp:6125
+msgid "Cursor"
+msgstr "游標"
+
+#: ../../src/Styles.cpp:126
 #, fuzzy
 msgid "Cursor color"
 msgstr "游標"
 
-#: ../../src/ToolBar.cpp:208 ../../src/Worksheet.cpp:1683
+#: ../../src/ToolBar.cpp:379 ../../src/ToolBar.cpp:383
+#: ../../src/worksheet/WorksheetContextMenu.cpp:456
 msgid "Cut"
 msgstr "剪下"
 
-#: ../../src/wxMaximaFrame.cpp:636
+#: ../../src/wxMaximaFrame.cpp:673
 msgid "Cut\tCtrl+X"
 msgstr "剪下\tCtrl+X"
 
-#: ../../src/ToolBar.cpp:208 ../../src/wxMaximaFrame.cpp:636
+#: ../../src/ToolBar.cpp:379 ../../src/ToolBar.cpp:383
+#: ../../src/wxMaximaFrame.cpp:673
 msgid "Cut selection"
 msgstr "剪下所選區域"
 
-#: ../../src/wxMaxima.cpp:9589 ../../src/wxMaxima.cpp:9629
+#: ../../src/dialogs/ConfigDialogue.cpp:193
+msgid "Czech"
+msgstr "Czech"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:194
+msgid "Danish"
+msgstr "Danish"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:2069
+msgid "Dark"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:1829 ../../src/MaximaCommandMenus.cpp:1869
 msgid "Data Matrix:"
 msgstr "資料矩陣："
 
-#: ../../src/wxMaxima.cpp:9599
+#: ../../src/MaximaCommandMenus.cpp:1839
 msgid "Data file (*.csv, *.tab, *.txt)|*.csv;*.tab;*.txt"
 msgstr "資料檔 (*.csv, *.tab, *.txt)|*.csv;*.tab;*.txt"
 
-#: ../../src/wxMaxima.cpp:9529 ../../src/wxMaxima.cpp:9534
-#: ../../src/wxMaxima.cpp:9539 ../../src/wxMaxima.cpp:9543
-#: ../../src/wxMaxima.cpp:9547 ../../src/wxMaxima.cpp:9551
-#: ../../src/wxMaxima.cpp:9555 ../../src/wxMaxima.cpp:9559
-#: ../../src/wxMaxima.cpp:9563 ../../src/wxMaxima.cpp:9577
-#: ../../src/wxMaxima.cpp:9582 ../../src/wxMaxima.cpp:10030
+#: ../../src/wizards/DrawWiz.cpp:810
+#, fuzzy
+msgid "Data format"
+msgstr "繪圖格式"
+
+#: ../../src/MaximaCommandMenus.cpp:1767 ../../src/MaximaCommandMenus.cpp:1772
+#: ../../src/MaximaCommandMenus.cpp:1777 ../../src/MaximaCommandMenus.cpp:1781
+#: ../../src/MaximaCommandMenus.cpp:1785 ../../src/MaximaCommandMenus.cpp:1789
+#: ../../src/MaximaCommandMenus.cpp:1793 ../../src/MaximaCommandMenus.cpp:1797
+#: ../../src/MaximaCommandMenus.cpp:1801 ../../src/MaximaCommandMenus.cpp:1815
+#: ../../src/MaximaCommandMenus.cpp:1822 ../../src/MaximaCommandMenus.cpp:3519
 msgid "Data:"
 msgstr "資料："
 
-#: ../../src/wxMaximaFrame.cpp:1057
+#: ../../src/wxMaximaFrame.cpp:1091
 msgid "Debugger trigger"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:779
+#: ../../src/wxMaximaFrame.cpp:816
 msgid "Declare Text to always be displayed as subscript"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7069
+#: ../../src/MaximaCommandMenus.cpp:3941
 msgid "Declare a function local to a Program"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:6539
+#: ../../src/MaximaCommandMenus.cpp:3059
 msgid "Declare a text snippet to always be displayed as subscript"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:2044
+#: ../../src/worksheet/WorksheetContextMenu.cpp:816
 #, c-format
 msgid "Declare facts about %s"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8800
+#: ../../src/MaximaCommandMenus.cpp:807
 #, fuzzy
 msgid "Declare main variable:"
 msgstr "刪除變數"
 
-#: ../../src/wxMaxima.cpp:7171
+#: ../../src/MaximaCommandMenus.cpp:4043
 msgid "Declare the type of a function parameter"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:2038
+#: ../../src/worksheet/WorksheetContextMenu.cpp:810
 msgid "Declare these chars as ordinary letters"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1500 ../../src/wxMaximaFrame.cpp:1536
+#: ../../src/wxMaximaFrame.cpp:1537 ../../src/wxMaximaFrame.cpp:1573
 msgid "Decompose rational function to partial fractions"
 msgstr "將有理函數分解為部分分式"
 
-#: ../../src/Worksheet.cpp:2010
+#: ../../src/worksheet/WorksheetContextMenu.cpp:782
 #, fuzzy
 msgid "Decreasing function f(x)<x"
 msgstr "刪除該函數："
 
-#: ../../src/wxMaxima.cpp:7134
+#: ../../src/dialogs/ConfigDialogue.cpp:1336
+msgid "Default animation framerate:"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:717
+msgid "Default plot size for new maxima sessions:"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1534
+#, fuzzy
+msgid "Default port for communication with wxMaxima:"
+msgstr "供 Maxima 與 wxMaxima 溝通的預設埠"
+
+#: ../../src/MaximaCommandMenus.cpp:4006
 #, fuzzy
 msgid "Define a function"
 msgstr "刪除函數"
 
-#: ../../src/wxMaxima.cpp:7147
+#: ../../src/MaximaCommandMenus.cpp:4019
 msgid "Define a macro"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7189
+#: ../../src/MaximaCommandMenus.cpp:4061
 msgid "Define a structure"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7183
+#: ../../src/MaximaCommandMenus.cpp:4055
 msgid "Define a structure type"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7156
+#: ../../src/MaximaCommandMenus.cpp:4028
 #, fuzzy
 msgid "Define a variable"
 msgstr "刪除變數"
 
-#: ../../src/wxMaximaFrame.cpp:1072
+#: ../../src/wxMaximaFrame.cpp:1106
 #, fuzzy
 msgid "Define function..."
 msgstr "刪除函數(&U)..."
 
-#: ../../src/wxMaximaFrame.cpp:1079
+#: ../../src/wxMaximaFrame.cpp:1113
 msgid "Define macro..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1077
+#: ../../src/wxMaximaFrame.cpp:1111
 msgid "Define parameter type..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1081
+#: ../../src/wxMaximaFrame.cpp:1115
 msgid "Define struct..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1080
+#: ../../src/dialogs/ConfigDialogue.cpp:404
+msgid "Define the default speed (in frames per second) animations are played back with."
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1114
 #, fuzzy
 msgid "Define variable..."
 msgstr "刪除變數"
 
-#: ../../src/wxMaximaFrame.cpp:1776
+#: ../../src/wxMaximaFrame.cpp:1813
 msgid "Defines if an animation is automatically started or only by clicking on it."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8935
+#: ../../src/MaximaCommandMenus.cpp:186
 msgid "Degree:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:985
+#: ../../src/wxMaximaFrame.cpp:1019
 msgid "Delete F&unction..."
 msgstr "刪除函數(&U)..."
 
-#: ../../src/Worksheet.cpp:1386 ../../src/Worksheet.cpp:1525
+#: ../../src/worksheet/WorksheetContextMenu.cpp:157
+#: ../../src/worksheet/WorksheetContextMenu.cpp:298
 msgid "Delete Selection"
 msgstr "刪除所選區域"
 
-#: ../../src/wxMaximaFrame.cpp:987
+#: ../../src/wxMaximaFrame.cpp:1021
 msgid "Delete V&ariable..."
 msgstr "刪除變數(&A)..."
 
-#: ../../src/wxMaximaFrame.cpp:986
+#: ../../src/wxMaximaFrame.cpp:1020
 msgid "Delete a function"
 msgstr "刪除函數"
 
-#: ../../src/wxMaximaFrame.cpp:988
+#: ../../src/wxMaximaFrame.cpp:1022
 msgid "Delete a variable"
 msgstr "刪除變數"
 
-#: ../../src/wxMaximaFrame.cpp:982
+#: ../../src/wxMaximaFrame.cpp:1016
 msgid "Delete all objects with a given name"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:991
+#: ../../src/wxMaximaFrame.cpp:1025
 msgid "Delete all values from memory"
 msgstr "刪除記憶體中全部的值"
 
-#: ../../src/wxMaxima.cpp:7588
+#: ../../src/MaximaCommandMenus.cpp:4460
 #, fuzzy
 msgid "Delete file"
 msgstr "刪除變數"
 
-#: ../../src/wxMaximaFrame.cpp:1216
+#: ../../src/wxMaximaFrame.cpp:1250
 #, fuzzy
 msgid "Delete file..."
 msgstr "刪除變數(&A)..."
 
-#: ../../src/wxMaxima.cpp:7683
+#: ../../src/MaximaCommandMenus.cpp:4555
 #, fuzzy
 msgid "Delete function(s)"
 msgstr "刪除該函數："
 
-#: ../../src/wxMaxima.cpp:7679
+#: ../../src/MaximaCommandMenus.cpp:4551
 #, fuzzy
 msgid "Delete named object(s)"
 msgstr "刪除該函數："
 
-#: ../../src/wxMaximaFrame.cpp:981
+#: ../../src/wxMaximaFrame.cpp:1015
 #, fuzzy
 msgid "Delete named object..."
 msgstr "刪除函數(&U)..."
 
-#: ../../src/wxMaxima.cpp:7674
+#: ../../src/MaximaCommandMenus.cpp:4546
 #, fuzzy
 msgid "Delete variable(s)"
 msgstr "刪除該變數："
 
-#: ../../src/wxMaxima.cpp:7430
+#: ../../src/MaximaCommandMenus.cpp:4302
 #, fuzzy
 msgid "Delimiter:"
 msgstr "消去"
 
-#: ../../src/Worksheet.cpp:1347 ../../src/Worksheet.cpp:1785
+#: ../../src/sidebars/GreekSidebar.cpp:181
+msgid "Delta"
+msgstr ""
+
+#: ../../src/worksheet/WorksheetContextMenu.cpp:110
+#: ../../src/worksheet/WorksheetContextMenu.cpp:558
 #, c-format
 msgid "Demo for \"%s\""
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1930
+#: ../../src/wxMaximaFrame.cpp:1967
 msgid "Demos"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8927
+#: ../../src/MaximaCommandMenus.cpp:178
 msgid "Denom. deg:"
 msgstr "分母 degree："
 
-#: ../../src/wxMaxima.cpp:7923
+#: ../../src/MaximaCommandMenus.cpp:1104
 msgid "Denominator:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1030
+#: ../../src/wxMaximaFrame.cpp:1064
 msgid "Dependencies"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7813
+#: ../../src/wizards/SeriesWiz.cpp:42
+msgid "Depth:"
+msgstr "深度："
+
+#: ../../src/MaximaCommandMenus.cpp:994
 msgid "Derivate of y at that point:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1497
+#: ../../src/wizards/ListSortWiz.cpp:56
+msgid "Descending by magnitude (numeric only)"
+msgstr ""
+
+#: ../../src/wizards/GenWizPanel.cpp:255
+msgid "Description"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:435 ../../src/MaximaCommandMenus.cpp:448
+#: ../../src/MaximaCommandMenus.cpp:461 ../../src/MaximaCommandMenus.cpp:475
+#: ../../src/MaximaCommandMenus.cpp:486 ../../src/MaximaCommandMenus.cpp:499
+#: ../../src/MaximaCommandMenus.cpp:514 ../../src/MaximaCommandMenus.cpp:528
+#: ../../src/MaximaCommandMenus.cpp:546 ../../src/MaximaCommandMenus.cpp:561
+#: ../../src/MaximaCommandMenus.cpp:576 ../../src/MaximaCommandMenus.cpp:591
+#: ../../src/MaximaCommandMenus.cpp:605
+msgid "Desired absolute error of approximation."
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:434 ../../src/MaximaCommandMenus.cpp:447
+#: ../../src/MaximaCommandMenus.cpp:460 ../../src/MaximaCommandMenus.cpp:474
+#: ../../src/MaximaCommandMenus.cpp:513 ../../src/MaximaCommandMenus.cpp:527
+#: ../../src/MaximaCommandMenus.cpp:545 ../../src/MaximaCommandMenus.cpp:560
+#: ../../src/MaximaCommandMenus.cpp:575 ../../src/MaximaCommandMenus.cpp:590
+#: ../../src/MaximaCommandMenus.cpp:604
+msgid "Desired relative error of approximation."
+msgstr ""
+
+#: ../../src/sidebars/StatSidebar.cpp:61
+msgid "Deviation..."
+msgstr "偏差..."
+
+#: ../../src/wxMaximaFrame.cpp:1534
 msgid "Di&vide Polynomials..."
 msgstr "多項式相除(&V)..."
 
-#: ../../src/MaximaManual.cpp:517
+#: ../../src/worksheet/WorksheetExport.cpp:1400
+msgid "Diagram"
+msgstr ""
+
+#: ../../src/sidebars/DrawSidebar.cpp:71
+msgid "Diagram title"
+msgstr ""
+
+#: ../../src/sidebars/HelpBrowser.cpp:51
+msgid "Didn't find an installed offline manual."
+msgstr ""
+
+#: ../../src/MaximaManual.cpp:534
 msgid "Didn't find the maxima HTML manual."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:4907
+#: ../../src/wxMaxima.cpp:1685
 msgid "Didn't get a help browser launch program command line, but can request the system's default help browser."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:9010 ../../src/wxMaxima.cpp:10055
+#: ../../src/Styles.cpp:129
+msgid "Diff viewer: changed text"
+msgstr ""
+
+#: ../../src/sidebars/MathSidebar.cpp:80
+msgid "Diff..."
+msgstr "微分..."
+
+#: ../../src/dialogs/DiffFrame.cpp:308
+#, c-format
+msgid "Difference %d / %d"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:264 ../../src/MaximaCommandMenus.cpp:3544
 msgid "Differentiate"
 msgstr "微分"
 
-#: ../../src/wxMaximaFrame.cpp:1467
+#: ../../src/wxMaximaFrame.cpp:1504
 msgid "Differentiate expression"
 msgstr "對數式微分"
 
-#: ../../src/Worksheet.cpp:1590
+#: ../../src/worksheet/WorksheetContextMenu.cpp:363
 msgid "Differentiate..."
 msgstr "微分..."
 
-#: ../../src/wxMaxima.cpp:9010
+#: ../../src/MaximaCommandMenus.cpp:264
 #, fuzzy
 msgid "Differentiates an expression n times"
 msgstr "對數式微分"
 
-#: ../../src/wxMaxima.cpp:10055
+#: ../../src/MaximaCommandMenus.cpp:3544
 #, fuzzy
 msgid "Differentiates the expression n times"
 msgstr "對數式微分"
 
-#: ../../src/wxMaximaFrame.cpp:1212
+#: ../../src/wizards/LimitWiz.cpp:41
+msgid "Direction:"
+msgstr "方向："
+
+#: ../../src/wxMaximaFrame.cpp:1246
 #, fuzzy
 msgid "Directory operations"
 msgstr "方向："
 
-#: ../../src/wxMaximaFrame.cpp:1041
+#: ../../src/main.cpp:315
+msgid "Disabled the console's QuickEdit mode for this batch run so a click into the console cannot suspend wxMaxima."
+msgstr ""
+
+#: ../../src/wizards/Plot2dWiz.cpp:418 ../../src/wizards/Plot2dWiz.cpp:619
+msgid "Discrete plot"
+msgstr "離散繪圖"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:699
+#, fuzzy
+msgid "Display"
+msgstr "切換計算時間顯示(&T)"
+
+#: ../../src/wxMaximaFrame.cpp:1075
 msgid "Display Te&X Form"
 msgstr "以 TeX 格式顯示(&X)"
 
-#: ../../src/wxMaxima.cpp:6972
+#: ../../src/MaximaCommandMenus.cpp:3844
 msgid "Display algorithm"
 msgstr "用於顯示的演算法"
 
-#: ../../src/wxMaximaFrame.cpp:751
+#: ../../src/dialogs/ConfigDialogue.cpp:827
+msgid "Display all and allow linebreaks in long numbers"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:820
+#, fuzzy
+msgid "Display all digits"
+msgstr "用於顯示的演算法"
+
+#: ../../src/wxMaximaFrame.cpp:788
 msgid "Display an expression as maxima's internal lisp representation"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:754
+#: ../../src/wxMaximaFrame.cpp:791
 msgid "Display an expression as wxMaxima's internal XML representation"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:758
+#: ../../src/wxMaximaFrame.cpp:795
 #, fuzzy
 msgid "Display equations"
 msgstr "解方程式"
 
-#: ../../src/wxMaxima.cpp:6508
+#: ../../src/MaximaCommandMenus.cpp:3028
 msgid "Display expression in maxima's internal representation"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:6514
+#: ../../src/MaximaCommandMenus.cpp:3034
 msgid "Display expression in wxMaxima's internal representation"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1042
+#: ../../src/wxMaximaFrame.cpp:1076
 msgid "Display last result in TeX form"
 msgstr "將最後的結果以 TeX 格式顯示"
 
-#: ../../src/ToolBar.cpp:360
+#: ../../src/dialogs/ConfigDialogue.cpp:804
+msgid "Display of long numbers"
+msgstr ""
+
+#: ../../src/ToolBar.cpp:580
 #, c-format
 msgid "Display resolution according to wxWidgets: %li x %li ppi"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:802
+#: ../../src/wxMaximaFrame.cpp:839
 #, fuzzy
 msgid "Display string quotation marks"
 msgstr "解方程式"
 
-#: ../../src/wxMaximaFrame.cpp:1036
+#: ../../src/wxMaximaFrame.cpp:1070
 msgid "Display time used for evaluation"
 msgstr "顯示評算所花費的時間"
 
-#: ../../src/wxMaxima.cpp:9206
+#: ../../src/MaximaCommandMenus.cpp:397
 #, fuzzy
 msgid "Displayed Precision"
 msgstr "解方程式"
 
-#: ../../src/wxMaximaFrame.cpp:1913
+#: ../../src/wxMaximaFrame.cpp:1950
 msgid "Displaying 3d curves"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1462
+#: ../../src/wxMaximaFrame.cpp:1499
 #, fuzzy
 msgid "Dito, and evaluate the result..."
 msgstr "評算名詞形式(&N)"
 
-#: ../../src/wxMaximaFrame.cpp:1445
+#: ../../src/wxMaximaFrame.cpp:1482
 msgid "Dito, but affect all clones of the Matrix..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1255
+#: ../../src/wxMaximaFrame.cpp:1289
 msgid "Dito, but as fraction (real only)..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1532
+#: ../../src/wxMaximaFrame.cpp:1569
 msgid "Dito, including denominator"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1715 ../../src/wxMaximaFrame.cpp:944
+#: ../../src/worksheet/WorksheetContextMenu.cpp:488
+#: ../../src/wxMaximaFrame.cpp:978
 msgid "Divide Cell"
 msgstr "分割單元"
 
-#: ../../src/wxMaximaFrame.cpp:1498
+#: ../../src/wxMaximaFrame.cpp:1535
 msgid "Divide numbers or polynomials"
 msgstr "將數字或多項式相除"
 
-#: ../../src/wxMaxima.cpp:8578
+#: ../../src/cells/TextCell.cpp:297
+msgid "Division by 0."
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:1596
 #, fuzzy
 msgid "Do for each list element"
 msgstr "套用函數至串列"
 
-#: ../../src/wxMaxima.cpp:11197
+#: ../../src/wxMaxima.cpp:3503
 #, fuzzy, c-format
 msgid "Do you want to save the changes you made in the document \"%s\"?"
 msgstr "您是否想儲存於此文件中的變更： \""
 
-#: ../../src/wxMaximaFrame.cpp:724
+#: ../../src/wxMaximaFrame.cpp:761
 msgid "Dock all Sidebars"
 msgstr ""
 
-#: ../../src/Configuration.cpp:94
+#: ../../src/Styles.cpp:123
 msgid "Document background"
 msgstr "文件背景"
 
-#: ../../src/wxMaxima.cpp:4611
+#: ../../src/MaximaFileIO.cpp:534
 #, fuzzy
 msgid "Document was saved using a newer version of wxMaxima so it may not load correctly. Please update your wxMaxima."
 msgstr " 是以新版的 wxMaxima 儲存，所以可能無法正確的讀取。請更新您的 wxMaxima。"
 
-#: ../../src/wxMaxima.cpp:4603
+#: ../../src/MaximaFileIO.cpp:526
 #, fuzzy
 msgid "Document was saved using a newer version of wxMaxima. Please update your wxMaxima."
 msgstr " 是以新版的 wxMaxima 儲存，請更新您的 wxMaxima 。"
 
-#: ../../src/wxMaximaFrame.cpp:770
+#: ../../src/dialogs/ConfigDialogue.cpp:1170
+msgid "Documentclass for TeX export:"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1178
+msgid "Documentclass options:"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:807
 msgid "Don't autosubscript after an underscore"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1086
+#: ../../src/wxMaximaFrame.cpp:1120
 #, fuzzy
 msgid "Don't evaluate Expression..."
 msgstr "對數式積分"
 
-#: ../../src/wxMaxima.cpp:7117
+#: ../../src/MaximaCommandMenus.cpp:3989
 #, fuzzy
 msgid "Don't evaluate one command"
 msgstr "顯示這個指令的使用範例："
 
-#: ../../src/wxMaxima.cpp:7129
+#: ../../src/MaximaCommandMenus.cpp:4001
 #, fuzzy
 msgid "Don't evaluate one whole expression"
 msgstr "取得複數數式的實部"
 
-#: ../../src/Worksheet.cpp:1931 ../../src/Worksheet.cpp:2064
+#: ../../src/worksheet/WorksheetContextMenu.cpp:703
+#: ../../src/worksheet/WorksheetContextMenu.cpp:836
 msgid "Don't mark cells that contain tooltips in yellow"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1938 ../../src/Worksheet.cpp:2070
+#: ../../src/worksheet/WorksheetContextMenu.cpp:710
+#: ../../src/worksheet/WorksheetContextMenu.cpp:842
 msgid "Don't mark this message text in yellow"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:11203
+#: ../../src/wxMaxima.cpp:3509
 msgid "Don't save"
 msgstr "不要儲存"
 
-#: ../../src/Worksheet.cpp:1620
+#: ../../src/worksheet/WorksheetContextMenu.cpp:393
 msgid "Don't show labels"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1979
+#: ../../src/worksheet/WorksheetContextMenu.cpp:751
 msgid "Don't use if unassigned"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:797
+#: ../../src/wxMaximaFrame.cpp:834
 msgid "Don't use parenthesis for matrices"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8525
+#: ../../src/dialogs/DiffFrame.cpp:428 ../../src/dialogs/FindReplacePane.cpp:83
+msgid "Down"
+msgstr ""
+
+#: ../../src/sidebars/SymbolsSidebar.cpp:185
+msgid "Drag-and-drop unicode symbols here"
+msgstr ""
+
+#: ../../src/wizards/DrawWiz.cpp:155
+msgid "Draw all points where an equation is true."
+msgstr ""
+
+#: ../../src/wizards/DrawWiz.cpp:802
+msgid "Draw points"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:1536
 #, fuzzy
 msgid "Drop the first n list elements"
 msgstr "套用函數至串列"
 
-#: ../../src/wxMaxima.cpp:8531 ../../src/wxMaxima.cpp:8537
+#: ../../src/MaximaCommandMenus.cpp:1542
 #, fuzzy
 msgid "Drop the last n list elements"
 msgstr "套用函數至串列"
 
-#: ../../src/wxMaximaFrame.cpp:1306
+#: ../../src/dialogs/ConfigDialogue.cpp:195
+msgid "Dutch"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1340
 msgid "E&quations"
 msgstr "方程式(&Q)"
 
-#: ../../src/wxMaximaFrame.cpp:625
+#: ../../src/wxMaximaFrame.cpp:658
 msgid "E&xit\tCtrl+Q"
 msgstr "結束(&X)\tCtrl+Q"
 
-#: ../../src/wxMaximaFrame.cpp:1368
+#: ../../src/wxMaximaFrame.cpp:1402
 msgid "Eige&nvectors"
 msgstr "特徵向量(&N)"
 
-#: ../../src/wxMaximaFrame.cpp:1365
+#: ../../src/wxMaximaFrame.cpp:1399
 msgid "Eigen&values"
 msgstr "特徵值(&V)"
 
-#: ../../src/wxMaximaFrame.cpp:1387
+#: ../../src/wxMaximaFrame.cpp:1421
 #, fuzzy
 msgid "Eigenvalues (complex)"
 msgstr "特徵值(&V)"
 
-#: ../../src/wxMaximaFrame.cpp:1384
+#: ../../src/wxMaximaFrame.cpp:1418
 #, fuzzy
 msgid "Eigenvalues (real)"
 msgstr "特徵值(&V)"
 
-#: ../../src/wxMaximaFrame.cpp:1393
+#: ../../src/wxMaximaFrame.cpp:1427
 msgid "Eigenvalues, left+right eigenvectors (complex)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1390
+#: ../../src/wxMaximaFrame.cpp:1424
 msgid "Eigenvalues, left+right eigenvectors (real)"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8584
+#: ../../src/MaximaCommandMenus.cpp:1602
 msgid "Either a single expression or a comma-separated list of expressions between parenthesis. In the latter case the result of the last expression in the parenthesis is used."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8593
+#: ../../src/cells/TextCell.cpp:176
+msgid ""
+"Either negative or zero.\n"
+"A possible result of sign()."
+msgstr ""
+
+#: ../../src/cells/TextCell.cpp:172
+msgid ""
+"Either positive or zero.\n"
+"A possible result of sign()."
+msgstr ""
+
+#: ../../src/cells/TextCell.cpp:168
+msgid ""
+"Either positive, negative or zero.\n"
+"Normally the result of sign() if the sign cannot be determined."
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:1612
 msgid "Element"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8549
+#: ../../src/MaximaCommandMenus.cpp:1562
 msgid "Element number"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8005
+#: ../../src/MaximaCommandMenus.cpp:1189
 msgid "Element-by-element Product of matrices of the same size (Hadamard product)"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8012
+#: ../../src/MaximaCommandMenus.cpp:1196
 msgid "Element-by-element exponentiation of two matrices"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1342
+#: ../../src/wxMaximaFrame.cpp:1376
 msgid "Element-by-element multiplication"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8510
+#: ../../src/MaximaCommandMenus.cpp:1516
 msgid "Element:"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7204
+#: ../../src/MaximaCommandMenus.cpp:4076
 msgid "Elements:"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7847
+#: ../../src/MaximaCommandMenus.cpp:1028
 #, fuzzy
 msgid "Eliminate a variable"
 msgstr "消去變數(&E)..."
 
-#: ../../src/wxMaximaFrame.cpp:1247
+#: ../../src/wxMaximaFrame.cpp:1281
 msgid "Eliminate a variable from a system of equations"
 msgstr "自方程組中消去變數"
 
-#: ../../src/wxMaxima.cpp:10651
+#: ../../src/MaximaEvaluator.cpp:536
 msgid "Empty command => re-triggering evaluation"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:9225
+#: ../../src/MaximaCommandMenus.cpp:416
 #, fuzzy
 msgid "Enable:"
 msgstr "變數："
 
-#: ../../src/MathParser.cpp:99
+#: ../../src/MathParser.cpp:94
 #, c-format
 msgid "Encountered an unknown XML tag: <%s>"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2476
+#: ../../src/MaximaProcessManager.cpp:137
 msgid "Encountered an unknown socket event."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7843
+#: ../../src/sidebars/SymbolsSidebar.cpp:129
+msgid "End of proof"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:1024
 msgid "End of t:"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:4097
+#: ../../src/wizards/DrawWiz.cpp:71 ../../src/wizards/DrawWiz.cpp:176
+msgid "End of the x value"
+msgstr ""
+
+#: ../../src/wizards/DrawWiz.cpp:88 ../../src/wizards/DrawWiz.cpp:191
+msgid "End of the y value"
+msgstr ""
+
+#: ../../src/wizards/DrawWiz.cpp:208
+msgid "End of the z value"
+msgstr ""
+
+#: ../../src/wizards/DrawWiz.cpp:760
+msgid "End value of the parameter"
+msgstr ""
+
+#: ../../src/MaximaResponseReader.cpp:432
+#: ../../src/MaximaResponseReader.cpp:586
 msgid "Ended lisp mode after receiving a maxima prompt!"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1828
+#: ../../src/wxMaximaFrame.cpp:1865
 msgid "Engineering format (12.1e6 etc.)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1319
+#: ../../src/dialogs/ConfigDialogue.cpp:196
+msgid "English"
+msgstr "English"
+
+#: ../../src/wizards/DrawWiz.cpp:552
+msgid "Enhanced 3D settings:"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1919
+msgid "Enhanced meta file (emf)"
+msgstr ""
+
+#: ../../src/sidebars/StatSidebar.cpp:106
+msgid "Enter Matrix..."
+msgstr "輸入矩陣..."
+
+#: ../../src/MaximaCommandMenus.cpp:2255
+msgid "Enter UUID to jump to:"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1353
 msgid "Enter a matrix"
 msgstr "輸入一個矩陣"
 
-#: ../../src/wxMaxima.cpp:8866
+#: ../../src/dialogs/ConfigDialogue.cpp:925
+#, fuzzy
+msgid "Enter adds newlines, Ctrl+Enter evaluates cells"
+msgstr "按 Enter 評算單元"
+
+#: ../../src/MaximaCommandMenus.cpp:873
 msgid "Enter an equation for rational simplification:"
 msgstr "輸入供化簡有理數式的方程式："
 
-#: ../../src/wxMaxima.cpp:8169
+#: ../../src/wizards/SystemWiz.cpp:50
+msgid "Enter comma separated list of variables."
+msgstr "輸入以逗號分隔的所有變數"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:921
+#, fuzzy
+msgid "Enter evaluates cells, Ctrl+Enter adds newlines"
+msgstr "按 Enter 評算單元"
+
+#: ../../src/MaximaCommandMenus.cpp:1357
 msgid "Enter matrix"
 msgstr "輸入矩陣"
 
-#: ../../src/wxMaxima.cpp:9095
+#: ../../src/MaximaCommandMenus.cpp:100
 msgid "Enter new animation frame rate [Hz, integer]:"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:9201
+#: ../../src/MaximaCommandMenus.cpp:392
 #, fuzzy
 msgid "Enter new precision for bigfloats:"
 msgstr "輸入新的精確度："
 
-#: ../../src/wxMaxima.cpp:7922
+#: ../../src/dialogs/ConfigDialogue.cpp:388
+msgid "Enter the path to the Maxima executable."
+msgstr "輸入可執行 Maxima 的路徑"
+
+#: ../../src/MaximaCommandMenus.cpp:1103
 msgid "Enumerator:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1220
+#: ../../src/wxMaximaFrame.cpp:1254
 #, fuzzy
 msgid "Environment variables"
 msgstr "附加參數："
 
-#: ../../src/wxMaxima.cpp:9045
+#: ../../src/dialogs/ConfigDialogue.cpp:1605
+#, fuzzy
+msgid "Environment variables for maxima"
+msgstr "附加參數："
+
+#: ../../src/sidebars/GreekSidebar.cpp:182
+#, fuzzy
+msgid "Epsilon"
+msgstr "Epsilon:"
+
+#: ../../src/MaximaCommandMenus.cpp:299
 msgid "Epsilon:"
 msgstr "Epsilon:"
 
-#: ../../src/wxMaximaFrame.cpp:1124 ../../src/wxMaximaFrame.cpp:1135
+#: ../../src/wxMaximaFrame.cpp:1158 ../../src/wxMaximaFrame.cpp:1169
 msgid "Equal, ignoring case?..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1133
+#: ../../src/wxMaximaFrame.cpp:1167
 msgid "Equal?..."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8561
+#: ../../src/MaximaCommandMenus.cpp:1577 ../../src/wizards/DrawWiz.cpp:161
 #, fuzzy
 msgid "Equation"
 msgstr "方程式："
 
-#: ../../src/wxMaxima.cpp:7751 ../../src/wxMaxima.cpp:7765
+#: ../../src/wizards/SystemWiz.cpp:67
+#, c-format
+msgid "Equation %ld:"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:932 ../../src/MaximaCommandMenus.cpp:946
 #, fuzzy
 msgid "Equation(s)"
 msgstr "方程式："
 
-#: ../../src/wxMaxima.cpp:7848 ../../src/wxMaxima.cpp:7900
+#: ../../src/MaximaCommandMenus.cpp:1029 ../../src/MaximaCommandMenus.cpp:1081
 msgid "Equation(s):"
 msgstr "方程式："
 
-#: ../../src/wxMaxima.cpp:7776 ../../src/wxMaxima.cpp:7788
-#: ../../src/wxMaxima.cpp:8899 ../../src/wxMaxima.cpp:8919
-#: ../../src/wxMaxima.cpp:9592 ../../src/wxMaxima.cpp:10039
+#: ../../src/MaximaCommandMenus.cpp:150 ../../src/MaximaCommandMenus.cpp:170
+#: ../../src/MaximaCommandMenus.cpp:957 ../../src/MaximaCommandMenus.cpp:969
+#: ../../src/MaximaCommandMenus.cpp:1832 ../../src/MaximaCommandMenus.cpp:3528
 msgid "Equation:"
 msgstr "方程式："
 
-#: ../../src/WXMXformat.cpp:258 ../../src/WXMXformat.cpp:288
-#: ../../src/WXMXformat.cpp:296 ../../src/WXMXformat.cpp:311
-#: ../../src/WXMXformat.cpp:332 ../../src/WXMXformat.cpp:362
-#: ../../src/wxMaxima.cpp:3020 ../../src/wxMaxima.cpp:4163
-#: ../../src/wxMaxima.cpp:4222 ../../src/wxMaxima.cpp:4231
-#: ../../src/wxMaxima.cpp:4491 ../../src/wxMaxima.cpp:4502
-#: ../../src/wxMaxima.cpp:4605 ../../src/wxMaxima.cpp:4634
-#: ../../src/wxMaxima.cpp:4645 ../../src/wxMaxima.cpp:11125
-#: ../../src/wxMaxima.cpp:11166
+#: ../../src/dialogs/TipOfTheDay.cpp:196
+msgid "Equations have several advantages over functions. For example they can be manipulated with factor(), expand() and similar functions. They can easily be introduced one into another. Also they are always printed out as 2D maths."
+msgstr ""
+
+#: ../../src/MaximaFileIO.cpp:64 ../../src/MaximaFileIO.cpp:121
+#: ../../src/MaximaFileIO.cpp:130 ../../src/MaximaFileIO.cpp:399
+#: ../../src/MaximaFileIO.cpp:410 ../../src/MaximaFileIO.cpp:528
+#: ../../src/MaximaFileIO.cpp:557 ../../src/MaximaFileIO.cpp:568
+#: ../../src/MaximaProcessManager.cpp:581 ../../src/WXMXformat.cpp:260
+#: ../../src/WXMXformat.cpp:290 ../../src/WXMXformat.cpp:298
+#: ../../src/WXMXformat.cpp:313 ../../src/WXMXformat.cpp:334
+#: ../../src/WXMXformat.cpp:364 ../../src/dialogs/BinaryNameCtrl.cpp:78
+#: ../../src/main.cpp:725 ../../src/wxMaxima.cpp:3384
+#: ../../src/wxMaxima.cpp:3420 ../../src/wxMaxima.cpp:3438
+#: ../../src/wxMaxima.cpp:3472
 msgid "Error"
 msgstr "錯誤"
 
-#: ../../src/wxMaxima.cpp:2456
+#: ../../src/MaximaProcessManager.cpp:789
 msgid "Error writing to Maxima"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:6164 ../../src/wxMaxima.cpp:6176
-#: ../../src/wxMaxima.cpp:6187 ../../src/wxMaxima.cpp:7858
-#: ../../src/wxMaxima.cpp:7880 ../../src/wxMaxima.cpp:8163
+#: ../../src/MaximaCommandMenus.cpp:1039 ../../src/MaximaCommandMenus.cpp:1061
+#: ../../src/MaximaCommandMenus.cpp:1351 ../../src/MaximaCommandMenus.cpp:2320
+#: ../../src/MaximaCommandMenus.cpp:2332 ../../src/MaximaCommandMenus.cpp:2343
+#: ../../src/MaximaFileIO.cpp:873 ../../src/sidebars/History.cpp:228
 msgid "Error!"
 msgstr "錯誤！"
 
-#: ../../src/Image.cpp:696
+#: ../../src/Image.cpp:779
 #, c-format
 msgid "Error: Cannot render %s."
 msgstr ""
 
-#: ../../src/Image.cpp:699
+#: ../../src/Image.cpp:782
 #, c-format
 msgid ""
 "Error: Cannot render %s:\n"
 "%s"
 msgstr ""
 
-#: ../../src/Image.cpp:704
+#: ../../src/Image.cpp:787
 msgid "Error: Cannot render the image."
 msgstr ""
 
-#: ../../src/Image.cpp:706
+#: ../../src/Image.cpp:789
 #, c-format
 msgid ""
 "Error: Cannot render the image:\n"
 "%s"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7544
+#: ../../src/MaximaCommandMenus.cpp:4416
 msgid "Escapes all special characters in a string. The result is a regex that matches this string exactly."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1652
+#: ../../src/sidebars/GreekSidebar.cpp:184
+msgid "Eta"
+msgstr ""
+
+#: ../../src/sidebars/TableOfContents.cpp:513
+#, fuzzy
+msgid "Evaluate"
+msgstr "評算單元"
+
+#: ../../src/wxMaximaFrame.cpp:1689
 #, fuzzy
 msgid "Evaluate &Noun Forms..."
 msgstr "評算名詞形式(&N)"
 
-#: ../../src/wxMaximaFrame.cpp:856
+#: ../../src/wxMaximaFrame.cpp:890
 #, fuzzy
 msgid "Evaluate All Cells\tCtrl+Shift+R"
 msgstr "評算所有單元\tCtrl+R"
 
-#: ../../src/wxMaximaFrame.cpp:851
+#: ../../src/wxMaximaFrame.cpp:885
 #, fuzzy
 msgid "Evaluate All Visible Cells\tCtrl+R"
 msgstr "評算所有單元\tCtrl+R"
 
-#: ../../src/Worksheet.cpp:1395
+#: ../../src/worksheet/WorksheetContextMenu.cpp:166
 #, fuzzy
 msgid "Evaluate Cell"
 msgstr "評算單元"
 
-#: ../../src/Worksheet.cpp:1398 ../../src/wxMaximaFrame.cpp:844
+#: ../../src/worksheet/WorksheetContextMenu.cpp:169
+#: ../../src/wxMaximaFrame.cpp:878
 msgid "Evaluate Cell(s)"
 msgstr "評算單元"
 
-#: ../../src/Worksheet.cpp:1391 ../../src/Worksheet.cpp:1674
+#: ../../src/worksheet/WorksheetContextMenu.cpp:162
+#: ../../src/worksheet/WorksheetContextMenu.cpp:447
 #, fuzzy
 msgid "Evaluate Cells Above"
 msgstr "評算單元"
 
-#: ../../src/wxMaximaFrame.cpp:866
+#: ../../src/wxMaximaFrame.cpp:900
 #, fuzzy
 msgid "Evaluate Cells Above\tCtrl+Shift+P"
 msgstr "評算所有單元\tCtrl+R"
 
-#: ../../src/Worksheet.cpp:1402 ../../src/Worksheet.cpp:1676
-#: ../../src/wxMaximaFrame.cpp:876
+#: ../../src/worksheet/WorksheetContextMenu.cpp:173
+#: ../../src/worksheet/WorksheetContextMenu.cpp:449
+#: ../../src/wxMaximaFrame.cpp:910
 #, fuzzy
 msgid "Evaluate Cells Below"
 msgstr "評算單元"
 
-#: ../../src/Worksheet.cpp:1451 ../../src/Worksheet.cpp:1756
-#: ../../src/Worksheet.cpp:1890
+#: ../../src/worksheet/WorksheetContextMenu.cpp:222
+#: ../../src/worksheet/WorksheetContextMenu.cpp:529
+#: ../../src/worksheet/WorksheetContextMenu.cpp:662
 msgid "Evaluate Heading 5\tShift+Ctrl+Enter"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1457 ../../src/Worksheet.cpp:1761
-#: ../../src/Worksheet.cpp:1901
+#: ../../src/worksheet/WorksheetContextMenu.cpp:228
+#: ../../src/worksheet/WorksheetContextMenu.cpp:534
+#: ../../src/worksheet/WorksheetContextMenu.cpp:673
 msgid "Evaluate Heading 6\tShift+Ctrl+Enter"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8626
+#: ../../src/MaximaCommandMenus.cpp:618
 #, fuzzy
 msgid "Evaluate Nouns"
 msgstr "評算名詞形式(&N)"
 
-#: ../../src/Worksheet.cpp:1425 ../../src/Worksheet.cpp:1736
+#: ../../src/worksheet/WorksheetContextMenu.cpp:196
+#: ../../src/worksheet/WorksheetContextMenu.cpp:509
 msgid "Evaluate Part\tShift+Ctrl+Enter"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1431 ../../src/Worksheet.cpp:1741
+#: ../../src/worksheet/WorksheetContextMenu.cpp:202
+#: ../../src/worksheet/WorksheetContextMenu.cpp:514
 msgid "Evaluate Section\tShift+Ctrl+Enter"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1445 ../../src/Worksheet.cpp:1751
-#: ../../src/Worksheet.cpp:1879
+#: ../../src/worksheet/WorksheetContextMenu.cpp:216
+#: ../../src/worksheet/WorksheetContextMenu.cpp:524
+#: ../../src/worksheet/WorksheetContextMenu.cpp:651
 msgid "Evaluate Sub-Subsection\tShift+Ctrl+Enter"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1438 ../../src/Worksheet.cpp:1746
-#: ../../src/Worksheet.cpp:1868
+#: ../../src/worksheet/WorksheetContextMenu.cpp:209
+#: ../../src/worksheet/WorksheetContextMenu.cpp:519
+#: ../../src/worksheet/WorksheetContextMenu.cpp:640
 msgid "Evaluate Subsection\tShift+Ctrl+Enter"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:845
+#: ../../src/wxMaximaFrame.cpp:879
 msgid "Evaluate active or selected cell(s)"
 msgstr "評算正在活動中或所選擇的單元"
 
-#: ../../src/ToolBar.cpp:251
+#: ../../src/ToolBar.cpp:445 ../../src/ToolBar.cpp:457
 msgid "Evaluate all"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:857
+#: ../../src/wxMaximaFrame.cpp:891
 msgid "Evaluate all cells in the document"
 msgstr "評算這份文件中的所有單元"
 
-#: ../../src/wxMaximaFrame.cpp:1653
+#: ../../src/wxMaximaFrame.cpp:1690
 msgid "Evaluate all noun forms in expression"
 msgstr "評算數式中所有的名詞形式"
 
-#: ../../src/wxMaximaFrame.cpp:852
+#: ../../src/wxMaximaFrame.cpp:886
 #, fuzzy
 msgid "Evaluate all visible cells in the document"
 msgstr "評算這份文件中的所有單元"
 
-#: ../../src/ToolBar.cpp:248
+#: ../../src/ToolBar.cpp:442 ../../src/ToolBar.cpp:454
 msgid "Evaluate current cell"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7395
+#: ../../src/MaximaCommandMenus.cpp:4267
 #, fuzzy
 msgid "Evaluate string"
 msgstr "評算名詞形式(&N)"
 
-#: ../../src/wxMaximaFrame.cpp:1151
+#: ../../src/wxMaximaFrame.cpp:1185
 #, fuzzy
 msgid "Evaluate string..."
 msgstr "評算名詞形式(&N)"
 
-#: ../../src/ToolBar.cpp:256
+#: ../../src/ToolBar.cpp:449 ../../src/ToolBar.cpp:461
 msgid "Evaluate the file from its beginning to the cell above the cursor"
 msgstr ""
 
-#: ../../src/ToolBar.cpp:259
+#: ../../src/ToolBar.cpp:452 ../../src/ToolBar.cpp:464
 #, fuzzy
 msgid "Evaluate the file from the cursor to its end"
 msgstr "評算這份文件中的所有單元"
 
-#: ../../src/ToolBar.cpp:258
+#: ../../src/ToolBar.cpp:451 ../../src/ToolBar.cpp:463
 #, fuzzy
 msgid "Evaluate the rest"
 msgstr "評算名詞形式(&N)"
 
-#: ../../src/ToolBar.cpp:255
+#: ../../src/ToolBar.cpp:448 ../../src/ToolBar.cpp:460
 #, fuzzy
 msgid "Evaluate to point"
 msgstr "評算名詞形式(&N)"
 
-#: ../../src/wxMaxima.cpp:10518
+#: ../../src/MaximaEvaluator.cpp:351
 msgid "Evaluation ended, since evaluation queue is empty."
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1957
+#: ../../src/worksheet/WorksheetContextMenu.cpp:729
 msgid "Even number"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1703
+#: ../../src/dialogs/ConfigDialogue.cpp:2659
+msgid "Example text"
+msgstr "Example text 範例文字"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1547
+msgid "Examples:"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1740
 msgid "Execute a command for each element of the list"
 msgstr ""
 
-#: ../../src/main.cpp:438
+#: ../../src/main.cpp:677
 msgid "Exit"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:625
-msgid "Exit wxMaxima"
-msgstr ""
+#: ../../src/sidebars/MathSidebar.cpp:53
+msgid "Expand"
+msgstr "展開"
 
-#: ../../src/Worksheet.cpp:1583
+#: ../../src/sidebars/MathSidebar.cpp:68
+msgid "Expand (tr)"
+msgstr "展開 (三角)"
+
+#: ../../src/worksheet/WorksheetContextMenu.cpp:356
 msgid "Expand Expression"
 msgstr "展開數式"
 
-#: ../../src/wxMaximaFrame.cpp:1525
+#: ../../src/wxMaximaFrame.cpp:1562
 msgid "Expand an expression"
 msgstr "展開數式"
 
-#: ../../src/wxMaximaFrame.cpp:1531
+#: ../../src/wxMaximaFrame.cpp:1568
 #, fuzzy
 msgid "Expand for given variables"
 msgstr "變數變換"
 
-#: ../../src/wxMaxima.cpp:8781
+#: ../../src/MaximaCommandMenus.cpp:788
 msgid "Expand for variable(s) including denominator:"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8716
+#: ../../src/MaximaCommandMenus.cpp:708
 #, fuzzy
 msgid "Expand for variable(s):"
 msgstr "新變數："
 
-#: ../../src/wxMaximaFrame.cpp:1545
+#: ../../src/wxMaximaFrame.cpp:1582
 #, fuzzy
 msgid "Expand log in previous expression"
 msgstr "展開數式"
 
-#: ../../src/wxMaximaFrame.cpp:1598
+#: ../../src/wxMaximaFrame.cpp:1635
 msgid "Expand trigonometric expression"
 msgstr "展開三角函數數式"
 
-#: ../../src/wxMaximaFrame.cpp:1788
+#: ../../src/wxMaximaFrame.cpp:1825
 msgid "Expect numbers harder to be complex"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1789
+#: ../../src/wxMaximaFrame.cpp:1826
 msgid "Expect variables to contain complex numbers"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:6121
+#: ../../src/MaximaCommandMenus.cpp:2277
+#: ../../src/dialogs/ConfigDialogue.cpp:283
 msgid "Export"
 msgstr "匯出"
 
-#: ../../src/wxMaximaFrame.cpp:1705
+#: ../../src/sidebars/History.cpp:152
+#, fuzzy
+msgid "Export As"
+msgstr "匯出"
+
+#: ../../src/wxMaximaFrame.cpp:1742
 #, fuzzy
 msgid "Export List to csv file..."
 msgstr "匯出為 TeX 失敗！"
 
-#: ../../src/wxMaximaFrame.cpp:1706
+#: ../../src/wxMaximaFrame.cpp:1743
 #, fuzzy
 msgid "Export a list to a csv file"
 msgstr "讀取 Maxima package 檔"
 
-#: ../../src/wxMaximaFrame.cpp:1332
+#: ../../src/wxMaximaFrame.cpp:1366
 #, fuzzy
 msgid "Export a matrix to a csv file"
 msgstr "讀取 Maxima package 檔"
 
-#: ../../src/wxMaximaFrame.cpp:619
+#: ../../src/sidebars/History.cpp:102
+msgid "Export all history to a .mac file"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1016
+#, fuzzy
+msgid "Export all settings"
+msgstr "匯出為 TeX 失敗！"
+
+#: ../../src/sidebars/History.cpp:105
+msgid "Export commands from the current maxima session to a .mac file"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:652
 #, fuzzy
 msgid "Export document to a HTML or LaTeX file"
 msgstr "將文件匯出為 HTML 或 pdfLaTeX 檔案"
 
-#: ../../src/wxMaximaFrame.cpp:579
+#: ../../src/dialogs/ConfigDialogue.cpp:1218
+#, fuzzy
+msgid "Export equations to HTML as:"
+msgstr "匯出為 HTML 失敗！"
+
+#: ../../src/wxMaximaFrame.cpp:600
 #, fuzzy
 msgid "Export failed."
 msgstr "匯出為 TeX 失敗！"
 
-#: ../../src/wxMaximaFrame.cpp:567
+#: ../../src/worksheet/WorksheetContextMenu.cpp:154
+msgid "Export output as PNG to a folder..."
+msgstr ""
+
+#: ../../src/worksheet/WorksheetContextMenu.cpp:151
+msgid "Export output as SVG to a folder..."
+msgstr ""
+
+#: ../../src/sidebars/History.cpp:108
+msgid "Export selected commands to a .mac file"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:588
 msgid "Export successful."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:6187
+#: ../../src/MaximaCommandMenus.cpp:3468
+msgid "Export the selected output(s) to this folder"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1022
+#, fuzzy
+msgid "Export the style settings"
+msgstr "匯出為 TeX 失敗！"
+
+#: ../../src/sidebars/History.cpp:111
+msgid "Export visible commands to a .mac file"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:3477
+#, c-format
+msgid "Exported %d output image(s) to %s"
+msgstr ""
+
+#: ../../src/wxMaxima.cpp:2200 ../../src/wxMaxima.cpp:2242
+#, c-format
+msgid "Exported the worksheet to %s"
+msgstr ""
+
+#: ../../src/sidebars/History.cpp:228
+#, fuzzy
+msgid "Exporting to .mac file failed!"
+msgstr "匯出為 TeX 失敗！"
+
+#: ../../src/MaximaCommandMenus.cpp:2343
 msgid "Exporting to HTML failed!"
 msgstr "匯出為 HTML 失敗！"
 
-#: ../../src/wxMaxima.cpp:6164
+#: ../../src/MaximaCommandMenus.cpp:2320
 msgid "Exporting to TeX failed!"
 msgstr "匯出為 TeX 失敗！"
 
-#: ../../src/wxMaxima.cpp:6175
+#: ../../src/MaximaCommandMenus.cpp:2331
 #, fuzzy
 msgid "Exporting to maxima batch file failed!"
 msgstr "匯出為 TeX 失敗！"
 
-#: ../../src/wxMaximaFrame.cpp:561
+#: ../../src/wxMaximaFrame.cpp:582
 #, fuzzy
 msgid "Exporting..."
 msgstr "匯出(&E)..."
 
-#: ../../src/wxMaxima.cpp:6510 ../../src/wxMaxima.cpp:6516
-#: ../../src/wxMaxima.cpp:8218 ../../src/wxMaxima.cpp:8633
-#: ../../src/wxMaxima.cpp:8638 ../../src/wxMaxima.cpp:8658
-#: ../../src/wxMaxima.cpp:10065
+#: ../../src/MaximaCommandMenus.cpp:1480
+msgid "Expr:"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:625 ../../src/MaximaCommandMenus.cpp:630
+#: ../../src/MaximaCommandMenus.cpp:650 ../../src/MaximaCommandMenus.cpp:1408
+#: ../../src/MaximaCommandMenus.cpp:3030 ../../src/MaximaCommandMenus.cpp:3036
+#: ../../src/MaximaCommandMenus.cpp:3554 ../../src/sidebars/DrawSidebar.cpp:54
+#: ../../src/wizards/Plot3dWiz.cpp:32
 msgid "Expression"
 msgstr "數式"
 
-#: ../../src/wxMaxima.cpp:7019 ../../src/wxMaxima.cpp:7025
+#: ../../src/MaximaCommandMenus.cpp:3891 ../../src/MaximaCommandMenus.cpp:3897
 #, fuzzy
 msgid "Expression or a list of comma-separated expressions"
 msgstr "x 座標，以逗號分隔"
 
-#: ../../src/wxMaximaFrame.cpp:1088
+#: ../../src/wizards/DrawWiz.cpp:733
+msgid "Expression that calculates the x value"
+msgstr ""
+
+#: ../../src/wizards/DrawWiz.cpp:738
+msgid "Expression that calculates the y value"
+msgstr ""
+
+#: ../../src/wizards/DrawWiz.cpp:744
+msgid "Expression that calculates the z value"
+msgstr ""
+
+#: ../../src/wizards/DrawWiz.cpp:56
+msgid "Expression to plot"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1122
 #, fuzzy
 msgid "Expression to string..."
 msgstr "數式"
 
-#: ../../src/wxMaxima.cpp:7113
+#: ../../src/MaximaCommandMenus.cpp:3985
 msgid "Expression whose output is to be used as maxima's input."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7214
+#: ../../src/MaximaCommandMenus.cpp:4086 ../../src/wizards/Plot2dWiz.cpp:39
 msgid "Expression(s):"
 msgstr "數式："
 
-#: ../../src/wxMaxima.cpp:8933 ../../src/wxMaxima.cpp:8941
-#: ../../src/wxMaxima.cpp:8952 ../../src/wxMaxima.cpp:8976
-#: ../../src/wxMaxima.cpp:8981 ../../src/wxMaxima.cpp:8998
-#: ../../src/wxMaxima.cpp:9004 ../../src/wxMaxima.cpp:9011
-#: ../../src/wxMaxima.cpp:9043 ../../src/wxMaxima.cpp:9062
-#: ../../src/wxMaxima.cpp:10056
+#: ../../src/MaximaCommandMenus.cpp:184 ../../src/MaximaCommandMenus.cpp:195
+#: ../../src/MaximaCommandMenus.cpp:206 ../../src/MaximaCommandMenus.cpp:230
+#: ../../src/MaximaCommandMenus.cpp:235 ../../src/MaximaCommandMenus.cpp:252
+#: ../../src/MaximaCommandMenus.cpp:258 ../../src/MaximaCommandMenus.cpp:265
+#: ../../src/MaximaCommandMenus.cpp:297 ../../src/MaximaCommandMenus.cpp:316
+#: ../../src/MaximaCommandMenus.cpp:3545 ../../src/wizards/IntegrateWiz.cpp:33
+#: ../../src/wizards/LimitWiz.cpp:29 ../../src/wizards/SeriesWiz.cpp:30
+#: ../../src/wizards/SubstituteWiz.cpp:29 ../../src/wizards/SumWiz.cpp:31
 msgid "Expression:"
 msgstr "數式："
 
-#: ../../src/wxMaximaFrame.cpp:1423
+#: ../../src/wxMaximaFrame.cpp:1457
 #, fuzzy
 msgid "Extract Column..."
 msgstr "從數式產生串列"
 
-#: ../../src/wxMaximaFrame.cpp:1726
+#: ../../src/wxMaximaFrame.cpp:1763
 msgid "Extract Elements"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1421
+#: ../../src/wxMaximaFrame.cpp:1455
 #, fuzzy
 msgid "Extract Row..."
 msgstr "從數式產生串列"
 
-#: ../../src/wxMaximaFrame.cpp:1424
+#: ../../src/wxMaximaFrame.cpp:1458
 msgid "Extract a column from the matrix"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1435
+#: ../../src/wxMaximaFrame.cpp:1472
 msgid "Extract a column from the matrix and convert it to a list"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7960
+#: ../../src/MaximaCommandMenus.cpp:1140
 #, fuzzy
 msgid "Extract a matrix column"
 msgstr "輸入一個矩陣"
 
-#: ../../src/wxMaxima.cpp:7970
+#: ../../src/MaximaCommandMenus.cpp:1150
 #, fuzzy
 msgid "Extract a matrix column as a list"
 msgstr "輸入一個矩陣"
 
-#: ../../src/wxMaximaFrame.cpp:1313
+#: ../../src/wxMaximaFrame.cpp:1347
 #, fuzzy
 msgid "Extract a matrix from a 2-dimensional array"
 msgstr "以二維陣列產生一個矩陣"
 
-#: ../../src/wxMaxima.cpp:7955
+#: ../../src/MaximaCommandMenus.cpp:1135
 #, fuzzy
 msgid "Extract a matrix row"
 msgstr "輸入一個矩陣"
 
-#: ../../src/wxMaxima.cpp:7965
+#: ../../src/MaximaCommandMenus.cpp:1145
 #, fuzzy
 msgid "Extract a matrix row as a list"
 msgstr "輸入一個矩陣"
 
-#: ../../src/wxMaximaFrame.cpp:1422
+#: ../../src/wxMaximaFrame.cpp:1456
 msgid "Extract a row from the matrix"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1431
+#: ../../src/wxMaximaFrame.cpp:1468
 #, fuzzy
 msgid "Extract a row from the matrix and convert it to a list"
 msgstr "從數式產生串列"
 
-#: ../../src/wxMaxima.cpp:8564
+#: ../../src/MaximaCommandMenus.cpp:1580
 msgid "Extract a variable's value from a list of variable values"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1723
+#: ../../src/wxMaximaFrame.cpp:1760
 msgid "Extract an actual value for a variable"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1163
+#: ../../src/wxMaximaFrame.cpp:1197
 #, fuzzy
 msgid "Extract char..."
 msgstr "從數式產生串列"
 
-#: ../../src/wxMaximaFrame.cpp:1207
+#: ../../src/wxMaximaFrame.cpp:1241
 #, fuzzy
 msgid "Extract dir from path..."
 msgstr "從數式產生串列"
 
-#: ../../src/wxMaxima.cpp:7605
+#: ../../src/MaximaCommandMenus.cpp:4477
 #, fuzzy
 msgid "Extract directory part"
 msgstr "函數名"
 
-#: ../../src/wxMaxima.cpp:7617
+#: ../../src/MaximaCommandMenus.cpp:4489
 #, fuzzy
 msgid "Extract file type extension"
 msgstr "從數式產生串列"
 
-#: ../../src/wxMaximaFrame.cpp:1209
+#: ../../src/wxMaximaFrame.cpp:1243
 msgid "Extract filename from path..."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7611
+#: ../../src/MaximaCommandMenus.cpp:4483
 #, fuzzy
 msgid "Extract filename part"
 msgstr "從數式產生串列"
 
-#: ../../src/wxMaximaFrame.cpp:1211
+#: ../../src/wxMaximaFrame.cpp:1245
 msgid "Extract filetype from path..."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8445
+#: ../../src/MaximaCommandMenus.cpp:1442
 #, fuzzy
 msgid "Extract function arguments"
 msgstr "函數名"
 
-#: ../../src/wxMaximaFrame.cpp:1727
+#: ../../src/wxMaximaFrame.cpp:1764
 #, fuzzy
 msgid "Extract list Elements"
 msgstr "從數式產生串列"
 
-#: ../../src/wxMaxima.cpp:8187
+#: ../../src/MaximaCommandMenus.cpp:1375
 #, fuzzy
 msgid "Extract matrix from 2D array"
 msgstr "輸入一個矩陣"
 
-#: ../../src/wxMaximaFrame.cpp:1686
+#: ../../src/wxMaximaFrame.cpp:1723
 #, fuzzy
 msgid "Extract the argument list from a function call"
 msgstr "從數式產生串列"
 
-#: ../../src/wxMaxima.cpp:8538
+#: ../../src/MaximaCommandMenus.cpp:1551
 #, fuzzy
 msgid "Extract the last n elements from a list"
 msgstr "從數式產生串列"
 
-#: ../../src/wxMaxima.cpp:7376
+#: ../../src/MaximaCommandMenus.cpp:1550
+msgid "Extract the last n list elements"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:4248
 #, fuzzy
 msgid "Extract the nth char of a string"
 msgstr "從數式產生串列"
 
-#: ../../src/wxMaxima.cpp:8544
+#: ../../src/MaximaCommandMenus.cpp:1557
 #, fuzzy
 msgid "Extract the nth list elements"
 msgstr "從數式產生串列"
 
-#: ../../src/wxMaximaFrame.cpp:1724
+#: ../../src/wxMaximaFrame.cpp:1761
 msgid "Extract the value for one variable assigned in a list"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1439
+#: ../../src/wxMaximaFrame.cpp:1476
 msgid "Extract, append or delete rows or columns"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8188
+#: ../../src/MaximaCommandMenus.cpp:1376
 #, fuzzy
 msgid "Extracts a rectangle from a 2D array and converts it to a matrix"
 msgstr "從數式產生串列"
 
-#: ../../src/wxMaximaFrame.cpp:1521
+#: ../../src/sidebars/MathSidebar.cpp:50
+msgid "Factor"
+msgstr "因式分解"
+
+#: ../../src/wxMaximaFrame.cpp:1558
 msgid "Factor Complex"
 msgstr "複數因式分解"
 
-#: ../../src/Worksheet.cpp:1581
+#: ../../src/worksheet/WorksheetContextMenu.cpp:354
 msgid "Factor Expression"
 msgstr "因式分解數式"
 
-#: ../../src/wxMaximaFrame.cpp:1519
+#: ../../src/wxMaximaFrame.cpp:1556
 #, fuzzy
 msgid "Factor Expression including subexpressions"
 msgstr "因式分解含 Gaussian 數的數式"
 
-#: ../../src/wxMaximaFrame.cpp:1517 ../../src/wxMaximaFrame.cpp:1520
+#: ../../src/wxMaximaFrame.cpp:1554 ../../src/wxMaximaFrame.cpp:1557
 msgid "Factor an expression"
 msgstr "因式分解數式"
 
-#: ../../src/wxMaximaFrame.cpp:1522
+#: ../../src/wxMaximaFrame.cpp:1559
 msgid "Factor an expression in Gaussian numbers"
 msgstr "因式分解含 Gaussian 數的數式"
 
-#: ../../src/wxMaximaFrame.cpp:1587
+#: ../../src/wxMaximaFrame.cpp:1624
 msgid "Factorials and &Gamma"
 msgstr "階乘與 Gamma 函數(&G)"
 
-#: ../../src/Image.cpp:137
+#: ../../src/Image.cpp:173
 #, c-format
 msgid "Failed to delete gnuplot data file %s"
 msgstr ""
 
-#: ../../src/Image.cpp:121 ../../src/Image.cpp:128
+#: ../../src/Image.cpp:157 ../../src/Image.cpp:164
 #, c-format
 msgid "Failed to delete gnuplot file %s"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2667
+#: ../../src/MaximaProcessManager.cpp:352
 #, fuzzy
 msgid "Failed to start Maxima"
 msgstr "重新啟動 Maxima"
 
-#: ../../src/wxMaximaFrame.cpp:1418
+#: ../../src/MaximaProcessManager.cpp:628
+msgid "Failed to write to Maxima's stdin (LDB)."
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1452
 msgid "Fast fortran routines that perform numerical tasks"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1922
+#: ../../src/wxMaximaFrame.cpp:1959
 msgid "Fast list access"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2553
+#: ../../src/MaximaProcessManager.cpp:218
 msgid "Fatal error"
 msgstr "嚴重錯誤"
 
-#: ../../src/wxMaxima.cpp:7191
+#: ../../src/wizards/CsvWiz.cpp:38 ../../src/wizards/CsvWiz.cpp:109
+msgid "Field Separator"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:4063
 #, fuzzy
 msgid "Field contents:"
 msgstr "希臘字母"
 
-#: ../../src/wxMaxima.cpp:7198
+#: ../../src/MaximaCommandMenus.cpp:4070
 #, fuzzy
 msgid "Field name:"
 msgstr "舊變數："
 
-#: ../../src/wxMaxima.cpp:7185
+#: ../../src/MaximaCommandMenus.cpp:4057
 msgid "Fields:"
 msgstr ""
 
-#: ../../src/main.cpp:439
+#: ../../src/cells/GroupCell.cpp:2115
+#, c-format
+msgid "Figure %d:"
+msgstr "圖 %d:"
+
+#: ../../src/main.cpp:678
 msgid "File"
 msgstr "檔案"
 
-#: ../../src/wxMaximaFrame.cpp:1333
+#: ../../src/wxMaximaFrame.cpp:1367
 #, fuzzy
 msgid "File I/O"
 msgstr "檔案"
 
-#: ../../src/wxMaxima.cpp:4165 ../../src/wxMaxima.cpp:4224
-#: ../../src/wxMaxima.cpp:4493 ../../src/wxMaxima.cpp:4504
-#: ../../src/wxMaxima.cpp:4606 ../../src/wxMaxima.cpp:4636
-#: ../../src/wxMaxima.cpp:4647 ../../src/wxMaxima.cpp:5641
+#: ../../src/MaximaFileIO.cpp:66 ../../src/MaximaFileIO.cpp:123
+#: ../../src/MaximaFileIO.cpp:401 ../../src/MaximaFileIO.cpp:412
+#: ../../src/MaximaFileIO.cpp:529 ../../src/MaximaFileIO.cpp:559
+#: ../../src/MaximaFileIO.cpp:570 ../../src/MaximaFileIO.cpp:732
 #, fuzzy
 msgid "File could not be opened"
 msgstr "找不到檔案"
 
-#: ../../src/wxMaxima.cpp:7241 ../../src/wxMaxima.cpp:7246
-#: ../../src/wxMaxima.cpp:7251
+#: ../../src/MaximaCommandMenus.cpp:4113 ../../src/MaximaCommandMenus.cpp:4118
+#: ../../src/MaximaCommandMenus.cpp:4123
 #, fuzzy
 msgid "File name:"
 msgstr "舊變數："
 
-#: ../../src/wxMaxima.cpp:10225 ../../src/wxMaxima.cpp:10268
+#: ../../src/wxMaxima.cpp:2995 ../../src/wxMaxima.cpp:3038
 msgid "File not found"
 msgstr "找不到檔案"
 
-#: ../../src/wxMaxima.cpp:5631
+#: ../../src/MaximaFileIO.cpp:730
 #, fuzzy
 msgid "File opened"
 msgstr "找不到檔案"
 
-#: ../../src/wxMaximaFrame.cpp:1217
+#: ../../src/wxMaximaFrame.cpp:1251
 #, fuzzy
 msgid "File operations"
 msgstr "找不到檔案"
 
-#: ../../src/wxMaxima.cpp:10224 ../../src/wxMaxima.cpp:10267
+#: ../../src/wxMaxima.cpp:2994 ../../src/wxMaxima.cpp:3037
 msgid "File you tried to open does not exist."
 msgstr "找不到您想開啟的檔案。"
 
-#: ../../src/wxMaximaFrame.cpp:1221
+#: ../../src/wxMaximaFrame.cpp:1255
 #, fuzzy
 msgid "File/directory functions"
 msgstr "方向："
 
-#: ../../src/wxMaxima.cpp:7027
+#: ../../src/wizards/CsvWiz.cpp:54 ../../src/wizards/CsvWiz.cpp:128
+msgid "Filename"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:3899
 msgid "Filename or a list of comma-separated file names"
 msgstr ""
 
-#: ../../src/ToolBar.cpp:222
+#: ../../src/sidebars/DrawSidebar.cpp:93
+msgid "Fill color"
+msgstr ""
+
+#: ../../src/ToolBar.cpp:401 ../../src/ToolBar.cpp:403
 msgid "Find"
 msgstr "尋找"
 
-#: ../../src/wxMaximaFrame.cpp:670
+#: ../../src/wxMaximaFrame.cpp:707
 msgid "Find\tCtrl+F"
 msgstr "尋找\tCtrl+F"
 
-#: ../../src/wxMaximaFrame.cpp:1468
+#: ../../src/wxMaximaFrame.cpp:1505
 msgid "Find &Limit..."
 msgstr "求極限(&L)..."
 
-#: ../../src/wxMaximaFrame.cpp:1470
+#: ../../src/wxMaximaFrame.cpp:1507
 msgid "Find Minimum..."
 msgstr "求極小值..."
 
-#: ../../src/Worksheet.cpp:1576
+#: ../../src/worksheet/WorksheetContextMenu.cpp:349
 msgid "Find Root..."
 msgstr "找根..."
 
-#: ../../src/wxMaximaFrame.cpp:1471
+#: ../../src/wxMaximaFrame.cpp:1508
 msgid "Find a (unconstrained) minimum of an expression"
 msgstr "找數式的極小值(無區間限制)"
 
-#: ../../src/wxMaximaFrame.cpp:1804
+#: ../../src/wxMaximaFrame.cpp:1841
 msgid "Find a fraction that represents this float exactly"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1469
+#: ../../src/wxMaximaFrame.cpp:1506
 msgid "Find a limit of an expression"
 msgstr "求數式的極限"
 
-#: ../../src/wxMaximaFrame.cpp:1807
+#: ../../src/wxMaximaFrame.cpp:1844
 msgid "Find a nice fraction that is similar to this float"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1283
+#: ../../src/wxMaximaFrame.cpp:1317
 #, fuzzy
 msgid "Find a numerical solution for a first degree ODE"
 msgstr "解 1 階常微分方程的初始值問題"
 
-#: ../../src/wxMaximaFrame.cpp:1252
+#: ../../src/wxMaximaFrame.cpp:1286
 msgid "Find a root of an equation on an interval"
 msgstr "在區間中找方程式的根"
 
-#: ../../src/wxMaximaFrame.cpp:1259
+#: ../../src/wxMaximaFrame.cpp:1293
 msgid "Find all roots of a polynomial"
 msgstr "找多項式所有的根"
 
-#: ../../src/wxMaximaFrame.cpp:1262
+#: ../../src/wxMaximaFrame.cpp:1296
 msgid "Find all roots of a polynomial (bfloat)"
 msgstr "找多項式所有的根(以長浮點數表示)"
 
-#: ../../src/wxMaxima.cpp:6589
+#: ../../src/MaximaCommandMenus.cpp:3103
 msgid "Find and Replace"
 msgstr "尋找及取代"
 
-#: ../../src/ToolBar.cpp:222 ../../src/wxMaximaFrame.cpp:670
+#: ../../src/ToolBar.cpp:401 ../../src/ToolBar.cpp:403
+#: ../../src/wxMaximaFrame.cpp:707
 msgid "Find and replace"
 msgstr "尋找及取代"
 
-#: ../../src/wxMaxima.cpp:7434
+#: ../../src/MaximaCommandMenus.cpp:4306
 msgid "Find char in string"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1172
+#: ../../src/wxMaximaFrame.cpp:1206
 msgid "Find char in string..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1534
+#: ../../src/wxMaximaFrame.cpp:1571
 msgid "Find common denominator"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1366
+#: ../../src/wxMaximaFrame.cpp:1400
 msgid "Find eigenvalues of a matrix"
 msgstr "尋找矩陣的特徵值"
 
-#: ../../src/wxMaximaFrame.cpp:1369
+#: ../../src/wxMaximaFrame.cpp:1403
 msgid "Find eigenvectors of a matrix"
 msgstr "尋找矩陣的特徵向量"
 
-#: ../../src/wxMaxima.cpp:7424
+#: ../../src/MaximaCommandMenus.cpp:4296
 msgid "Find first difference"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1170
+#: ../../src/wxMaximaFrame.cpp:1204
 msgid "Find first difference..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1256
+#: ../../src/wxMaximaFrame.cpp:1290
 #, fuzzy
 msgid "Find fractions that real roots of a polynomial and "
 msgstr "找多項式所有的實根"
 
-#: ../../src/wxMaxima.cpp:9039
+#: ../../src/MaximaCommandMenus.cpp:293
 msgid "Find minimum"
 msgstr "求極小值"
 
-#: ../../src/wxMaximaFrame.cpp:1251
+#: ../../src/wxMaximaFrame.cpp:1285
 msgid "Find numerical solution..."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:10035
+#: ../../src/MaximaCommandMenus.cpp:3524
 msgid "Find root (solve numerically)"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8062 ../../src/wxMaxima.cpp:8083
+#: ../../src/MaximaCommandMenus.cpp:1248 ../../src/MaximaCommandMenus.cpp:1271
 #, fuzzy
 msgid "Find the maximum absolute value of a matrix entry"
 msgstr "尋找矩陣的特徵值"
 
-#: ../../src/wxMaxima.cpp:8068 ../../src/wxMaxima.cpp:8089
+#: ../../src/MaximaCommandMenus.cpp:1254 ../../src/MaximaCommandMenus.cpp:1277
 msgid "Find the maximum sum of the absolute values of a matrix column"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8073 ../../src/wxMaxima.cpp:8094
+#: ../../src/MaximaCommandMenus.cpp:1259 ../../src/MaximaCommandMenus.cpp:1282
 msgid "Find the maximum sum of the absolute values of a matrix row"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1832
+#: ../../src/dialogs/FindReplacePane.cpp:46
+#, fuzzy
+msgid "Find:"
+msgstr "尋找"
+
+#: ../../src/wxMaximaFrame.cpp:1869
 msgid "Fine-tune the display of engineering-format numbers"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1712
+#: ../../src/dialogs/ConfigDialogue.cpp:197
+#, fuzzy
+msgid "Finnish"
+msgstr "Danish"
+
+#: ../../src/wxMaximaFrame.cpp:1749
 msgid "First"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1918
+#: ../../src/wxMaximaFrame.cpp:1955
 msgid "Fitting curves to measurement data"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7227
+#: ../../src/dialogs/ConfigDialogue.cpp:1404
+#, c-format
+msgid "Fix reordered reference indices (of %i, %o) before saving"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:873
+msgid "Fixed font in text controls"
+msgstr "文字控制項使用等寬字型"
+
+#: ../../src/MaximaCommandMenus.cpp:4099
 msgid "Flush stream"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1103
+#: ../../src/wxMaximaFrame.cpp:1137
 msgid "Flush..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:922
+#: ../../src/wxMaximaFrame.cpp:956
 #, fuzzy
 msgid "Fold All\tCtrl+Alt+["
 msgstr "全部選取\tCtrl+A"
 
-#: ../../src/wxMaximaFrame.cpp:923
+#: ../../src/wxMaximaFrame.cpp:957
 msgid "Fold all sections"
 msgstr ""
 
-#: ../../src/ToolBar.cpp:240
+#: ../../src/ToolBar.cpp:424 ../../src/ToolBar.cpp:432
 msgid "Follow"
 msgstr ""
 
-#: ../../src/ToolBar.cpp:285
+#: ../../src/dialogs/ConfigDialogue.cpp:2070
+msgid "Follow system"
+msgstr ""
+
+#: ../../src/wizards/DrawWiz.cpp:341
+msgid "Following plots use secondary x axis"
+msgstr ""
+
+#: ../../src/wizards/DrawWiz.cpp:347
+msgid "Following plots use secondary y axis"
+msgstr ""
+
+#: ../../src/sidebars/PerformanceSidebar.cpp:37
+msgid "Font cache hits:"
+msgstr ""
+
+#: ../../src/sidebars/PerformanceSidebar.cpp:38
+msgid "Font cache misses:"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:2047
+msgid "Fonts"
+msgstr "字型"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:442
+msgid "For each Text-, Sectioning or code cell wxMaxima can display a bracket showing the extend of the cell and allowing to fold it. This setting now tells if this bracket is to be printed, as well."
+msgstr ""
+
+#: ../../src/ToolBar.cpp:495
 msgid ""
 "For faster creation of cells the following shortcuts exist:\n"
 "\n"
@@ -3282,429 +4835,634 @@ msgid ""
 "   Ctrl+7: Heading6 cell\n"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7038
+#: ../../src/MaximaCommandMenus.cpp:3910
 msgid "For loop"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1062
+#: ../../src/wxMaximaFrame.cpp:1096
 msgid "For loop..."
 msgstr ""
 
-#: ../../src/Worksheet.cpp:237 ../../src/wxMaxima.cpp:11217
+#: ../../src/wizards/Plot2dWiz.cpp:69 ../../src/wizards/Plot3dWiz.cpp:60
+msgid "Format:"
+msgstr "格式："
+
+#: ../../src/worksheet/Worksheet.cpp:301 ../../src/wxMaxima.cpp:3523
 msgid "Forwarding the keyboard focus to a text control"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:11220
+#: ../../src/wxMaxima.cpp:3526
 msgid "Forwarding the keyboard focus to the worksheet"
 msgstr ""
 
-#: ../../src/MaximaManual.cpp:452
+#: ../../src/MaximaManual.cpp:469
 #, c-format
 msgid "Found %li anchors, URLs (individual files): %li, URLs (singlepage): %li"
 msgstr ""
 
-#: ../../src/MaximaManual.cpp:313
+#: ../../src/graphical_io/Printout.cpp:182
+#, c-format
+msgid "Found %li line breaks"
+msgstr ""
+
+#: ../../src/MaximaManual.cpp:326
 #, c-format
 msgid "Found only %li keywords in maxima's manual. Not caching them to disc."
 msgstr ""
 
-#: ../../src/MaximaManual.cpp:513
+#: ../../src/MaximaManual.cpp:530
 #, c-format
 msgid "Found the maxima HTML manual in the folder %s."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8948
+#: ../../src/MaximaCommandMenus.cpp:202
 msgid "Fourier coefficients"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1476
+#: ../../src/wxMaximaFrame.cpp:1513
 msgid "Fourier coefficients..."
 msgstr ""
 
-#: ../../src/ToolBar.cpp:137
+#: ../../src/ToolBar.cpp:132
 #, c-format
 msgid "Frame %li of %li"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:9097
+#: ../../src/wizards/DrawWiz.cpp:488
+msgid "Frame counter"
+msgstr ""
+
+#: ../../src/wizards/DrawWiz.cpp:499
+#, fuzzy
+msgid "Frame counter end"
+msgstr "找不到檔案"
+
+#: ../../src/wizards/DrawWiz.cpp:494
+msgid "Frame counter start"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:102
 msgid "Frame rate"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1005 ../../src/wxMaximaFrame.cpp:1009
+#: ../../src/wxMaximaFrame.cpp:1039 ../../src/wxMaximaFrame.cpp:1043
 msgid "Free all unused items now"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1413
+#: ../../src/dialogs/ConfigDialogue.cpp:198
+msgid "French"
+msgstr "French"
+
+#: ../../src/wxMaximaFrame.cpp:1447
 msgid "Frobenius Norm sqrt(sum((A(i,j))^2)) (complex)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1411
+#: ../../src/wxMaximaFrame.cpp:1445
 msgid "Frobenius Norm sqrt(sum((A(i,j))^2)) (real)"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:9064
+#: ../../src/MaximaCommandMenus.cpp:318 ../../src/wizards/IntegrateWiz.cpp:41
+#: ../../src/wizards/Plot2dWiz.cpp:48 ../../src/wizards/Plot2dWiz.cpp:58
+#: ../../src/wizards/Plot2dWiz.cpp:499 ../../src/wizards/Plot3dWiz.cpp:37
+#: ../../src/wizards/Plot3dWiz.cpp:46 ../../src/wizards/SumWiz.cpp:37
 msgid "From:"
 msgstr "從："
 
-#: ../../src/wxMaximaFrame.cpp:827
+#: ../../src/wxMaximaFrame.cpp:864
 msgid "Full Screen\tAlt+Enter"
 msgstr "全螢幕\tAlt+Enter"
 
-#: ../../src/wxMaximaFrame.cpp:824
+#: ../../src/wxMaximaFrame.cpp:861
 msgid "Full Screen\tF11"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7140
+#: ../../src/sidebars/PerformanceSidebar.cpp:48
+msgid "Full-window repaints:"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:4012
 #, fuzzy
 msgid "Function contents:"
 msgstr "函數名"
 
-#: ../../src/wxMaxima.cpp:7908
+#: ../../src/MaximaCommandMenus.cpp:1089
 #, fuzzy
 msgid "Function f(x):"
 msgstr "函數："
 
-#: ../../src/wxMaxima.cpp:8572
+#: ../../src/MaximaCommandMenus.cpp:1590
 #, fuzzy
 msgid "Function name"
 msgstr "函數名"
 
-#: ../../src/wxMaxima.cpp:7167
+#: ../../src/MaximaCommandMenus.cpp:4039
 #, fuzzy
 msgid "Function name(s):"
 msgstr "函數名"
 
-#: ../../src/wxMaxima.cpp:7135 ../../src/wxMaxima.cpp:7684
+#: ../../src/MaximaCommandMenus.cpp:4007 ../../src/MaximaCommandMenus.cpp:4556
 #, fuzzy
 msgid "Function name:"
 msgstr "函數名"
 
-#: ../../src/wxMaxima.cpp:8135
+#: ../../src/MaximaCommandMenus.cpp:1323
 msgid "Function:"
 msgstr "函數："
 
-#: ../../src/wxMaximaFrame.cpp:1630
+#: ../../src/wxMaximaFrame.cpp:1667
 msgid "Functions for complex simplification"
 msgstr "用以化簡複數數式的函數"
 
-#: ../../src/wxMaximaFrame.cpp:1588
+#: ../../src/wxMaximaFrame.cpp:1625
 msgid "Functions for simplifying factorials and gamma function"
 msgstr "用以化簡階乘及 gamma 函數的函數"
 
-#: ../../src/wxMaximaFrame.cpp:1606
+#: ../../src/wxMaximaFrame.cpp:1643
 msgid "Functions for simplifying trigonometric expressions"
 msgstr "用以化簡三角函數數式的函數"
 
-#: ../../src/wxMaxima.cpp:8965 ../../src/wxMaxima.cpp:8970
+#: ../../src/MaximaCommandMenus.cpp:219 ../../src/MaximaCommandMenus.cpp:224
 msgid "GCD"
 msgstr "最大公因式"
 
-#: ../../src/wxMaxima.cpp:10186
+#: ../../src/MaximaCommandMenus.cpp:3715
 msgid "GIF image (*.gif)|*.gif"
 msgstr "GIF (*.gif)|*.gif"
 
-#: ../../src/Worksheet.cpp:103
-msgid "GTK_IM_MODULE is set to \"xim\". Expect the program to hideously flicker and hotkeys to be broken, see for example https://trac.wxwidgets.org/ticket/18462."
+#: ../../src/MaximaCommandMenus.cpp:3615
+msgid "GIF image (*.gif)|*.gif|Portable anymap (*.pnm)|*.pnm|Tagged image file format (*.tif)|*.tif|X pixmap (*.xpm)|*.xpm"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:295
+#: ../../src/worksheet/Worksheet.cpp:117
+msgid "GTK_IM_MODULE is set to \"xim\". Expect the program to hideously flicker and hotkeys to be broken, see for example https://github.com/wxWidgets/wxWidgets/issues/18462."
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:199
+msgid "Galician"
+msgstr ""
+
+#: ../../src/sidebars/GreekSidebar.cpp:180
+msgid "Gamma"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:316
 msgid "General Math"
 msgstr "常用數學"
 
-#: ../../src/wxMaximaFrame.cpp:699
+#: ../../src/wxMaximaFrame.cpp:734
 msgid "General Math\tAlt+Shift+M"
 msgstr "常用數學\tAlt+Shift+M"
 
-#: ../../src/wxMaximaFrame.cpp:1316
+#: ../../src/wxMaximaFrame.cpp:1350
 msgid "Generate Matrix from Expression..."
 msgstr "以數式產生矩陣..."
 
-#: ../../src/wxMaximaFrame.cpp:1317
+#: ../../src/wxMaximaFrame.cpp:1351
 msgid "Generate a matrix from a lambda expression"
 msgstr "以 lambda 數式產生矩陣"
 
-#: ../../src/wxMaximaFrame.cpp:1675
+#: ../../src/wxMaximaFrame.cpp:1712
 msgid "Generate a new list using a lists' elements"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1681
+#: ../../src/wxMaximaFrame.cpp:1718
 msgid "Generate a storage for variable values that can be introduced into equations at any time"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1672
+#: ../../src/wxMaximaFrame.cpp:1709
 msgid "Generate list elements using a rule"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8196
+#: ../../src/MaximaCommandMenus.cpp:1386
 #, fuzzy
 msgid "Generate matrix from a rule"
 msgstr "從數式產生串列"
 
-#: ../../src/wxMaximaFrame.cpp:1094
+#: ../../src/wxMaximaFrame.cpp:1128
 msgid "Generate unused symbol name"
 msgstr ""
 
-#: ../../src/WXMXformat.cpp:231
+#: ../../src/WXMXformat.cpp:232
 msgid "Generated the XML representation of the document"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8197
+#: ../../src/MaximaCommandMenus.cpp:1387
 msgid "Generates a matrix and fills each element with the result of the expression \"Rule\"."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1619
+#: ../../src/dialogs/ConfigDialogue.cpp:200
+msgid "Georgian"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:201
+msgid "German"
+msgstr "German"
+
+#: ../../src/wxMaximaFrame.cpp:1656
 msgid "Get &Imaginary Part"
 msgstr "取虛部(&I)"
 
-#: ../../src/wxMaximaFrame.cpp:1485
+#: ../../src/wxMaximaFrame.cpp:1522
 msgid "Get Laplace transformation of an expression"
 msgstr "計算數式的 Laplace 變換"
 
-#: ../../src/wxMaximaFrame.cpp:1615
+#: ../../src/wxMaximaFrame.cpp:1652
 msgid "Get Real P&art"
 msgstr "取實部(&A)"
 
-#: ../../src/wxMaximaFrame.cpp:1201
+#: ../../src/wxMaximaFrame.cpp:1235
 msgid "Get current directory"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1489
+#: ../../src/wxMaximaFrame.cpp:1526
 msgid "Get inverse Laplace transformation of an expression"
 msgstr "計算數式的 Laplace 逆變換"
 
-#: ../../src/wxMaxima.cpp:7223
+#: ../../src/MaximaCommandMenus.cpp:4095
 msgid "Get position in stream"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1102
+#: ../../src/wxMaximaFrame.cpp:1136
 #, fuzzy
 msgid "Get position..."
 msgstr "偏差..."
 
-#: ../../src/wxMaximaFrame.cpp:1620
+#: ../../src/wxMaximaFrame.cpp:1657
 msgid "Get the imaginary part of complex expression"
 msgstr "取得複數數式的虛部"
 
-#: ../../src/wxMaximaFrame.cpp:1616
+#: ../../src/wxMaximaFrame.cpp:1653
 msgid "Get the real part of complex expression"
 msgstr "取得複數數式的實部"
 
-#: ../../src/wxMaxima.cpp:3609
+#: ../../src/MaximaProcessManager.cpp:1220
 #, c-format
 msgid "Gnuplot (command line) found at: %s"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3607
+#: ../../src/dialogs/ConfigDialogue.cpp:1629
+msgid "Gnuplot flavour"
+msgstr ""
+
+#: ../../src/MaximaProcessManager.cpp:1218
 #, c-format
 msgid "Gnuplot found at: %s"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2974
+#: ../../src/MaximaProcessManager.cpp:994
 msgid "Gnuplot has closed."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3598 ../../src/wxMaxima.cpp:3603
+#: ../../src/MaximaProcessManager.cpp:1209
+#: ../../src/MaximaProcessManager.cpp:1214
 #, c-format
 msgid "Gnuplot not found, using the default: %s"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:9428 ../../src/wxMaximaFrame.cpp:1887
+#: ../../src/MaximaProcessManager.cpp:1097
+#, c-format
+msgid ""
+"Gnuplot reported the following while preparing the popped-out plot:\n"
+"%s"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:2071 ../../src/wxMaximaFrame.cpp:1924
 msgid "Go to URL"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3989
+#: ../../src/MaximaResponseReader.cpp:396
 #, fuzzy
 msgid "Got a new input prompt!"
 msgstr "插入新的輸入單元"
 
-#: ../../src/Worksheet.cpp:6354
+#: ../../src/worksheet/Worksheet.cpp:4306
 msgid "Got a request to undo an action that involves a delete which isn't possible at this moment."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1031
+#: ../../src/wxMaximaFrame.cpp:1065
 msgid "Gradefs"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1967
+#: ../../src/worksheet/WorksheetContextMenu.cpp:739
 #, fuzzy
 msgid "Greater or less than a value"
 msgstr "子章節單元"
 
-#: ../../src/wxMaximaFrame.cpp:1130
+#: ../../src/wxMaximaFrame.cpp:1164
 msgid "Greater, ignoring case?..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:260
+#: ../../src/dialogs/ConfigDialogue.cpp:202
+msgid "Greek"
+msgstr "Greek"
+
+#: ../../src/wxMaximaFrame.cpp:281
 #, fuzzy
 msgid "Greek Letters"
 msgstr "希臘字母"
 
-#: ../../src/wxMaximaFrame.cpp:703
+#: ../../src/wxMaximaFrame.cpp:738
 #, fuzzy
 msgid "Greek Letters\tAlt+Shift+G"
 msgstr "常用數學\tAlt+Shift+M"
 
-#: ../../src/wxMaximaFrame.cpp:1815
+#: ../../src/sidebars/DrawSidebar.cpp:97
+msgid "Grid"
+msgstr ""
+
+#: ../../src/wizards/Plot3dWiz.cpp:52
+msgid "Grid:"
+msgstr "格線："
+
+#: ../../src/wxMaximaFrame.cpp:1852
 msgid "Guess an exact number that could be meant by this float"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:6123
+#: ../../src/dialogs/ConfigDialogue.cpp:1215
+msgid "HTML"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:2279
 #, fuzzy
 msgid "HTML file (*.html)|*.html|maxima batch file (*.mac)|*.mac|LaTeX file (*.tex)|*.tex"
 msgstr "HTML 檔案 (*.html)|*.html|pdfLaTeX 檔案 (*.tex)|*.tex|所有類型|*"
 
-#: ../../src/wxMaximaFrame.cpp:1341
+#: ../../src/wxMaximaFrame.cpp:1375
 msgid "Hadamard (element-by-element) product..."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8004
+#: ../../src/MaximaCommandMenus.cpp:1188
 #, fuzzy
 msgid "Hadamard Product"
 msgstr "乘積"
 
-#: ../../src/wxMaxima.cpp:8011
+#: ../../src/MaximaCommandMenus.cpp:1195
 msgid "Hadamard exponent"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1345
+#: ../../src/wxMaximaFrame.cpp:1379
 #, fuzzy
 msgid "Hadamard exponent..."
 msgstr "矩陣名："
 
-#: ../../src/MaximaManual.cpp:260
+#: ../../src/MaximaManual.cpp:269
 #, c-format
 msgid "Have only %li keyword anchors at the end of parsing the maxima manual => Not caching the result of using the built-in keyword list"
 msgstr ""
 
-#: ../../src/Configuration.cpp:88 ../../src/ToolBar.cpp:276
+#: ../../src/Styles.cpp:117 ../../src/ToolBar.cpp:486
+#: ../../src/sidebars/FormatSidebar.cpp:60
 msgid "Heading 5"
 msgstr ""
 
-#: ../../src/Configuration.cpp:87 ../../src/ToolBar.cpp:277
+#: ../../src/Styles.cpp:116 ../../src/ToolBar.cpp:487
+#: ../../src/sidebars/FormatSidebar.cpp:63
 msgid "Heading 6"
 msgstr ""
 
-#: ../../src/ToolBar.cpp:328 ../../src/wxMaximaFrame.cpp:330
+#: ../../src/dialogs/ConfigDialogue.cpp:203
+msgid "Hebrew"
+msgstr ""
+
+#: ../../src/ToolBar.cpp:544 ../../src/ToolBar.cpp:546
+#: ../../src/wxMaximaFrame.cpp:351
 msgid "Help"
 msgstr "說明"
 
-#: ../../src/ToolBar.cpp:635
+#: ../../src/dialogs/ConfigDialogue.cpp:1461
+msgid "Help browser:"
+msgstr ""
+
+#: ../../src/ToolBar.cpp:835
 msgid "Help button"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1340 ../../src/Worksheet.cpp:1778
+#: ../../src/worksheet/WorksheetContextMenu.cpp:102
+#: ../../src/worksheet/WorksheetContextMenu.cpp:551
 #, c-format
 msgid "Help on \"%s\""
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:729
-#, fuzzy
-msgid "Hide All Toolbars\tAlt+Shift+-"
-msgstr "全部隱藏\tAlt+Shift+-"
+#: ../../src/wizards/GenWizPanel.cpp:248
+#, c-format
+msgid "Help on %s"
+msgstr ""
 
-#: ../../src/ToolBar.cpp:264
+#: ../../src/sidebars/TableOfContents.cpp:510
+#, fuzzy
+msgid "Hide"
+msgstr "分割單元"
+
+#: ../../src/ToolBar.cpp:471 ../../src/ToolBar.cpp:473
 #, fuzzy
 msgid "Hide Code"
 msgstr "分割單元"
 
-#: ../../src/wxMaximaFrame.cpp:727
+#: ../../src/wxMaximaFrame.cpp:764
 #, fuzzy
 msgid "Hide Code Cells\tAlt+Ctrl+H"
 msgstr "插入(單元)\tAlt+Shift+C"
 
-#: ../../src/Worksheet.cpp:1896
+#: ../../src/worksheet/WorksheetContextMenu.cpp:668
 msgid "Hide Heading 5"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1907
+#: ../../src/worksheet/WorksheetContextMenu.cpp:679
 msgid "Hide Heading 6"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1855
+#: ../../src/worksheet/WorksheetContextMenu.cpp:627
 #, fuzzy
 msgid "Hide Part"
 msgstr "分割單元"
 
-#: ../../src/Worksheet.cpp:1863
+#: ../../src/worksheet/WorksheetContextMenu.cpp:635
 #, fuzzy
 msgid "Hide Section"
 msgstr "章節"
 
-#: ../../src/Worksheet.cpp:1874
+#: ../../src/worksheet/WorksheetContextMenu.cpp:646
 #, fuzzy
 msgid "Hide Subsection"
 msgstr "子章節"
 
-#: ../../src/Worksheet.cpp:1885
+#: ../../src/worksheet/WorksheetContextMenu.cpp:657
 #, fuzzy
 msgid "Hide Subsubsection"
 msgstr "子章節"
 
-#: ../../src/wxMaximaFrame.cpp:730
+#: ../../src/wxMaximaFrame.cpp:766
+msgid "Hide all Sidebars\tAlt+Shift+-"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:487
+msgid "Hide all multiplication signs that aren't really necessary for understanding the equation"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:767
 msgid "Hide all panes"
 msgstr "隱藏所有窗格"
 
-#: ../../src/Worksheet.cpp:1491
+#: ../../src/worksheet/WorksheetContextMenu.cpp:262
 #, fuzzy
 msgid "Hide cell brackets"
 msgstr "作用中的單元框"
 
-#: ../../src/Worksheet.cpp:1915
+#: ../../src/worksheet/WorksheetContextMenu.cpp:687
 #, fuzzy
 msgid "Hide contents"
 msgstr "希臘字母"
 
-#: ../../src/Worksheet.cpp:1552
+#: ../../src/worksheet/WorksheetContextMenu.cpp:325
 msgid "Hide multiplication dots"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1930 ../../src/Worksheet.cpp:2063
+#: ../../src/dialogs/ConfigDialogue.cpp:854
+msgid "Hide multiplication signs, if possible"
+msgstr ""
+
+#: ../../src/wizards/DrawWiz.cpp:555
+msgid "Hide objects behind the surface"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:502
+msgid "Hide the brackets that mark the extend of the worksheet cells at the worksheet's right side and that contain the \"hide\" button of the cell if the cells aren't active."
+msgstr ""
+
+#: ../../src/worksheet/WorksheetContextMenu.cpp:702
+#: ../../src/worksheet/WorksheetContextMenu.cpp:835
 msgid "Hide yellow tooltip marker for this cell"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1937 ../../src/Worksheet.cpp:2069
+#: ../../src/worksheet/WorksheetContextMenu.cpp:709
+#: ../../src/worksheet/WorksheetContextMenu.cpp:841
 msgid "Hide yellow tooltip marker for this message type"
 msgstr ""
 
-#: ../../src/Configuration.cpp:82
+#: ../../src/Styles.cpp:111
 #, fuzzy
 msgid "Highlight (box)"
 msgstr "高亮度標記(於dpart函數中)"
 
-#: ../../src/wxMaxima.cpp:9528
+#: ../../src/dialogs/ConfigDialogue.cpp:869
+#, fuzzy
+msgid "Highlight the matching parenthesis"
+msgstr "在文字控制項中輸入時匹配括弧"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:463
+msgid "Highlight the opening or closing parenthesis for the parenthesis the cursor is at."
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:204
+msgid "Hindi"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:1766
 msgid "Histogram"
 msgstr "直方圖"
 
-#: ../../src/wxMaximaFrame.cpp:232
+#: ../../src/sidebars/StatSidebar.cpp:85
+msgid "Histogram..."
+msgstr "直方圖..."
+
+#: ../../src/wxMaximaFrame.cpp:246
 msgid "History"
 msgstr "歷史記錄"
 
-#: ../../src/wxMaximaFrame.cpp:709
+#: ../../src/wxMaximaFrame.cpp:744
 #, fuzzy
 msgid "History\tAlt+Shift+I"
 msgstr "歷史記錄\tAlt+Shift+H"
 
-#: ../../src/wxMaximaFrame.cpp:1526
+#: ../../src/dialogs/TipOfTheDay.cpp:105
+msgid "Horizontal cursor works like a normal cursor, but it operates on cells: press up or down arrow to move it, holding down Shift while moving will select cells, pressing backspace or delete twice will delete a cell next to it."
+msgstr "水平游標就像一般游標一樣，但是它是對單元操作。按向上或向下箭頭來移動它，在移動時按住 Shift 鍵將會選擇單元，按 backspace 或 delete 鍵兩次會刪除相鄰的單元。"
+
+#: ../../src/wxMaximaFrame.cpp:1563
 msgid "Horner's rule"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:9207
+#: ../../src/dialogs/ConfigDialogue.cpp:918
+msgid "Hotkeys for sending commands to maxima"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:398
 msgid "How many digits to show:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:759
+#: ../../src/wxMaximaFrame.cpp:796
 msgid "How to display new equations"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1113
+#: ../../src/dialogs/ConfigDialogue.cpp:205
+msgid "Hungarian"
+msgstr "Hungarian"
+
+#: ../../src/wxMaximaFrame.cpp:1147
 msgid "I/O"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7062
-msgid "If a program doesn't need local variables maxima allows to put the commands between parenthesis. The result of the last operation is the return value of the program."
+#: ../../src/sidebars/SymbolsSidebar.cpp:121
+msgid "Identical to"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7172
+#: ../../src/MaximaCommandMenus.cpp:3934
+msgid "If a program doesn't need local variables, Maxima allows putting the commands between parentheses. The result of the last operation is the return value of the program."
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:145
+msgid "If maxima versions compiled with different lisps are installed: The name of the lisp to use by default"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:174
+msgid "If maxima was compiled by GCL: Garbage Collect at minimum allocation past this heapsize"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:171
+msgid "If maxima was compiled by GCL: Minimum allocation fraction between Garbage Collects"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:168
+msgid "If maxima was compiled by GCL: Only garbage collect past this heapsize fraction of working mem"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:180
+msgid "If maxima was compiled by GCL: Share the allocated memory between gcl processes. Allows more than one gcl-compiled maxima to run at the same time, but might provoke crashes."
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:177
+msgid "If maxima was compiled by GCL: The fraction of the total installed RAM to reserve for maxima"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:375
+msgid "If multiple cells are evaluated in one go: Abort evaluation if wxMaxima detects that maxima has encountered any error."
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:727
+msgid "If not extremely long"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:726
+msgid "If not very long"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:418
+msgid "If numbers are getting longer than this number of digits they will be displayed abbreviated by an ellipsis."
+msgstr ""
+
+#: ../../src/dialogs/TipOfTheDay.cpp:181
+msgid "If the \"Autosave\" functionality is enabled in the configuration dialogue wxMaxima acts like mobile apps that backup the file every few minutes and save it on closing."
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:396
+msgid "If the font provides big parenthesis symbols: Use them when big parenthesis are needed for maths display."
+msgstr ""
+
+#: ../../src/cells/TextCell.cpp:327
+msgid "If the thing maxima complains about actually looks like a polynomial you can try running it through ratdisrep() in order to fix that problem."
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:4044
 msgid ""
 "If the type of a function parameter is known when compiling a function the code can vastly be optimized.\n"
 "Known types:\n"
@@ -3712,1280 +5470,2019 @@ msgid ""
 "array, boolean, integer, fixnum (machine-length integer), float (machine-size floating-point numbers), real or any (which is useful for declaring arrays of any)"
 msgstr ""
 
-#: ../../src/MathParser.cpp:890
+#: ../../src/dialogs/ConfigDialogue.cpp:399
+msgid "If this checkbox is checked wxMaxima automatically saves the file closing and every few minutes giving wxMaxima a more cellphone-app-like feel as the file is virtually always saved. If this checkbox is unchecked from time to time a backup is made in the temp folder instead."
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:378
+msgid "If this checkbox is set a new code cell is opened as soon as maxima requests data. If it isn't set a new code cell is opened in this case as soon as the user starts typing in code."
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:372
+msgid "If this checkbox isn't checked the current command is sent to maxima only on pressing Ctrl+Enter"
+msgstr ""
+
+#: ../../src/MathParser.cpp:945
 msgid "If this isn't a function returning a lambda() expression a multiplication sign (*) between closing and opening parenthesis is missing here."
 msgstr ""
 
-#: ../../src/MaximaManual.cpp:403
+#: ../../src/dialogs/ConfigDialogue.cpp:942
+msgid ""
+"If this option is enabled, the filename and path of images inserted with \"Cell\" -> \"Insert Image...\" is stored in the worksheet file on save. This enables reloading of the image file via the context menu after re-opening the worksheet, but storing the filenames and paths may be an undesired data leak. If this option is disabled, reloading still works as long as the worksheet is not closed.\n"
+"\n"
+"Note: Storing the filenames for the reload functionality is independent of the automatically generated image captions."
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:439
+msgid "If this option is set the .wxmx source of the current file is copied to a place a link to is put into the result of an export."
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1873
+msgid "If unset, Maxima's output is announced to the screen reader as maths in a linear text form. Set this option if your screen reader can speak MathML properly."
+msgstr ""
+
+#: ../../src/dialogs/TipOfTheDay.cpp:247
+msgid "If you have ideas, how to improve the design or functionality of wxMaxima, please share your ideas at the issue list or discussion forum at https://github.com/wxMaxima-developers/wxmaxima/."
+msgstr ""
+
+#: ../../src/dialogs/TipOfTheDay.cpp:76
+msgid "If you type an operator (one of +*/^=,) as the first symbol in an input cell, % will be automatically inserted before the operator, as on a graphing calculator. You can disable this feature from the 'Edit->Configure' dialog."
+msgstr ""
+
+#: ../../src/dialogs/TipOfTheDay.cpp:122
+msgid "If your calculation is taking too long to evaluate, you can try 'Maxima->Interrupt' or 'Maxima->Restart Maxima' menu commands."
+msgstr "若您的計算花費過長的時間，您可以嘗試「Maxima(M)」->「中斷(I)」或「Maxima(M)」->「重新啟動 Maxima(R)」這兩個功能表命令。"
+
+#: ../../src/MaximaManual.cpp:420
 msgid "Ignoring the cache version for the manual anchors."
 msgstr ""
 
-#: ../../src/Image.cpp:79
+#: ../../src/sidebars/FormatSidebar.cpp:66
+msgid "Image"
+msgstr "圖片"
+
+#: ../../src/Image.cpp:110
 msgid "Image data had zero length!"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:10147 ../../src/wxMaxima.cpp:10855
-msgid "Image files (*.png, *.jpg, *.bmp, *.xpm, *.gif, *.svg, *.svgz)|*.png;*.jpg;*.bmp;*.xpm;*.gif;*.svg;*.svgz"
+#: ../../src/MaximaCommandMenus.cpp:2564 ../../src/MaximaCommandMenus.cpp:2933
+#: ../../src/MaximaCommandMenus.cpp:3642
+msgid "Image files ("
 msgstr ""
 
-#: ../../src/Worksheet.cpp:5509
+#: ../../src/Image.cpp:74
+#, c-format
+msgid "Image of type %s found."
+msgstr ""
+
+#: ../../src/worksheet/WorksheetExport.cpp:1407
 msgid "ImageCell without image."
 msgstr ""
 
-#: ../../src/MathParser.cpp:347
+#: ../../src/sidebars/DrawSidebar.cpp:60
+msgid "Implicit Plot"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1028
+msgid "Import settings"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1013
+#, fuzzy
+msgid "Import+Export"
+msgstr "匯出"
+
+#: ../../src/MathParser.cpp:395
 msgid "Importing compressed gnuplot sources for an animation"
 msgstr ""
 
-#: ../../src/MathParser.cpp:334
+#: ../../src/MathParser.cpp:382
 msgid "Importing uncompressed gnuplot sources for an animation"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7993
+#: ../../src/MaximaCommandMenus.cpp:1177
 msgid ""
 "In order to save memory the \":\" operator does clone the matrix, not copy it:\n"
 "If you change an element of one matrix the same element will change in all of its clones. copymatrix() instead generates a copy of a matrix: A new matrix that, if changed in any way, won't change the original."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7404
+#: ../../src/MaximaCommandMenus.cpp:4276
 msgid "In order to save memory the : operator doesn't create an individual copy of the string, but a clone that changes when the original string changes."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:9629
+#: ../../src/dialogs/TipOfTheDay.cpp:175
+msgid ""
+"In order to visualize how a parameter affects an equation wxMaxima provides commands that start with \"with_slider_\" and that create animations. One example would be:\n"
+"\n"
+"    with_slider_draw(\n"
+"        a,[-16,-9,-4,-2,0,1,2,3,4,5,6,7],\n"
+"        title=concat(\"a=\",a),\n"
+"        grid=true,\n"
+"        explicit(\n"
+"            x^2-a*x,\n"
+"            x,-10,10\n"
+"        )\n"
+"    );"
+msgstr ""
+
+#: ../../src/dialogs/TipOfTheDay.cpp:214
+msgid "In text cells bullet lists can be created by beginning a line with \" * \". The number of spaces in front of the \"*\" determines the indentation level; Indentation can be continued in the next line by indenting the line using spaces."
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:421
+msgid "In the LaTeX output: Put exponents after an eventual subscript instead of above it. Might increase readability for some fonts and short subscripts."
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:1869
 msgid "Include columns:"
 msgstr "包含欄位："
 
-#: ../../src/Worksheet.cpp:2008
+#: ../../src/worksheet/WorksheetContextMenu.cpp:780
 msgid "Increasing function f(x)>x"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8470
+#: ../../src/dialogs/ConfigDialogue.cpp:884
+msgid "Incremental Search"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:844
+msgid "Indent equations by the label width"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:512
+msgid "Indent maths so all lines are in par with the first line that starts after the label."
+msgstr ""
+
+#: ../../src/sidebars/TableOfContents.cpp:583
+msgid "Indentation"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:1473
 msgid "Index End:"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8470
+#: ../../src/MaximaCommandMenus.cpp:1473
 msgid "Index Start:"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8471
+#: ../../src/MaximaCommandMenus.cpp:1474
 msgid "Index Step:"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8467 ../../src/wxMaxima.cpp:8480
+#: ../../src/MaximaCommandMenus.cpp:1470 ../../src/MaximaCommandMenus.cpp:1484
 #, fuzzy
 msgid "Index variable:"
 msgstr "新變數："
 
-#: ../../src/wxMaximaFrame.cpp:1949
+#: ../../src/dialogs/ConfigDialogue.cpp:206
+msgid "Indonesian"
+msgstr ""
+
+#: ../../src/cells/TextCell.cpp:186
+msgid "Infinitesimal above zero."
+msgstr ""
+
+#: ../../src/cells/TextCell.cpp:188
+msgid "Infinitesimal below zero."
+msgstr ""
+
+#: ../../src/sidebars/SymbolsSidebar.cpp:91
+#: ../../src/wizards/IntegrateWiz.cpp:192
+#: ../../src/wizards/IntegrateWiz.cpp:200
+#: ../../src/wizards/IntegrateWiz.cpp:207
+#: ../../src/wizards/IntegrateWiz.cpp:215 ../../src/wizards/LimitWiz.cpp:132
+#: ../../src/wizards/LimitWiz.cpp:140
+msgid "Infinity"
+msgstr "無限大"
+
+#: ../../src/wxMaximaFrame.cpp:1986
 msgid "Info about Maxima build"
 msgstr "關於 Maxima 建置的資訊"
 
-#: ../../src/Worksheet.cpp:2046
+#: ../../src/worksheet/WorksheetContextMenu.cpp:818
 msgid "Inform maxima about facts you know for this symbol"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1988
+#: ../../src/worksheet/WorksheetContextMenu.cpp:760
 msgid "Inform maxima about the value of the function at a specific point, e.G. for declaring initial conditions"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7793 ../../src/wxMaxima.cpp:7804
+#: ../../src/MaximaCommandMenus.cpp:974 ../../src/MaximaCommandMenus.cpp:985
 #, fuzzy
 msgid "Initial Condition"
 msgstr "條件："
 
-#: ../../src/wxMaximaFrame.cpp:1270
+#: ../../src/wxMaximaFrame.cpp:1304
 msgid "Initial Value Problem (&1)..."
 msgstr "一階常微方初始值問題(&1)..."
 
-#: ../../src/wxMaximaFrame.cpp:1274
+#: ../../src/wxMaximaFrame.cpp:1308
 msgid "Initial Value Problem (&2)..."
 msgstr "二階常微方初始值問題(&2)..."
 
-#: ../../src/wxMaxima.cpp:9044
+#: ../../src/MaximaCommandMenus.cpp:298
 #, fuzzy
 msgid "Initial estimates:"
 msgstr "起始預估："
 
-#: ../../src/wxMaxima.cpp:7840
+#: ../../src/MaximaCommandMenus.cpp:1021
 #, fuzzy
 msgid "Initial x:"
 msgstr "起始預估："
 
-#: ../../src/Configuration.cpp:78
+#: ../../src/dialogs/FindReplacePane.cpp:107
+msgid "Input"
+msgstr ""
+
+#: ../../src/sidebars/RegexCtrl.cpp:38
+msgid ""
+"Input a RegEx here to filter the results.\n"
+"Right-click for options!"
+msgstr ""
+
+#: ../../src/Styles.cpp:107
 msgid "Input labels"
 msgstr "輸入標籤"
 
-#: ../../src/wxMaximaFrame.cpp:314
+#: ../../src/sidebars/RegexCtrl.cpp:42
+msgid ""
+"Input your filter text here.\n"
+"Right-click for options!"
+msgstr ""
+
+#: ../../src/wizards/GenWizPanel.cpp:103 ../../src/wxMaximaFrame.cpp:335
 msgid "Insert"
 msgstr "插入"
 
-#: ../../src/wxMaximaFrame.cpp:905
+#: ../../src/dialogs/ConfigDialogue.cpp:889
+msgid "Insert % before an operator at the beginning of a cell"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:939
 msgid "Insert &Section Cell\tCtrl+3"
 msgstr "插入章節單元(&S)\tCtrl+3"
 
-#: ../../src/wxMaximaFrame.cpp:901
+#: ../../src/wxMaximaFrame.cpp:935
 msgid "Insert &Text Cell\tCtrl+1"
 msgstr "插入文字單元(&T)\tCtrl+1"
 
-#: ../../src/wxMaximaFrame.cpp:713
+#: ../../src/wxMaximaFrame.cpp:748
 msgid "Insert Cell\tAlt+Shift+C"
 msgstr "插入(單元)\tAlt+Shift+C"
 
-#: ../../src/Worksheet.cpp:1669
+#: ../../src/worksheet/WorksheetContextMenu.cpp:442
 msgid "Insert Heading5 Cell"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1671
+#: ../../src/worksheet/WorksheetContextMenu.cpp:444
 msgid "Insert Heading6 Cell"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:10854
+#: ../../src/MaximaCommandMenus.cpp:2563
 msgid "Insert Image"
 msgstr "插入圖片"
 
-#: ../../src/wxMaximaFrame.cpp:917
+#: ../../src/wxMaximaFrame.cpp:951
 msgid "Insert Image..."
 msgstr "插入圖片..."
 
-#: ../../src/wxMaximaFrame.cpp:899
+#: ../../src/wxMaximaFrame.cpp:933
 #, fuzzy
 msgid "Insert Input &Cell\tCtrl+0"
 msgstr "插入輸入單元(&C)"
 
-#: ../../src/wxMaximaFrame.cpp:919
+#: ../../src/wxMaximaFrame.cpp:953
 msgid "Insert Page Break"
 msgstr "插入換頁符號"
 
-#: ../../src/wxMaximaFrame.cpp:907
+#: ../../src/wxMaximaFrame.cpp:941
 msgid "Insert S&ubsection Cell\tCtrl+4"
 msgstr "插入子章節單元(&U)\tCtrl+4"
 
-#: ../../src/wxMaximaFrame.cpp:910
+#: ../../src/wxMaximaFrame.cpp:944
 #, fuzzy
 msgid "Insert S&ubsubsection Cell\tCtrl+5"
 msgstr "插入子章節單元(&U)\tCtrl+4"
 
-#: ../../src/Worksheet.cpp:1662
+#: ../../src/worksheet/WorksheetContextMenu.cpp:435
 msgid "Insert Section Cell"
 msgstr "插入章節單元"
 
-#: ../../src/Worksheet.cpp:1664
+#: ../../src/worksheet/WorksheetContextMenu.cpp:437
 msgid "Insert Subsection Cell"
 msgstr "插入子章節單元"
 
-#: ../../src/Worksheet.cpp:1667
+#: ../../src/worksheet/WorksheetContextMenu.cpp:440
 #, fuzzy
 msgid "Insert Subsubsection Cell"
 msgstr "插入子章節單元"
 
-#: ../../src/wxMaximaFrame.cpp:903
+#: ../../src/wxMaximaFrame.cpp:937
 msgid "Insert T&itle Cell\tCtrl+2"
 msgstr "插入標題單元(&I)\tCtrl+2"
 
-#: ../../src/Worksheet.cpp:1658
+#: ../../src/worksheet/WorksheetContextMenu.cpp:431
 msgid "Insert Text Cell"
 msgstr "插入文字單元"
 
-#: ../../src/Worksheet.cpp:1660
+#: ../../src/worksheet/WorksheetContextMenu.cpp:433
 msgid "Insert Title Cell"
 msgstr "插入標題單元"
 
-#: ../../src/wxMaximaFrame.cpp:913
+#: ../../src/wxMaximaFrame.cpp:947
 msgid "Insert a new heading5 cell"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:915
+#: ../../src/wxMaximaFrame.cpp:949
 msgid "Insert a new heading6 cell"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:900
+#: ../../src/wxMaximaFrame.cpp:934
 msgid "Insert a new input cell"
 msgstr "插入新的輸入單元"
 
-#: ../../src/wxMaximaFrame.cpp:906
+#: ../../src/wxMaximaFrame.cpp:940
 msgid "Insert a new section cell"
 msgstr "插入新的章節單元"
 
-#: ../../src/wxMaximaFrame.cpp:908
+#: ../../src/wxMaximaFrame.cpp:942
 msgid "Insert a new subsection cell"
 msgstr "插入新的子章節單元"
 
-#: ../../src/wxMaximaFrame.cpp:911
+#: ../../src/wxMaximaFrame.cpp:945
 #, fuzzy
 msgid "Insert a new subsubsection cell"
 msgstr "插入新的子章節單元"
 
-#: ../../src/wxMaximaFrame.cpp:902
+#: ../../src/wxMaximaFrame.cpp:936
 msgid "Insert a new text cell"
 msgstr "插入新的文字單元"
 
-#: ../../src/wxMaximaFrame.cpp:904
+#: ../../src/wxMaximaFrame.cpp:938
 msgid "Insert a new title cell"
 msgstr "插入新的標題單元"
 
-#: ../../src/wxMaximaFrame.cpp:920
+#: ../../src/wxMaximaFrame.cpp:954
 msgid "Insert a page break"
 msgstr "插入一個換頁符號"
 
-#: ../../src/wxMaximaFrame.cpp:1164
+#: ../../src/MaximaCommandMenus.cpp:4261
+msgid "Insert a string into another"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1198
 #, fuzzy
 msgid "Insert char..."
 msgstr "插入圖片..."
 
-#: ../../src/wxMaximaFrame.cpp:912
+#: ../../src/wxMaximaFrame.cpp:946
 msgid "Insert heading5 Cell\tCtrl+6"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:914
+#: ../../src/wxMaximaFrame.cpp:948
 msgid "Insert heading6 Cell\tCtrl+7"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:917
+#: ../../src/wxMaximaFrame.cpp:951
 msgid "Insert image"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:916
+#: ../../src/wxMaximaFrame.cpp:950
 #, fuzzy
 msgid "Insert textbased cell"
 msgstr "插入文字單元"
 
-#: ../../src/wxMaxima.cpp:3566
+#: ../../src/worksheet/Worksheet.cpp:6131
+msgid "Insertion point between cells"
+msgstr ""
+
+#: ../../src/sidebars/HelpBrowser.cpp:111
+msgid "Instantiating the HTML manual browser"
+msgstr ""
+
+#: ../../src/MaximaProcessManager.cpp:1177
 msgid "Instructed to prefer gnuplot over wgnuplot"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3554
+#: ../../src/MaximaProcessManager.cpp:1165
 msgid "Instructed to prefer wgnuplot over gnuplot"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8898 ../../src/wxMaxima.cpp:8919
+#: ../../src/dialogs/ConfigDialogue.cpp:749
+msgid "Integers and single letters"
+msgstr ""
+
+#: ../../src/sidebars/SymbolsSidebar.cpp:113
+#, fuzzy
+msgid "Integral sign"
+msgstr "對數式積分"
+
+#: ../../src/MaximaCommandMenus.cpp:149 ../../src/MaximaCommandMenus.cpp:170
 msgid "Integral/Sum:"
 msgstr "積分／加總："
 
-#: ../../src/wxMaxima.cpp:8986 ../../src/wxMaxima.cpp:10044
+#: ../../src/MaximaCommandMenus.cpp:240 ../../src/MaximaCommandMenus.cpp:3533
+#: ../../src/wizards/IntegrateWiz.cpp:73
 msgid "Integrate"
 msgstr "積分"
 
-#: ../../src/wxMaxima.cpp:8980
+#: ../../src/MaximaCommandMenus.cpp:234
 msgid "Integrate (risch)"
 msgstr "Risch 積分"
 
-#: ../../src/wxMaximaFrame.cpp:1454
+#: ../../src/wxMaximaFrame.cpp:1491
 msgid "Integrate expression"
 msgstr "對數式積分"
 
-#: ../../src/wxMaximaFrame.cpp:1456
+#: ../../src/wxMaximaFrame.cpp:1493
 msgid "Integrate expression with Risch algorithm"
 msgstr "使用 Risch 演算法積分數式"
 
-#: ../../src/wxMaximaFrame.cpp:1869
-#, fuzzy
-msgid "Integrate numerically"
-msgstr "Risch 積分"
+#: ../../src/wxMaximaFrame.cpp:1906
+msgid "Integrate numerically (QUADPACK)"
+msgstr ""
 
-#: ../../src/Worksheet.cpp:1588
+#: ../../src/sidebars/MathSidebar.cpp:83
+#: ../../src/worksheet/WorksheetContextMenu.cpp:361
 msgid "Integrate..."
 msgstr "積分..."
 
-#: ../../src/wxMaximaFrame.cpp:1737
+#: ../../src/dialogs/ConfigDialogue.cpp:834
+#, fuzzy
+msgid "Intelligently hide cell brackets"
+msgstr "作用中的單元框"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:881
+#, fuzzy
+msgid "Interaction"
+msgstr "方向："
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1349
+msgid "Interactive popup memory limit [MB/plot]:"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1774
 #, fuzzy
 msgid "Interleave"
 msgstr "積分"
 
-#: ../../src/wxMaximaFrame.cpp:1738
+#: ../../src/wxMaximaFrame.cpp:1775
 #, fuzzy
 msgid "Interleave the values of two lists"
 msgstr "積分"
 
-#: ../../src/wxMaxima.cpp:8612
+#: ../../src/MaximaCommandMenus.cpp:1631
 #, fuzzy
 msgid "Interleave two lists"
 msgstr "積分"
 
-#: ../../src/wxMaximaFrame.cpp:1087
+#: ../../src/dialogs/ConfigDialogue.cpp:1465
+#, fuzzy
+msgid "Internal"
+msgstr "積分"
+
+#: ../../src/wxMaximaFrame.cpp:1121
 msgid "Interpret like input..."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7104
+#: ../../src/MaximaCommandMenus.cpp:3976
 msgid "Interpret maxima's output as input"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7502
+#: ../../src/MaximaCommandMenus.cpp:4374
 msgid "Interpret string as maxima code"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1089
+#: ../../src/wxMaximaFrame.cpp:1123
 #, fuzzy
 msgid "Interpret string..."
 msgstr "輸入矩陣..."
 
-#: ../../src/ToolBar.cpp:231
+#: ../../src/ToolBar.cpp:413 ../../src/ToolBar.cpp:419
 msgid "Interrupt"
 msgstr "中斷"
 
-#: ../../src/wxMaximaFrame.cpp:965
+#: ../../src/wxMaximaFrame.cpp:999
 msgid "Interrupt current computation"
 msgstr "中斷目前的計算"
 
-#: ../../src/ToolBar.cpp:232
+#: ../../src/ToolBar.cpp:414 ../../src/ToolBar.cpp:420
 msgid "Interrupt current computation. To completely restart maxima press the button left to this one."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2766
+#: ../../src/MaximaProcessManager.cpp:876
 #, c-format
 msgid "Interrupting maxima: %s"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8557
+#: ../../src/MaximaCommandMenus.cpp:1570
 msgid "Introduce a list of actual values into an equation"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1697
+#: ../../src/wxMaximaFrame.cpp:1734
 msgid "Introduce the actual values for variables stored in the list"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:10062
+#: ../../src/MaximaCommandMenus.cpp:3551
 msgid "Introduces one or more assignments into an expression"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:9003
+#: ../../src/sidebars/RegexCtrl.cpp:40
+msgid "Invalid RegEx!"
+msgstr ""
+
+#: ../../src/MathParser.cpp:1338
+#, c-format
+msgid "Invalid XML: %s"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:257
 msgid "Inverse Laplace"
 msgstr "Laplace 逆變換"
 
-#: ../../src/wxMaximaFrame.cpp:1488
+#: ../../src/wxMaximaFrame.cpp:1525
 msgid "Inverse Laplace T&ransform..."
 msgstr "反 Laplace 變換(&R)..."
 
-#: ../../src/wxMaximaFrame.cpp:832
-msgid "Invert worksheet brightness"
+#: ../../src/sidebars/GreekSidebar.cpp:186
+msgid "Iota"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7338
+#: ../../src/MaximaCommandMenus.cpp:4210
 msgid "Is Char 1 greater than Char2, if case is ignored?"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7333
+#: ../../src/MaximaCommandMenus.cpp:4205
 #, fuzzy
 msgid "Is Char 1 greater than Char2?"
 msgstr "子章節單元"
 
-#: ../../src/wxMaxima.cpp:7327
+#: ../../src/MaximaCommandMenus.cpp:4199
 msgid "Is Char 1 less than Char2, if case is ignored?"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7322
+#: ../../src/MaximaCommandMenus.cpp:4194
 msgid "Is Char 1 less than Char2?"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7280
+#: ../../src/MaximaCommandMenus.cpp:4152
 msgid "Is a char?"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1115
+#: ../../src/wxMaximaFrame.cpp:1149
 msgid "Is a char?..."
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1952
+#: ../../src/worksheet/WorksheetContextMenu.cpp:724
 #, fuzzy
 msgid "Is a complex variable"
 msgstr "新變數："
 
-#: ../../src/wxMaxima.cpp:7292
+#: ../../src/MaximaCommandMenus.cpp:4164
 #, fuzzy
 msgid "Is a digit?"
 msgstr "用於顯示的演算法"
 
-#: ../../src/wxMaximaFrame.cpp:1118
+#: ../../src/wxMaximaFrame.cpp:1152
 msgid "Is a digit?..."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7304
+#: ../../src/MaximaCommandMenus.cpp:4176
 msgid "Is a lowercase char?"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7296
+#: ../../src/MaximaCommandMenus.cpp:4168
 msgid "Is a printable char?"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1949
+#: ../../src/worksheet/WorksheetContextMenu.cpp:721
 #, fuzzy
 msgid "Is a real variable"
 msgstr "變數變換"
 
-#: ../../src/wxMaxima.cpp:7300
+#: ../../src/MaximaCommandMenus.cpp:4172
 msgid "Is a uppercase char?"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1116
+#: ../../src/wxMaximaFrame.cpp:1150
 msgid "Is alphabetic?..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1117
+#: ../../src/wxMaximaFrame.cpp:1151
 msgid "Is alphanumeric?..."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7284
+#: ../../src/MaximaCommandMenus.cpp:4156
 msgid "Is an alphabetic char?"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7288
+#: ../../src/MaximaCommandMenus.cpp:4160
 msgid "Is an alphanumeric char?"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1991
+#: ../../src/worksheet/WorksheetContextMenu.cpp:763
 #, fuzzy
 msgid "Is an even function"
 msgstr "刪除函數"
 
-#: ../../src/Worksheet.cpp:1955
+#: ../../src/worksheet/WorksheetContextMenu.cpp:727
 #, fuzzy
 msgid "Is an imaginary variable"
 msgstr "變數變換"
 
-#: ../../src/Worksheet.cpp:1960
+#: ../../src/worksheet/WorksheetContextMenu.cpp:732
 #, fuzzy
 msgid "Is an integer variable"
 msgstr "變數變換"
 
-#: ../../src/Worksheet.cpp:1993
+#: ../../src/worksheet/WorksheetContextMenu.cpp:765
 #, fuzzy
 msgid "Is an odd function"
 msgstr "刪除函數"
 
-#: ../../src/wxMaximaFrame.cpp:1122
+#: ../../src/wxMaximaFrame.cpp:1156
 msgid "Is equal?..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1128
+#: ../../src/wxMaximaFrame.cpp:1162
 #, fuzzy
 msgid "Is greater?..."
 msgstr "產生串列"
 
-#: ../../src/wxMaximaFrame.cpp:1125
+#: ../../src/wxMaximaFrame.cpp:1159
 msgid "Is lower?..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1121
+#: ../../src/wxMaximaFrame.cpp:1155
 msgid "Is lowercase?..."
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1962
+#: ../../src/worksheet/WorksheetContextMenu.cpp:734
 #, fuzzy
 msgid "Is no integer variable"
 msgstr "變數變換"
 
-#: ../../src/wxMaximaFrame.cpp:1119
+#: ../../src/wxMaximaFrame.cpp:1153
 msgid "Is printable?..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1120
+#: ../../src/wxMaximaFrame.cpp:1154
 msgid "Is uppercase?..."
 msgstr ""
 
-#: ../../src/Worksheet.cpp:6256
+#: ../../src/dialogs/ConfigDialogue.cpp:498
+msgid "Issue a notification if maxima finishes calculating while the wxMaxima window isn't in focus."
+msgstr ""
+
+#: ../../src/worksheet/Worksheet.cpp:4247
 msgid "Issuing the active cell's undo function"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:6261
+#: ../../src/worksheet/Worksheet.cpp:4251
 msgid "Issuing the worksheet's undo function"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8598 ../../src/wxMaxima.cpp:8604
+#: ../../src/dialogs/TipOfTheDay.cpp:185
+msgid "It is possible to add custom symbols to the \"symbols\" sidebar by copying them into the respective field in the configuration dialogue."
+msgstr ""
+
+#: ../../src/dialogs/TipOfTheDay.cpp:152
+msgid "It is possible to define reusable Maxima libraries with wxMaxima that can be later loaded by using the load() function. All that has to be done is to export a file in the .mac or to save it in the .wxm format. Note, though, that a few special characters like the \"not equal\" symbol for \"#\" are handled by wxMaxima, not by Maxima and therefore cannot be recognized on load()."
+msgstr ""
+
+#: ../../src/wizards/DrawWiz.cpp:476
+msgid "It needs to be filled with objects to draw afterwards."
+msgstr ""
+
+#: ../../src/wizards/ActualValuesStorageWiz.cpp:38
+msgid "It therefore makes sense to apply the known values for variables as late as possible."
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:207
+msgid "Italian"
+msgstr "Italian"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:2111
+msgid "Italic"
+msgstr "斜體"
+
+#: ../../src/MaximaCommandMenus.cpp:1617 ../../src/MaximaCommandMenus.cpp:1623
 msgid "Item"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8581
+#: ../../src/MaximaCommandMenus.cpp:1599
 #, fuzzy
 msgid "Iterator name:"
 msgstr "矩陣名："
 
-#: ../../src/wxMaximaFrame.cpp:1048
-msgid "Jump to first error"
+#: ../../src/dialogs/ConfigDialogue.cpp:208
+msgid "Japanese"
+msgstr "Japanese"
+
+#: ../../src/MaximaCommandMenus.cpp:2255
+msgid "Jump to UUID"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1049
-msgid "Jump to the first cell Maxima has reported an error in."
+#: ../../src/wxMaximaFrame.cpp:661
+msgid "Jump to UUID..."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8960
+#: ../../src/wxMaximaFrame.cpp:1082
+msgid "Jump to last error"
+msgstr ""
+
+#: ../../src/dialogs/DiffFrame.cpp:405
+msgid "Jump to next difference"
+msgstr ""
+
+#: ../../src/dialogs/DiffFrame.cpp:404
+msgid "Jump to previous difference"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1083
+msgid "Jump to the last cell Maxima has reported an error in."
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:210
+msgid "Kabyle"
+msgstr ""
+
+#: ../../src/sidebars/GreekSidebar.cpp:187
+msgid "Kappa"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:864
+#, c-format
+msgid "Keep percent sign with special symbols: %e, %i, etc."
+msgstr "保留特殊符號前的百分比號，像是「%e」、「%i」等..."
+
+#: ../../src/dialogs/ConfigDialogue.cpp:212
+msgid "Korean"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:214
 msgid "LCM"
 msgstr "最小公倍式"
 
-#: ../../src/wxMaximaFrame.cpp:1407
+#: ../../src/wxMaximaFrame.cpp:1441
 msgid "L[1] Norm (complex)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1406
+#: ../../src/wxMaximaFrame.cpp:1440
 msgid "L[1] Norm (real)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1409
+#: ../../src/wxMaximaFrame.cpp:1443
 msgid "L[inf] Norm (complex)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1408
+#: ../../src/wxMaximaFrame.cpp:1442
 msgid "L[inf] Norm (real)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1025
+#: ../../src/dialogs/ConfigDialogue.cpp:1166
+msgid "LaTeX"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1199
+msgid "LaTeX: Place exponents after, instead above subscripts"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1204
+msgid "LaTeX: Use the \"partial derivative\" symbol to represent diff()"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:758
+msgid "Label width:"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1059
 #, fuzzy
 msgid "Labels"
 msgstr "輸入標籤"
 
-#: ../../src/wxMaxima.cpp:7090
+#: ../../src/MaximaCommandMenus.cpp:3962
+#: ../../src/sidebars/GreekSidebar.cpp:188
 msgid "Lambda"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7091
+#: ../../src/MaximaCommandMenus.cpp:3963
 msgid ""
 "Lambda generates a function, but doesn't give it a name.\n"
 "This is useful if you want to use a function only once, perhaps as a parameter to another function and don't need it to be named.\n"
 "Also you can fill a variable with a lambda() construct, effectively generating a function pointer: A variable that can be used as a function, and filled with a different function, if needed."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8997
+#: ../../src/dialogs/ConfigDialogue.cpp:470
+msgid "Language used for wxMaxima GUI."
+msgstr "wxMaxima 圖形介面的語言"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1311
+msgid "Language:"
+msgstr "語言："
+
+#: ../../src/MaximaCommandMenus.cpp:251
 msgid "Laplace"
 msgstr "Laplace 變換"
 
-#: ../../src/wxMaximaFrame.cpp:1484
+#: ../../src/wxMaximaFrame.cpp:1521
 msgid "Laplace &Transform..."
 msgstr "Laplace 變換(&T)..."
 
-#: ../../src/wxMaximaFrame.cpp:1718
+#: ../../src/wxMaximaFrame.cpp:1755
 msgid "Last"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3006
+#: ../../src/MaximaProcessManager.cpp:557
 #, c-format
 msgid "Last message from maxima's stderr: %s"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2993
+#: ../../src/MaximaProcessManager.cpp:544
 #, c-format
 msgid "Last message from maxima's stdout: %s"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1720
+#: ../../src/wxMaximaFrame.cpp:1757
 #, fuzzy
 msgid "Last n"
 msgstr "串列："
 
-#: ../../src/wxMaxima.cpp:10400
+#: ../../src/wxMaxima.cpp:3087
 msgid "Last non-whitespace is a question mark"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:4899
+#: ../../src/dialogs/ConfigDialogue.cpp:213
+msgid "Latvian"
+msgstr ""
+
+#: ../../src/wxMaxima.cpp:1675
 #, c-format
 msgid "Launching the system's default help browser as %s."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:4909
+#: ../../src/wxMaxima.cpp:1666 ../../src/wxMaxima.cpp:1687
 msgid "Launching the system's default help browser failed."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1493
+#: ../../src/sidebars/SymbolsSidebar.cpp:126
+msgid "Leads to"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1530
 msgid "Least Common Multiple..."
 msgstr "最小公倍式..."
 
-#: ../../src/wxMaxima.cpp:9587
+#: ../../src/MaximaCommandMenus.cpp:1827
 msgid "Least Squares Fit"
 msgstr "最小平方法"
 
-#: ../../src/wxMaxima.cpp:7982 ../../src/wxMaxima.cpp:7987
-#: ../../src/wxMaxima.cpp:8007 ../../src/wxMaxima.cpp:8013
+#: ../../src/sidebars/StatSidebar.cpp:79
+msgid "Least Squares Fit..."
+msgstr "最小平方法..."
+
+#: ../../src/dialogs/ConfigDialogue.cpp:2007
+msgid "Left"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:1166 ../../src/MaximaCommandMenus.cpp:1171
+#: ../../src/MaximaCommandMenus.cpp:1191 ../../src/MaximaCommandMenus.cpp:1197
 #, fuzzy
 msgid "Left Matrix:"
 msgstr "開啟矩陣"
 
-#: ../../src/wxMaxima.cpp:8191
+#: ../../src/MaximaCommandMenus.cpp:1381
 msgid "Left end"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1297
+#: ../../src/wxMaximaFrame.cpp:1331
 msgid "Left side to the \"=\""
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1741
+#: ../../src/wxMaximaFrame.cpp:1778
 msgid "Length"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1104 ../../src/wxMaximaFrame.cpp:1167
+#: ../../src/wxMaximaFrame.cpp:1138 ../../src/wxMaximaFrame.cpp:1201
 msgid "Length..."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7421
+#: ../../src/MaximaCommandMenus.cpp:4293
 msgid "Length:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1032
+#: ../../src/wxMaximaFrame.cpp:1066
 msgid "Letrules"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1976
+#: ../../src/dialogs/TipOfTheDay.cpp:163
+msgid "Libraries can be accessed by any wxMaxima process regardless of which directory it runs in, if they are placed in the user directory. This directory can be found by typing maxima_userdir;"
+msgstr ""
+
+#: ../../src/dialogs/LicenseDialog.cpp:63
+#: ../../src/dialogs/LicenseDialog.cpp:77
+msgid "License"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:2068
+msgid "Light"
+msgstr ""
+
+#: ../../src/worksheet/WorksheetContextMenu.cpp:748
 #, fuzzy
 msgid "Likely to be the main variable"
 msgstr "刪除變數"
 
-#: ../../src/wxMaxima.cpp:9028
+#: ../../src/MaximaCommandMenus.cpp:282 ../../src/wizards/LimitWiz.cpp:64
 msgid "Limit"
 msgstr "極限"
 
-#: ../../src/wxMaxima.cpp:7256
+#: ../../src/sidebars/MathSidebar.cpp:86
+msgid "Limit..."
+msgstr "極限..."
+
+#: ../../src/sidebars/DrawSidebar.cpp:88
+msgid "Line color"
+msgstr ""
+
+#: ../../src/sidebars/StatSidebar.cpp:76
+msgid "Linear Regression..."
+msgstr "線性迴歸..."
+
+#: ../../src/MaximaCommandMenus.cpp:4128
 #, fuzzy
 msgid "Lisp format string:"
 msgstr "Maxima 詢問"
 
-#: ../../src/wxMaxima.cpp:7258
+#: ../../src/MaximaCommandMenus.cpp:4130
 msgid "Lisp format strings are more powerful than c++ format strings"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:5066
+#: ../../src/wxMaxima.cpp:1874
 msgid "Lisp mode."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1010 ../../src/wxMaximaFrame.cpp:1012
+#: ../../src/wxMaximaFrame.cpp:1044 ../../src/wxMaximaFrame.cpp:1046
 msgid "Lisp normally frees memory only when it has time or runs out of space"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3691
+#: ../../src/MaximaResponseReader.cpp:908
 #, c-format
 msgid "Lisp version: %s"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8435 ../../src/wxMaxima.cpp:8539
-#: ../../src/wxMaxima.cpp:8548 ../../src/wxMaxima.cpp:8565
-#: ../../src/wxMaxima.cpp:8574 ../../src/wxMaxima.cpp:8594
-#: ../../src/wxMaxima.cpp:8599 ../../src/wxMaxima.cpp:8603
+#: ../../src/MaximaCommandMenus.cpp:1432 ../../src/MaximaCommandMenus.cpp:1552
+#: ../../src/MaximaCommandMenus.cpp:1561 ../../src/MaximaCommandMenus.cpp:1583
+#: ../../src/MaximaCommandMenus.cpp:1592 ../../src/MaximaCommandMenus.cpp:1613
+#: ../../src/MaximaCommandMenus.cpp:1618 ../../src/MaximaCommandMenus.cpp:1622
 #, fuzzy
 msgid "List"
 msgstr "串列："
 
-#: ../../src/wxMaxima.cpp:8608 ../../src/wxMaxima.cpp:8613
+#: ../../src/MaximaCommandMenus.cpp:1627 ../../src/MaximaCommandMenus.cpp:1632
 #, fuzzy
 msgid "List #1"
 msgstr "串列："
 
-#: ../../src/wxMaxima.cpp:8609 ../../src/wxMaxima.cpp:8614
+#: ../../src/MaximaCommandMenus.cpp:1628 ../../src/MaximaCommandMenus.cpp:1633
 #, fuzzy
 msgid "List #2"
 msgstr "串列："
 
-#: ../../src/wxMaximaFrame.cpp:1200
+#: ../../src/wxMaximaFrame.cpp:1234
 msgid "List directory"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1205
+#: ../../src/wxMaximaFrame.cpp:1239
 msgid "List directory..."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7385 ../../src/wxMaxima.cpp:7389
+#: ../../src/wizards/ListSortWiz.cpp:34
+msgid "List name:"
+msgstr ""
+
+#: ../../src/sidebars/VariablesPane.cpp:188
+msgid "List of arrays"
+msgstr ""
+
+#: ../../src/sidebars/VariablesPane.cpp:191
+msgid "List of changed options"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:4257
 msgid "List of char to String"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1150
+#: ../../src/wxMaximaFrame.cpp:1184
 #, fuzzy
 msgid "List of chars to string..."
 msgstr "數式"
 
-#: ../../src/wxMaxima.cpp:7386
+#: ../../src/MaximaCommandMenus.cpp:4258
 #, fuzzy
 msgid "List of chars:"
 msgstr "輸入標籤"
 
-#: ../../src/wxMaxima.cpp:8559
+#: ../../src/sidebars/VariablesPane.cpp:179
+msgid "List of functional dependencies"
+msgstr ""
+
+#: ../../src/sidebars/VariablesPane.cpp:203
+#, fuzzy
+msgid "List of labels"
+msgstr "輸入標籤"
+
+#: ../../src/sidebars/VariablesPane.cpp:200
+msgid "List of structs"
+msgstr ""
+
+#: ../../src/sidebars/VariablesPane.cpp:197
+msgid "List of user aliases"
+msgstr ""
+
+#: ../../src/sidebars/VariablesPane.cpp:185
+msgid "List of user functions"
+msgstr ""
+
+#: ../../src/sidebars/VariablesPane.cpp:194
+msgid "List of user rules"
+msgstr ""
+
+#: ../../src/sidebars/VariablesPane.cpp:182
+msgid "List of user variables"
+msgstr ""
+
+#: ../../src/sidebars/VariablesPane.cpp:206
+msgid "List of user-defined derivatives"
+msgstr ""
+
+#: ../../src/sidebars/VariablesPane.cpp:216
+msgid "List of user-defined let rule packages"
+msgstr ""
+
+#: ../../src/sidebars/VariablesPane.cpp:212
+msgid "List of user-defined macros"
+msgstr ""
+
+#: ../../src/sidebars/VariablesPane.cpp:209
+msgid "List of user-defined properties"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:1575
 msgid "List with values"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8509 ../../src/wxMaxima.cpp:8527
-#: ../../src/wxMaxima.cpp:8533 ../../src/wxMaxima.cpp:8579
+#: ../../src/MaximaCommandMenus.cpp:1451 ../../src/MaximaCommandMenus.cpp:1510
+#: ../../src/MaximaCommandMenus.cpp:1515 ../../src/MaximaCommandMenus.cpp:1520
+#: ../../src/MaximaCommandMenus.cpp:1524 ../../src/MaximaCommandMenus.cpp:1528
+#: ../../src/MaximaCommandMenus.cpp:1532 ../../src/MaximaCommandMenus.cpp:1538
+#: ../../src/MaximaCommandMenus.cpp:1544 ../../src/MaximaCommandMenus.cpp:1597
+#: ../../src/MaximaCommandMenus.cpp:1608
 msgid "List:"
 msgstr "串列："
 
-#: ../../src/wxMaxima.cpp:6200
+#: ../../src/dialogs/ConfigDialogue.cpp:214
+msgid "Lithuanian"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:2162
+msgid "Load"
+msgstr "載入"
+
+#: ../../src/MaximaCommandMenus.cpp:2356
 msgid "Load Package"
 msgstr "載入 Package"
 
-#: ../../src/wxMaximaFrame.cpp:613
+#: ../../src/wxMaximaFrame.cpp:644
 #, fuzzy
 msgid "Load Recent Package"
 msgstr "載入 Package"
 
-#: ../../src/wxMaximaFrame.cpp:616
+#: ../../src/wxMaximaFrame.cpp:647
 msgid "Load a Maxima file using the batch command"
 msgstr "以批次命令的方式載入 Maxima 檔"
 
-#: ../../src/wxMaximaFrame.cpp:611
+#: ../../src/wxMaximaFrame.cpp:642
 msgid "Load a Maxima package file"
 msgstr "讀取 Maxima package 檔"
 
-#: ../../src/wxMaximaFrame.cpp:1678
-#, fuzzy
-msgid "Load a list from a csv file"
-msgstr "讀取 Maxima package 檔"
-
-#: ../../src/wxMaximaFrame.cpp:1324 ../../src/wxMaximaFrame.cpp:1330
+#: ../../src/wxMaximaFrame.cpp:1358 ../../src/wxMaximaFrame.cpp:1364
 #, fuzzy
 msgid "Load a matrix from a csv file"
 msgstr "讀取 Maxima package 檔"
 
-#: ../../src/wxMaximaFrame.cpp:1381 ../../src/wxMaximaFrame.cpp:1382
+#: ../../src/wxMaximaFrame.cpp:1715
+msgid "Load a nested list from a csv file"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1415 ../../src/wxMaximaFrame.cpp:1416
 #, fuzzy
 msgid "Load lapack"
 msgstr "載入 Package"
 
-#: ../../src/wxMaxima.cpp:7208
+#: ../../src/MaximaCommandMenus.cpp:4080
 #, fuzzy
 msgid "Load lisp code"
 msgstr "載入 Package"
 
-#: ../../src/wxMaximaFrame.cpp:1092
+#: ../../src/wxMaximaFrame.cpp:1126
 #, fuzzy
 msgid "Load lisp..."
 msgstr "載入 Package"
 
-#: ../../src/wxMaximaFrame.cpp:1198
+#: ../../src/dialogs/ConfigDialogue.cpp:2645
+msgid "Load style from file"
+msgstr "自檔案載入樣式"
+
+#: ../../src/wxMaximaFrame.cpp:1232
 msgid "Load the file/dir operations (operatingsystem)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1187
+#: ../../src/wxMaximaFrame.cpp:1221
 msgid "Load the regular expression package (sregex)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1224
+#: ../../src/wxMaximaFrame.cpp:1258
 msgid "Load the translation generator (gentran)"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8219
+#: ../../src/sidebars/SymbolsSidebar.cpp:128
+msgid "Long Right arrow"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:1409
 #, fuzzy
 msgid "Loop variable"
 msgstr "新變數："
 
-#: ../../src/wxMaxima.cpp:7778 ../../src/wxMaxima.cpp:10040
+#: ../../src/MaximaCommandMenus.cpp:959 ../../src/MaximaCommandMenus.cpp:3529
 msgid "Lower bound:"
 msgstr "下界："
 
-#: ../../src/wxMaximaFrame.cpp:1127
+#: ../../src/wxMaximaFrame.cpp:1161
 msgid "Lower, ignoring case?..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1448
+#: ../../src/wxMaximaFrame.cpp:1485
 #, fuzzy
 msgid "M&atrix"
 msgstr "矩陣"
 
-#: ../../src/wxMaxima.cpp:7153
+#: ../../src/sidebars/XmlInspector.cpp:104
+msgid "MAXIMA RESPONSE:"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:4025
 #, fuzzy
 msgid "Macro contents:"
 msgstr "希臘字母"
 
-#: ../../src/wxMaxima.cpp:7148
+#: ../../src/MaximaCommandMenus.cpp:4020
 #, fuzzy
 msgid "Macro name:"
 msgstr "矩陣名："
 
-#: ../../src/wxMaximaFrame.cpp:1024
+#: ../../src/wxMaximaFrame.cpp:1058
 msgid "Macros"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:697
-#, fuzzy
-msgid "Main Toolbar\tAlt+Shift+B"
-msgstr "工具列\tAlt+Shift+T"
+#: ../../src/wxMaximaFrame.cpp:869
+msgid "Main Toolbar\tShift+Alt+B"
+msgstr ""
 
-#: ../../src/wxMaxima.cpp:7906
+#: ../../src/MaximaCommandMenus.cpp:1087
 msgid "Make a function value at a specific point known"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:2028
+#: ../../src/worksheet/WorksheetContextMenu.cpp:800
 msgid "Make an eventual ev() evaluate this"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1070
+#: ../../src/wxMaximaFrame.cpp:1104
 #, fuzzy
 msgid "Make function local..."
 msgstr "映射函數至串列"
 
-#: ../../src/wxMaxima.cpp:8207
+#: ../../src/dialogs/ConfigDialogue.cpp:215
+msgid "Malay"
+msgstr ""
+
+#: ../../src/sidebars/PerformanceSidebar.cpp:33
+msgid "Manual anchors (built-in):"
+msgstr ""
+
+#: ../../src/sidebars/PerformanceSidebar.cpp:34
+msgid "Manual anchors (cache):"
+msgstr ""
+
+#: ../../src/sidebars/PerformanceSidebar.cpp:35
+msgid "Manual anchors (compiled):"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:1397
 msgid "Map"
 msgstr "映射"
 
-#: ../../src/wxMaxima.cpp:8215
+#: ../../src/MaximaCommandMenus.cpp:1405
 #, fuzzy
 msgid "Map an expression"
 msgstr "展開數式"
 
-#: ../../src/wxMaximaFrame.cpp:1443
+#: ../../src/wxMaximaFrame.cpp:1480
 msgid "Map function to a matrix"
 msgstr "映射函數至矩陣"
 
-#: ../../src/wxMaximaFrame.cpp:1446
+#: ../../src/wxMaximaFrame.cpp:1483
 #, fuzzy
 msgid "Map function to a matrix, affecting all of its clones"
 msgstr "映射函數至矩陣"
 
-#: ../../src/Configuration.cpp:109
+#: ../../src/dialogs/FindReplacePane.cpp:71
+#, fuzzy
+msgid "Match Case"
+msgstr "以批次檔載入"
+
+#: ../../src/Styles.cpp:139
 #, fuzzy
 msgid "Math Default"
 msgstr "預設"
 
-#: ../../src/wxMaximaFrame.cpp:286
+#: ../../src/dialogs/ConfigDialogue.cpp:789
+msgid "Math layout strategy"
+msgstr ""
+
+#: ../../src/cells/Cell.cpp:1490
+msgid "Math output"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1221
+msgid "MathML (rendered by the browser)"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1222
+msgid "MathML + MathJaX fall-back for old browsers"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1906
+msgid "MathML as HTML"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1902
+msgid "MathML description"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:307
 msgid "Mathematical Symbols"
 msgstr ""
 
-#: ../../src/ToolBar.cpp:270
+#: ../../src/ToolBar.cpp:480
 msgid "Maths"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7945 ../../src/wxMaxima.cpp:8022
-#: ../../src/wxMaxima.cpp:8027 ../../src/wxMaxima.cpp:8032
-#: ../../src/wxMaxima.cpp:8037 ../../src/wxMaxima.cpp:8041
-#: ../../src/wxMaxima.cpp:8053 ../../src/wxMaxima.cpp:8059
-#: ../../src/wxMaxima.cpp:8064 ../../src/wxMaxima.cpp:8069
-#: ../../src/wxMaxima.cpp:8075 ../../src/wxMaxima.cpp:8080
-#: ../../src/wxMaxima.cpp:8085 ../../src/wxMaxima.cpp:8090
-#: ../../src/wxMaxima.cpp:8096 ../../src/wxMaxima.cpp:8101
-#: ../../src/wxMaxima.cpp:8152 ../../src/wxMaxima.cpp:8182
+#: ../../src/MaximaCommandMenus.cpp:1125 ../../src/MaximaCommandMenus.cpp:1206
+#: ../../src/MaximaCommandMenus.cpp:1211 ../../src/MaximaCommandMenus.cpp:1216
+#: ../../src/MaximaCommandMenus.cpp:1221 ../../src/MaximaCommandMenus.cpp:1225
+#: ../../src/MaximaCommandMenus.cpp:1239 ../../src/MaximaCommandMenus.cpp:1245
+#: ../../src/MaximaCommandMenus.cpp:1250 ../../src/MaximaCommandMenus.cpp:1255
+#: ../../src/MaximaCommandMenus.cpp:1261 ../../src/MaximaCommandMenus.cpp:1266
+#: ../../src/MaximaCommandMenus.cpp:1273 ../../src/MaximaCommandMenus.cpp:1278
+#: ../../src/MaximaCommandMenus.cpp:1284 ../../src/MaximaCommandMenus.cpp:1289
+#: ../../src/MaximaCommandMenus.cpp:1340 ../../src/MaximaCommandMenus.cpp:1370
 msgid "Matrix"
 msgstr "矩陣"
 
-#: ../../src/wxMaxima.cpp:7986
+#: ../../src/MaximaCommandMenus.cpp:1170
 #, fuzzy
 msgid "Matrix Exponent"
 msgstr "矩陣名："
 
-#: ../../src/wxMaximaFrame.cpp:1339
+#: ../../src/wxMaximaFrame.cpp:1373
 #, fuzzy
 msgid "Matrix exponent..."
 msgstr "矩陣名："
 
-#: ../../src/wxMaximaFrame.cpp:1329
+#: ../../src/wxMaximaFrame.cpp:1363
 #, fuzzy
 msgid "Matrix from csv file"
 msgstr "自檔案載入樣式"
 
-#: ../../src/wxMaximaFrame.cpp:1323
+#: ../../src/wxMaximaFrame.cpp:1357
 #, fuzzy
 msgid "Matrix from csv file..."
 msgstr "自檔案載入樣式"
 
-#: ../../src/wxMaxima.cpp:8137
+#: ../../src/MaximaCommandMenus.cpp:1325
 msgid "Matrix map"
 msgstr "矩陣映射"
 
-#: ../../src/wxMaxima.cpp:9630
+#: ../../src/MaximaCommandMenus.cpp:1870
 msgid "Matrix name:"
 msgstr "矩陣名："
 
-#: ../../src/wxMaximaFrame.cpp:798
+#: ../../src/wxMaximaFrame.cpp:835
 #, fuzzy
 msgid "Matrix parenthesis"
 msgstr "在文字控制項中輸入時匹配括弧"
 
-#: ../../src/wxMaximaFrame.cpp:1331
+#: ../../src/wxMaximaFrame.cpp:1365
 #, fuzzy
 msgid "Matrix to csv file"
 msgstr "自檔案載入樣式"
 
-#: ../../src/wxMaximaFrame.cpp:1334
+#: ../../src/wxMaximaFrame.cpp:1368
 msgid "Matrix to file or Matrix from file"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1761
+#: ../../src/wxMaximaFrame.cpp:1798
 msgid "Matrix to nested List"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7956 ../../src/wxMaxima.cpp:7961
-#: ../../src/wxMaxima.cpp:7966 ../../src/wxMaxima.cpp:7971
-#: ../../src/wxMaxima.cpp:7976 ../../src/wxMaxima.cpp:8000
-#: ../../src/wxMaxima.cpp:8136
+#: ../../src/MaximaCommandMenus.cpp:1456
+msgid "Matrix to nested list"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:1136 ../../src/MaximaCommandMenus.cpp:1141
+#: ../../src/MaximaCommandMenus.cpp:1146 ../../src/MaximaCommandMenus.cpp:1151
+#: ../../src/MaximaCommandMenus.cpp:1156 ../../src/MaximaCommandMenus.cpp:1161
+#: ../../src/MaximaCommandMenus.cpp:1184 ../../src/MaximaCommandMenus.cpp:1324
+#: ../../src/MaximaCommandMenus.cpp:1457
 msgid "Matrix:"
 msgstr "矩陣："
 
-#: ../../src/wxMaxima.cpp:8627
-msgid ""
-"Maxima allows to make functions \"nouns\", which means that they aren't automatically evaluated as soon as maxima encounters them.\n"
-"Ways make a function a noun include declaring it a noun, preceding it with a  ' or putting it between the parenthesis of '().\n"
-"\n"
-"This command tells maxima that the nouns in this expression shall now be evaluated, too."
+#: ../../src/dialogs/ConfigDialogue.cpp:1370
+msgid "Max. layout time [s] (0=no limit)"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3473
+#: ../../src/dialogs/ConfigDialogue.cpp:281
+msgid "Maxima"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1433
+#, fuzzy
+msgid "Maxima Location"
+msgstr "Maxima 詢問"
+
+#: ../../src/MaximaCommandMenus.cpp:619
+msgid ""
+"Maxima allows making functions \"nouns\", which means that they aren't automatically evaluated as soon as Maxima encounters them.\n"
+"Ways to make a function a noun include declaring it a noun, preceding it with a single quote or putting it between the parentheses of '().\n"
+"\n"
+"This command tells Maxima that the nouns in this expression shall now be evaluated, too."
+msgstr ""
+
+#: ../../src/MaximaResponseReader.cpp:803
 #, c-format
 msgid "Maxima architecture: %s"
 msgstr ""
 
-#: ../../src/StatusBar.cpp:252
+#: ../../src/StatusBar.cpp:330
 #, fuzzy
 msgid "Maxima asks a question"
 msgstr "Maxima 詢問"
 
-#: ../../src/wxMaxima.cpp:4066
+#: ../../src/MaximaResponseReader.cpp:560
 #, fuzzy
 msgid "Maxima asks a question!"
 msgstr "Maxima 詢問"
 
-#: ../../src/wxMaxima.cpp:7118
+#: ../../src/dialogs/ConfigDialogue.cpp:362
+#, c-format
+msgid "Maxima assigns each command/equation an automatic label (which looks like %i1 or %o1). If a command begins with a descriptive name followed by a : wxMaxima will call the descriptive name a \"user-defined label\" instead. This selection now allows telling wxMaxima whether to show only automatic labels, automatic labels if there aren't user-defined ones or no label at all until a user-defined label can be found by wxMaxima's heuristics. If automatic labels are suppressed extra vertical space is added between equations in order to ease discerning which line starts a new equation and which one only continues the one from the last line."
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:3990
 msgid ""
 "Maxima automatically simplifies expressions it gets as input and then tries to evaluate their value. The ' operator tells maxima that we want a command to be in noun form, which means: stand here as is, and unevaluated.\n"
 "The ' operator can be undone by using the '' operator."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3304
+#: ../../src/cells/EditorCell.cpp:4516
+msgid "Maxima code"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1110
+msgid "Maxima commands to be executed at every start of Maxima"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1063
+msgid "Maxima commands to be executed every time wxMaxima starts Maxima"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1507
+#, fuzzy
+msgid "Maxima configuration"
+msgstr "wxMaxima 設定"
+
+#: ../../src/MaximaResponseReader.cpp:346
 msgid "Maxima didn't attempt to authenticate!"
 msgstr ""
 
-#: ../../src/Configuration.cpp:84
+#: ../../src/Styles.cpp:113
 msgid "Maxima errors"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3289
+#: ../../src/MaximaResponseReader.cpp:338
 #, fuzzy
 msgid "Maxima has authenticated!"
 msgstr "Maxima 程序已結束"
 
-#: ../../src/wxMaxima.cpp:10533
+#: ../../src/MaximaEvaluator.cpp:369
 #, fuzzy
 msgid "Maxima has finished calculating."
 msgstr "Maxima 計算中"
 
-#: ../../src/wxMaxima.cpp:5832
+#: ../../src/MaximaEvaluator.cpp:191
 #, fuzzy
 msgid "Maxima has issued an error!"
 msgstr "Maxima 詢問"
 
-#: ../../src/wxMaxima.cpp:3696
+#: ../../src/MaximaResponseReader.cpp:913
 #, c-format
 msgid "Maxima has loaded the file %s."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3382
+#: ../../src/MaximaResponseReader.cpp:761
 msgid "Maxima has sent a new variable value."
 msgstr ""
 
-#: ../../src/MaximaManual.cpp:552
+#: ../../src/StatusBar.cpp:349
+msgid ""
+"Maxima has stopped in a debugger and is waiting for a command.\n"
+"Common commands (type ':h' for the full list):\n"
+"  :bt        show a backtrace of the call stack\n"
+"  :continue  continue the computation\n"
+"  :top       return to the top level (abandon the computation)\n"
+"  :next / :step   step to the next line\n"
+"  :frame     show the current stack frame"
+msgstr ""
+
+#: ../../src/MaximaManual.cpp:576
 #, fuzzy
 msgid "Maxima help file not found!"
 msgstr "找不到檔案"
 
-#: ../../src/wxMaximaFrame.cpp:1043
+#: ../../src/wxMaximaFrame.cpp:1077
 msgid "Maxima input"
 msgstr "Maxima 輸入"
 
-#: ../../src/StatusBar.cpp:236
+#: ../../src/StatusBar.cpp:299
 msgid "Maxima is calculating"
 msgstr "Maxima 計算中"
 
-#: ../../src/wxMaxima.cpp:5068
+#: ../../src/wxMaxima.cpp:1876
 #, fuzzy
 msgid "Maxima is ready for input."
 msgstr "Maxima 輸入"
 
-#: ../../src/Dirstructure.cpp:144
+#: ../../src/Dirstructure.cpp:153
 #, c-format
 msgid "Maxima not found as %s"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:6211
+#: ../../src/MaximaCommandMenus.cpp:2367
 msgid "Maxima package (*.mac)|*.mac"
 msgstr "Maxima package (*.mac)|*.mac"
 
-#: ../../src/wxMaxima.cpp:6202
+#: ../../src/MaximaCommandMenus.cpp:2358
 msgid "Maxima package (*.mac)|*.mac|Lisp package (*.lisp)|*.lisp|All|*"
 msgstr "Maxima package (*.mac)|*.mac|Lisp package (*.lisp)|*.lisp|所有類型|*"
 
-#: ../../src/wxMaxima.cpp:3012
+#: ../../src/MaximaProcessManager.cpp:569
 msgid "Maxima process terminated unexpectedly."
 msgstr ""
 
-#: ../../src/Configuration.cpp:79
+#: ../../src/dialogs/ConfigDialogue.cpp:1437
+msgid "Maxima program:"
+msgstr "Maxima 程式："
+
+#: ../../src/dialogs/ConfigDialogue.cpp:382
+msgid "Maxima provides no \"forget all\" command that flushes all settings a maxima session could make. wxMaxima therefore normally defaults to starting a fresh maxima process every time the worksheet is to be re-evaluated. As this needs a little bit of time this switch allows to disable this behavior."
+msgstr ""
+
+#: ../../src/Styles.cpp:108
 #, fuzzy
 msgid "Maxima question labels"
 msgstr "Maxima 詢問"
 
-#: ../../src/wxMaxima.cpp:3380
+#: ../../src/StatusBar.cpp:339
+msgid "Maxima returned an error message"
+msgstr ""
+
+#: ../../src/MaximaResponseReader.cpp:759
 msgid "Maxima sends a new set of auto-completable symbols."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3908
+#: ../../src/MaximaResponseReader.cpp:1024
 msgid "Maxima sends us a new set of variables for the watch list."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1944
+#: ../../src/sidebars/History.cpp:153
+#, fuzzy
+msgid "Maxima session (*.mac)|*.mac"
+msgstr "Maxima package (*.mac)|*.mac"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1518 ../../src/wxMaximaFrame.cpp:1981
 msgid "Maxima shows help in a browser"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1940
+#: ../../src/dialogs/ConfigDialogue.cpp:1523 ../../src/wxMaximaFrame.cpp:1977
 msgid "Maxima shows help in a sidebar"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1935
+#: ../../src/dialogs/ConfigDialogue.cpp:1511 ../../src/wxMaximaFrame.cpp:1972
 #, fuzzy
 msgid "Maxima shows help in the console"
 msgstr "找不到檔案"
 
-#: ../../src/StatusBar.cpp:232
+#: ../../src/StatusBar.cpp:290
 #, fuzzy
 msgid "Maxima started. Waiting for authentication..."
 msgstr "Maxima 已啟動，等待連線中..."
 
-#: ../../src/StatusBar.cpp:212
+#: ../../src/StatusBar.cpp:245
 msgid "Maxima started. Waiting for connection..."
 msgstr "Maxima 已啟動，等待連線中..."
 
-#: ../../src/StatusBar.cpp:228
+#: ../../src/StatusBar.cpp:281
 #, fuzzy
 msgid "Maxima started. Waiting for initial prompt..."
 msgstr "Maxima 已啟動，等待連線中..."
 
-#: ../../src/wxMaximaFrame.cpp:1231
+#: ../../src/sidebars/PerformanceSidebar.cpp:36
+msgid "Maxima starts:"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1143
+msgid "Maxima startup file location: "
+msgstr ""
+
+#: ../../src/dialogs/TipOfTheDay.cpp:68
+msgid "Maxima supports three types of numbers: exact fractions (which can be generated for example by typing 1/10), IEEE floating-point numbers (0.2) and arbitrary precision big floats (1b-1). Note that, owing to their nature as binary (not decimal) numbers, there is for example no way to generate an IEEE floating-point number that exactly equals 0.1. If floating-point numbers are used instead of fractions, Maxima will therefore sometimes have to introduce a (very small) error and use things like 3602879701896397/36028797018963968 for 0.1."
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1265
 #, fuzzy
 msgid "Maxima to other language"
 msgstr "Maxima 詢問"
 
-#: ../../src/wxMaxima.cpp:7213
+#: ../../src/MaximaCommandMenus.cpp:4085
 #, fuzzy
 msgid "Maxima to string"
 msgstr "Maxima 詢問"
 
-#: ../../src/wxMaxima.cpp:3397
+#: ../../src/cells/TextCell.cpp:255
+msgid "Maxima tried to find out where between two points a curve crosses the zero line. Since the curve is on the same side of the zero line in both points its algorithms fails here. Set find_root_error to false if you want it to return false instead of an error."
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1615
+#, fuzzy
+msgid "Maxima usage"
+msgstr "wxMaxima 圖示"
+
+#: ../../src/MaximaResponseReader.cpp:776
 #, c-format
 msgid "Maxima user configuration is located in directory %s"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3443
+#: ../../src/dialogs/TipOfTheDay.cpp:59
+msgid ""
+"Maxima uses ':' to assign values to a variable ('a : 3;'), not '=' as most programming languages do.\n"
+"This allows, that a mathematical equation can be assigned to a variable, e.g.\n"
+" eq1:3*x=4;\n"
+"which may then be solved for x with\n"
+"solve(eq1,x);"
+msgstr ""
+
+#: ../../src/dialogs/TipOfTheDay.cpp:63
+#, fuzzy
+msgid ""
+"Maxima uses ':=' to define functions, e.g.:\n"
+"f(x) := x^2;"
+msgstr "Maxima 使用 \":\" 來設定數值 (例：\"a : 3;\")，使用 \":=\" 來定義函數 (例：\"f(x) := x^2\")。"
+
+#: ../../src/MaximaResponseReader.cpp:788
 #, c-format
 msgid "Maxima uses temp directory %s"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3469
+#: ../../src/dialogs/AboutDialog.cpp:50
+#, fuzzy
+msgid "Maxima version: "
+msgstr ""
+"\n"
+"Maxima 版本："
+
+#: ../../src/MaximaResponseReader.cpp:799
 #, c-format
 msgid "Maxima version: %s"
 msgstr ""
 
-#: ../../src/MaximaManual.cpp:390
+#: ../../src/MaximaManual.cpp:407
 #, c-format
 msgid "Maxima version: %s, Anchors cache version"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1925
+#: ../../src/wxMaximaFrame.cpp:1962
 #, fuzzy
 msgid "Maxima vs. Programming languages"
 msgstr "轉換為 Gamma 函數(&G)"
 
-#: ../../src/Configuration.cpp:83
+#: ../../src/Styles.cpp:112
 #, fuzzy
 msgid "Maxima warnings"
 msgstr "Maxima 選項"
 
-#: ../../src/wxMaxima.cpp:3687
+#: ../../src/MaximaResponseReader.cpp:904
 #, c-format
 msgid "Maxima was compiled using %s"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3487
+#: ../../src/dialogs/AboutDialog.cpp:53
+#, fuzzy
+msgid "Maxima was compiled using: "
+msgstr ""
+"\n"
+"Maxima 版本："
+
+#: ../../src/dialogs/TipOfTheDay.cpp:201
+msgid ""
+"Maxima's \"at\" function allows accessing arbitrary variables in a list of results:\n"
+"\n"
+"    g1:a*x+y=0;\n"
+"    g2:b*y+x*x=1;\n"
+"    solve([g1,g2],[a,b]);\n"
+"    %[1];\n"
+"    result_b:b=at(b,%);"
+msgstr ""
+
+#: ../../src/MaximaResponseReader.cpp:817
 #, c-format
 msgid "Maxima's HTML manuals are in directory %s"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3099
+#: ../../src/MaximaResponseReader.cpp:599
+msgid "Maxima's Lisp (sbcl) has stopped in its low-level debugger (LDB). The Lisp cannot continue; you can enter LDB commands - for example \"backtrace\" for a stack trace, or \"exit\" to quit it."
+msgstr ""
+
+#: ../../src/MaximaResponseReader.cpp:597
+msgid "Maxima's Lisp entered sbcl's low-level debugger (LDB)."
+msgstr ""
+
+#: ../../src/MaximaResponseReader.cpp:240
+#: ../../src/MaximaResponseReader.cpp:242
 #, c-format
 msgid "Maxima's PID is %li"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3681
+#: ../../src/MaximaResponseReader.cpp:898
 #, c-format
 msgid "Maxima's demo files are located in directory %s"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3478
+#: ../../src/MaximaResponseReader.cpp:808
 #, c-format
 msgid "Maxima's manual is located in directory %s"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3670
+#: ../../src/wizards/ActualValuesStorageWiz.cpp:34
+msgid "Maxima's power lies in symbolic operations."
+msgstr ""
+
+#: ../../src/StatusBar.cpp:365
+msgid ""
+"Maxima's reader is in Lisp mode (after to_lisp()).\n"
+"Type Lisp forms; enter (to-maxima) to return to Maxima mode."
+msgstr ""
+
+#: ../../src/MaximaResponseReader.cpp:887
 #, fuzzy, c-format
 msgid "Maxima's share files are located in directory %s"
 msgstr "開始動畫"
 
-#: ../../src/StatusBar.cpp:66
+#: ../../src/dialogs/TipOfTheDay.cpp:188
+msgid ""
+"Maxima's strengths are manipulating equations and in symbolic calculations. It therefore makes sense to use functions (as opposed to equations with labels) sparingly and to keep the actual values of variables in a list, instead of directly assigning them values. An example session that does do so would be:\n"
+"\n"
+"/* We keep the actual values in a list so we can use them later on */\n"
+"    Values:[a=10,c=100];\n"
+"    Pyth:a^2+b^2=c^2;\n"
+"    solve(%,b);\n"
+"    result:%[2];\n"
+"    at(result,Values);\n"
+"    float(%);"
+msgstr ""
+
+#: ../../src/StatusBar.cpp:73
 msgid "Maxima, the program that does the actual mathematics and wxMaxima, which displays the worksheet are kept in separate processes. This means that even if maxima crashes wxMaxima (and therefore the worksheet) stays intact. Both programs communicate over a local network socket. This time this socket could not be created which might be caused by a firewall that it setup to not only intercepts connections from the outside, but also to intercept connections between two programs that run on the same computer."
 msgstr ""
 
-#: ../../src/StatusBar.cpp:75
+#: ../../src/StatusBar.cpp:82
 msgid "Maxima, the program that does the actual mathematics and wxMaxima, which displays the worksheet are kept in separate processes. This means that even if maxima crashes wxMaxima (and therefore the worksheet) stays intact. Currently the two programs aren't connected to each other which might mean that maxima is still starting up or couldn't be started. Alternatively it can be caused by a firewall that it setup to not only intercepts connections from the outside, but also to intercept connections between two programs that run on the same computer. Another reason for maxima not starting up might be that maxima cannot be found (see wxMaxima's Configuration dialogue for a way to specify maxima's location) or isn't in a working order."
 msgstr ""
 
-#: ../../src/StatusBar.cpp:61
+#: ../../src/StatusBar.cpp:68
 msgid ""
 "Maxima, the program that does the actual mathematics is started as a separate process. This has the advantage that an eventual crash of maxima cannot harm wxMaxima, which displays the worksheet.\n"
 "This icon indicates if data is transferred between maxima and wxMaxima."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:9228
+#: ../../src/dialogs/MaximaNotStartingDialog.cpp:39
+msgid "Maxima, the program that does the actual maths, cannot be started. This might mean that it isn't installed (it can be found at ↗https://maxima.sourceforge.net) or that wxMaxima doesn't know where to search for it. In that case please choose the location of a working maxima binary"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:419
 msgid "Maximum absolute value printed without exponent"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:9230
+#: ../../src/dialogs/ConfigDialogue.cpp:1931
+msgid "Maximum bitmap size on clipboard [Mb]:"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:488 ../../src/MaximaCommandMenus.cpp:501
+#: ../../src/MaximaCommandMenus.cpp:516 ../../src/MaximaCommandMenus.cpp:530
+msgid "Maximum number of Chebyshev moments. Must be greater than 0."
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:421
 msgid "Maximum number of digits to be displayed:"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:9568
+#: ../../src/dialogs/ConfigDialogue.cpp:811
+msgid "Maximum number of displayed digits:"
+msgstr ""
+
+#: ../../src/sidebars/StatSidebar.cpp:70
+msgid "Mean Difference Test..."
+msgstr "平均差檢驗..."
+
+#: ../../src/sidebars/StatSidebar.cpp:67
+msgid "Mean Test..."
+msgstr "平均值檢驗..."
+
+#: ../../src/sidebars/StatSidebar.cpp:52
+msgid "Mean..."
+msgstr "平均..."
+
+#: ../../src/MaximaCommandMenus.cpp:1806
 msgid "Mean:"
 msgstr "平均值："
 
-#: ../../src/wxMaximaFrame.cpp:1924
+#: ../../src/sidebars/StatSidebar.cpp:55
+msgid "Median..."
+msgstr "中位數..."
+
+#: ../../src/wxMaximaFrame.cpp:1961
 msgid "Memoizing"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1013
+#: ../../src/wxMaximaFrame.cpp:1047
 #, fuzzy
 msgid "Memory"
 msgstr "清除記憶體(&C)"
 
-#: ../../src/Worksheet.cpp:1409 ../../src/wxMaximaFrame.cpp:935
+#: ../../src/worksheet/WorksheetContextMenu.cpp:180
+#: ../../src/wxMaximaFrame.cpp:969
 msgid "Merge Cells"
 msgstr "合併單元"
 
-#: ../../src/wxMaxima.cpp:5780
+#: ../../src/MaximaResponseReader.cpp:641
 msgid "Message from the stdout of Maxima: "
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1326
+#: ../../src/wizards/IntegrateWiz.cpp:55
+msgid "Method:"
+msgstr "方法："
+
+#: ../../src/wxMaximaFrame.cpp:1360
 msgid "Methods of generating a matrix"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:6866
+#: ../../src/worksheet/Worksheet.cpp:4869
 #, c-format
 msgid "Middle-click clipboard data: %s"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:9226
+#: ../../src/cells/TextCell.cpp:303
+msgid "Might also indicate a missing multiplication sign (\"*\")."
+msgstr ""
+
+#: ../../src/cells/TextCell.cpp:323
+msgid ""
+"Might be caused by reading an csv file with an empty last line:\n"
+"Technically that line can be described as having the length 0 which differs from the other lines of this file."
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:417
 msgid "Minimum absolute value printed without exponent:"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:10449 ../../src/wxMaxima.cpp:10451
+#: ../../src/dialogs/ConfigDialogue.cpp:1270
+msgid "Misc"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1963
+#, fuzzy
+msgid "Misc settings"
+msgstr "匯出為 TeX 失敗！"
+
+#: ../../src/wxMaxima.cpp:3136 ../../src/wxMaxima.cpp:3138
 #, fuzzy
 msgid "Mismatched parenthesis"
 msgstr "在文字控制項中輸入時匹配括弧"
 
-#: ../../src/wxMaximaFrame.cpp:1352
+#: ../../src/cells/VisiblyInvalidCell.cpp:43
+msgid "Missing contents. Bug?"
+msgstr ""
+
+#: ../../src/cells/TextCell.cpp:245
+msgid "Most probable cause: A dot instead a comma between two list items containing assignments."
+msgstr ""
+
+#: ../../src/cells/TextCell.cpp:308
+msgid "Most probable cause: A function was called with a parameter that causes it to return infinity and/or -infinity."
+msgstr ""
+
+#: ../../src/cells/TextCell.cpp:249
+msgid "Most probable cause: Two commas or similar separators in a row."
+msgstr ""
+
+#: ../../src/cells/TextCell.cpp:251
+msgid "Most probable cause: an operator was directly followed by a closing parenthesis."
+msgstr ""
+
+#: ../../src/cells/TextCell.cpp:318
+msgid ""
+"Most probably it was attempted to append something to a list that isn't a list.\n"
+"Enclosing the new element for the list in brackets ([]) converts it to a list and makes it appendable."
+msgstr ""
+
+#: ../../src/cells/TextCell.cpp:155
+msgid "Most questions can be avoided using the assume() and the declare() command. If that isn't possible the \"Automatically answer questions\" button makes wxMaxima automatically fill in all answers it still remembers from a previous run."
+msgstr ""
+
+#: ../../src/sidebars/GreekSidebar.cpp:189
+msgid "Mu"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1386
 msgid "Multiplication, exponent and similar"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1998
+#: ../../src/worksheet/WorksheetContextMenu.cpp:770
 msgid "Multiplicative function: f(a*b)=f(a)*f(b)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1338
+#: ../../src/wxMaximaFrame.cpp:1372
 msgid "Multiply matrices..."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7981
+#: ../../src/MaximaCommandMenus.cpp:1165
 msgid "Multiply two matrices"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:9581
-#, fuzzy
-msgid "Multivariate linear regression"
-msgstr "線性迴歸..."
-
-#: ../../src/wxMaxima.cpp:7842
+#: ../../src/MaximaCommandMenus.cpp:1023
 #, fuzzy
 msgid "Name of t:"
 msgstr "命名："
 
-#: ../../src/wxMaxima.cpp:7838
+#: ../../src/wizards/DrawWiz.cpp:750
+msgid "Name of the parameter"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:1019
 #, fuzzy
 msgid "Name of x:"
 msgstr "命名："
 
-#: ../../src/wxMaximaFrame.cpp:1320 ../../src/wxMaximaFrame.cpp:1759
+#: ../../src/wizards/MatWiz.cpp:163
+msgid "Name:"
+msgstr "命名："
+
+#: ../../src/dialogs/ConfigDialogue.cpp:216
+msgid "Nepali"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1354 ../../src/wxMaximaFrame.cpp:1796
 msgid "Nested list to Matrix"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:769 ../../src/wxMaximaFrame.cpp:1053
+#: ../../src/MaximaCommandMenus.cpp:1450
+msgid "Nested list to matrix"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:748
+#: ../../src/dialogs/ConfigDialogue.cpp:772 ../../src/wxMaximaFrame.cpp:806
+#: ../../src/wxMaximaFrame.cpp:1087
 msgid "Never"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:6534
+#: ../../src/MaximaCommandMenus.cpp:3054
 msgid "Never autosubscript this variable"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:776
+#: ../../src/wxMaximaFrame.cpp:813
 msgid "Never display this variable with subscript"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1469 ../../src/Worksheet.cpp:1843
+#: ../../src/worksheet/WorksheetContextMenu.cpp:240
+#: ../../src/worksheet/WorksheetContextMenu.cpp:615
 msgid "Never offer known answers"
 msgstr ""
 
-#: ../../src/ToolBar.cpp:174
+#: ../../src/ToolBar.cpp:324 ../../src/ToolBar.cpp:326
 msgid "New"
 msgstr "新增"
 
-#: ../../src/wxMaximaFrame.cpp:597
+#: ../../src/wxMaximaFrame.cpp:628
 msgid "New\tCtrl+N"
 msgstr "新增\tCtrl+N"
 
-#: ../../src/ToolBar.cpp:611
+#: ../../src/ToolBar.cpp:811
 msgid "New button"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2483
+#: ../../src/MaximaProcessManager.cpp:144
 msgid "New connection attempt whilst already connected."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2491
+#: ../../src/MaximaProcessManager.cpp:152
 msgid "New connection attempt, but no currently no socket maxima could connect to."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2487
+#: ../../src/MaximaProcessManager.cpp:148
 msgid "New connection attempt, but no currently running maxima process."
 msgstr ""
 
-#: ../../src/ToolBar.cpp:174
+#: ../../src/ToolBar.cpp:324 ../../src/ToolBar.cpp:326
 msgid "New document"
 msgstr "新增文件"
 
-#: ../../src/wxMaxima.cpp:3899
+#: ../../src/dialogs/ConfigDialogue.cpp:901
+msgid "New lines: Jump to text"
+msgstr ""
+
+#: ../../src/MaximaResponseReader.cpp:1015
 #, c-format
 msgid "New maxima Operators detected: %s"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7390
+#: ../../src/MaximaCommandMenus.cpp:4262
 #, fuzzy
 msgid "New part:"
 msgstr "新變數："
 
-#: ../../src/wxMaxima.cpp:8900 ../../src/wxMaxima.cpp:8920
-#: ../../src/wxMaxima.cpp:9000 ../../src/wxMaxima.cpp:9005
+#: ../../src/wizards/SubstituteWiz.cpp:35
+msgid "New value:"
+msgstr "新值："
+
+#: ../../src/MaximaCommandMenus.cpp:151 ../../src/MaximaCommandMenus.cpp:171
+#: ../../src/MaximaCommandMenus.cpp:254 ../../src/MaximaCommandMenus.cpp:259
 msgid "New variable:"
 msgstr "新變數："
 
-#: ../../src/wxMaximaFrame.cpp:929
+#: ../../src/wxMaximaFrame.cpp:963
 msgid "Next Command\tAlt+Down"
 msgstr "下一個命令\tAlt+Down"
 
-#: ../../src/wxMaximaFrame.cpp:748
+#: ../../src/dialogs/DiffFrame.cpp:405
+msgid "Next Difference"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:785
 msgid "Nice Graphical Equations"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1550
+#: ../../src/dialogs/ConfigDialogue.cpp:725
+#: ../../src/dialogs/ConfigDialogue.cpp:737 ../../src/wxMaximaFrame.cpp:1587
 msgid "No"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1972
+#: ../../src/worksheet/WorksheetContextMenu.cpp:744
 #, fuzzy
 msgid "No Array"
 msgstr "陣列："
 
-#: ../../src/Worksheet.cpp:1974
+#: ../../src/worksheet/WorksheetContextMenu.cpp:746
 msgid "No Scalar"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:10482
+#: ../../src/worksheet/Worksheet.cpp:5466
+msgid "No cells are selected. Anonymize the code in the whole document?"
+msgstr ""
+
+#: ../../src/wizards/DrawWiz.cpp:636
+msgid "No contour lines"
+msgstr ""
+
+#: ../../src/dialogs/DiffFrame.cpp:304
+msgid "No differences"
+msgstr ""
+
+#: ../../src/wxMaxima.cpp:3169
 msgid "No dollar ($) or semicolon (;) at the end of command"
 msgstr ""
 
-#: ../../src/MaximaManual.cpp:406
+#: ../../src/MaximaManual.cpp:423
 msgid "No entries in the caches for the subjects the manual contains."
 msgstr ""
 
@@ -4993,726 +7490,1091 @@ msgstr ""
 msgid "No file with the subjects the manual contained in the last wxMaxima run."
 msgstr ""
 
-#: ../../src/Image.cpp:495
+#: ../../src/Image.cpp:547
 msgid "No gnuplot data!"
 msgstr ""
 
-#: ../../src/Image.cpp:530
+#: ../../src/Image.cpp:582
 msgid "No gnuplot source!"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:6662 ../../src/wxMaxima.cpp:6668
-#: ../../src/wxMaxima.cpp:6687 ../../src/wxMaxima.cpp:6697
+#: ../../src/cells/GroupCell.cpp:1500
+msgid "No image to export"
+msgstr ""
+
+#: ../../src/wxMaxima.cpp:2653 ../../src/wxMaxima.cpp:2661
+#: ../../src/wxMaxima.cpp:2682 ../../src/wxMaxima.cpp:2694
 msgid "No matches found!"
 msgstr "找不到匹配的項目！"
 
-#: ../../src/wxMaxima.cpp:3240
+#: ../../src/wizards/DrawWiz.cpp:651
+msgid "No plot, only contour lines"
+msgstr ""
+
+#: ../../src/wizards/DrawWiz.cpp:837
+msgid "No points"
+msgstr ""
+
+#: ../../src/MaximaResponseReader.cpp:145
 msgid "No topics found in topic flag"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3227
+#: ../../src/MaximaResponseReader.cpp:130
 msgid "No topics found in topic tag"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:797
+#: ../../src/Image.cpp:1037
+msgid "No usable image data was found."
+msgstr ""
+
+#: ../../src/sidebars/SymbolsSidebar.cpp:179
+msgid "Non-builtin symbols"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:834
 msgid "None"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8163
+#: ../../src/sidebars/StatSidebar.cpp:73
+msgid "Normality Test..."
+msgstr "常態分布檢驗..."
+
+#: ../../src/cells/TextCell.cpp:271
+msgid ""
+"Normally computers use floating-point numbers that can be handled incredibly fast while being accurate to dozens of digits. They will, though, introduce a small error into some common numbers. For example 0.1 is represented as 3602879701896397/36028797018963968.\n"
+"As mathematics is based on the fact that numbers that are exactly equal cancel each other out small errors can quickly add up to big errors (see Wilkinson's Polynomials or Rump's Polynomials). Some maxima commands therefore use rat() in order to automatically convert floats to exact numbers (like 1/10 or sqrt(2)/2) where floating-point errors might add up.\n"
+"\n"
+"This error message doesn't occur if exact numbers (1/10 instead of 0.1) are used.\n"
+"The info that numbers have automatically been converted can be suppressed by setting ratprint to false."
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:431
+msgid "Normally html expects images to be rather low-res but space saving. These images tend to look rather blurry when viewed on modern screens. Therefore this setting was introduces that selects the factor by which the HTML export increases the resolution in respect to the default value."
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:217
+msgid "Norwegian"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:1351
 msgid "Not a valid matrix dimension!"
 msgstr "這不是有效的矩陣大小！"
 
-#: ../../src/wxMaxima.cpp:7858 ../../src/wxMaxima.cpp:7880
+#: ../../src/MaximaCommandMenus.cpp:1039 ../../src/MaximaCommandMenus.cpp:1061
 msgid "Not a valid number of equations!"
 msgstr "這不是有效的數字或方程式！"
 
-#: ../../src/StatusBar.cpp:256
+#: ../../src/StatusBar.cpp:375
 msgid "Not connected to Maxima"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:10496
+#: ../../src/MaximaResponseReader.cpp:841
+msgid "Not re-querying gnuplot's graphics drivers: same gnuplot as before."
+msgstr ""
+
+#: ../../src/MaximaFileIO.cpp:768
+msgid "Not saving: running non-interactively and no file name is set."
+msgstr ""
+
+#: ../../src/MaximaEvaluator.cpp:329
 msgid "Not triggering evaluation as maxima is still busy!"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:10503
+#: ../../src/MaximaEvaluator.cpp:336
 msgid "Not triggering evaluation as maxima still asks a question!"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:10511
+#: ../../src/MaximaEvaluator.cpp:344
 msgid "Not triggering evaluation as there is no working maxima process"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8926
+#: ../../src/sidebars/GreekSidebar.cpp:190
+msgid "Nu"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:177
 msgid "Num. deg:"
 msgstr "分子 degree："
 
-#: ../../src/wxMaxima.cpp:8540
+#: ../../src/MaximaCommandMenus.cpp:1553
 #, fuzzy
 msgid "Number of elements"
 msgstr "方程式數量："
 
-#: ../../src/wxMaxima.cpp:7852 ../../src/wxMaxima.cpp:7874
+#: ../../src/MaximaCommandMenus.cpp:1033 ../../src/MaximaCommandMenus.cpp:1055
 msgid "Number of equations:"
 msgstr "方程式數量："
 
-#: ../../src/wxMaxima.cpp:7481
+#: ../../src/MaximaCommandMenus.cpp:4353
 #, fuzzy
 msgid "Number to octets"
 msgstr "方程式數量："
 
-#: ../../src/wxMaximaFrame.cpp:1154
+#: ../../src/wxMaximaFrame.cpp:1188
 #, fuzzy
 msgid "Number to octets..."
 msgstr "方程式數量："
 
-#: ../../src/wxMaximaFrame.cpp:1906
+#: ../../src/wxMaximaFrame.cpp:1943
 msgid "Number types"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7482
+#: ../../src/MaximaCommandMenus.cpp:4354
 #, fuzzy
 msgid "Number:"
 msgstr "數字"
 
-#: ../../src/wxMaximaFrame.cpp:1786
+#: ../../src/wxMaximaFrame.cpp:1823
 #, fuzzy
 msgid "Numeric output"
 msgstr "切換數值輸出／數式輸出"
 
-#: ../../src/wxMaxima.cpp:8040
+#: ../../src/MaximaCommandMenus.cpp:1224
 msgid "Numerical QR decomposition of a matrix"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1417
+#: ../../src/wxMaximaFrame.cpp:1451
 #, fuzzy
 msgid "Numerical operations (lapack)"
 msgstr "數值積分(&N)"
 
-#: ../../src/wxMaxima.cpp:7831
+#: ../../src/MaximaCommandMenus.cpp:1012
 #, fuzzy
 msgid "Numerical solution for 1st degree ODE"
 msgstr "解 1 階常微分方程的初始值問題"
 
-#: ../../src/wxMaximaFrame.cpp:1282
+#: ../../src/wxMaximaFrame.cpp:1316
 #, fuzzy
 msgid "Numerical solution..."
 msgstr "切換數值輸出／數式輸出"
 
-#: ../../src/wxMaximaFrame.cpp:1261
+#: ../../src/wxMaximaFrame.cpp:1295
 #, fuzzy
 msgid "Numerical solutions of polynomial (bfloat)..."
 msgstr "找多項式所有的根"
 
-#: ../../src/wxMaximaFrame.cpp:1258
+#: ../../src/wxMaximaFrame.cpp:1292
 #, fuzzy
 msgid "Numerical solutions of polynomial..."
 msgstr "找多項式所有的根"
 
-#: ../../src/wxMaxima.cpp:9802 ../../src/wxMaxima.cpp:10161
+#: ../../src/MaximaCommandMenus.cpp:3265 ../../src/MaximaCommandMenus.cpp:3690
+#: ../../src/dialogs/ChangeLogDialog.cpp:131
+#: ../../src/dialogs/LicenseDialog.cpp:90
+#: ../../src/dialogs/MaxSizeChooser.cpp:44
+#: ../../src/dialogs/MaxSizeChooser.cpp:49
+#: ../../src/dialogs/MaximaNotStartingDialog.cpp:68
+#: ../../src/dialogs/MaximaNotStartingDialog.cpp:74
+#: ../../src/dialogs/ResolutionChooser.cpp:39
+#: ../../src/dialogs/ResolutionChooser.cpp:44
+#: ../../src/dialogs/TipOfTheDay.cpp:295
+#: ../../src/wizards/ActualValuesStorageWiz.cpp:60
+#: ../../src/wizards/ActualValuesStorageWiz.cpp:64
+#: ../../src/wizards/BC2Wiz.cpp:47 ../../src/wizards/BC2Wiz.cpp:51
+#: ../../src/wizards/CsvWiz.cpp:64 ../../src/wizards/CsvWiz.cpp:138
+#: ../../src/wizards/DrawWiz.cpp:110 ../../src/wizards/DrawWiz.cpp:221
+#: ../../src/wizards/DrawWiz.cpp:353 ../../src/wizards/DrawWiz.cpp:508
+#: ../../src/wizards/DrawWiz.cpp:567 ../../src/wizards/DrawWiz.cpp:664
+#: ../../src/wizards/DrawWiz.cpp:772 ../../src/wizards/DrawWiz.cpp:848
+#: ../../src/wizards/DrawWiz.cpp:986 ../../src/wizards/Gen1Wiz.cpp:43
+#: ../../src/wizards/Gen1Wiz.cpp:47 ../../src/wizards/Gen2Wiz.cpp:46
+#: ../../src/wizards/Gen2Wiz.cpp:50 ../../src/wizards/Gen3Wiz.cpp:54
+#: ../../src/wizards/Gen3Wiz.cpp:58 ../../src/wizards/Gen4Wiz.cpp:61
+#: ../../src/wizards/Gen4Wiz.cpp:65 ../../src/wizards/Gen5Wiz.cpp:69
+#: ../../src/wizards/Gen5Wiz.cpp:73 ../../src/wizards/GenWizPanel.cpp:106
+#: ../../src/wizards/GenWizPanel.cpp:114 ../../src/wizards/IntegrateWiz.cpp:61
+#: ../../src/wizards/IntegrateWiz.cpp:65 ../../src/wizards/LimitWiz.cpp:49
+#: ../../src/wizards/LimitWiz.cpp:53 ../../src/wizards/ListSortWiz.cpp:76
+#: ../../src/wizards/ListSortWiz.cpp:80 ../../src/wizards/MatWiz.cpp:39
+#: ../../src/wizards/MatWiz.cpp:43 ../../src/wizards/MatWiz.cpp:168
+#: ../../src/wizards/MatWiz.cpp:172 ../../src/wizards/Plot2dWiz.cpp:94
+#: ../../src/wizards/Plot2dWiz.cpp:98 ../../src/wizards/Plot2dWiz.cpp:511
+#: ../../src/wizards/Plot2dWiz.cpp:515 ../../src/wizards/Plot2dWiz.cpp:607
+#: ../../src/wizards/Plot2dWiz.cpp:611 ../../src/wizards/Plot3dWiz.cpp:89
+#: ../../src/wizards/Plot3dWiz.cpp:93 ../../src/wizards/PlotFormatWiz.cpp:47
+#: ../../src/wizards/PlotFormatWiz.cpp:51 ../../src/wizards/SeriesWiz.cpp:49
+#: ../../src/wizards/SeriesWiz.cpp:53 ../../src/wizards/SubstituteWiz.cpp:41
+#: ../../src/wizards/SubstituteWiz.cpp:45 ../../src/wizards/SumWiz.cpp:47
+#: ../../src/wizards/SumWiz.cpp:51 ../../src/wizards/SystemWiz.cpp:38
+#: ../../src/wizards/SystemWiz.cpp:42 ../../src/wizards/WizardHelp.cpp:37
 msgid "OK"
 msgstr "確認"
 
-#: ../../src/wxMaximaFrame.cpp:122
+#: ../../src/wxMaximaFrame.cpp:130
 #, c-format
 msgid "OS: %s Version %li.%li"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8211 ../../src/wxMaxima.cpp:8221
+#: ../../src/MaximaCommandMenus.cpp:1401 ../../src/MaximaCommandMenus.cpp:1411
 #, fuzzy
 msgid "Object composed of elements"
 msgstr "方程式數量："
 
-#: ../../src/wxMaxima.cpp:7680
+#: ../../src/MaximaCommandMenus.cpp:4552
 #, fuzzy
 msgid "Object name:"
 msgstr "串列："
 
-#: ../../src/wxMaxima.cpp:7281
+#: ../../src/MaximaCommandMenus.cpp:4153
 #, fuzzy
 msgid "Object:"
 msgstr "串列："
 
-#: ../../src/wxMaxima.cpp:7486
+#: ../../src/MaximaCommandMenus.cpp:4358
 msgid "Octets to Number"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7491
+#: ../../src/MaximaCommandMenus.cpp:4363
 msgid "Octets to String"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1156
+#: ../../src/wxMaximaFrame.cpp:1190
 msgid "Octets to number..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1158
+#: ../../src/wxMaximaFrame.cpp:1192
 #, fuzzy
 msgid "Octets to string..."
 msgstr "數式"
 
-#: ../../src/wxMaxima.cpp:7487 ../../src/wxMaxima.cpp:7492
+#: ../../src/MaximaCommandMenus.cpp:4359 ../../src/MaximaCommandMenus.cpp:4364
 msgid "Octets:"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1958
+#: ../../src/worksheet/WorksheetContextMenu.cpp:730
 msgid "Odd number"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8900 ../../src/wxMaxima.cpp:8921
-#: ../../src/wxMaxima.cpp:8999 ../../src/wxMaxima.cpp:9005
+#: ../../src/dialogs/ConfigDialogue.cpp:910
+msgid "Offer answers for questions known from previous runs"
+msgstr ""
+
+#: ../../src/cells/TextCell.cpp:332
+msgid "Often caused by recursive function calls. Some lisps allow increasing the control stack size using command-line arguments."
+msgstr ""
+
+#: ../../src/wizards/SubstituteWiz.cpp:32
+msgid "Old value:"
+msgstr "舊值："
+
+#: ../../src/MaximaCommandMenus.cpp:151 ../../src/MaximaCommandMenus.cpp:172
+#: ../../src/MaximaCommandMenus.cpp:253 ../../src/MaximaCommandMenus.cpp:259
 msgid "Old variable:"
 msgstr "舊變數："
 
-#: ../../src/wxMaximaFrame.cpp:1055
+#: ../../src/sidebars/GreekSidebar.cpp:201
+msgid "Omega"
+msgstr ""
+
+#: ../../src/sidebars/GreekSidebar.cpp:192
+msgid "Omicron"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1089
 #, fuzzy
 msgid "On all errors"
 msgstr "嚴重錯誤"
 
-#: ../../src/wxMaximaFrame.cpp:1054
+#: ../../src/wxMaximaFrame.cpp:1088
 msgid "On lisp errors"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:9566
+#: ../../src/MaximaCommandMenus.cpp:1804
 msgid "One sample t-test"
 msgstr "單樣本 t-檢驗"
 
-#: ../../src/wxMaximaFrame.cpp:1927
+#: ../../src/wxMaximaFrame.cpp:1964
 msgid "Online tutorials"
 msgstr "線上教材"
 
-#: ../../src/wxMaximaFrame.cpp:766
+#: ../../src/wxMaximaFrame.cpp:803
 msgid "Only Integers and single letters"
 msgstr ""
 
-#: ../../src/ToolBar.cpp:176 ../../src/main.cpp:593 ../../src/wxMaxima.cpp:6074
+#: ../../src/dialogs/ConfigDialogue.cpp:771
+msgid "Only user-defined labels"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:2197 ../../src/ToolBar.cpp:330
+#: ../../src/ToolBar.cpp:333 ../../src/main.cpp:882
 msgid "Open"
 msgstr "開啟"
 
-#: ../../src/wxMaximaFrame.cpp:598
+#: ../../src/dialogs/ConfigDialogue.cpp:905
+msgid "Open a cell when Maxima expects input"
+msgstr "當 Maxima 期望輸入時新增單元"
+
+#: ../../src/wxMaximaFrame.cpp:629
 msgid "Open a document"
 msgstr "開啟文件"
 
-#: ../../src/wxMaximaFrame.cpp:597
+#: ../../src/wxMaximaFrame.cpp:628
 msgid "Open a new window"
 msgstr "開新視窗"
 
-#: ../../src/ToolBar.cpp:617
+#: ../../src/ToolBar.cpp:817
 msgid "Open and save button"
 msgstr ""
 
-#: ../../src/ToolBar.cpp:176
+#: ../../src/ToolBar.cpp:330 ../../src/ToolBar.cpp:333
 msgid "Open document"
 msgstr "開啟文件"
 
-#: ../../src/wxMaxima.cpp:7239
+#: ../../src/MaximaCommandMenus.cpp:4111
 msgid "Open for appending"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1099
+#: ../../src/wxMaximaFrame.cpp:1133
 msgid "Open for appending..."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7244
+#: ../../src/MaximaCommandMenus.cpp:4116
 msgid "Open for reading"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1098
+#: ../../src/wxMaximaFrame.cpp:1132
 #, fuzzy
 msgid "Open for reading..."
 msgstr "數式"
 
-#: ../../src/wxMaxima.cpp:7249
+#: ../../src/MaximaCommandMenus.cpp:4121
 msgid "Open for writing"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1100
+#: ../../src/wxMaximaFrame.cpp:1134
 #, fuzzy
 msgid "Open for writing..."
 msgstr "匯出(&E)..."
 
-#: ../../src/wxMaxima.cpp:9598
+#: ../../src/MaximaCommandMenus.cpp:1838
 msgid "Open matrix"
 msgstr "開啟矩陣"
 
-#: ../../src/wxMaximaFrame.cpp:600
+#: ../../src/wxMaximaFrame.cpp:631
 #, fuzzy
 msgid "Open recent"
 msgstr "最近開啟的文件"
 
-#: ../../src/wxMaxima.cpp:4309
+#: ../../src/MaximaFileIO.cpp:231
 msgid "Opening a wxmx file"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:4153 ../../src/wxMaxima.cpp:4214
-#: ../../src/wxMaxima.cpp:4313 ../../src/wxMaxima.cpp:4622
+#: ../../src/MaximaFileIO.cpp:54 ../../src/MaximaFileIO.cpp:113
+#: ../../src/MaximaFileIO.cpp:235 ../../src/MaximaFileIO.cpp:545
 msgid "Opening file"
 msgstr "正在開啟檔案"
 
-#: ../../src/wxMaxima.cpp:5030
+#: ../../src/sidebars/HelpBrowser.cpp:175 ../../src/wxMaxima.cpp:1808
 #, c-format
 msgid "Opening help file %s"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1530
+#: ../../src/wxMaximaFrame.cpp:1567
 msgid "Optimize for CPU time"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1529
+#: ../../src/wxMaximaFrame.cpp:1566
 msgid "Optimize for memory"
 msgstr ""
 
-#: ../../src/ToolBar.cpp:199
+#: ../../src/wizards/DrawWiz.cpp:97
+msgid "Optional: A 2nd expression that defines a region to fill"
+msgstr ""
+
+#: ../../src/ToolBar.cpp:367 ../../src/ToolBar.cpp:369
+#: ../../src/dialogs/ConfigDialogue.cpp:284
 msgid "Options"
 msgstr "選項"
 
-#: ../../src/wxMaximaFrame.cpp:1225
+#: ../../src/wizards/Plot2dWiz.cpp:75 ../../src/wizards/Plot3dWiz.cpp:66
+msgid "Options:"
+msgstr "選項："
+
+#: ../../src/dialogs/FindReplacePane.cpp:109
+msgid "Output"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1259
 #, fuzzy
 msgid "Output C"
 msgstr "輸出標籤"
 
-#: ../../src/wxMaximaFrame.cpp:1226
+#: ../../src/wxMaximaFrame.cpp:1260
 msgid "Output Fortran"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1228
+#: ../../src/wxMaximaFrame.cpp:1262
 msgid "Output Rational Fortran"
 msgstr ""
 
-#: ../../src/Configuration.cpp:80
+#: ../../src/Styles.cpp:109
 msgid "Output labels"
 msgstr "輸出標籤"
 
-#: ../../src/Configuration.cpp:73
+#: ../../src/Styles.cpp:102
 #, fuzzy
 msgid "Output: Function names"
 msgstr "函數名"
 
-#: ../../src/Configuration.cpp:75
+#: ../../src/Styles.cpp:104
 msgid "Output: Latin names as greek symbols"
 msgstr ""
 
-#: ../../src/Configuration.cpp:72
+#: ../../src/Styles.cpp:101
 msgid "Output: Numbers and Digits"
 msgstr ""
 
-#: ../../src/Configuration.cpp:71
+#: ../../src/Styles.cpp:100
 #, fuzzy
 msgid "Output: Operators"
 msgstr "輸出標籤"
 
-#: ../../src/Configuration.cpp:74
+#: ../../src/Styles.cpp:103
 #, fuzzy, c-format
 msgid "Output: Special constants (%e,%i)"
 msgstr "特殊常數"
 
-#: ../../src/Configuration.cpp:76
+#: ../../src/Styles.cpp:105
 #, fuzzy
 msgid "Output: Strings"
 msgstr "字串"
 
-#: ../../src/Configuration.cpp:70
+#: ../../src/Styles.cpp:99
 #, fuzzy
 msgid "Output: Variable names"
 msgstr "舊變數："
 
-#: ../../src/wxMaxima.cpp:6442
-msgid "PNG image (*.png)|*.png|JPEG image (*.jpg)|*.jpg|GIF image (*.gif)|*.gif|Scaleable vector graphics (*.svg)|*.svg|Windows bitmap (*.bmp)|*.bmp|Portable anymap (*.pnm)|*.pnm|Tagged image file format (*.tif)|*.tif|X pixmap (*.xpm)|*.xpm"
+#: ../../src/dialogs/ConfigDialogue.cpp:839
+msgid "Overlay scrollbars (slow: repaints the worksheet while they fade)"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:10117
-msgid "PNG image (*.png)|*.png|JPEG image (*.jpg)|*.jpg|Windows bitmap (*.bmp)|*.bmp|GIF image (*.gif)|*.gif|Portable anymap (*.pnm)|*.pnm|Tagged image file format (*.tif)|*.tif|X pixmap (*.xpm)|*.xpm"
+#: ../../src/MaximaCommandMenus.cpp:3609
+msgid "PNG image (*.png)|*.png|JPEG image (*.jpg)|*.jpg|Windows bitmap (*.bmp)|*.bmp|"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8924
+#: ../../src/dialogs/ConfigDialogue.cpp:458
+msgid "PNG images can be read by old wxMaxima versions - but aren't really scalable."
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:175
 msgid "Pade approximation"
 msgstr "Pade 近似"
 
-#: ../../src/wxMaximaFrame.cpp:1478
+#: ../../src/wxMaximaFrame.cpp:1515
 msgid "Pade approximation of a Taylor series"
 msgstr "計算 Taylor 級數的 Pade 近似"
 
-#: ../../src/wxMaximaFrame.cpp:1637
+#: ../../src/sidebars/FormatSidebar.cpp:69
+msgid "Pagebreak"
+msgstr "換頁符號"
+
+#: ../../src/wxMaximaFrame.cpp:1674
 #, fuzzy
 msgid "Parallel Substitute..."
 msgstr "代換..."
 
-#: ../../src/wxMaxima.cpp:8738
+#: ../../src/MaximaCommandMenus.cpp:735
 msgid "Parallel substitution"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7179
+#: ../../src/sidebars/SymbolsSidebar.cpp:124
+msgid "Parallel to"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:4051
 #, fuzzy
 msgid "Parameter name:"
 msgstr "矩陣名："
 
-#: ../../src/wxMaxima.cpp:7136 ../../src/wxMaxima.cpp:7149
+#: ../../src/MaximaCommandMenus.cpp:4008 ../../src/MaximaCommandMenus.cpp:4021
 #, fuzzy
 msgid "Parameter(s):"
 msgstr "變數："
 
-#: ../../src/wxMaxima.cpp:7399
+#: ../../src/sidebars/DrawSidebar.cpp:64
+#, fuzzy
+msgid "Parametric Plot"
+msgstr "參數式繪圖"
+
+#: ../../src/wizards/Plot2dWiz.cpp:417 ../../src/wizards/Plot2dWiz.cpp:523
+msgid "Parametric plot"
+msgstr "參數式繪圖"
+
+#: ../../src/MaximaCommandMenus.cpp:4271
 msgid "Parse string"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1152
+#: ../../src/wxMaximaFrame.cpp:1186
 #, fuzzy
 msgid "Parse string only..."
 msgstr "輸入矩陣..."
 
-#: ../../src/StatusBar.cpp:240
+#: ../../src/StatusBar.cpp:308
 msgid "Parsing output"
 msgstr "解析輸出中"
 
-#: ../../src/wxMaxima.cpp:7464
+#: ../../src/MaximaCommandMenus.cpp:4336
 msgid "Part:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1499 ../../src/wxMaximaFrame.cpp:1535
+#: ../../src/wxMaximaFrame.cpp:1536 ../../src/wxMaximaFrame.cpp:1572
 msgid "Partial &Fractions..."
 msgstr "部分分式(&F)..."
 
-#: ../../src/wxMaxima.cpp:8975
+#: ../../src/MaximaCommandMenus.cpp:229
 #, fuzzy
 msgid "Partial Fractions"
 msgstr "部分分式"
 
-#: ../../src/wxMaxima.cpp:4702
-msgid "Parts of the document will not be loaded correctly!"
-msgstr "文件的某部分將無法被正確的讀取！"
-
-#: ../../src/ToolBar.cpp:210 ../../src/Worksheet.cpp:1654
-#: ../../src/Worksheet.cpp:1685
+#: ../../src/ToolBar.cpp:381 ../../src/ToolBar.cpp:385
+#: ../../src/worksheet/WorksheetContextMenu.cpp:427
+#: ../../src/worksheet/WorksheetContextMenu.cpp:458
 msgid "Paste"
 msgstr "貼上"
 
-#: ../../src/wxMaximaFrame.cpp:667
+#: ../../src/wxMaximaFrame.cpp:704
 msgid "Paste\tCtrl+V"
 msgstr "貼上\tCtrl+V"
 
-#: ../../src/ToolBar.cpp:211
+#: ../../src/ToolBar.cpp:381 ../../src/ToolBar.cpp:385
 msgid "Paste from clipboard"
 msgstr "從剪貼簿貼上"
 
-#: ../../src/wxMaximaFrame.cpp:668
+#: ../../src/wxMaximaFrame.cpp:705
 msgid "Paste text from clipboard"
 msgstr "從剪貼簿貼上文字"
 
-#: ../../src/wxMaxima.cpp:4841
+#: ../../src/wxMaximaFrame.cpp:272 ../../src/wxMaximaFrame.cpp:759
+msgid "Performance Monitor"
+msgstr ""
+
+#: ../../src/Configuration.cpp:1383
+msgid "Performance Statistics:"
+msgstr ""
+
+#: ../../src/sidebars/SymbolsSidebar.cpp:125
+msgid "Perpendicular to"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:218
+msgid "Persian"
+msgstr ""
+
+#: ../../src/sidebars/GreekSidebar.cpp:198
+msgid "Phi"
+msgstr ""
+
+#: ../../src/sidebars/GreekSidebar.cpp:193
+msgid "Pi"
+msgstr ""
+
+#: ../../src/sidebars/StatSidebar.cpp:94
+msgid "Piechart..."
+msgstr "圓餅圖..."
+
+#: ../../src/wxMaxima.cpp:1587
 msgid "Please configure wxMaxima with 'Edit->Configure'."
 msgstr "請從「編輯(E)」->「設定(O)」設定 wxMaxima"
 
-#: ../../src/wxMaximaFrame.cpp:1768
+#: ../../src/dialogs/ConfigDialogue.cpp:2606
+msgid "Please restart wxMaxima for changes to take effect!"
+msgstr "請重新啟動 wxMaxima 使變更生效！"
+
+#: ../../src/MaximaCommandMenus.cpp:2250
+msgid "Please select exactly 2 or 3 files."
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1805
 msgid "Plot &2d..."
 msgstr "二維繪圖(&2)..."
 
-#: ../../src/wxMaximaFrame.cpp:1770
+#: ../../src/wxMaximaFrame.cpp:1807
 msgid "Plot &3d..."
 msgstr "三維繪圖(&3)..."
 
-#: ../../src/wxMaximaFrame.cpp:1772
+#: ../../src/wxMaximaFrame.cpp:1809
 msgid "Plot &Format..."
 msgstr "繪圖格式(&F)..."
 
-#: ../../src/wxMaxima.cpp:9101 ../../src/wxMaxima.cpp:10068
+#: ../../src/MaximaCommandMenus.cpp:107 ../../src/MaximaCommandMenus.cpp:3557
+#: ../../src/wizards/Plot2dWiz.cpp:108 ../../src/wizards/Plot2dWiz.cpp:428
+#: ../../src/wizards/Plot2dWiz.cpp:441
 msgid "Plot 2D"
 msgstr "二維繪圖"
 
-#: ../../src/Worksheet.cpp:1593
+#: ../../src/sidebars/MathSidebar.cpp:89
+#: ../../src/worksheet/WorksheetContextMenu.cpp:366
 msgid "Plot 2D..."
 msgstr "二維繪圖..."
 
-#: ../../src/wxMaxima.cpp:9078 ../../src/wxMaxima.cpp:10079
+#: ../../src/MaximaCommandMenus.cpp:85 ../../src/MaximaCommandMenus.cpp:3568
+#: ../../src/wizards/Plot3dWiz.cpp:103
 msgid "Plot 3D"
 msgstr "三維繪圖"
 
-#: ../../src/Worksheet.cpp:1595
+#: ../../src/sidebars/MathSidebar.cpp:92
+#: ../../src/worksheet/WorksheetContextMenu.cpp:368
 msgid "Plot 3D..."
 msgstr "三維繪圖..."
 
-#: ../../src/wxMaxima.cpp:9538
+#: ../../src/wizards/DrawWiz.cpp:713
+msgid "Plot a parametric curve"
+msgstr ""
+
+#: ../../src/wizards/DrawWiz.cpp:45 ../../src/wizards/DrawWiz.cpp:148
+#: ../../src/wizards/DrawWiz.cpp:255
+#, fuzzy
+msgid "Plot an explicit expression"
+msgstr "求數式的極限"
+
+#: ../../src/wizards/DrawWiz.cpp:53
+msgid "Plot an expression, for example sin(x) or (x+1)^2."
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:1776
 msgid "Plot as bars"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:9542
-msgid "Plot as error bars"
-msgstr ""
-
-#: ../../src/wxMaxima.cpp:9546
+#: ../../src/MaximaCommandMenus.cpp:1784
 msgid "Plot as pie chart"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:9112
+#: ../../src/MaximaCommandMenus.cpp:118
 msgid "Plot format"
 msgstr "繪圖格式"
 
-#: ../../src/wxMaximaFrame.cpp:1768
+#: ../../src/wxMaximaFrame.cpp:1805
 msgid "Plot in 2 dimensions"
 msgstr "二維繪圖"
 
-#: ../../src/wxMaximaFrame.cpp:1770
+#: ../../src/wxMaximaFrame.cpp:1807
 msgid "Plot in 3 dimensions"
 msgstr "三維繪圖"
 
-#: ../../src/wxMaximaFrame.cpp:320 ../../src/wxMaximaFrame.cpp:714
+#: ../../src/sidebars/DrawSidebar.cpp:83
+msgid "Plot name"
+msgstr ""
+
+#: ../../src/wizards/Plot2dWiz.cpp:84 ../../src/wizards/Plot3dWiz.cpp:80
+msgid "Plot to file:"
+msgstr "繪圖存檔："
+
+#: ../../src/wxMaximaFrame.cpp:341 ../../src/wxMaximaFrame.cpp:749
 msgid "Plot using Draw"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7824
+#: ../../src/MaximaCommandMenus.cpp:1005
 msgid "Point #1 with known value:"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7826
+#: ../../src/MaximaCommandMenus.cpp:1007
 msgid "Point #2 with known value:"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7800 ../../src/wxMaxima.cpp:7811
+#: ../../src/MaximaCommandMenus.cpp:981 ../../src/MaximaCommandMenus.cpp:992
 msgid "Point the value is known at:"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7909 ../../src/wxMaxima.cpp:8935
+#: ../../src/wizards/DrawWiz.cpp:842
+#, fuzzy
+msgid "Point type:"
+msgstr "點："
+
+#: ../../src/MaximaCommandMenus.cpp:186 ../../src/MaximaCommandMenus.cpp:1090
+#: ../../src/wizards/BC2Wiz.cpp:33 ../../src/wizards/BC2Wiz.cpp:39
+#: ../../src/wizards/LimitWiz.cpp:35 ../../src/wizards/SeriesWiz.cpp:36
 msgid "Point:"
 msgstr "點："
 
-#: ../../src/wxMaxima.cpp:8961 ../../src/wxMaxima.cpp:8966
-#: ../../src/wxMaxima.cpp:8971
+#: ../../src/sidebars/DrawSidebar.cpp:67
+msgid "Points"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:219
+msgid "Polish"
+msgstr "Polish"
+
+#: ../../src/MaximaCommandMenus.cpp:215 ../../src/MaximaCommandMenus.cpp:220
+#: ../../src/MaximaCommandMenus.cpp:225
 msgid "Polynomial 1:"
 msgstr "多項式 1："
 
-#: ../../src/wxMaxima.cpp:8961 ../../src/wxMaxima.cpp:8966
-#: ../../src/wxMaxima.cpp:8971
+#: ../../src/MaximaCommandMenus.cpp:215 ../../src/MaximaCommandMenus.cpp:220
+#: ../../src/MaximaCommandMenus.cpp:225
 msgid "Polynomial 2:"
 msgstr "多項式 2："
 
-#: ../../src/wxMaxima.cpp:7713 ../../src/wxMaxima.cpp:7724
-#: ../../src/wxMaxima.cpp:7739
+#: ../../src/MaximaCommandMenus.cpp:896 ../../src/MaximaCommandMenus.cpp:906
+#: ../../src/MaximaCommandMenus.cpp:920
 #, fuzzy
 msgid "Polynomial:"
 msgstr "多項式 1："
 
-#: ../../src/wxMaximaFrame.cpp:1754
+#: ../../src/wxMaximaFrame.cpp:1791
 msgid "Pop"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1331 ../../src/Worksheet.cpp:1485
+#: ../../src/worksheet/WorksheetContextMenu.cpp:93
+#: ../../src/worksheet/WorksheetContextMenu.cpp:256
 msgid "Popout interactively"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1189
+#: ../../src/MaximaCommandMenus.cpp:3605
+msgid "Portable anymap (*.pnm)|*.pnm|Tagged image file format (*.tif)|*.tif|X pixmap (*.xpm)|*.xpm"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:220
+msgid "Portuguese"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:221
+msgid "Portuguese (Brazilian)"
+msgstr "Portuguese (Brazilian)"
+
+#: ../../src/wxMaximaFrame.cpp:1223
 msgid "Position of a match"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7220 ../../src/wxMaxima.cpp:7391
+#: ../../src/MaximaCommandMenus.cpp:4092 ../../src/MaximaCommandMenus.cpp:4263
 #, fuzzy
 msgid "Position:"
 msgstr "條件："
 
-#: ../../src/wxMaxima.cpp:8939
+#: ../../src/dialogs/DiffFrame.cpp:51
+msgid "Positions of the differences. Click to jump to one."
+msgstr ""
+
+#: ../../src/wizards/Plot2dWiz.cpp:474 ../../src/wizards/Plot3dWiz.cpp:422
+msgid "Postscript file (*.eps)|*.eps|All|*"
+msgstr "Postscript 檔 (*.eps)|*.eps|所有類型|*"
+
+#: ../../src/MaximaCommandMenus.cpp:190
 #, fuzzy
 msgid "Power series"
 msgstr "冪級數(&P)"
 
-#: ../../src/wxMaximaFrame.cpp:1475
+#: ../../src/wxMaximaFrame.cpp:1512
 #, fuzzy
 msgid "Power series..."
 msgstr "冪級數(&P)"
 
-#: ../../src/wxMaxima.cpp:9202
+#: ../../src/MaximaCommandMenus.cpp:393
 msgid "Precision"
 msgstr "精確度"
 
-#: ../../src/Worksheet.cpp:1616
+#: ../../src/dialogs/ConfigDialogue.cpp:787
+msgid "Prefer 1D"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1492
+msgid "Prefer the all-in-one-file >1000 page manual"
+msgstr ""
+
+#: ../../src/worksheet/WorksheetContextMenu.cpp:389
 msgid "Prefer user labels"
 msgstr ""
 
-#: ../../src/main.cpp:437
+#: ../../src/main.cpp:676
 #, fuzzy
 msgid "Preferences"
 msgstr "偏好設定...\tCTRL+,"
 
-#: ../../src/ToolBar.cpp:626
+#: ../../src/ToolBar.cpp:826
 msgid "Preferences button"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:685
+#: ../../src/wxMaximaFrame.cpp:722
 #, fuzzy
 msgid "Preferences...\tCtrl+,"
 msgstr "偏好設定...\tCTRL+,"
 
-#: ../../src/wxMaximaFrame.cpp:1733
+#: ../../src/wxMaximaFrame.cpp:1770
 #, fuzzy
 msgid "Prepend an element"
 msgstr "開啟文件"
 
-#: ../../src/wxMaximaFrame.cpp:927
+#: ../../src/ToolBar.cpp:266 ../../src/sidebars/CharButton.cpp:137
+msgid "Press"
+msgstr ""
+
+#: ../../src/dialogs/TipOfTheDay.cpp:146
+msgid "Pressing Ctrl+Space or Ctrl+Tab starts an autocomplete function that can not only complete all functions that are integrated into the Maxima core and their parameters: It also knows about parameters from currently loaded packages and from functions that are defined in the current file."
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:961
 msgid "Previous Command\tAlt+Up"
 msgstr "上一個命令\tAlt+Up"
 
-#: ../../src/ToolBar.cpp:184
+#: ../../src/dialogs/DiffFrame.cpp:404
+msgid "Previous Difference"
+msgstr ""
+
+#: ../../src/ToolBar.cpp:343 ../../src/ToolBar.cpp:345
 msgid "Print"
 msgstr "列印"
 
-#: ../../src/ToolBar.cpp:620
+#: ../../src/dialogs/ConfigDialogue.cpp:1988
+#, fuzzy
+msgid "Print Margins"
+msgstr "列印"
+
+#: ../../src/ToolBar.cpp:820
 msgid "Print button"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1493
+#: ../../src/worksheet/WorksheetContextMenu.cpp:264
 #, fuzzy
 msgid "Print cell brackets"
 msgstr "作用中的單元框"
 
-#: ../../src/ToolBar.cpp:184 ../../src/wxMaximaFrame.cpp:622
+#: ../../src/ToolBar.cpp:343 ../../src/ToolBar.cpp:345
+#: ../../src/wxMaximaFrame.cpp:655
 msgid "Print document"
 msgstr "列印文件"
 
-#: ../../src/wxMaximaFrame.cpp:1829
+#: ../../src/wxMaximaFrame.cpp:1866
 msgid "Print floating-point numbers with exponents dividable by 3"
 msgstr ""
 
-#: ../../src/WXMXformat.cpp:255
-msgid "Produced invalid XML. The erroneous XML data has therefore not been saved but has been put on the clipboard in order to allow to debug it."
+#: ../../src/dialogs/ConfigDialogue.cpp:1968
+#, fuzzy
+msgid "Print scale:"
+msgstr "列印文件"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1981
+msgid "Print the cell brackets [drawn to their left]"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:9061
+#: ../../src/dialogs/ConfigDialogue.cpp:287
+#, fuzzy
+msgid "Printout settings"
+msgstr "匯出為 TeX 失敗！"
+
+#: ../../src/graphical_io/Printout.cpp:208
+msgid "Printout: Cannot find a suitable point for a page break!"
+msgstr ""
+
+#: ../../src/graphical_io/Printout.cpp:162
+msgid "Printout: Composing a list of all line starts as possible locations for page breaks"
+msgstr ""
+
+#: ../../src/graphical_io/Printout.cpp:279
+msgid "Printout: Layouting the whole worksheet as a endless scroll of the width of the paper"
+msgstr ""
+
+#: ../../src/graphical_io/Printout.cpp:201
+#, c-format
+msgid "Printout: PageStart=%li, PageHeight=%li, canvasSize=%li"
+msgstr ""
+
+#: ../../src/graphical_io/Printout.cpp:235
+#, c-format
+msgid "Printout: Print ppi: %lix%li"
+msgstr ""
+
+#: ../../src/graphical_io/Printout.cpp:134
+#, c-format
+msgid "Printout: Printing the region %li-%li"
+msgstr ""
+
+#: ../../src/graphical_io/Printout.cpp:76
+#, c-format
+msgid "Printout: Request to print page %li"
+msgstr ""
+
+#: ../../src/graphical_io/Printout.cpp:240
+#, c-format
+msgid "Printout: Scalefactor: %ex%e"
+msgstr ""
+
+#: ../../src/graphical_io/Printout.cpp:112
+#, c-format
+msgid "Printout: Setting the device origin to %lix%li"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:936
+#, fuzzy
+msgid "Privacy settings"
+msgstr "匯出為 TeX 失敗！"
+
+#: ../../src/WXMXformat.cpp:256
+msgid ""
+"Produced invalid XML. The erroneous XML data has therefore not been saved but has been put on the clipboard in order to allow debugging it.\n"
+"Try saving the document in wxm format. Or maybe it helps to remove all output before saving the file, if the conversion of the output causes the problem."
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:315
 msgid "Product"
 msgstr "乘積"
 
-#: ../../src/wxMaximaFrame.cpp:1095
+#: ../../src/sidebars/SymbolsSidebar.cpp:123
+#, fuzzy
+msgid "Product sign"
+msgstr "乘積"
+
+#: ../../src/wxMaximaFrame.cpp:1129
 #, fuzzy
 msgid "Program"
 msgstr "直方圖"
 
-#: ../../src/wxMaxima.cpp:7061
+#: ../../src/MaximaCommandMenus.cpp:3933
 #, fuzzy
 msgid "Program (no local variables)"
 msgstr "變數變換"
 
-#: ../../src/wxMaxima.cpp:7052
+#: ../../src/MaximaCommandMenus.cpp:3924
 msgid "Program block"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1066
+#: ../../src/wxMaximaFrame.cpp:1100
 msgid "Program block with local variables..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1068
+#: ../../src/wxMaximaFrame.cpp:1102
 msgid "Program block, no local variables..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1751
+#: ../../src/sidebars/GreekSidebar.cpp:200
+msgid "Psi"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1788
 msgid "Push"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8508
+#: ../../src/MaximaCommandMenus.cpp:1514
 #, fuzzy
 msgid "Push an element to a list"
 msgstr "從數式產生串列"
 
-#: ../../src/wxMaximaFrame.cpp:1395
+#: ../../src/wxMaximaFrame.cpp:1429
 msgid "QR decomposition"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3621
+#: ../../src/MaximaResponseReader.cpp:845
 msgid "Querying gnuplot which graphics drivers it supports."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8953
+#: ../../src/wxMaximaFrame.cpp:658
+msgid "Quit wxMaxima"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1910
+msgid "RTF with OMML maths"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:207
 msgid "Range radius:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1374
+#: ../../src/wxMaximaFrame.cpp:1408
 msgid "Rank"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:246 ../../src/wxMaximaFrame.cpp:722
+#: ../../src/wxMaximaFrame.cpp:260 ../../src/wxMaximaFrame.cpp:757
 msgid "Raw XML monitor"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:2117
+#: ../../src/wxMaximaFrame.cpp:2168
 #, c-format
 msgid "Re-Reading the config from %s."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:2114
+#: ../../src/wxMaximaFrame.cpp:2165
 msgid "Re-Reading the config from the default location."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:867
+#: ../../src/wxMaximaFrame.cpp:901
 #, fuzzy
 msgid "Re-evaluate all cells above the one the cursor is in"
 msgstr "評算這份文件中的所有單元"
 
-#: ../../src/wxMaximaFrame.cpp:877
+#: ../../src/wxMaximaFrame.cpp:911
 #, fuzzy
 msgid "Re-evaluate all cells below the one the cursor is in"
 msgstr "評算這份文件中的所有單元"
 
-#: ../../src/main.cpp:366
+#: ../../src/main.cpp:605
 msgid "Re-opening STDERR failed."
 msgstr ""
 
-#: ../../src/main.cpp:367
+#: ../../src/main.cpp:606
 #, fuzzy
 msgid "Re-opening STDIN failed."
 msgstr "正在開啟檔案"
 
-#: ../../src/main.cpp:365
+#: ../../src/main.cpp:604
 msgid "Re-opening STDOUT failed."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7512
+#: ../../src/wxMaxima.cpp:2889
+#, c-format
+msgid "Re-pointed the .wxmx file association at %s"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:4384
 msgid "Re-using a compiled regex is faster that using the same regex string multiple times."
 msgstr ""
 
-#: ../../src/Worksheet.cpp:6668
+#: ../../src/worksheet/Worksheet.cpp:4659
 #, fuzzy
 msgid "Read .wxm data from clipboard"
 msgstr "從剪貼簿貼上文字"
 
-#: ../../src/wxMaxima.cpp:7599
+#: ../../src/MaximaCommandMenus.cpp:4471
 msgid "Read Directory"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1677
-#, fuzzy
-msgid "Read List from csv file..."
-msgstr "自檔案載入樣式"
+#: ../../src/sidebars/StatSidebar.cpp:103
+msgid "Read Matrix..."
+msgstr "讀取矩陣..."
 
-#: ../../src/wxMaxima.cpp:7196
+#: ../../src/MaximaCommandMenus.cpp:4068
 msgid "Read a structure field"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7270 ../../src/wxMaxima.cpp:7274
+#: ../../src/MaximaCommandMenus.cpp:4142 ../../src/MaximaCommandMenus.cpp:4146
 msgid "Read byte"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7266
+#: ../../src/MaximaCommandMenus.cpp:4138
 #, fuzzy
 msgid "Read char"
 msgstr "讀取矩陣..."
 
-#: ../../src/wxMaxima.cpp:7593
+#: ../../src/dialogs/ConfigDialogue.cpp:2488
+#, fuzzy
+msgid "Read config to file"
+msgstr "儲存選取區域至檔案"
+
+#: ../../src/MaximaCommandMenus.cpp:4465
 #, fuzzy
 msgid "Read environment variable"
 msgstr "附加參數："
 
-#: ../../src/wxMaximaFrame.cpp:1219
+#: ../../src/wxMaximaFrame.cpp:1253
 #, fuzzy
 msgid "Read environment variable..."
 msgstr "刪除變數"
 
-#: ../../src/wxMaxima.cpp:7262
+#: ../../src/MaximaCommandMenus.cpp:4134
 msgid "Read line"
 msgstr ""
 
-#: ../../src/MaximaManual.cpp:113
+#: ../../src/wxMaximaFrame.cpp:1714
+msgid "Read nested list from csv file..."
+msgstr ""
+
+#: ../../src/MaximaManual.cpp:114
 #, c-format
 msgid "Read the entries the maxima manual offers from %s"
 msgstr ""
 
-#: ../../src/StatusBar.cpp:245
+#: ../../src/StatusBar.cpp:318
 msgid "Reading Maxima output"
 msgstr "正在讀取 Maxima 的輸出"
 
-#: ../../src/StatusBar.cpp:247
+#: ../../src/StatusBar.cpp:320
 #, c-format
 msgid "Reading Maxima output: %li bytes"
 msgstr ""
@@ -5726,527 +8588,794 @@ msgstr ""
 msgid "Reading the Lisp part of wxMaxima from the included header file."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:148
+#: ../../src/wxMaximaFrame.cpp:156
 #, c-format
 msgid "Reading the config from %s."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:151
+#: ../../src/wxMaximaFrame.cpp:159
 msgid "Reading the config from the default location."
 msgstr ""
 
-#: ../../src/StatusBar.cpp:224
+#: ../../src/StatusBar.cpp:272
 msgid "Ready for user input"
 msgstr "準備就緒"
 
-#: ../../src/Worksheet.cpp:960
-msgid "Recalculated the whole worksheet at once => Updating its size"
+#: ../../src/sidebars/PerformanceSidebar.cpp:43
+msgid "Recalc (Cells appended):"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:946
-msgid "Recalculation hit the end of the worksheet => Updating its size"
+#: ../../src/sidebars/PerformanceSidebar.cpp:42
+msgid "Recalc (Config changed):"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:930
+#: ../../src/sidebars/PerformanceSidebar.cpp:44
+msgid "Recalc (Editor dirty):"
+msgstr ""
+
+#: ../../src/sidebars/PerformanceSidebar.cpp:39
+msgid "Recalc (Font invalid):"
+msgstr ""
+
+#: ../../src/sidebars/PerformanceSidebar.cpp:41
+msgid "Recalc (Font mismatch):"
+msgstr ""
+
+#: ../../src/sidebars/PerformanceSidebar.cpp:40
+msgid "Recalc (Size invalid):"
+msgstr ""
+
+#: ../../src/worksheet/WorksheetLayout.cpp:162
+#, c-format
+msgid "Recalculated the whole worksheet at once => Updating its size (Visited %d cells, recalculated %d, in %ld ms)"
+msgstr ""
+
+#: ../../src/worksheet/WorksheetLayout.cpp:125
+#, c-format
+msgid "Recalculation covered the whole dirty range => stopping early (Visited %d cells, recalculated %d, in %ld ms)"
+msgstr ""
+
+#: ../../src/worksheet/WorksheetLayout.cpp:146
+#, c-format
+msgid "Recalculation hit the end of the worksheet => Updating its size (Visited %d cells, recalculated %d, in %ld ms)"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:964
 msgid "Recall next command from history"
 msgstr "呼叫歷史記錄中的下一個命令"
 
-#: ../../src/wxMaximaFrame.cpp:928
+#: ../../src/wxMaximaFrame.cpp:962
 msgid "Recall previous command from history"
 msgstr "呼叫歷史紀錄中的上一個命令"
 
-#: ../../src/wxMaxima.cpp:3235
+#: ../../src/MaximaResponseReader.cpp:138
 #, c-format
 msgid "Received manual topic request: %s"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3097
+#: ../../src/MaximaResponseReader.cpp:237
 #, c-format
 msgid "Received maxima's first prompt: %s"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:603
+#: ../../src/dialogs/ConfigDialogue.cpp:1327
+msgid "Recent files list length:"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:634
 #, fuzzy
 msgid "Recover unsaved"
 msgstr "未儲存"
 
-#: ../../src/wxMaximaFrame.cpp:1640
+#: ../../src/sidebars/MathSidebar.cpp:56
+msgid "Rectform"
+msgstr "直角坐標形式"
+
+#: ../../src/wxMaximaFrame.cpp:1677
 #, fuzzy
 msgid "Recursive Substitute..."
 msgstr "代換..."
 
-#: ../../src/wxMaxima.cpp:8746
+#: ../../src/MaximaCommandMenus.cpp:744
 msgid "Recursive substitution"
 msgstr ""
 
-#: ../../src/ToolBar.cpp:192
+#: ../../src/ToolBar.cpp:355 ../../src/ToolBar.cpp:358
 msgid "Redo"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:633
+#: ../../src/wxMaximaFrame.cpp:670
 #, fuzzy
 msgid "Redo\tCtrl+Y"
 msgstr "復原\tCtrl+Z"
 
-#: ../../src/wxMaximaFrame.cpp:633
+#: ../../src/wxMaximaFrame.cpp:670
 msgid "Redo last change"
 msgstr "重作上次的變更"
 
-#: ../../src/wxMaximaFrame.cpp:1595
+#: ../../src/sidebars/MathSidebar.cpp:71
+msgid "Reduce (tr)"
+msgstr "縮併 (三角)"
+
+#: ../../src/wxMaximaFrame.cpp:1632
 msgid "Reduce trigonometric expression"
 msgstr "縮併三角函數數式"
 
-#: ../../src/wxMaxima.cpp:2366 ../../src/wxMaxima.cpp:10630
+#: ../../src/MaximaEvaluator.cpp:395
+msgid ""
+"Refusing to evaluate cell: its text changed between being queued and being evaluated (see GH #2196).\n"
+"Queued as: "
+msgstr ""
+
+#: ../../src/MaximaEvaluator.cpp:123 ../../src/MaximaEvaluator.cpp:515
 msgid "Refusing to send cell to maxima: "
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7523
+#: ../../src/dialogs/FindReplacePane.cpp:85
+msgid "Regex"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:4395
 msgid "Regex match"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7518
+#: ../../src/MaximaCommandMenus.cpp:4390
 msgid "Regex match position"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1195
+#: ../../src/wxMaximaFrame.cpp:2009
+msgid "Register wxMaxima as the tool that compares .wxmx files in TortoiseSVN and TortoiseGit"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1229
 #, fuzzy
 msgid "Regular expression that matches a string"
 msgstr "x 座標，以逗號分隔"
 
-#: ../../src/wxMaximaFrame.cpp:1196
+#: ../../src/wxMaximaFrame.cpp:1230
 #, fuzzy
 msgid "Regular expressions"
 msgstr "對數式積分"
 
-#: ../../src/Worksheet.cpp:1314
+#: ../../src/worksheet/WorksheetContextMenu.cpp:76
 #, fuzzy
 msgid "Reload Image"
 msgstr "複製為圖片"
 
-#: ../../src/Worksheet.cpp:1320
+#: ../../src/worksheet/WorksheetContextMenu.cpp:82
 #, c-format
 msgid "Reload Image \"%s\""
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:9809
+#: ../../src/dialogs/ConfigDialogue.cpp:997
+msgid "Reload all GUI settings from disc"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1004
+msgid "Reload the style settings from disc"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:3272
 #, c-format
 msgid "Reloading image file %s."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:883
+#: ../../src/dialogs/ConfigDialogue.cpp:2573
+msgid "Reloading the configuration from disc"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:2581
+#, fuzzy
+msgid "Reloading the styles from disc"
+msgstr "自檔案載入樣式"
+
+#: ../../src/sidebars/VariablesPane.cpp:220
+msgid "Remove"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:917
 msgid "Remove All Output"
 msgstr "移除所有輸出"
 
-#: ../../src/wxMaximaFrame.cpp:1426
-msgid "Remove Rows or Columns..."
+#: ../../src/wxMaximaFrame.cpp:1463
+msgid "Remove Columns..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1748
+#: ../../src/wxMaximaFrame.cpp:1460
+msgid "Remove Rows..."
+msgstr ""
+
+#: ../../src/sidebars/VariablesPane.cpp:225
+msgid "Remove all"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1785
 msgid "Remove all list elements that appear twice in a row. Normally used in conjunction with sort."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1174
+#: ../../src/wxMaximaFrame.cpp:1208
 msgid "Remove all occurrences of a word..."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7439
+#: ../../src/MaximaCommandMenus.cpp:4311
 msgid "Remove all occurrences of part"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8592
+#: ../../src/MaximaCommandMenus.cpp:1611
 #, fuzzy
 msgid "Remove an element from a list"
 msgstr "從數式產生串列"
 
-#: ../../src/wxMaxima.cpp:7566
+#: ../../src/MaximaCommandMenus.cpp:1519
+msgid "Remove and return the first element of a list"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1464
+msgid "Remove columns from a matrix"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:4438
 msgid "Remove directory"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1204
+#: ../../src/wxMaximaFrame.cpp:1238
 msgid "Remove directory..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1747
+#: ../../src/wxMaximaFrame.cpp:1784
 msgid "Remove duplicates"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1176
+#: ../../src/wxMaximaFrame.cpp:1210
 msgid "Remove first occurrence of a word..."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7444
+#: ../../src/MaximaCommandMenus.cpp:4316
 msgid "Remove first occurrence of part"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:884
+#: ../../src/MaximaCommandMenus.cpp:1155
+msgid "Remove matrix columns"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:1160
+msgid "Remove matrix rows"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:918
 msgid "Remove output from input cells"
 msgstr "移除所有輸入單元的輸出"
 
-#: ../../src/wxMaxima.cpp:7975
-msgid "Remove rows and/or columns"
+#: ../../src/wxMaximaFrame.cpp:1461
+msgid "Remove rows from the a matrix"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1427
-msgid "Remove rows and/or columns from the matrix"
-msgstr ""
-
-#: ../../src/wxMaxima.cpp:7582
+#: ../../src/MaximaCommandMenus.cpp:4454
 #, fuzzy
 msgid "Rename file"
 msgstr "正在開啟檔案"
 
-#: ../../src/wxMaximaFrame.cpp:1215
+#: ../../src/wxMaximaFrame.cpp:1249
 #, fuzzy
 msgid "Rename file..."
 msgstr "刪除變數"
 
-#: ../../src/wxMaximaFrame.cpp:1527
+#: ../../src/wxMaximaFrame.cpp:1564
 #, fuzzy
 msgid "Reorganize an expression using horner's rule"
 msgstr "因式分解含 Gaussian 數的數式"
 
-#: ../../src/wxMaximaFrame.cpp:1346
+#: ../../src/wxMaximaFrame.cpp:1380
 msgid "Repetitive element-by-element multiplication"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7538
+#: ../../src/dialogs/FindReplacePane.cpp:117
+#, fuzzy
+msgid "Replace All"
+msgstr "全部選取"
+
+#: ../../src/MaximaCommandMenus.cpp:4410
 msgid "Replace all regex matches"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7533
+#: ../../src/MaximaCommandMenus.cpp:4405
 msgid "Replace first regex match"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7463
+#: ../../src/wxMaximaFrame.cpp:1990
+msgid "Replace non-builtin variable and function names in the selected code cells (or the whole document) with random names, so a worksheet can be shared without revealing its original names"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:4335
 #, fuzzy
 msgid "Replace the first occurrence of Part"
 msgstr "找到 %d 個並取代。"
 
-#: ../../src/wxMaximaFrame.cpp:1180
+#: ../../src/wxMaximaFrame.cpp:1214
 #, fuzzy
 msgid "Replace..."
 msgstr "全部選取"
 
-#: ../../src/wxMaxima.cpp:6719
+#: ../../src/wxMaxima.cpp:2720
 #, fuzzy, c-format
 msgid "Replaced %li occurrences."
 msgstr "找到 %d 個並取代。"
 
-#: ../../src/wxMaximaFrame.cpp:1950
+#: ../../src/dialogs/FindReplacePane.cpp:62
+msgid "Replacement:"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:768
+msgid "Replaces the subexpression that part(expr, n_1, n_2, ...) would select by a new value. The part numbers form a path: n_1 selects a part of the expression, n_2 a part of that, and so on."
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1987
 msgid "Report bug"
 msgstr "回報發現的錯誤"
 
-#: ../../src/wxMaximaFrame.cpp:996
+#: ../../src/dialogs/ConfigDialogue.cpp:983
+msgid "Reset all GUI settings"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1030
 #, fuzzy
 msgid "Reset option variables"
 msgstr "變數變換"
 
-#: ../../src/ToolBar.cpp:229 ../../src/wxMaximaFrame.cpp:974
+#: ../../src/dialogs/ConfigDialogue.cpp:990
+msgid "Reset the Style settings"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:2557
+#: ../../src/dialogs/ConfigDialogue.cpp:2565
+msgid "Resetting all configuration settings"
+msgstr ""
+
+#: ../../src/ToolBar.cpp:411 ../../src/ToolBar.cpp:417
+#: ../../src/wxMaximaFrame.cpp:1008
 msgid "Restart Maxima"
 msgstr "重新啟動 Maxima"
 
-#: ../../src/Worksheet.cpp:1304 ../../src/Worksheet.cpp:1477
+#: ../../src/worksheet/WorksheetContextMenu.cpp:66
+#: ../../src/worksheet/WorksheetContextMenu.cpp:248
 #, fuzzy
 msgid "Restrict Maximum size"
 msgstr "重新啟動 Maxima"
 
-#: ../../src/wxMaxima.cpp:10031
+#: ../../src/MaximaCommandMenus.cpp:3520
 #, fuzzy
 msgid "Result variables:"
 msgstr "刪除該變數："
 
-#: ../../src/wxMaxima.cpp:8135
+#: ../../src/MaximaCommandMenus.cpp:1323
 msgid "Resulting Matrix name (may be empty):"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1190
+#: ../../src/wxMaximaFrame.cpp:1224
 msgid "Return a match"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7077
+#: ../../src/MaximaCommandMenus.cpp:3949
 msgid "Return from a block or loop"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1069
+#: ../../src/wxMaximaFrame.cpp:1103
 msgid "Return from current block/loop..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1755
+#: ../../src/wxMaximaFrame.cpp:1792
 msgid "Return the first item of the list and remove it from the list. Useful for creating stacks."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8526
+#: ../../src/MaximaCommandMenus.cpp:1537
 msgid "Return the list without its first n elements"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8532
+#: ../../src/MaximaCommandMenus.cpp:1543
 msgid "Return the list without its last n elements"
 msgstr ""
 
-#: ../../src/ToolBar.cpp:241
+#: ../../src/ToolBar.cpp:424 ../../src/ToolBar.cpp:433
 msgid "Return to the cell that is currently being evaluated"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1711
+#: ../../src/wxMaximaFrame.cpp:1748
 msgid "Returns an arbitrary list item"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1713
+#: ../../src/MaximaCommandMenus.cpp:1527
+msgid "Returns the first element of a list"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1750
 msgid "Returns the first item of the list"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1719
+#: ../../src/MaximaCommandMenus.cpp:1531
+msgid "Returns the last element of a list"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1756
 msgid "Returns the last item of the list"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1721
+#: ../../src/wxMaximaFrame.cpp:1758
 msgid "Returns the last n items of the list"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1742
+#: ../../src/wxMaximaFrame.cpp:1779
 msgid "Returns the length of the list"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1715
+#: ../../src/wxMaximaFrame.cpp:1752
 msgid "Returns the list without its first n elements"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1717
+#: ../../src/wxMaximaFrame.cpp:1754
 msgid "Returns the list without its last n elements"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1743
+#: ../../src/MaximaCommandMenus.cpp:1509
+msgid "Returns the number of elements of a list"
+msgstr ""
+
+#: ../../src/wizards/DrawWiz.cpp:836
+#, fuzzy
+msgid "Reuse last"
+msgstr "產生串列"
+
+#: ../../src/wxMaximaFrame.cpp:1780
 msgid "Reverse"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1744
+#: ../../src/wxMaximaFrame.cpp:1781
 msgid "Reverse the order of the list items"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7983 ../../src/wxMaxima.cpp:7988
-#: ../../src/wxMaxima.cpp:8008 ../../src/wxMaxima.cpp:8014
+#: ../../src/MaximaCommandMenus.cpp:1523
+msgid "Reverses the order of the members of a list"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:295
+msgid "Revert all to defaults"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:980
+#, fuzzy
+msgid "Revert changes"
+msgstr "重作上次的變更"
+
+#: ../../src/sidebars/GreekSidebar.cpp:194
+msgid "Rho"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:2015
+#, fuzzy
+msgid "Right"
+msgstr "右"
+
+#: ../../src/MaximaCommandMenus.cpp:1167 ../../src/MaximaCommandMenus.cpp:1172
+#: ../../src/MaximaCommandMenus.cpp:1192 ../../src/MaximaCommandMenus.cpp:1198
 #, fuzzy
 msgid "Right Matrix:"
 msgstr "輸入矩陣"
 
-#: ../../src/wxMaxima.cpp:8190
+#: ../../src/sidebars/SymbolsSidebar.cpp:127
+msgid "Right arrow"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:1380
 msgid "Right end"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1301
+#: ../../src/wxMaximaFrame.cpp:1335
 msgid "Right side to the \"=\""
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1455
+#: ../../src/wxMaximaFrame.cpp:1492
 msgid "Risch Integration..."
 msgstr "Risch 積分..."
 
-#: ../../src/wxMaximaFrame.cpp:785
+#: ../../src/dialogs/ConfigDialogue.cpp:222
+msgid "Romanian"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:822
 msgid "Rounded"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1437
+#: ../../src/wxMaximaFrame.cpp:1474
 msgid "Row and column operations"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7957 ../../src/wxMaxima.cpp:7967
-#: ../../src/wxMaxima.cpp:7972
+#: ../../src/MaximaCommandMenus.cpp:1137 ../../src/MaximaCommandMenus.cpp:1147
 msgid "Row number:"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7977
+#: ../../src/MaximaCommandMenus.cpp:1162
 #, fuzzy
 msgid "Row numbers:"
 msgstr "數字"
 
-#: ../../src/wxMaxima.cpp:8203
+#: ../../src/MaximaCommandMenus.cpp:1393
 #, fuzzy
 msgid "Rows"
 msgstr "列："
 
-#: ../../src/wxMaxima.cpp:8201
+#: ../../src/wizards/MatWiz.cpp:152
+msgid "Rows:"
+msgstr "列："
+
+#: ../../src/MaximaCommandMenus.cpp:1391
 msgid "Rule"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8464 ../../src/wxMaxima.cpp:8477
+#: ../../src/MaximaCommandMenus.cpp:1467
 msgid "Rule:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1027
+#: ../../src/wxMaximaFrame.cpp:1061
 msgid "Rules"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1693
+#: ../../src/wxMaximaFrame.cpp:1730
 #, fuzzy
 msgid "Run each element through an expression"
 msgstr "求數式的極限"
 
-#: ../../src/wxMaxima.cpp:6355
+#: ../../src/MaximaCommandMenus.cpp:2790
 #, c-format
 msgid "Running %s on the file %s: "
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2633
+#: ../../src/MaximaProcessManager.cpp:297
 #, c-format
 msgid "Running maxima as: %s"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:130
+#: ../../src/wxMaximaFrame.cpp:138
 msgid "Running on DirectFB"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:114
+#: ../../src/wxMaximaFrame.cpp:122
 msgid "Running on MS Windows"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:116
+#: ../../src/wxMaximaFrame.cpp:124
 msgid "Running on MS Windows using DirectDraw"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:136
+#: ../../src/wxMaximaFrame.cpp:144
 msgid "Running on Mac OS"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:127
+#: ../../src/wxMaximaFrame.cpp:135
 msgid "Running on Motif"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:133
+#: ../../src/wxMaximaFrame.cpp:141
 msgid "Running on the universal wxWidgets port"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8208
+#: ../../src/MaximaCommandMenus.cpp:1398
 msgid "Runs each element of an object (list, matrix, equation,...) through a function individually"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8216
+#: ../../src/MaximaCommandMenus.cpp:1406
 msgid "Runs each element of an object (list, matrix, equation,...) through an expression individually"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1691
+#: ../../src/wxMaximaFrame.cpp:1728
 msgid "Runs each element through a function"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1694
+#: ../../src/wxMaximaFrame.cpp:1731
 #, fuzzy
 msgid "Runs each element through an expression"
 msgstr "求數式的極限"
 
-#: ../../src/wxMaxima.cpp:9572
+#: ../../src/dialogs/ConfigDialogue.cpp:223
+msgid "Russian"
+msgstr "Russian"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1578
+msgid "SBCL: use <int>Mbytes of heap"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1585
+msgid "SBCL: use <int>Mbytes of stack for function calls"
+msgstr ""
+
+#: ../../src/sidebars/XmlInspector.cpp:78
+msgid "SENT TO MAXIMA:"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1224
+msgid "SVG graphics"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:1810
 msgid "Sample 1:"
 msgstr "樣本 1："
 
-#: ../../src/wxMaxima.cpp:9573
+#: ../../src/MaximaCommandMenus.cpp:1811
 msgid "Sample 2:"
 msgstr "樣本 2："
 
-#: ../../src/wxMaxima.cpp:9567
+#: ../../src/MaximaCommandMenus.cpp:1805
 msgid "Sample:"
 msgstr "樣本："
 
-#: ../../src/ToolBar.cpp:177 ../../src/wxMaxima.cpp:11203
+#: ../../src/wizards/DrawWiz.cpp:956
+msgid "Samples for explicit and parametric plots:"
+msgstr ""
+
+#: ../../src/wizards/DrawWiz.cpp:969
+msgid "Samples for implicit plots and regions:"
+msgstr ""
+
+#: ../../src/wizards/DrawWiz.cpp:937
+msgid "Samples for implicit plots:"
+msgstr ""
+
+#: ../../src/wizards/DrawWiz.cpp:924
+msgid "Samples on a line:"
+msgstr ""
+
+#: ../../src/ToolBar.cpp:331 ../../src/ToolBar.cpp:334
+#: ../../src/dialogs/ConfigDialogue.cpp:2163 ../../src/wxMaxima.cpp:3509
 msgid "Save"
 msgstr "儲存"
 
-#: ../../src/Worksheet.cpp:1294
+#: ../../src/worksheet/WorksheetContextMenu.cpp:55
 msgid "Save Animation..."
 msgstr "儲存動畫..."
 
-#: ../../src/wxMaxima.cpp:5672
+#: ../../src/MaximaFileIO.cpp:779
 msgid "Save As"
 msgstr "另存新檔"
 
-#: ../../src/wxMaximaFrame.cpp:609
+#: ../../src/wxMaximaFrame.cpp:640
 msgid "Save As...\tShift+Ctrl+S"
 msgstr "另存新檔...\tShift+Ctrl+S"
 
-#: ../../src/Worksheet.cpp:1291
+#: ../../src/worksheet/WorksheetContextMenu.cpp:50
 msgid "Save Image..."
 msgstr "儲存圖片..."
 
-#: ../../src/wxMaxima.cpp:6440
+#: ../../src/MaximaCommandMenus.cpp:2926
 msgid "Save Selection to Image"
 msgstr "儲存所選區域為圖片"
 
-#: ../../src/wxMaximaFrame.cpp:675
+#: ../../src/wxMaximaFrame.cpp:712
 msgid "Save Selection to Image..."
 msgstr "儲存為圖片..."
 
-#: ../../src/wxMaxima.cpp:10184
+#: ../../src/MaximaCommandMenus.cpp:3713
 msgid "Save animation to file"
 msgstr "儲存動畫至檔案"
 
-#: ../../src/wxMaxima.cpp:7203
+#: ../../src/MaximaCommandMenus.cpp:4075
 msgid "Save as lisp code"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1091
+#: ../../src/wxMaximaFrame.cpp:1125
 #, fuzzy
 msgid "Save as lisp..."
 msgstr "載入 Package"
 
-#: ../../src/ToolBar.cpp:177 ../../src/wxMaximaFrame.cpp:608
+#: ../../src/dialogs/ConfigDialogue.cpp:2478
+#, fuzzy
+msgid "Save config to file"
+msgstr "儲存選取區域至檔案"
+
+#: ../../src/ToolBar.cpp:331 ../../src/ToolBar.cpp:334
+#: ../../src/wxMaximaFrame.cpp:639
 msgid "Save document"
 msgstr "儲存文件"
 
-#: ../../src/wxMaximaFrame.cpp:609
+#: ../../src/wxMaximaFrame.cpp:640
 msgid "Save document as"
 msgstr "將文件另存新檔"
 
-#: ../../src/wxMaximaFrame.cpp:676
+#: ../../src/wizards/Plot2dWiz.cpp:473 ../../src/wizards/Plot3dWiz.cpp:421
+msgid "Save plot to file"
+msgstr "儲存繪圖至檔案"
+
+#: ../../src/wxMaximaFrame.cpp:713
 msgid "Save selection from document to an image file"
 msgstr "儲存所選區域為圖片檔"
 
-#: ../../src/wxMaxima.cpp:10125
+#: ../../src/MaximaCommandMenus.cpp:3620
 msgid "Save selection to file"
 msgstr "儲存選取區域至檔案"
 
-#: ../../src/wxMaximaFrame.cpp:573
+#: ../../src/dialogs/ConfigDialogue.cpp:2640
+msgid "Save style to file"
+msgstr "將樣式儲存至檔案"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1384
+msgid "Save the worksheet automatically"
+msgstr ""
+
+#: ../../src/MaximaFileIO.cpp:873
+msgid "Saving failed!"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:594
 #, fuzzy
 msgid "Saving failed."
 msgstr "伺服器啟動失敗"
 
-#: ../../src/WXMXformat.cpp:310
+#: ../../src/WXMXformat.cpp:312
 msgid "Saving succeeded, but the resulting files has disappeared ?!?."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:10107
-msgid "Scalable Vector image (*.svg)|*.svg|Compressed Scalable Vector Image (*.svgz)|*.svgz|PNG image (*.png)|*.png|JPEG image (*.jpg)|*.jpg|GIF image (*.gif)|*.gif|Windows bitmap (*.bmp)|*.bmp|Portable anymap (*.pnm)|*.pnm|Tagged image file format (*.tif)|*.tif|X pixmap (*.xpm)|*.xpm"
+#: ../../src/dialogs/ConfigDialogue.cpp:1914
+msgid "Scalable Vector Graphics (svg)"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:9533
+#: ../../src/MaximaCommandMenus.cpp:3596
+msgid "Scalable Vector image (*.svg)|*.svg|Compressed Scalable Vector Image (*.svgz)|*.svgz|PNG image (*.png)|*.png|JPEG image (*.jpg)|*.jpg|GIF image (*.gif)|*.gif|Windows bitmap (*.bmp)|*.bmp|"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:1771
 msgid "Scatterplot"
 msgstr "散布圖"
 
-#: ../../src/Autocomplete.cpp:125
+#: ../../src/sidebars/StatSidebar.cpp:88
+msgid "Scatterplot..."
+msgstr "散布圖..."
+
+#: ../../src/Autocomplete.cpp:157
 msgid "Scheduling a background task that compiles a new list of autocompletable maxima commands."
 msgstr ""
 
-#: ../../src/Autocomplete.cpp:458
+#: ../../src/Autocomplete.cpp:586
 msgid "Scheduling a background task that scans for autocompletable file names."
 msgstr ""
 
-#: ../../src/ToolBar.cpp:632
+#: ../../src/dialogs/ConfigDialogue.cpp:1867
+msgid "Screen reader"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:662
+msgid "Scroll to a cell with a certain UUID"
+msgstr ""
+
+#: ../../src/ToolBar.cpp:832
 msgid "Search button"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7454
+#: ../../src/MaximaCommandMenus.cpp:4326
 msgid "Search first occurrence of part"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1178
+#: ../../src/dialogs/DiffFrame.cpp:420
+msgid "Search input / UUID"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1212
 msgid "Search..."
 msgstr ""
 
-#: ../../src/ToolBar.cpp:273
+#: ../../src/ToolBar.cpp:483 ../../src/sidebars/FormatSidebar.cpp:51
 msgid "Section"
 msgstr "章節"
 
-#: ../../src/Configuration.cpp:91
+#: ../../src/Styles.cpp:120
 msgid "Section cell (Heading 2)"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7218
+#: ../../src/sidebars/TableOfContents.cpp:585
+msgid "Section numbers"
+msgstr ""
+
+#: ../../src/wizards/DrawWiz.cpp:158
+msgid "See also the speed <-> accuracy button."
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:4090
 #, fuzzy
 msgid "Seek to position"
 msgstr "Pade 近似"
@@ -6255,1147 +9384,1662 @@ msgstr "Pade 近似"
 msgid "Seems like something is broken with a font."
 msgstr ""
 
-#: ../../src/Autocomplete.cpp:350
+#: ../../src/Autocomplete.cpp:438
 msgid "Seems like the package with the maxima share files isn't installed."
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1655 ../../src/Worksheet.cpp:1687
+#: ../../src/sidebars/TableOfContents.cpp:511
+#, fuzzy
+msgid "Select"
+msgstr "所選區域"
+
+#: ../../src/MaximaCommandMenus.cpp:2239
+msgid "Select 2 or 3 files to compare"
+msgstr ""
+
+#: ../../src/worksheet/WorksheetContextMenu.cpp:428
+#: ../../src/worksheet/WorksheetContextMenu.cpp:460
 msgid "Select All"
 msgstr "全部選取"
 
-#: ../../src/wxMaximaFrame.cpp:673
+#: ../../src/wxMaximaFrame.cpp:710
 msgid "Select All\tCtrl+A"
 msgstr "全部選取\tCtrl+A"
 
-#: ../../src/ToolBar.cpp:629
+#: ../../src/ToolBar.cpp:829
 msgid "Select All button"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:9631
+#: ../../src/MaximaCommandMenus.cpp:1871
 msgid "Select Subsample"
 msgstr "選取子樣本"
 
-#: ../../src/ToolBar.cpp:214 ../../src/ToolBar.cpp:215
-#: ../../src/wxMaximaFrame.cpp:673
+#: ../../src/wizards/IntegrateWiz.cpp:193
+#: ../../src/wizards/IntegrateWiz.cpp:208 ../../src/wizards/LimitWiz.cpp:133
+#: ../../src/wizards/SeriesWiz.cpp:105
+msgid "Select a constant"
+msgstr "選擇常數"
+
+#: ../../src/ToolBar.cpp:390 ../../src/ToolBar.cpp:392
+#: ../../src/wxMaximaFrame.cpp:710
 msgid "Select all"
 msgstr "全部選取"
 
-#: ../../src/wxMaxima.cpp:6971
+#: ../../src/dialogs/BinaryNameCtrl.cpp:64
+msgid "Select binary location program"
+msgstr ""
+
+#: ../../src/wizards/CsvWiz.cpp:92 ../../src/wizards/CsvWiz.cpp:166
+msgid "Select csv file to read"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:3843
 msgid "Select math display algorithm"
 msgstr "選擇用於顯示數學的演算法"
 
-#: ../../src/Configuration.cpp:98
+#: ../../src/dialogs/TipOfTheDay.cpp:109
+#, fuzzy
+msgid "Selecting a part of an output and right-clicking on the selection will bring up a menu with convenient functions that will operate on the selection."
+msgstr "選取輸出並點擊右鍵會顯示功能表，其中含有一些供您方便操作所選區域的函數。"
+
+#: ../../src/Styles.cpp:127
 #, fuzzy
 msgid "Selection color"
 msgstr "所選區域"
 
-#: ../../src/ToolBar.cpp:252
+#: ../../src/wizards/CsvWiz.cpp:40 ../../src/wizards/CsvWiz.cpp:111
+msgid "Semicolon"
+msgstr ""
+
+#: ../../src/ToolBar.cpp:446 ../../src/ToolBar.cpp:458
 msgid "Send all cells to maxima"
 msgstr ""
 
-#: ../../src/ToolBar.cpp:249
+#: ../../src/ToolBar.cpp:443 ../../src/ToolBar.cpp:455
 msgid "Send the current cell to maxima"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2810
+#: ../../src/MaximaProcessManager.cpp:921
 msgid "Sending Maxima a SIGINT signal."
 msgstr ""
 
-#: ../../src/StatusBar.cpp:220
+#: ../../src/StatusBar.cpp:263
 msgid "Sending a command to Maxima"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:10598
+#: ../../src/MaximaEvaluator.cpp:471
 msgid "Sending a new command to Maxima."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2792
+#: ../../src/MaximaProcessManager.cpp:902
 msgid "Sending an interrupt signal to Maxima."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:169
+#: ../../src/wxMaxima.cpp:218
 msgid "Sending configuration data to maxima."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:4718
+#: ../../src/MaximaEvaluator.cpp:558
 msgid "Sending maxima the info how to express 2d maths as XML"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1533
+#: ../../src/wxMaximaFrame.cpp:1570
 #, fuzzy
 msgid "Sequential Comparative Simplification"
 msgstr "複數化簡(&C)"
 
-#: ../../src/wxMaxima.cpp:9016
+#: ../../src/dialogs/ConfigDialogue.cpp:224
+msgid "Serbian"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:270 ../../src/wizards/SeriesWiz.cpp:60
 msgid "Series"
 msgstr "級數"
 
-#: ../../src/wxMaximaFrame.cpp:1479
+#: ../../src/wxMaximaFrame.cpp:1516
 #, fuzzy
 msgid "Series approximation"
 msgstr "Pade 近似"
 
-#: ../../src/wxMaxima.cpp:2561
+#: ../../src/MaximaProcessManager.cpp:227
 msgid "Server started"
 msgstr "伺服器已啟動"
 
-#: ../../src/wxMaximaFrame.cpp:1824
+#: ../../src/wxMaximaFrame.cpp:1861
 #, fuzzy
 msgid "Set &displayed Precision..."
 msgstr "設定精確度(&P)..."
 
-#: ../../src/wxMaximaFrame.cpp:1563
+#: ../../src/wxMaximaFrame.cpp:1600
 msgid "Set Maxima option variable logexpand:all"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1567
+#: ../../src/wxMaximaFrame.cpp:1604
 msgid "Set Maxima option variable logexpand:super"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1560
+#: ../../src/wxMaximaFrame.cpp:1597
 msgid "Set Maxima option variable logexpand:true"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:822
+#: ../../src/wxMaximaFrame.cpp:859
 msgid "Set Zoom"
 msgstr "顯示比例"
 
-#: ../../src/wxMaximaFrame.cpp:1819
+#: ../../src/wxMaximaFrame.cpp:1856
 #, fuzzy
 msgid "Set bigfloat &Precision..."
 msgstr "設定 bigfloat 的精確度"
 
-#: ../../src/Worksheet.cpp:1306 ../../src/Worksheet.cpp:1479
+#: ../../src/dialogs/ConfigDialogue.cpp:479
+msgid "Set fixed font in text controls."
+msgstr "在文字控制項中使用等寬字型"
+
+#: ../../src/worksheet/WorksheetContextMenu.cpp:68
+#: ../../src/worksheet/WorksheetContextMenu.cpp:250
 msgid "Set image resolution"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1510
+#: ../../src/dialogs/ResolutionChooser.cpp:29
+msgid "Set image resolution [in ppi]"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1547
 #, fuzzy
 msgid "Set main variable..."
 msgstr "刪除變數"
 
-#: ../../src/wxMaximaFrame.cpp:1773
+#: ../../src/dialogs/MaxSizeChooser.cpp:29
+msgid "Set maximum image size [in mm]"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1810
 msgid "Set plot format"
 msgstr "設定繪圖格式"
 
-#: ../../src/wxMaximaFrame.cpp:1101
+#: ../../src/wxMaximaFrame.cpp:1135
 #, fuzzy
 msgid "Set position..."
 msgstr "儲存動畫..."
 
-#: ../../src/wxMaximaFrame.cpp:1656
+#: ../../src/wxMaximaFrame.cpp:1693
 #, fuzzy
 msgid "Set the \"algebraic\" flag"
 msgstr "切換代數旗標"
 
-#: ../../src/wxMaxima.cpp:8314
+#: ../../src/MaximaCommandMenus.cpp:1960
 msgid "Set the diagram title"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1779
+#: ../../src/wxMaximaFrame.cpp:1816
 #, fuzzy
 msgid "Set the frame rate for animations."
 msgstr "開始動畫"
 
-#: ../../src/wxMaxima.cpp:8377
+#: ../../src/MaximaCommandMenus.cpp:2023
 msgid "Set the grid density."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8327
+#: ../../src/MaximaCommandMenus.cpp:1973
 msgid "Set the next plot's title. Empty = no title."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1820
+#: ../../src/wxMaximaFrame.cpp:1857
 msgid "Set the precision for numbers that are defined as bigfloat. Such numbers can be generated by entering 1.5b12 or as bfloat(1.234)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:811
+#: ../../src/wxMaximaFrame.cpp:848
 msgid "Set zoom to 100%"
 msgstr "將顯示比例設定為 100%"
 
-#: ../../src/wxMaximaFrame.cpp:813
+#: ../../src/wxMaximaFrame.cpp:850
 msgid "Set zoom to 120%"
 msgstr "將顯示比例設定為 120%"
 
-#: ../../src/wxMaximaFrame.cpp:815
+#: ../../src/wxMaximaFrame.cpp:852
 msgid "Set zoom to 150%"
 msgstr "將顯示比例設定為 150%"
 
-#: ../../src/wxMaximaFrame.cpp:817
+#: ../../src/wxMaximaFrame.cpp:854
 msgid "Set zoom to 200%"
 msgstr "將顯示比例設定為 200%"
 
-#: ../../src/wxMaximaFrame.cpp:819
+#: ../../src/wxMaximaFrame.cpp:856
 msgid "Set zoom to 300%"
 msgstr "將顯示比例設定為 300%"
 
-#: ../../src/wxMaximaFrame.cpp:809
+#: ../../src/wxMaximaFrame.cpp:846
 msgid "Set zoom to 80%"
 msgstr "將顯示比例設定為 80%"
 
-#: ../../src/wxMaxima.cpp:4731
+#: ../../src/dialogs/ConfigDialogue.cpp:163
+msgid "Sets the language, line ending type and charset encoding programs will use"
+msgstr ""
+
+#: ../../src/MaximaEvaluator.cpp:574
 #, c-format
 msgid "Setting gnuplot_binary to %s"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:4804
+#: ../../src/MaximaEvaluator.cpp:642
 #, fuzzy
 msgid "Setting prompt and help format"
 msgstr "設定繪圖格式"
 
-#: ../../src/wxMaximaFrame.cpp:1292
+#: ../../src/dialogs/ConfigDialogue.cpp:165
+msgid "Setting this to \"cat\" causes gnuplot not to halt if there is much output"
+msgstr ""
+
+#: ../../src/wizards/DrawWiz.cpp:546
+msgid "Settings for the following 3d plots"
+msgstr ""
+
+#: ../../src/wizards/DrawWiz.cpp:462
+#, c-format
+msgid "Setup a %iD scene"
+msgstr ""
+
+#: ../../src/sidebars/DrawSidebar.cpp:48
+msgid "Setup a 2D plot"
+msgstr ""
+
+#: ../../src/sidebars/DrawSidebar.cpp:52
+msgid "Setup a 3D plot"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1326
 msgid "Setup atvalues for solving ODE with Laplace transformation"
 msgstr "在使用 Laplace 變換解常微分方程前將定點設值"
 
-#: ../../src/wxMaximaFrame.cpp:1661
+#: ../../src/wxMaximaFrame.cpp:1698
 msgid "Setup modulus computation"
 msgstr "設定模運算"
 
-#: ../../src/wxMaxima.cpp:9220
+#: ../../src/sidebars/DrawSidebar.cpp:78
+msgid "Setup the axis"
+msgstr ""
+
+#: ../../src/wizards/DrawWiz.cpp:263
+msgid "Setup the axis for the current plot."
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:411
 msgid "Setup the engineering format"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1831
+#: ../../src/wxMaximaFrame.cpp:1868
 msgid "Setup the engineering format..."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:9576
+#: ../../src/MaximaCommandMenus.cpp:1814
 msgid "Shapiro-Wilk test for normality"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1543
+#: ../../src/worksheet/WorksheetContextMenu.cpp:316
 #, fuzzy
 msgid "Show \"%\" in special constants"
 msgstr "特殊常數"
 
-#: ../../src/wxMaximaFrame.cpp:1889
+#: ../../src/wxMaximaFrame.cpp:1926
 msgid "Show &Tips..."
 msgstr "顯示小秘訣(&T)..."
 
-#: ../../src/Worksheet.cpp:1556
+#: ../../src/worksheet/WorksheetContextMenu.cpp:329
 msgid "Show * as multiplication dot"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:895
+#: ../../src/wxMaximaFrame.cpp:929
 #, fuzzy
 msgid "Show Template\tCtrl+Shift+Space"
 msgstr "顯示範本\tCtrl+Shift+K"
 
-#: ../../src/wxMaximaFrame.cpp:753
+#: ../../src/wxMaximaFrame.cpp:790
 #, fuzzy
 msgid "Show XML representation"
 msgstr "顯示長的數式"
 
-#: ../../src/wxMaximaFrame.cpp:1889
+#: ../../src/wxMaximaFrame.cpp:1926
 msgid "Show a tip"
 msgstr "顯示小秘訣"
 
-#: ../../src/Worksheet.cpp:1607
+#: ../../src/worksheet/WorksheetContextMenu.cpp:380
 msgid "Show all + allow linebreaks in long numbers"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:9475
+#: ../../src/MaximaCommandMenus.cpp:2118
 msgid "Show all commands similar to:"
 msgstr "顯示全部與此指令相似的指令："
 
-#: ../../src/wxMaxima.cpp:9468
+#: ../../src/sidebars/SymbolsSidebar.cpp:206
+msgid "Show all unicode symbols"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:2111
 msgid "Show an example for the command:"
 msgstr "顯示這個指令的使用範例："
 
-#: ../../src/wxMaximaFrame.cpp:1883
+#: ../../src/wxMaximaFrame.cpp:1920
 msgid "Show an example of usage"
 msgstr "顯示一個使用範例"
 
-#: ../../src/wxMaximaFrame.cpp:1884
+#: ../../src/sidebars/History.cpp:121
+msgid "Show commands from current session only"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1921
 msgid "Show commands similar to"
 msgstr "顯示相似的指令"
 
-#: ../../src/wxMaximaFrame.cpp:1020
+#: ../../src/wxMaximaFrame.cpp:1054
 msgid "Show defined functions"
 msgstr "顯示已定義的函數"
 
-#: ../../src/wxMaximaFrame.cpp:1022
+#: ../../src/wxMaximaFrame.cpp:1056
 msgid "Show defined variables"
 msgstr "顯示已定義的變數"
 
-#: ../../src/wxMaximaFrame.cpp:1074
+#: ../../src/wxMaximaFrame.cpp:1108
 msgid "Show definition of a function"
 msgstr "顯示函數的定義"
 
-#: ../../src/wxMaximaFrame.cpp:740
+#: ../../src/wxMaximaFrame.cpp:777
 msgid "Show equations in their linear form"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1073
+#: ../../src/wxMaximaFrame.cpp:1107
 #, fuzzy
 msgid "Show function &Definition..."
 msgstr "顯示函數定義(&D)..."
 
-#: ../../src/wxMaximaFrame.cpp:896
+#: ../../src/wxMaximaFrame.cpp:930
 msgid "Show function template"
 msgstr "顯示函數範本"
 
-#: ../../src/Worksheet.cpp:1614
+#: ../../src/worksheet/WorksheetContextMenu.cpp:387
 #, fuzzy
 msgid "Show input labels"
 msgstr "輸入標籤"
 
-#: ../../src/wxMaximaFrame.cpp:750
+#: ../../src/dialogs/ConfigDialogue.cpp:766
+#, fuzzy
+msgid "Show labels:"
+msgstr "顯示變數(&V)"
+
+#: ../../src/wxMaximaFrame.cpp:787
 #, fuzzy
 msgid "Show lisp representation"
 msgstr "顯示長的數式"
 
-#: ../../src/Worksheet.cpp:1604
+#: ../../src/dialogs/ConfigDialogue.cpp:465
+msgid "Show long expressions in wxMaxima document."
+msgstr "在 wxMaxima 文件中顯示長的數式"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:722
+#, fuzzy
+msgid "Show long expressions:"
+msgstr "顯示長的數式"
+
+#: ../../src/worksheet/WorksheetContextMenu.cpp:377
 msgid "Show max. 100 digits"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1602
+#: ../../src/worksheet/WorksheetContextMenu.cpp:375
 msgid "Show max. 20 digits"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1603
+#: ../../src/worksheet/WorksheetContextMenu.cpp:376
 msgid "Show max. 50 digits"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:835
+#: ../../src/wxMaximaFrame.cpp:868
 msgid "Show or hide the wxMaxima logging window"
 msgstr ""
 
-#: ../../src/ToolBar.cpp:612
+#: ../../src/ToolBar.cpp:812
 msgid "Show the \"New\" button?"
 msgstr ""
 
-#: ../../src/ToolBar.cpp:636
+#: ../../src/ToolBar.cpp:836
 msgid "Show the \"help\" button?"
 msgstr ""
 
-#: ../../src/ToolBar.cpp:633
+#: ../../src/ToolBar.cpp:833
 msgid "Show the \"search\" button?"
 msgstr ""
 
-#: ../../src/ToolBar.cpp:630
+#: ../../src/ToolBar.cpp:830
 msgid "Show the \"select all\" button?"
 msgstr ""
 
-#: ../../src/ToolBar.cpp:624
+#: ../../src/ToolBar.cpp:824
 msgid "Show the Copy, Cut and the Paste button?"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7033
+#: ../../src/wxMaximaFrame.cpp:650
+msgid "Show the differences between 2 or 3 files"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:3905
 #, fuzzy
 msgid "Show the function's definition"
 msgstr "顯示該函數的定義："
 
-#: ../../src/ToolBar.cpp:618
+#: ../../src/ToolBar.cpp:818
 msgid "Show the open and the save button?"
 msgstr ""
 
-#: ../../src/ToolBar.cpp:627
+#: ../../src/ToolBar.cpp:827
 msgid "Show the preferences button?"
 msgstr ""
 
-#: ../../src/ToolBar.cpp:621
+#: ../../src/ToolBar.cpp:821
 msgid "Show the print button?"
 msgstr ""
 
-#: ../../src/ToolBar.cpp:615
+#: ../../src/ToolBar.cpp:815
 #, fuzzy
 msgid "Show the undo and redo button?"
 msgstr "顯示該函數的定義："
 
-#: ../../src/wxMaximaFrame.cpp:1006 ../../src/wxMaximaFrame.cpp:1011
+#: ../../src/dialogs/TipOfTheDay.cpp:288
+msgid "Show tips at Startup"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1040 ../../src/wxMaximaFrame.cpp:1045
 msgid "Show used + to-be-freed memory"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1033
+#: ../../src/wxMaximaFrame.cpp:1067
 #, fuzzy
 msgid "Show user definitions"
 msgstr "顯示該函數的定義："
 
-#: ../../src/ToolBar.cpp:328 ../../src/wxMaximaFrame.cpp:1877
-#: ../../src/wxMaximaFrame.cpp:1879
+#: ../../src/ToolBar.cpp:544 ../../src/ToolBar.cpp:546
+#: ../../src/wxMaximaFrame.cpp:1914 ../../src/wxMaximaFrame.cpp:1916
 #, fuzzy
 msgid "Show wxMaxima help"
 msgstr "顯示 Maxima 說明"
 
-#: ../../src/wxMaximaFrame.cpp:1825
+#: ../../src/wxMaximaFrame.cpp:1862
 msgid "Shows how many digits of a numbers are displayed"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:732
+#: ../../src/wxMaximaFrame.cpp:769
 msgid "Sidebars"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1513
+#: ../../src/sidebars/GreekSidebar.cpp:195
+msgid "Sigma"
+msgstr ""
+
+#: ../../src/dialogs/FindReplacePane.cpp:88
+#, fuzzy
+msgid "Simple"
+msgstr "樣本："
+
+#: ../../src/MaximaCommandMenus.cpp:1819
+msgid "Simple linear regression"
+msgstr ""
+
+#: ../../src/sidebars/MathSidebar.cpp:44
+msgid "Simplify"
+msgstr "化簡"
+
+#: ../../src/wxMaximaFrame.cpp:1550
 #, fuzzy
 msgid "Simplify &Radicals..."
 msgstr "化簡根式(&R)"
 
-#: ../../src/Worksheet.cpp:1579
+#: ../../src/sidebars/MathSidebar.cpp:47
+msgid "Simplify (r)"
+msgstr "化簡根式"
+
+#: ../../src/sidebars/MathSidebar.cpp:65
+msgid "Simplify (tr)"
+msgstr "化簡 (三角)"
+
+#: ../../src/worksheet/WorksheetContextMenu.cpp:352
 msgid "Simplify Expression"
 msgstr "化簡數式"
 
-#: ../../src/wxMaximaFrame.cpp:1568
+#: ../../src/wxMaximaFrame.cpp:1605
 #, fuzzy
 msgid "Simplify Logarithms"
 msgstr "化簡此加總"
 
-#: ../../src/wxMaximaFrame.cpp:1582
+#: ../../src/wxMaximaFrame.cpp:1619
 msgid "Simplify an expression containing factorials"
 msgstr "化簡包含階乘的數式"
 
-#: ../../src/wxMaximaFrame.cpp:1539
+#: ../../src/wxMaximaFrame.cpp:1576
 #, fuzzy
 msgid "Simplify equations"
 msgstr "解方程式"
 
-#: ../../src/wxMaximaFrame.cpp:1514
+#: ../../src/wxMaximaFrame.cpp:1551
 msgid "Simplify expression containing radicals"
 msgstr "化簡包含根號的數式"
 
-#: ../../src/wxMaxima.cpp:8649
+#: ../../src/MaximaCommandMenus.cpp:641
 #, fuzzy
 msgid "Simplify radicals"
 msgstr "化簡根式(&R)"
 
-#: ../../src/wxMaximaFrame.cpp:1512
+#: ../../src/wxMaximaFrame.cpp:1549
 msgid "Simplify rational expression"
 msgstr "化簡有理數式"
 
-#: ../../src/wxMaximaFrame.cpp:1538
+#: ../../src/wxMaximaFrame.cpp:1575
 msgid "Simplify sum() commands..."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8636
+#: ../../src/MaximaCommandMenus.cpp:628
 #, fuzzy
 msgid "Simplify sums"
 msgstr "化簡"
 
-#: ../../src/wxMaximaFrame.cpp:1592
+#: ../../src/wizards/SumWiz.cpp:68
+msgid "Simplify the sum"
+msgstr "化簡此加總"
+
+#: ../../src/wxMaximaFrame.cpp:1629
 msgid "Simplify trigonometric expression"
 msgstr "化簡三角函數數式"
 
-#: ../../src/wxMaximaFrame.cpp:1399
+#: ../../src/dialogs/TipOfTheDay.cpp:139
+#, fuzzy
+msgid "Since wxMaxima 0.8.2 you can also insert images into your documents. Use 'Cell->Insert Image...' menu command."
+msgstr "自 wxMaxima 0.8.2 版開始您可以使用「單元(C)」->「插入圖片...」功能表在文件中插入圖片。請注意：若您希望將圖片與文件一起儲存，您必須將您的文件儲存為 「wxMaxima XML 文件」。"
+
+#: ../../src/wxMaximaFrame.cpp:1433
 msgid "Singular Values"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1400 ../../src/wxMaximaFrame.cpp:1403
+#: ../../src/wxMaximaFrame.cpp:1434 ../../src/wxMaximaFrame.cpp:1437
 msgid "Singular values using dgesvd"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1402
+#: ../../src/wxMaximaFrame.cpp:1436
 msgid "Singular values, left + right vectors"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1635
+#: ../../src/MaximaCommandMenus.cpp:487 ../../src/MaximaCommandMenus.cpp:500
+msgid "Size of internal work array. (limit - limlst)/2 is the maximum number of subintervals to use."
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:436 ../../src/MaximaCommandMenus.cpp:449
+#: ../../src/MaximaCommandMenus.cpp:462 ../../src/MaximaCommandMenus.cpp:476
+#: ../../src/MaximaCommandMenus.cpp:547 ../../src/MaximaCommandMenus.cpp:562
+#: ../../src/MaximaCommandMenus.cpp:577 ../../src/MaximaCommandMenus.cpp:592
+#: ../../src/MaximaCommandMenus.cpp:606
+msgid "Size of internal work array. limit is the maximum number of subintervals to use."
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:515 ../../src/MaximaCommandMenus.cpp:529
+msgid "Size of internal work array. limit/2 is the maximum number of subintervals to use."
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:2113
+msgid "Slanted"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:225
+msgid "Slovak"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:226
+msgid "Slovenian"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1672
 #, fuzzy
 msgid "Smart Substitute..."
 msgstr "代換..."
 
-#: ../../src/wxMaxima.cpp:8730
+#: ../../src/MaximaCommandMenus.cpp:725
 #, fuzzy
 msgid "Smart substitution"
 msgstr "代換"
 
-#: ../../src/wxMaxima.cpp:7799 ../../src/wxMaxima.cpp:7810
-#: ../../src/wxMaxima.cpp:7823
+#: ../../src/MaximaCommandMenus.cpp:980 ../../src/MaximaCommandMenus.cpp:991
+#: ../../src/MaximaCommandMenus.cpp:1004
 #, fuzzy
 msgid "Solution of the ODE:"
 msgstr "一般解："
 
-#: ../../src/wxMaxima.cpp:10017
+#: ../../src/wizards/BC2Wiz.cpp:30
+msgid "Solution:"
+msgstr "一般解："
+
+#: ../../src/MaximaCommandMenus.cpp:3506
 msgid "Solve"
 msgstr "求解"
 
-#: ../../src/wxMaximaFrame.cpp:1244
+#: ../../src/wxMaximaFrame.cpp:1278
 msgid "Solve &Algebraic System..."
 msgstr "解代數系統(&A)..."
 
-#: ../../src/wxMaximaFrame.cpp:1242
+#: ../../src/wxMaximaFrame.cpp:1276
 msgid "Solve &Linear System..."
 msgstr "解線性系統(&L)..."
 
-#: ../../src/wxMaximaFrame.cpp:1266
+#: ../../src/wxMaximaFrame.cpp:1300
 msgid "Solve &ODE..."
 msgstr "解常微分方程(&O)..."
 
-#: ../../src/wxMaximaFrame.cpp:1240
+#: ../../src/wxMaximaFrame.cpp:1274
 msgid "Solve (to_poly)..."
 msgstr "求解 (to_poly)..."
 
-#: ../../src/wxMaxima.cpp:8045
+#: ../../src/MaximaCommandMenus.cpp:1231
 msgid "Solve A*x=b numerically"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1397
+#: ../../src/wxMaximaFrame.cpp:1431
 #, fuzzy
 msgid "Solve Ax=b"
 msgstr "求解"
 
-#: ../../src/wxMaxima.cpp:7783
+#: ../../src/MaximaCommandMenus.cpp:964
 msgid "Solve ODE"
 msgstr "解常微分方程"
 
-#: ../../src/wxMaximaFrame.cpp:1287
+#: ../../src/wxMaximaFrame.cpp:1321
 msgid "Solve ODE with Lapla&ce..."
 msgstr "以 Laplace 變換解常微分方程(&C)..."
 
-#: ../../src/wxMaximaFrame.cpp:1398
+#: ../../src/sidebars/MathSidebar.cpp:77
+msgid "Solve ODE..."
+msgstr "解常微分方程..."
+
+#: ../../src/wxMaximaFrame.cpp:1432
 #, fuzzy
 msgid "Solve a linear equation system using dgesv"
 msgstr "解線性方程組"
 
-#: ../../src/wxMaxima.cpp:7852 ../../src/wxMaxima.cpp:7863
+#: ../../src/MaximaCommandMenus.cpp:1033 ../../src/MaximaCommandMenus.cpp:1044
 msgid "Solve algebraic system"
 msgstr "解代數系統"
 
-#: ../../src/wxMaximaFrame.cpp:1245
+#: ../../src/wxMaximaFrame.cpp:1279
 msgid "Solve algebraic system of equations"
 msgstr "解代數方程組"
 
-#: ../../src/wxMaximaFrame.cpp:1279
+#: ../../src/wxMaximaFrame.cpp:1313
 msgid "Solve boundary value problem for second degree ODE"
 msgstr "解 2 階常微分方程的邊界值問題"
 
-#: ../../src/wxMaxima.cpp:7895
+#: ../../src/MaximaCommandMenus.cpp:1076
 #, fuzzy
 msgid "Solve differential equations using laplace()"
 msgstr "以 Laplace 變換解常微分方程式"
 
-#: ../../src/wxMaxima.cpp:7744 ../../src/wxMaximaFrame.cpp:1238
+#: ../../src/MaximaCommandMenus.cpp:925 ../../src/wxMaximaFrame.cpp:1272
 msgid "Solve equation(s)"
 msgstr "解方程式"
 
-#: ../../src/wxMaximaFrame.cpp:1241
+#: ../../src/wxMaximaFrame.cpp:1275
 msgid "Solve equation(s) with to_poly_solve"
 msgstr "使用 to_poly_solve 解方程式"
 
-#: ../../src/wxMaxima.cpp:7773
+#: ../../src/MaximaCommandMenus.cpp:954
 #, fuzzy
 msgid "Solve equations numerically"
 msgstr "解方程式"
 
-#: ../../src/wxMaxima.cpp:7757
+#: ../../src/MaximaCommandMenus.cpp:938
 #, fuzzy
 msgid "Solve equations to polynom"
 msgstr "使用 to_poly_solve 解方程式"
 
-#: ../../src/wxMaximaFrame.cpp:1271
+#: ../../src/wxMaximaFrame.cpp:1305
 msgid "Solve initial value problem for first degree ODE"
 msgstr "解 1 階常微分方程的初始值問題"
 
-#: ../../src/wxMaximaFrame.cpp:1275
+#: ../../src/wxMaximaFrame.cpp:1309
 msgid "Solve initial value problem for second degree ODE"
 msgstr "解 2 階常微分方程的初始值問題"
 
-#: ../../src/wxMaxima.cpp:7874 ../../src/wxMaxima.cpp:7884
+#: ../../src/MaximaCommandMenus.cpp:1055 ../../src/MaximaCommandMenus.cpp:1065
 msgid "Solve linear system"
 msgstr "解線性系統"
 
-#: ../../src/wxMaximaFrame.cpp:1243
+#: ../../src/wxMaximaFrame.cpp:1277
 msgid "Solve linear system of equations"
 msgstr "解線性方程組"
 
-#: ../../src/wxMaximaFrame.cpp:1263
+#: ../../src/wxMaximaFrame.cpp:1297
 msgid "Solve numerical, 1 Variable"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1267
+#: ../../src/wxMaximaFrame.cpp:1301
 msgid "Solve ordinary differential equation of maximum degree 2"
 msgstr "解常微分方程式 (最大 2 階)"
 
-#: ../../src/wxMaximaFrame.cpp:1288
+#: ../../src/wxMaximaFrame.cpp:1322
 msgid "Solve ordinary differential equations with Laplace transformation"
 msgstr "以 Laplace 變換解常微分方程式"
 
-#: ../../src/wxMaxima.cpp:7708
+#: ../../src/MaximaCommandMenus.cpp:891
 #, fuzzy
 msgid "Solve polynomials numerically"
 msgstr "解方程式"
 
-#: ../../src/wxMaxima.cpp:7718
+#: ../../src/MaximaCommandMenus.cpp:900
 #, fuzzy
 msgid "Solve polynomials numerically (bfloats)"
 msgstr "解方程式"
 
-#: ../../src/wxMaxima.cpp:7729
+#: ../../src/MaximaCommandMenus.cpp:910
 #, fuzzy
 msgid "Solve polynomials numerically (real roots)"
 msgstr "解方程式"
 
-#: ../../src/wxMaximaFrame.cpp:1249
+#: ../../src/wxMaximaFrame.cpp:1283
 #, fuzzy
 msgid "Solve symbolically"
 msgstr "解方程式"
 
-#: ../../src/Worksheet.cpp:1574
+#: ../../src/sidebars/MathSidebar.cpp:74
+#: ../../src/worksheet/WorksheetContextMenu.cpp:347
 msgid "Solve..."
 msgstr "求解..."
 
-#: ../../src/wxMaximaFrame.cpp:1916
+#: ../../src/wxMaximaFrame.cpp:1953
 msgid "Solving differential equations"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1904
+#: ../../src/wxMaximaFrame.cpp:1941
 msgid "Solving equations with Maxima"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7105
+#: ../../src/MaximaCommandMenus.cpp:3977
 #, c-format
 msgid ""
 "Sometimes one wants maxima to loose the information that a function name was used with the ' operator in order to make maxima not evaluate it. In other places one wants % to mean \"the last expression at the time this function was created\", not \"the last expression now\".\n"
 "In both cases the '' operator will do what is requested."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1746
+#: ../../src/wxMaximaFrame.cpp:1783
 msgid "Sort"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8496
+#: ../../src/wizards/ListSortWiz.cpp:41
+msgid "Sort Criterion:"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:1500
 #, fuzzy
 msgid "Sort a list"
 msgstr "產生串列"
 
-#: ../../src/wxMaxima.cpp:7459
+#: ../../src/MaximaCommandMenus.cpp:4331
 msgid "Sort all characters in string"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1179
+#: ../../src/wxMaximaFrame.cpp:1213
 #, fuzzy
 msgid "Sort the characters..."
 msgstr "希臘字母"
 
-#: ../../src/wxMaxima.cpp:8482
+#: ../../src/MaximaCommandMenus.cpp:1486
 #, fuzzy
 msgid "Source list:"
 msgstr "產生串列"
 
-#: ../../src/wxMaxima.cpp:7429
+#: ../../src/dialogs/ConfigDialogue.cpp:227
+msgid "Spanish"
+msgstr "Spanish"
+
+#: ../../src/wizards/IntegrateWiz.cpp:44 ../../src/wizards/IntegrateWiz.cpp:50
+#: ../../src/wizards/LimitWiz.cpp:38 ../../src/wizards/SeriesWiz.cpp:39
+msgid "Special"
+msgstr "特殊"
+
+#: ../../src/wizards/DrawWiz.cpp:918
+msgid "Speed versus accuracy"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:4301
 msgid "Split"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1191
+#: ../../src/wxMaximaFrame.cpp:1225
 msgid "Split on match"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7528
+#: ../../src/MaximaCommandMenus.cpp:4400
 msgid "Split on regex match"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7449
+#: ../../src/MaximaCommandMenus.cpp:4321
 msgid "Split string into tokens"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1171
+#: ../../src/wxMaximaFrame.cpp:1205
 #, fuzzy
 msgid "Split..."
 msgstr "箱形圖..."
 
-#: ../../src/wxMaximaFrame.cpp:788
+#: ../../src/wxMaximaFrame.cpp:825
 msgid "Square"
 msgstr ""
 
-#: ../../src/Configuration.cpp:86
+#: ../../src/dialogs/ConfigDialogue.cpp:1300
+#, fuzzy
+msgid "Standard Options"
+msgstr "選項"
+
+#: ../../src/Styles.cpp:115
 #, fuzzy
 msgid "Standard Text"
 msgstr "選項"
 
-#: ../../src/Worksheet.cpp:1298
+#: ../../src/worksheet/WorksheetContextMenu.cpp:60
 msgid "Start Animation"
 msgstr "開始動畫"
 
-#: ../../src/wxMaxima.cpp:7842
+#: ../../src/dialogs/ConfigDialogue.cpp:1622
+msgid "Start a new maxima for each re-evaluation"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:1023
 msgid "Start of t:"
 msgstr ""
 
-#: ../../src/ToolBar.cpp:305
+#: ../../src/wizards/DrawWiz.cpp:66 ../../src/wizards/DrawWiz.cpp:171
+msgid "Start of the x value"
+msgstr ""
+
+#: ../../src/wizards/DrawWiz.cpp:83 ../../src/wizards/DrawWiz.cpp:186
+msgid "Start of the y value"
+msgstr ""
+
+#: ../../src/wizards/DrawWiz.cpp:203
+msgid "Start of the z value"
+msgstr ""
+
+#: ../../src/ToolBar.cpp:507 ../../src/ToolBar.cpp:519
 #, fuzzy
 msgid "Start or Stop animation"
 msgstr "開始動畫"
 
-#: ../../src/ToolBar.cpp:306
+#: ../../src/ToolBar.cpp:508 ../../src/ToolBar.cpp:520
 msgid "Start or stop the currently selected animation that has been created with the with_slider class of commands"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:386
+#: ../../src/dialogs/ConfigDialogue.cpp:496
+msgid "Start searching while the phrase to search for is still being typed."
+msgstr ""
+
+#: ../../src/wizards/DrawWiz.cpp:755
+#, fuzzy
+msgid "Start value of the parameter"
+msgstr "將最後的計算結果以浮點數 (float) 表示"
+
+#: ../../src/wxMaxima.cpp:403
 msgid "Starting Maxima process failed"
 msgstr "Maxima 程序啟動失敗"
 
-#: ../../src/main.cpp:667
+#: ../../src/main.cpp:956
 #, fuzzy
 msgid "Starting a new wxMaxima process for a new window"
 msgstr "Maxima 程序啟動失敗"
 
-#: ../../src/wxMaxima.cpp:3105 ../../src/wxMaxima.cpp:5633
+#: ../../src/wxMaxima.cpp:1858 ../../src/wxMaxima.cpp:1884
 msgid "Starting evaluation of the document"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2544
+#: ../../src/MaximaProcessManager.cpp:205
 msgid "Starting server failed"
 msgstr "伺服器啟動失敗"
 
-#: ../../src/WXMXformat.cpp:64
-msgid "Starting to save the worksheet as .wxmx"
+#: ../../src/WXMXformat.cpp:65
+#, c-format
+msgid "Starting to save the worksheet as .wxmx. Filename: %s"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:252
+#: ../../src/dialogs/ConfigDialogue.cpp:286
+msgid "Startup commands"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:266
 msgid "Statistics"
 msgstr "統計"
 
-#: ../../src/wxMaximaFrame.cpp:701
+#: ../../src/wxMaximaFrame.cpp:736
 msgid "Statistics\tAlt+Shift+S"
 msgstr "統計\tAlt+Shift+S"
 
-#: ../../src/wxMaxima.cpp:7844
+#: ../../src/MaximaCommandMenus.cpp:1025
 #, fuzzy
 msgid "Step width:"
 msgstr "乘積"
 
-#: ../../src/wxMaximaFrame.cpp:794
+#: ../../src/dialogs/ConfigDialogue.cpp:939
+msgid "Store filenames in image cells to enable image reloading after re-opening the worksheet"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:831
 msgid "Straight lines"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1106
+#: ../../src/wxMaximaFrame.cpp:1140
 msgid "Stream"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7231
+#: ../../src/MaximaCommandMenus.cpp:4103
 msgid "Stream length"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7219 ../../src/wxMaxima.cpp:7224
-#: ../../src/wxMaxima.cpp:7228 ../../src/wxMaxima.cpp:7232
-#: ../../src/wxMaxima.cpp:7236 ../../src/wxMaxima.cpp:7240
-#: ../../src/wxMaxima.cpp:7245 ../../src/wxMaxima.cpp:7250
-#: ../../src/wxMaxima.cpp:7256 ../../src/wxMaxima.cpp:7263
-#: ../../src/wxMaxima.cpp:7267 ../../src/wxMaxima.cpp:7271
-#: ../../src/wxMaxima.cpp:7276
+#: ../../src/MaximaCommandMenus.cpp:4091 ../../src/MaximaCommandMenus.cpp:4096
+#: ../../src/MaximaCommandMenus.cpp:4100 ../../src/MaximaCommandMenus.cpp:4104
+#: ../../src/MaximaCommandMenus.cpp:4108 ../../src/MaximaCommandMenus.cpp:4112
+#: ../../src/MaximaCommandMenus.cpp:4117 ../../src/MaximaCommandMenus.cpp:4122
+#: ../../src/MaximaCommandMenus.cpp:4128 ../../src/MaximaCommandMenus.cpp:4135
+#: ../../src/MaximaCommandMenus.cpp:4139 ../../src/MaximaCommandMenus.cpp:4143
+#: ../../src/MaximaCommandMenus.cpp:4148
 msgid "Stream:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1185
+#: ../../src/dialogs/ConfigDialogue.cpp:2117
+msgid "Strike Through"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1219
 #, fuzzy
 msgid "String"
 msgstr "字串"
 
-#: ../../src/wxMaxima.cpp:7345 ../../src/wxMaxima.cpp:7350
-#: ../../src/wxMaxima.cpp:7425
+#: ../../src/MaximaCommandMenus.cpp:4217 ../../src/MaximaCommandMenus.cpp:4222
+#: ../../src/MaximaCommandMenus.cpp:4297
 #, fuzzy
 msgid "String #1:"
 msgstr "字串"
 
-#: ../../src/wxMaxima.cpp:7346 ../../src/wxMaxima.cpp:7351
-#: ../../src/wxMaxima.cpp:7426
+#: ../../src/MaximaCommandMenus.cpp:4218 ../../src/MaximaCommandMenus.cpp:4223
+#: ../../src/MaximaCommandMenus.cpp:4298
 #, fuzzy
 msgid "String #2:"
 msgstr "字串"
 
-#: ../../src/wxMaximaFrame.cpp:1136
+#: ../../src/wxMaximaFrame.cpp:1170
 #, fuzzy
 msgid "String Tests"
 msgstr "字串"
 
-#: ../../src/wxMaxima.cpp:7415
+#: ../../src/MaximaCommandMenus.cpp:4287
 #, fuzzy
 msgid "String length"
 msgstr "字串"
 
-#: ../../src/wxMaxima.cpp:7381
+#: ../../src/MaximaCommandMenus.cpp:4253
 msgid "String to list of char"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1148
+#: ../../src/wxMaximaFrame.cpp:1182
 msgid "String to list of chars..."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7496
+#: ../../src/MaximaCommandMenus.cpp:4368
 #, fuzzy
 msgid "String to octets"
 msgstr "字串"
 
-#: ../../src/wxMaximaFrame.cpp:1160
+#: ../../src/wxMaximaFrame.cpp:1194
 msgid "String to octets..."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7377 ../../src/wxMaxima.cpp:7382
-#: ../../src/wxMaxima.cpp:7391 ../../src/wxMaxima.cpp:7396
-#: ../../src/wxMaxima.cpp:7400 ../../src/wxMaxima.cpp:7407
-#: ../../src/wxMaxima.cpp:7412 ../../src/wxMaxima.cpp:7416
-#: ../../src/wxMaxima.cpp:7420 ../../src/wxMaxima.cpp:7430
-#: ../../src/wxMaxima.cpp:7436 ../../src/wxMaxima.cpp:7441
-#: ../../src/wxMaxima.cpp:7446 ../../src/wxMaxima.cpp:7450
-#: ../../src/wxMaxima.cpp:7456 ../../src/wxMaxima.cpp:7460
-#: ../../src/wxMaxima.cpp:7465 ../../src/wxMaxima.cpp:7470
-#: ../../src/wxMaxima.cpp:7474 ../../src/wxMaxima.cpp:7478
-#: ../../src/wxMaxima.cpp:7497
+#: ../../src/MaximaCommandMenus.cpp:4249 ../../src/MaximaCommandMenus.cpp:4254
+#: ../../src/MaximaCommandMenus.cpp:4263 ../../src/MaximaCommandMenus.cpp:4268
+#: ../../src/MaximaCommandMenus.cpp:4272 ../../src/MaximaCommandMenus.cpp:4279
+#: ../../src/MaximaCommandMenus.cpp:4284 ../../src/MaximaCommandMenus.cpp:4288
+#: ../../src/MaximaCommandMenus.cpp:4292 ../../src/MaximaCommandMenus.cpp:4302
+#: ../../src/MaximaCommandMenus.cpp:4308 ../../src/MaximaCommandMenus.cpp:4313
+#: ../../src/MaximaCommandMenus.cpp:4318 ../../src/MaximaCommandMenus.cpp:4322
+#: ../../src/MaximaCommandMenus.cpp:4328 ../../src/MaximaCommandMenus.cpp:4332
+#: ../../src/MaximaCommandMenus.cpp:4337 ../../src/MaximaCommandMenus.cpp:4342
+#: ../../src/MaximaCommandMenus.cpp:4346 ../../src/MaximaCommandMenus.cpp:4350
+#: ../../src/MaximaCommandMenus.cpp:4369
 #, fuzzy
 msgid "String:"
 msgstr "字串"
 
-#: ../../src/wxMaxima.cpp:7197
+#: ../../src/MaximaCommandMenus.cpp:4069
 msgid "Struct :"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7184 ../../src/wxMaxima.cpp:7190
+#: ../../src/MaximaCommandMenus.cpp:4056 ../../src/MaximaCommandMenus.cpp:4062
 msgid "Struct type name:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1029
+#: ../../src/wxMaximaFrame.cpp:1063
 msgid "Structs"
 msgstr ""
 
-#: ../../src/ToolBar.cpp:274
+#: ../../src/dialogs/ConfigDialogue.cpp:282
+msgid "Style"
+msgstr "樣式"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:2082
+msgid "Styles"
+msgstr "樣式"
+
+#: ../../src/sidebars/StatSidebar.cpp:112
+msgid "Subsample..."
+msgstr "子樣本..."
+
+#: ../../src/ToolBar.cpp:484 ../../src/sidebars/FormatSidebar.cpp:54
 msgid "Subsection"
 msgstr "子章節"
 
-#: ../../src/Configuration.cpp:90
+#: ../../src/Styles.cpp:119
 msgid "Subsection cell (Heading 3)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1643
+#: ../../src/wxMaximaFrame.cpp:1680
 msgid "Subst constant t into eq with diff(x,t)..."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8724
+#: ../../src/MaximaCommandMenus.cpp:716
 msgid "Subst is a better string-search-and-replace for expressions."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7688 ../../src/wxMaxima.cpp:8723
-#: ../../src/wxMaxima.cpp:10061 ../../src/wxMaximaFrame.cpp:1651
+#: ../../src/sidebars/MathSidebar.cpp:59
+msgid "Subst..."
+msgstr "代換"
+
+#: ../../src/MaximaCommandMenus.cpp:715 ../../src/MaximaCommandMenus.cpp:3550
+#: ../../src/MaximaCommandMenus.cpp:4560 ../../src/wizards/SubstituteWiz.cpp:53
+#: ../../src/wxMaximaFrame.cpp:1688
 msgid "Substitute"
 msgstr "代換"
 
-#: ../../src/wxMaximaFrame.cpp:1193
+#: ../../src/wxMaximaFrame.cpp:1227
 #, fuzzy
 msgid "Substitute all matches"
 msgstr "代換..."
 
-#: ../../src/wxMaximaFrame.cpp:1192
+#: ../../src/wxMaximaFrame.cpp:1226
 msgid "Substitute first match"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1646
+#: ../../src/MaximaCommandMenus.cpp:767
+msgid "Substitute only in a specific part"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1683
 #, fuzzy
 msgid "Substitute only in parts..."
 msgstr "代換..."
 
-#: ../../src/wxMaxima.cpp:8763
-msgid "Substitute only in specific parts"
-msgstr ""
-
-#: ../../src/wxMaximaFrame.cpp:1647
+#: ../../src/wxMaximaFrame.cpp:1684
 msgid "Substitute only in the elements n_1, n_2,..."
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1585 ../../src/wxMaximaFrame.cpp:1633
+#: ../../src/worksheet/WorksheetContextMenu.cpp:358
+#: ../../src/wxMaximaFrame.cpp:1670
 msgid "Substitute..."
 msgstr "代換..."
 
-#: ../../src/wxMaximaFrame.cpp:1641 ../../src/wxMaximaFrame.cpp:1644
+#: ../../src/wxMaximaFrame.cpp:1678 ../../src/wxMaximaFrame.cpp:1681
 msgid "Substitutes until the equation no more changes"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8747
+#: ../../src/MaximaCommandMenus.cpp:745
 msgid "Substitutes up to lrats_max_iter times, or until the expression stops changing when substituting."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8756
+#: ../../src/MaximaCommandMenus.cpp:757
 #, c-format
 msgid "Substitutes, but makes sure that if substituting t=0 in diff(x,t) the result isn't 0 (as t no more changes), but %at(diff(x,t),t=0)."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8739
+#: ../../src/MaximaCommandMenus.cpp:736
 msgid "Substitutes, but makes sure that nothing is substituted into the other substituents."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1638
+#: ../../src/wxMaximaFrame.cpp:1675
 msgid "Substitutes, but not in the other substituents"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8764
-msgid "Substitutes, but only in the n_1th, n_2th and so on term of the equation."
-msgstr ""
-
-#: ../../src/ToolBar.cpp:275
+#: ../../src/ToolBar.cpp:485 ../../src/sidebars/FormatSidebar.cpp:57
 #, fuzzy
 msgid "Subsubsection"
 msgstr "子章節"
 
-#: ../../src/Configuration.cpp:89
+#: ../../src/Styles.cpp:118
 msgid "Subsubsection cell (Heading 4)"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1831
+#: ../../src/worksheet/WorksheetContextMenu.cpp:603
 #, fuzzy
 msgid "Suggestion: "
 msgstr "子章節"
 
-#: ../../src/Worksheet.cpp:2030
+#: ../../src/worksheet/WorksheetContextMenu.cpp:802
 msgid "Suitable as flag for ev()"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:9049
+#: ../../src/MaximaCommandMenus.cpp:303 ../../src/wizards/SumWiz.cpp:60
 msgid "Sum"
 msgstr "加總"
 
-#: ../../src/wxMaximaFrame.cpp:1551
+#: ../../src/sidebars/SymbolsSidebar.cpp:122
+msgid "Sum sign"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:228
+msgid "Swedish"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1588
 msgid "Switch off simplifications of log(). Set Maxima option variable logexpand:false"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:4090
+#: ../../src/MaximaResponseReader.cpp:569
 msgid "Switched to lisp mode after receiving a lisp debug prompt!"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:4092
+#: ../../src/MaximaResponseReader.cpp:428
+#: ../../src/MaximaResponseReader.cpp:571
 msgid "Switched to lisp mode after receiving a lisp prompt!"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1971
+#: ../../src/worksheet/WorksheetContextMenu.cpp:743
 #, fuzzy
 msgid "Symbolic Constant"
 msgstr "選擇常數"
 
-#: ../../src/wxMaximaFrame.cpp:705
+#: ../../src/wxMaximaFrame.cpp:740
 #, fuzzy
 msgid "Symbols\tAlt+Shift+Y"
 msgstr "統計\tAlt+Shift+S"
 
-#: ../../src/Worksheet.cpp:2006
+#: ../../src/dialogs/ConfigDialogue.cpp:472
+msgid "Symbols that are entered or copied here will appear in the symbols sidebar so they can be entered into the worksheet easily."
+msgstr ""
+
+#: ../../src/worksheet/WorksheetContextMenu.cpp:778
 msgid "Symmetric function: f(x)=f(-x)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:238
+#: ../../src/dialogs/DiffFrame.cpp:370 ../../src/dialogs/DiffFrame.cpp:387
+msgid "Sync Horizontal"
+msgstr ""
+
+#: ../../src/dialogs/DiffFrame.cpp:382 ../../src/dialogs/DiffFrame.cpp:388
+msgid "Sync Vertical"
+msgstr ""
+
+#: ../../src/wizards/CsvWiz.cpp:42 ../../src/wizards/CsvWiz.cpp:113
+msgid "Tab"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:252
 msgid "Table of Contents"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:711
+#: ../../src/wxMaximaFrame.cpp:746
 #, fuzzy
 msgid "Table of Contents\tAlt+Shift+T"
 msgstr "工具列\tAlt+Shift+T"
 
-#: ../../src/wxMaxima.cpp:8930
+#: ../../src/wizards/DrawWiz.cpp:561
+msgid "Take surface color from steepness"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:229
+msgid "Tamil"
+msgstr ""
+
+#: ../../src/sidebars/GreekSidebar.cpp:196
+msgid "Tau"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:181
 #, fuzzy
 msgid "Taylor series"
 msgstr "Taylor 級數："
 
-#: ../../src/wxMaximaFrame.cpp:1474
+#: ../../src/wxMaximaFrame.cpp:1511
 #, fuzzy
 msgid "Taylor series..."
 msgstr "Taylor 級數："
 
-#: ../../src/wxMaxima.cpp:8925
+#: ../../src/MaximaCommandMenus.cpp:176
 msgid "Taylor series:"
 msgstr "Taylor 級數："
 
-#: ../../src/wxMaxima.cpp:4132
+#: ../../src/wxMaxima.cpp:1488
 msgid "Telling maxima about the new working directory."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7907
+#: ../../src/MaximaCommandMenus.cpp:1088
 msgid "Tells maxima for an f(x), that f(x=t)=a"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1945
+#: ../../src/wxMaximaFrame.cpp:1982
 msgid "Tells maxima to show the help for ?, ?? and describe() in a separate browser window"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1941
+#: ../../src/wxMaximaFrame.cpp:1978
 msgid "Tells maxima to show the help for ?, ?? and describe() in a wxMaxima sidebar"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1936
+#: ../../src/wxMaximaFrame.cpp:1973
 msgid "Tells maxima to show the help for ?, ?? and describe() on the console"
 msgstr ""
 
-#: ../../src/ToolBar.cpp:271
+#: ../../src/dialogs/ConfigDialogue.cpp:148
+msgid "Tells maxima where to store the result of compiling libraries"
+msgstr ""
+
+#: ../../src/ToolBar.cpp:481 ../../src/sidebars/FormatSidebar.cpp:45
 msgid "Text"
 msgstr "文字"
 
-#: ../../src/Configuration.cpp:93
+#: ../../src/dialogs/ConfigDialogue.cpp:739
+msgid "Text & Code"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:738
+#, fuzzy
+msgid "Text Only"
+msgstr "文字單元"
+
+#: ../../src/Styles.cpp:122
 msgid "Text cell background"
 msgstr "文字單元背景"
 
-#: ../../src/wxMaxima.cpp:6541
+#: ../../src/dialogs/TipOfTheDay.cpp:219
+msgid "Text cells can hold citations that as marked as such by beginning a line with \" > \". The number of spaces in front of the \">\" determines the indentation level, as it does with bullet lists."
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:3061
 msgid "Text snippet"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:4632
+#: ../../src/dialogs/TipOfTheDay.cpp:205
+msgid ""
+"The \"at\" function allows introducing one equation into another:\n"
+"\n"
+"    ohm:U=R*I;\n"
+"    r_parallel:R=R_1*R_2/(R_1+R_2);\n"
+"    result:at(ohm,r_parallel);"
+msgstr ""
+
+#: ../../src/MaximaFileIO.cpp:555
 msgid "The .xml file doesn't seem to be valid xml or isn't a content.xml extracted from a .wxmx zip archive"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2734
+#: ../../src/MaximaProcessManager.cpp:844
 msgid "The Maxima process doesn't offer a shared memory segment we can send an interrupt signal to."
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:392
+msgid "The URL MathJaX.js should be downloaded from by our HTML export."
+msgstr ""
+
+#: ../../src/cells/TextCell.cpp:336
+msgid "The [] or the part() command tried to access a list or matrix element that doesn't exist."
+msgstr ""
+
+#: ../../src/sidebars/DrawSidebar.cpp:106
+msgid "The accuracy versus speed tradeoff"
+msgstr ""
+
+#: ../../src/cells/TextCell.cpp:357
+msgid "The argument of a function was of the wrong type. Most probably an equation was expected but was lacking an \"=\"."
 msgstr ""
 
 #: ../../src/MaximaManual.cpp:107
 msgid "The cache for the subjects the manual contains cannot be read."
 msgstr ""
 
-#: ../../src/MaximaManual.cpp:378
+#: ../../src/MaximaManual.cpp:395
 msgid "The cache for the subjects the manual contains has no head node."
 msgstr ""
 
-#: ../../src/MaximaManual.cpp:396
+#: ../../src/MaximaManual.cpp:413
 msgid "The cache for the subjects the manual contains is from a different Maxima version."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1379
+#: ../../src/wxMaximaFrame.cpp:1413
 msgid "The classic operations one typically uses matrices for"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7193
+#: ../../src/sidebars/DrawSidebar.cpp:91
+msgid "The color of the next line to draw"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:4065
 msgid "The comma-separated contents of the struct fields"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7186
+#: ../../src/MaximaCommandMenus.cpp:4058
 #, fuzzy
 msgid "The comma-separated names of the struct fields"
 msgstr "輸入以逗號分隔的所有變數"
 
-#: ../../src/wxMaxima.cpp:7070
-msgid "The command local() allows to tell maxima which functions to make local to the current program when defined."
+#: ../../src/MaximaCommandMenus.cpp:3942
+msgid "The command local() allows telling Maxima which functions to make local to the current program when defined."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:303
+#: ../../src/wxMaximaFrame.cpp:324
 msgid "The current Wizard"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:9592
+#: ../../src/dialogs/ConfigDialogue.cpp:415
+msgid "The default height for embedded plots. Can be read out or overridden by the maxima variable wxplot_size."
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:492
+msgid "The default port used for communication between Maxima and wxMaxima."
+msgstr "供 Maxima 與 wxMaxima 溝通的預設埠"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:412
+msgid "The default width for embedded plots. Can be read out or overridden by the maxima variable wxplot_size"
+msgstr ""
+
+#: ../../src/sidebars/DrawSidebar.cpp:74
+msgid "The diagram title"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:2401
+#, c-format
+msgid "The directory %s with maxima's startup file doesn't exist. Trying to create it..."
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:150
+msgid "The directory containing the startup files, any user libraries and, if MAXIMA_OBJDIR isn't set the subdirectory with the results from compiling maxima libraries."
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:154
+msgid "The directory maxima places temporary files in, for example plots that are to be included in the worksheet."
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:157
+msgid "The directory the compiled versions of maxima are placed in"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:159
+msgid "The directory the maxima manual can be found in"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:160
+msgid "The directory the user's home directory is in"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:475
+msgid "The document class LaTeX is instructed to use for our documents."
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:1832
 msgid "The equation to fit the data to"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8447
+#: ../../src/MaximaCommandMenus.cpp:774
+msgid "The expression to substitute in"
+msgstr ""
+
+#: ../../src/MaximaFileIO.cpp:444
+#, c-format
+msgid "The file claims %ld watch variables; capping at %ld."
+msgstr ""
+
+#: ../../src/sidebars/DrawSidebar.cpp:96
+msgid "The fill color for the next objects"
+msgstr ""
+
+#: ../../src/cells/TextCell.cpp:354
+msgid "The first argument of subst() isn't an equation or a list of equations. Most probably it was lacking an \"=\"."
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:1444
 msgid "The function call whose arguments to extract"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1298
+#: ../../src/sidebars/DrawSidebar.cpp:100
+msgid "The grid in the background of the diagram"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1332
 msgid "The half of the equation that is to the left of the \"=\""
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1302
+#: ../../src/wxMaximaFrame.cpp:1336
 msgid "The half of the equation that is to the right of the \"=\""
 msgstr ""
 
-#: ../../src/MaximaManual.cpp:399
+#: ../../src/MaximaManual.cpp:416
 msgid "The help dir from the cache differs from the current one."
 msgstr ""
 
-#: ../../src/Image.cpp:985
+#: ../../src/Image.cpp:1136
 msgid ""
 "The image could not be displayed. It may be broken, in a wrong format or be the result of gnuplot not being able to write the image or not being able to understand what maxima wanted to plot.\n"
 "One example of the latter would be: Gnuplot refuses to plot entirely empty images"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:9799 ../../src/wxMaxima.cpp:10158
+#: ../../src/MaximaCommandMenus.cpp:3262 ../../src/MaximaCommandMenus.cpp:3687
 #, c-format
 msgid "The image file \"%s\" cannot be found."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:718
+#: ../../src/wxMaximaFrame.cpp:753
 msgid "The integrated help browser"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:9591
+#: ../../src/cells/TextCell.cpp:397
+#, fuzzy
+msgid "The inverse laplace transform."
+msgstr "反 Laplace 變換(&R)..."
+
+#: ../../src/dialogs/TipOfTheDay.cpp:223
+msgid "The key combination Shift+Space results in a non-breakable space."
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:162
+msgid "The list of directories the operating system looks for programs in"
+msgstr ""
+
+#: ../../src/cells/TextCell.cpp:293
+msgid "The list of time-dependent variables to solve to doesn't match the time-dependent variables the list of dgls contains."
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:1831
 msgid "The list of variables contained in each matrix row"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:214
+#: ../../src/dialogs/TipOfTheDay.cpp:166
+msgid "The load() command of Maxima versions >5.38 is able to load .wxm files as library of Maxima's commands."
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:228
 msgid "The main toolbar"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1882
+#: ../../src/wxMaximaFrame.cpp:1919
 msgid "The manual of Maxima"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1881
+#: ../../src/wxMaximaFrame.cpp:1918
 #, fuzzy
 msgid "The manual of wxMaxima"
 msgstr "歡迎使用 wxMaxima"
 
-#: ../../src/wxMaxima.cpp:7125
+#: ../../src/dialogs/MaxSizeChooser.cpp:59
+msgid "The maximum size for this image. Values <= 0 mean: Unspecified."
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:3997
 msgid "The name of a function we don't want to be evaluated here"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7131
+#: ../../src/MaximaCommandMenus.cpp:4003
 msgid "The name of an expression that we don't want to be evaluated."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7199
+#: ../../src/MaximaCommandMenus.cpp:4071
 msgid "The name of the field to read"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7185
+#: ../../src/MaximaCommandMenus.cpp:4057
 msgid "The name of the new struct type"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7198
+#: ../../src/MaximaCommandMenus.cpp:4070
 msgid "The name of the struct"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7191
+#: ../../src/MaximaCommandMenus.cpp:4063
 msgid "The name of the struct type"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8220
+#: ../../src/MaximaCommandMenus.cpp:1410
 msgid "The name of the variable that shall contain the current element"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8468
+#: ../../src/sidebars/DrawSidebar.cpp:86
+msgid "The next plot's title"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:494
+msgid "The number of recently opened files that is to be remembered."
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:1471
 msgid "The number of the item which is stepped from \"Index Start\" to \"Index End\"."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8465 ../../src/wxMaxima.cpp:8478
+#: ../../src/dialogs/ConfigDialogue.cpp:477
+msgid "The options the document class LaTeX is instructed to use for our documents gets."
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1065
+#: ../../src/dialogs/ConfigDialogue.cpp:1112
+msgid "The part of the output of these commands that isn't declared as \"math\" might be suppressed by wxMaxima. As always maxima commands are required to end in a \";\" or a \"$\""
+msgstr ""
+
+#: ../../src/dialogs/ResolutionChooser.cpp:51
+msgid "The resolution for this image."
+msgstr ""
+
+#: ../../src/cells/TextCell.cpp:182
+msgid "The result was indefinite, which might be infinity, both plus or minus infinity or something additionally potentially involving a complex infinity."
+msgstr ""
+
+#: ../../src/cells/TextCell.cpp:180
+msgid "The result was undefined."
+msgstr ""
+
+#: ../../src/dialogs/TipOfTheDay.cpp:209
+msgid ""
+"The rhs() (\"right hand side\") command allows retrieving the result of an equation in exactly the format a function would have:\n"
+"\n"
+"    Values:[\n"
+"        /* m=1.2 tons */\n"
+"        m=1.2*10^3,\n"
+"        /* 100 km/h*/\n"
+"        v=100*10^3/(60*60)\n"
+"    ];\n"
+"    Energy:W=1/2*m*v^2;\n"
+"    at(Energy,Values);\n"
+"    W_mech:rhs(%);"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:1468
 msgid ""
 "The rule that explains how to generate the value of a list item.\n"
 "Might be something like \"i\", \"i^2\" or \"sin(i)\""
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7785
+#: ../../src/cells/TextCell.cpp:351
+msgid "The second argument of at() isn't an equation or a list of equations. Most probably it was lacking an \"=\"."
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:3481
+msgid "The selection contains no output that could be exported."
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:966
 msgid "The solution of an ODE describes the general shape of the resulting curve. The actual height of that curve is defined by the initial condition or boundary values, later on."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7818
+#: ../../src/MaximaCommandMenus.cpp:999
 msgid ""
 "The solution of an ODE tells the shape, but not the height of the solution.\n"
 "If the ODE's result is known at two points this function fills in the correct values for the  constants"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7794 ../../src/wxMaxima.cpp:7805
+#: ../../src/MaximaCommandMenus.cpp:975 ../../src/MaximaCommandMenus.cpp:986
 msgid ""
 "The solution of an ODE tells the shape, but not the height of the solution.\n"
 "If the ODE's state is known at a point this function fills in the correct values for the constants"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7896
+#: ../../src/MaximaCommandMenus.cpp:1077
 msgid ""
 "The solution variable needs to be in the form\n"
 "   U(t)=1/2*U(t)+3*diff(U(t),t)\n"
 "for this to work; Initial conditions can be specified using atvalue()."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8481 ../../src/wxMaxima.cpp:8582
+#: ../../src/sidebars/DrawSidebar.cpp:58
+msgid "The standard plot command: Plot an equation as a curve"
+msgstr ""
+
+#: ../../src/cells/TextCell.cpp:267
+msgid "The value of few special variables is assigned by Maxima and cannot be changed by the user. Also a few constructs aren't variable names and therefore cannot be written to."
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:1485 ../../src/MaximaCommandMenus.cpp:1600
 msgid "The variable the value of the current source item is stored in."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:9594
+#: ../../src/MaximaCommandMenus.cpp:1834
 msgid "The variables to search the optimum solution for"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:193
+#: ../../src/wxMaximaFrame.cpp:207
 msgid "The worksheet"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:8122
+#: ../../src/worksheet/Worksheet.cpp:6371
 msgid "The worksheet containing maxima's input and output"
 msgstr ""
 
-#: ../../src/MathParser.cpp:629
+#: ../../src/MathParser.cpp:682
 msgid ""
 "The xml data from maxima or from the .wxmx file was missing data here.\n"
 "If you find a way how to reproduce this problem please file a bug report against wxMaxima."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2143
+#: ../../src/MaximaCommandMenus.cpp:1481
+msgid ""
+"The ‘j’th element is equal to ‘ev (<expr>, <x>=<list>[j])’ \n"
+"j are the elements of the source list.\n"
+"Might be something like \"x=i\""
+msgstr ""
+
+#: ../../src/dialogs/TipOfTheDay.cpp:95
+msgid "There are many resources about Maxima and wxMaxima on the internet. Visit https://wxMaxima-developers.github.io/wxmaxima/help.html for more information and to find tutorials on using wxMaxima and Maxima."
+msgstr ""
+
+#: ../../src/dialogs/TipOfTheDay.cpp:251
+msgid ""
+"There is a discussion forum for wxMaxima at https://github.com/wxMaxima-developers/wxmaxima/discussions.\n"
+"You can ask questions there - and please help other users, by answering their questions, if you know an answer."
+msgstr ""
+
+#: ../../src/MaximaResponseReader.cpp:63
+msgid ""
+"There was an error in the XML describing a worksheet-export request.\n"
+"Please report this as a bug to the wxMaxima project."
+msgstr ""
+
+#: ../../src/MaximaOutputAppender.cpp:66 ../../src/MaximaOutputAppender.cpp:194
 #, fuzzy
 msgid ""
 "There was an error in the XML maxima has generated.\n"
@@ -7405,25 +11049,25 @@ msgstr ""
 "\n"
 "請回報此錯誤。"
 
-#: ../../src/wxMaxima.cpp:3911
+#: ../../src/MaximaResponseReader.cpp:1027
 msgid ""
 "There was an error in the XML that should contain a list of watch variables.\n"
 "Please report this as a bug to the wxMaxima project."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3869
+#: ../../src/MaximaResponseReader.cpp:986
 msgid ""
 "There was an error in the XML that should contain the list of operators.\n"
 "Please report this as a bug to the wxMaxima project."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3321
+#: ../../src/MaximaResponseReader.cpp:719
 msgid ""
 "There was an error in the XML that should describe the contents of some variables.\n"
 "Please report this as a bug to the wxMaxima project."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3257
+#: ../../src/MaximaResponseReader.cpp:163
 #, fuzzy
 msgid ""
 "There was an error in the XML that should describe the manual topics.\n"
@@ -7433,141 +11077,234 @@ msgstr ""
 "\n"
 "請回報此錯誤。"
 
-#: ../../src/wxMaxima.cpp:3202
+#: ../../src/MaximaResponseReader.cpp:42
 msgid ""
 "There was an error in the XML that should describe the status bar message.\n"
 "Please report this as a bug to the wxMaxima project."
 msgstr ""
 
-#: ../../src/MaximaManual.cpp:363
+#: ../../src/sidebars/GreekSidebar.cpp:185
+msgid "Theta"
+msgstr ""
+
+#: ../../src/dialogs/LicenseDialog.cpp:85
+msgid "Third-party notices"
+msgstr ""
+
+#: ../../src/cells/TextCell.cpp:312
+msgid ""
+"This error message is most probably caused by a try to assign a value to a number instead of a variable name.\n"
+"One probable cause is using a variable that already has a numeric value as a loop counter."
+msgstr ""
+
+#: ../../src/MaximaManual.cpp:376
 msgid ""
 "This file is generated by wxMaxima\n"
 "It caches the list of subjects maxima's manual offers and is automatically\n"
 "overwritten if maxima's version changes or the file cannot be read"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1992
+#: ../../src/dialogs/ConfigDialogue.cpp:1097
+msgid "This file won't be read by maxima if maxima is used without wxMaxima. In order to add startup commands that are executed in this case, too, please add them to maxima-init.mac, instead."
+msgstr ""
+
+#: ../../src/worksheet/WorksheetContextMenu.cpp:764
 msgid "This function will return even integers"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1994
+#: ../../src/worksheet/WorksheetContextMenu.cpp:766
 msgid "This function will return odd integers"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1950
+#: ../../src/cells/TextCell.cpp:229
+msgid "This message can appear when trying to numerically find an optimum. In this case it might indicate that a starting point lies in a local optimum that fits the data best if one parameter is increased to infinity or decreased to -infinity. It also can indicate that an attempt was made to fit data to an equation that actually matches the data best if one parameter is set to +/- infinity."
+msgstr ""
+
+#: ../../src/worksheet/WorksheetContextMenu.cpp:722
 msgid "This symbol has no imaginary part"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1956
+#: ../../src/worksheet/WorksheetContextMenu.cpp:728
 msgid "This symbol has no real part"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1953
+#: ../../src/worksheet/WorksheetContextMenu.cpp:725
 msgid "This symbol might have both real and imaginary part"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1980
+#: ../../src/cells/TextCell.cpp:300
+msgid "This warning can be deactivated by setting factor_max_degree_print_warning to false."
+msgstr ""
+
+#: ../../src/wizards/DrawWiz.cpp:471
+#, c-format
+msgid "This wizard setups a %iD scene."
+msgstr ""
+
+#: ../../src/worksheet/WorksheetContextMenu.cpp:752
 msgid "Throw an error if this symbol is used before assigning it any contents"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:9013 ../../src/wxMaxima.cpp:10058
+#: ../../src/wizards/Plot2dWiz.cpp:65 ../../src/wizards/Plot2dWiz.cpp:505
+msgid "Ticks:"
+msgstr "描繪密度："
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1359
+msgid "Time [in Minutes] between autosaves"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:267 ../../src/MaximaCommandMenus.cpp:3547
 msgid "Times:"
 msgstr "次數："
 
-#: ../../src/ToolBar.cpp:272
+#: ../../src/dialogs/TipOfTheDay.cpp:49 ../../src/dialogs/TipOfTheDay.cpp:267
+msgid "Tip of the day"
+msgstr ""
+
+#: ../../src/ToolBar.cpp:482 ../../src/sidebars/FormatSidebar.cpp:48
 msgid "Title"
 msgstr "標題"
 
-#: ../../src/wxMaxima.cpp:8315 ../../src/wxMaxima.cpp:8328
+#: ../../src/MaximaCommandMenus.cpp:1961 ../../src/MaximaCommandMenus.cpp:1974
 msgid "Title (Sub- and superscripts as x_{10} or x^{10})"
 msgstr ""
 
-#: ../../src/Configuration.cpp:92
+#: ../../src/Styles.cpp:121
 msgid "Title cell (Heading 1)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1794
+#: ../../src/dialogs/TipOfTheDay.cpp:89
+msgid "Title, section and subsection cells can be folded to hide their contents. To fold or unfold, click in the square next to the cell. If you shift-click, all sublevels of that cell will also fold/unfold."
+msgstr "標題單元、章節單元和子章節單元可被折疊並隱藏它們的內容。欲折疊或取消折疊，點擊該單元左側的小正方形。如果您按住 Shift 鍵並點擊小正方形，所有該單元中的子單元也會跟著折疊或取消折疊。"
+
+#: ../../src/wxMaximaFrame.cpp:1831
 msgid "To &Bigfloat"
 msgstr "計算長浮點數(&B)"
 
-#: ../../src/wxMaximaFrame.cpp:1791
+#: ../../src/wxMaximaFrame.cpp:1828
 msgid "To &Float"
 msgstr "計算浮點數(&F)"
 
-#: ../../src/Worksheet.cpp:1571
+#: ../../src/worksheet/WorksheetContextMenu.cpp:344
 msgid "To Float"
 msgstr "計算浮點數"
 
-#: ../../src/wxMaximaFrame.cpp:1797
+#: ../../src/wxMaximaFrame.cpp:1834
 msgid "To Numeri&c\tCtrl+Shift+N"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1803
+#: ../../src/wxMaximaFrame.cpp:1840
 #, fuzzy
 msgid "To exact fraction"
 msgstr "部分分式"
 
-#: ../../src/wxMaximaFrame.cpp:1814
+#: ../../src/wxMaximaFrame.cpp:1851
 #, fuzzy
 msgid "To exact number"
 msgstr "顯示函數(&F)"
 
-#: ../../src/wxMaxima.cpp:9064
+#: ../../src/dialogs/TipOfTheDay.cpp:124
+msgid "To plot in polar coordinates, select 'set polar' in the Options entry for Plot2d dialog. You can also plot in spherical and cylindrical coordinates in 3D."
+msgstr "欲在極座標上繪圖，在二維繪圖對話視窗的「選項」中選擇 \"set polar\" 。您也可以在三維繪圖中在球座標或柱座標上繪圖。"
+
+#: ../../src/dialogs/TipOfTheDay.cpp:131
+#, fuzzy
+msgid "To put parentheses around an expression, select it, and press '(' or ')' depending on where you want the cursor to appear afterwards."
+msgstr "欲在數式外側加上括號，請先選取它，再依照您想要游標出現的位置按「(」或「)」。"
+
+#: ../../src/dialogs/TipOfTheDay.cpp:137
+msgid "To save the size and position of wxMaxima windows between session, use 'Edit->Configure' dialog."
+msgstr "欲儲存工作階段之間 wxMaxima 視窗的大小及位置，請從「編輯(E)」->「設定(O)」變更。"
+
+#: ../../src/dialogs/TipOfTheDay.cpp:51
+#, fuzzy
+msgid "To start using wxMaxima right away, start typing your command. An input cell should appear. Then press Shift-Enter to evaluate your command."
+msgstr "欲立即使用 wxMaxima，請開始輸入命令，此時應該會出現一個輸入單元，然後按 Shift+Enter 鍵評算您的命令。"
+
+#: ../../src/MaximaCommandMenus.cpp:318 ../../src/wizards/IntegrateWiz.cpp:47
+#: ../../src/wizards/Plot2dWiz.cpp:51 ../../src/wizards/Plot2dWiz.cpp:61
+#: ../../src/wizards/Plot2dWiz.cpp:502 ../../src/wizards/Plot3dWiz.cpp:40
+#: ../../src/wizards/Plot3dWiz.cpp:49 ../../src/wizards/SumWiz.cpp:40
 msgid "To:"
 msgstr "到："
 
-#: ../../src/wxMaximaFrame.cpp:825 ../../src/wxMaximaFrame.cpp:828
+#: ../../src/sidebars/TableOfContents.cpp:579
+msgid "Toc levels shown here"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:862 ../../src/wxMaximaFrame.cpp:865
 msgid "Toggle full screen editing"
 msgstr "切換全螢幕編輯模式"
 
-#: ../../src/ToolBar.cpp:265
+#: ../../src/dialogs/DiffFrame.cpp:370 ../../src/dialogs/DiffFrame.cpp:387
+msgid "Toggle horizontal scroll synchronization"
+msgstr ""
+
+#: ../../src/ToolBar.cpp:471 ../../src/ToolBar.cpp:473
 msgid "Toggle the visibility of code cells"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1177
+#: ../../src/dialogs/DiffFrame.cpp:382 ../../src/dialogs/DiffFrame.cpp:388
+msgid "Toggle vertical scroll synchronization"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1211
 msgid "Tokenize..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1909
+#: ../../src/wxMaximaFrame.cpp:1946
 msgid "Tolerance calculations with Maxima"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8192
+#: ../../src/ToolBar.cpp:176
+msgid "Toolbar"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1991
+#, fuzzy
+msgid "Top"
+msgstr "到："
+
+#: ../../src/MaximaCommandMenus.cpp:1382
 msgid "Top end"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1078
+#: ../../src/wxMaxima.cpp:2862
+msgid "Tortoise diff tool"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1112
 #, fuzzy
 msgid "Trace a function..."
 msgstr "刪除函數"
 
-#: ../../src/wxMaxima.cpp:7084
+#: ../../src/MaximaCommandMenus.cpp:3956
 #, fuzzy
 msgid "Trace function(s)"
 msgstr "刪除該函數："
 
-#: ../../src/wxMaximaFrame.cpp:1184
+#: ../../src/wxMaximaFrame.cpp:1218
 #, fuzzy
 msgid "Transformations"
 msgstr "計算轉置矩陣"
 
-#: ../../src/wxMaximaFrame.cpp:1376
+#: ../../src/wxMaximaFrame.cpp:1410
 msgid "Transpose a matrix"
 msgstr "計算轉置矩陣"
 
-#: ../../src/wxMaxima.cpp:7832
+#: ../../src/MaximaCommandMenus.cpp:1013
 msgid "Tries to find a numerical solution for a 1st order ODE (or in other words: a equation of the format depends(x,t);diff(x,t)=(something containing x and t)"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:10036
+#: ../../src/MaximaCommandMenus.cpp:3525
 msgid "Tries to find a solution of the equation that lies between the two bounds."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7774
+#: ../../src/MaximaCommandMenus.cpp:955
 msgid "Tries to find a value of the variable that solves the equation between the two bonds"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7719
+#: ../../src/MaximaCommandMenus.cpp:901
 msgid ""
 "Tries to find all solutions of a polynomial numerically using bfloats.\n"
 "Might be able to detect solutions in non-polynomials, as well, if the expression is approximated by an polynomial, beforehand:\n"
@@ -7575,7 +11312,7 @@ msgid ""
 "    bfallroots(ratdisrep(taylor(expression,0,30)));"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7709
+#: ../../src/MaximaCommandMenus.cpp:892
 msgid ""
 "Tries to find all solutions of a polynomial numerically.\n"
 "Might be able to detect solutions in non-polynomials, as well, if the expression is approximated by an polynomial, beforehand:\n"
@@ -7583,7 +11320,7 @@ msgid ""
 "    allroots(ratdisrep(taylor(expression,0,30)));"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7730
+#: ../../src/MaximaCommandMenus.cpp:911
 #, c-format
 msgid ""
 "Tries to find exact fractions that match the numerical solutions of a polynomial.\n"
@@ -7595,298 +11332,413 @@ msgid ""
 "See also guess_exact_value()"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1181
+#: ../../src/wxMaximaFrame.cpp:1215
 msgid "Trim both ends..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1182
+#: ../../src/wxMaximaFrame.cpp:1216
 #, fuzzy
 msgid "Trim left..."
 msgstr "極限..."
 
-#: ../../src/wxMaximaFrame.cpp:1183
+#: ../../src/wxMaximaFrame.cpp:1217
 #, fuzzy
 msgid "Trim right..."
 msgstr "極限..."
 
-#: ../../src/wxMaxima.cpp:7473
+#: ../../src/MaximaCommandMenus.cpp:4345
 msgid "Trim string left"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7469
+#: ../../src/MaximaCommandMenus.cpp:4341
 msgid "Trim string on both ends"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7477
+#: ../../src/MaximaCommandMenus.cpp:4349
 msgid "Trim string right"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1511
+#: ../../src/wxMaximaFrame.cpp:1548
 msgid "Try to guess which form is &simple"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8637
+#: ../../src/MaximaCommandMenus.cpp:629
 msgid "Try to simplify sums that result from sum() commands."
 msgstr ""
 
-#: ../../src/MaximaManual.cpp:369
+#: ../../src/MaximaManual.cpp:382
 #, c-format
 msgid "Trying to cache the list of subjects the manual contains in the file %s."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:4423
+#: ../../src/MaximaFileIO.cpp:357
 msgid "Trying to discard all output."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:4380
+#: ../../src/MaximaFileIO.cpp:326
 msgid "Trying to extract content.xml out of a broken .zip file."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:5519
+#: ../../src/MaximaFileIO.cpp:610
 msgid "Trying to open a file with an empty name!"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:5523
+#: ../../src/MaximaFileIO.cpp:622
 #, c-format
 msgid "Trying to open the non-existing file %s"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:4457
+#: ../../src/MaximaFileIO.cpp:378
 msgid "Trying to reconstruct the xml closing markers."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:4376
+#: ../../src/MaximaFileIO.cpp:322
 msgid "Trying to recover a broken .wxmx file."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:6026
+#: ../../src/MaximaFileIO.cpp:907
 #, c-format
 msgid "Trying to remove the old temp file %s"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2507
+#: ../../src/MaximaProcessManager.cpp:168
 msgid "Trying to restart maxima."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2523
+#: ../../src/MaximaProcessManager.cpp:184
 #, c-format
 msgid "Trying to start the socket a Maxima on the local machine can connect to on port %i"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1928
+#: ../../src/dialogs/ConfigDialogue.cpp:230
+msgid "Turkish"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1965
 msgid "Tutorials"
 msgstr "教材"
 
-#: ../../src/wxMaxima.cpp:9571
+#: ../../src/MaximaCommandMenus.cpp:1809
 msgid "Two sample t-test"
 msgstr "雙樣本 t-檢驗"
 
-#: ../../src/Worksheet.cpp:8013
+#: ../../src/worksheet/Worksheet.cpp:6249
 #, fuzzy
 msgid "Type"
 msgstr "類型："
 
-#: ../../src/wxMaxima.cpp:7180
+#: ../../src/cells/EditorCell.cpp:4550
+#, fuzzy
+msgid "Type in text"
+msgstr "複製為圖片"
+
+#: ../../src/MaximaCommandMenus.cpp:4052 ../../src/wizards/MatWiz.cpp:158
 msgid "Type:"
 msgstr "類型："
 
-#: ../../src/wxMaxima.cpp:9429
+#: ../../src/MaximaCommandMenus.cpp:2072
 msgid "URL"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1146
+#: ../../src/dialogs/ConfigDialogue.cpp:1231
+msgid "URL MathJaX.js is located at:"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1180
 msgid "UTF8 to Unicode code point..."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:10479
+#: ../../src/dialogs/ConfigDialogue.cpp:231
+msgid "Ukrainian"
+msgstr "Ukrainian"
+
+#: ../../src/wxMaxima.cpp:3166
 msgid "Un-closed parenthesis"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:10467
+#: ../../src/wxMaxima.cpp:3154
 msgid "Un-closed parenthesis on encountering ; or $"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:11160
-msgid "Unable to interpret the version info I got from http://wxMaxima-developers.github.io/wxmaxima/version.txt: "
+#: ../../src/wxMaxima.cpp:3468
+#, c-format
+msgid "Unable to interpret the version info I got from %s: %s"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1007
+#: ../../src/wxMaxima.cpp:3414
+#, c-format
+msgid "Unable to interpret the version info I got: %s"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1041
 #, fuzzy
 msgid "Undefine"
 msgstr "底線"
 
-#: ../../src/ToolBar.cpp:191
+#: ../../src/sidebars/VariablesPane.cpp:303
+#: ../../src/sidebars/VariablesPane.cpp:386
+msgid "Undefined"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:2115
+msgid "Underlined"
+msgstr "底線"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:745
+msgid "Underscore converts to subscripts:"
+msgstr ""
+
+#: ../../src/ToolBar.cpp:354 ../../src/ToolBar.cpp:357
 msgid "Undo"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:631
+#: ../../src/wxMaximaFrame.cpp:668
 msgid "Undo\tCtrl+Z"
 msgstr "復原\tCtrl+Z"
 
-#: ../../src/ToolBar.cpp:614
+#: ../../src/ToolBar.cpp:814
 msgid "Undo and redo button"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:631
+#: ../../src/wxMaximaFrame.cpp:668
 msgid "Undo last change"
 msgstr "復原上次的變更"
 
-#: ../../src/wxMaximaFrame.cpp:924
+#: ../../src/cells/TextCell.cpp:115
+#, c-format
+msgid "Unexpected text style %li for TextCell"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:958
 #, fuzzy
 msgid "Unfold All\tCtrl+Alt+]"
 msgstr "全部選取\tCtrl+A"
 
-#: ../../src/wxMaximaFrame.cpp:925
+#: ../../src/wxMaximaFrame.cpp:959
 msgid "Unfold all folded sections"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1893
+#: ../../src/sidebars/TableOfContents.cpp:507
+msgid "Unhide"
+msgstr ""
+
+#: ../../src/worksheet/WorksheetContextMenu.cpp:665
 msgid "Unhide Heading 5"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1904
+#: ../../src/worksheet/WorksheetContextMenu.cpp:676
 msgid "Unhide Heading 6"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1852
+#: ../../src/worksheet/WorksheetContextMenu.cpp:624
 msgid "Unhide Part"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1860
+#: ../../src/worksheet/WorksheetContextMenu.cpp:632
 #, fuzzy
 msgid "Unhide Section"
 msgstr "章節"
 
-#: ../../src/Worksheet.cpp:1871
+#: ../../src/worksheet/WorksheetContextMenu.cpp:643
 #, fuzzy
 msgid "Unhide Subsection"
 msgstr "子章節"
 
-#: ../../src/Worksheet.cpp:1882
+#: ../../src/worksheet/WorksheetContextMenu.cpp:654
 #, fuzzy
 msgid "Unhide Subsubsection"
 msgstr "子章節"
 
-#: ../../src/Worksheet.cpp:1912
+#: ../../src/worksheet/WorksheetContextMenu.cpp:684
 #, fuzzy
 msgid "Unhide contents"
 msgstr "希臘字母"
 
-#: ../../src/wxMaximaFrame.cpp:266
+#: ../../src/wxMaximaFrame.cpp:287
 #, fuzzy
 msgid "Unicode characters"
 msgstr "希臘字母"
 
-#: ../../src/wxMaximaFrame.cpp:707
+#: ../../src/wxMaximaFrame.cpp:742
 msgid "Unicode chars\tAlt+Shift+U"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1144
+#: ../../src/wxMaximaFrame.cpp:1178
 msgid "Unicode code point to UTF8..."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7366
+#: ../../src/MaximaCommandMenus.cpp:4238
 msgid "Unicode code point to char"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1142
+#: ../../src/wxMaximaFrame.cpp:1176
 msgid "Unicode code point to char..."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7371
+#: ../../src/MaximaCommandMenus.cpp:4243
 msgid "Unicode code point to utf8 numbers"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7078
+#: ../../src/sidebars/SymbolsSidebar.cpp:180
+msgid "Unicode symbols:"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:3950
 msgid "Unlike in other programming language return() only exits from the current loop or block(), not from the whole function."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:10418
+#: ../../src/wxMaxima.cpp:3105
 msgid "Unterminated comment."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:10461
+#: ../../src/wxMaxima.cpp:3148
 msgid "Unterminated string."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:4786
+#: ../../src/wizards/ActualValuesStorageWiz.cpp:43
+msgid "Until then the actual values for all variables can be kept in a list."
+msgstr ""
+
+#: ../../src/dialogs/DiffFrame.cpp:429 ../../src/dialogs/FindReplacePane.cpp:80
+msgid "Up"
+msgstr ""
+
+#: ../../src/MaximaEvaluator.cpp:629
 msgid "Updating maxima's configuration"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:11150 ../../src/wxMaxima.cpp:11157
-#: ../../src/wxMaxima.cpp:11163
+#: ../../src/wxMaxima.cpp:3407 ../../src/wxMaxima.cpp:3412
+#: ../../src/wxMaxima.cpp:3414 ../../src/wxMaxima.cpp:3461
+#: ../../src/wxMaxima.cpp:3466 ../../src/wxMaxima.cpp:3469
 msgid "Upgrade"
 msgstr "升級"
 
-#: ../../src/wxMaxima.cpp:7779 ../../src/wxMaxima.cpp:10041
+#: ../../src/MaximaCommandMenus.cpp:489 ../../src/MaximaCommandMenus.cpp:502
+#: ../../src/MaximaCommandMenus.cpp:517 ../../src/MaximaCommandMenus.cpp:531
+msgid "Upper bound on the number of cycles. Must be greater than or equal to 3."
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:960 ../../src/MaximaCommandMenus.cpp:3530
 msgid "Upper bound:"
 msgstr "上界："
 
-#: ../../src/wxMaximaFrame.cpp:792
+#: ../../src/sidebars/GreekSidebar.cpp:197
+#, fuzzy
+msgid "Upsilon"
+msgstr "Epsilon:"
+
+#: ../../src/wxMaximaFrame.cpp:829
 msgid "Use \"<\" and \">\" as parenthesis for matrices"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1708 ../../src/wxMaximaFrame.cpp:1739
+#: ../../src/dialogs/ConfigDialogue.cpp:507
+msgid "Use GTK's overlay scrollbars, which appear over the worksheet and fade out when unused. Looks modern, but GTK repaints the whole worksheet on every frame of the fade animation - which runs after every mouse movement - so classic scrollbars are much faster."
+msgstr ""
+
+#: ../../src/wizards/SumWiz.cpp:69
+msgid "Use Gosper algorithm"
+msgstr "使用 Gosper 演算法"
+
+#: ../../src/sidebars/RegexCtrl.cpp:133
+msgid "Use RegEx filtering"
+msgstr ""
+
+#: ../../src/sidebars/RegexCtrl.cpp:134
+msgid "Use Text search filtering"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1745 ../../src/wxMaximaFrame.cpp:1776
 #, fuzzy
 msgid "Use a list"
 msgstr "產生串列"
 
-#: ../../src/wxMaxima.cpp:8571
+#: ../../src/MaximaCommandMenus.cpp:1589
 msgid "Use a list as parameter list for a function"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1708
+#: ../../src/wxMaximaFrame.cpp:2008
+msgid "Use as TortoiseSVN/Git diff tool"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:485
+msgid "Use centered dot and Minus, not Star and Hyphen"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:849
+msgid "Use centered dot character for multiplication"
+msgstr "用圓點符號表示乘法"
+
+#: ../../src/wxMaximaFrame.cpp:1745
 #, fuzzy
 msgid "Use list"
 msgstr "產生串列"
 
-#: ../../src/wxMaximaFrame.cpp:1701
+#: ../../src/wxMaximaFrame.cpp:1738
 msgid "Use list as the arguments of a function"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:786
+#: ../../src/wxMaximaFrame.cpp:823
 msgid "Use rounded parenthesis for matrices"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:789
+#: ../../src/wxMaximaFrame.cpp:826
 msgid "Use square parenthesis for matrices"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1083
+#: ../../src/wxMaximaFrame.cpp:1117
 #, fuzzy
 msgid "Use struct field..."
 msgstr "連分數(&C)"
 
-#: ../../src/wxMaximaFrame.cpp:795
+#: ../../src/dialogs/ConfigDialogue.cpp:425
+msgid "Use the \"partial derivative\" symbol to represent the fraction that represents a diff() when exporting LaTeX"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:2052
+msgid "Use unicode Math Symbols, if available"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:832
 msgid "Use vertical lines instead of parenthesis for matrices"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1619
+#: ../../src/worksheet/WorksheetContextMenu.cpp:392
 msgid "User labels only"
 msgstr ""
 
-#: ../../src/Configuration.cpp:81
+#: ../../src/dialogs/ConfigDialogue.cpp:1248
+#: ../../src/dialogs/ConfigDialogue.cpp:1452
+#: ../../src/dialogs/ConfigDialogue.cpp:1480
+#: ../../src/dialogs/MaximaNotStartingDialog.cpp:54
+msgid "User specified"
+msgstr ""
+
+#: ../../src/Styles.cpp:110
 msgid "User-defined labels"
 msgstr ""
 
-#: ../../src/MaximaManual.cpp:483
+#: ../../src/dialogs/ConfigDialogue.cpp:770
+msgid "User-defined labels if available"
+msgstr ""
+
+#: ../../src/MaximaManual.cpp:500
 msgid "Using Maxima help file from wxMaxima configuration file (helpFile=...))"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:4825
+#: ../../src/wxMaxima.cpp:1566
 msgid "Using Maxima path from command line."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:4822
+#: ../../src/wxMaxima.cpp:1563
 #, fuzzy
 msgid "Using configured Maxima path."
 msgstr "設定 wxMaxima"
 
-#: ../../src/wxMaxima.cpp:2961
+#: ../../src/MaximaProcessManager.cpp:976
 msgid "Using gnuplot's antialiassing-less png driver for embedded plots as pngcairo could not be found"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2956
+#: ../../src/MaximaProcessManager.cpp:971
 msgid "Using gnuplot's pngcairo driver for embedded plots"
 msgstr ""
 
@@ -7894,478 +11746,963 @@ msgstr ""
 msgid "Using the built-in list of manual anchors."
 msgstr ""
 
-#: ../../src/WXMXformat.cpp:266
+#: ../../src/dialogs/AboutDialog.cpp:46
+#, c-format
+msgid ""
+"Using: %s\n"
+"\n"
+msgstr ""
+
+#: ../../src/WXMXformat.cpp:268
 msgid "Validated that the XML representation of the document actually is valid XML"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8755
+#: ../../src/dialogs/ConfigDialogue.cpp:542
+#: ../../src/wizards/ActualValuesStorageWiz.cpp:49
+#, fuzzy
+msgid "Value"
+msgstr "值："
+
+#: ../../src/MaximaCommandMenus.cpp:756
 #, fuzzy
 msgid "Value at a given point"
 msgstr "評算名詞形式(&N)"
 
-#: ../../src/Worksheet.cpp:1987
+#: ../../src/worksheet/WorksheetContextMenu.cpp:759
 msgid "Value at a specific point"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7801
+#: ../../src/MaximaCommandMenus.cpp:982
 #, fuzzy
 msgid "Value at that point:"
 msgstr "評算名詞形式(&N)"
 
-#: ../../src/wxMaxima.cpp:7812 ../../src/wxMaxima.cpp:7825
-#: ../../src/wxMaxima.cpp:7827
+#: ../../src/MaximaCommandMenus.cpp:993 ../../src/MaximaCommandMenus.cpp:1006
+#: ../../src/MaximaCommandMenus.cpp:1008
 #, fuzzy
 msgid "Value y at that point:"
 msgstr "評算名詞形式(&N)"
 
-#: ../../src/wxMaxima.cpp:7910
+#: ../../src/MaximaCommandMenus.cpp:1091 ../../src/wizards/BC2Wiz.cpp:36
+#: ../../src/wizards/BC2Wiz.cpp:42
 msgid "Value:"
 msgstr "值："
 
-#: ../../src/wxMaxima.cpp:8201
+#: ../../src/MaximaCommandMenus.cpp:1391
 msgid "Var #1"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8202
+#: ../../src/MaximaCommandMenus.cpp:1392
 msgid "Var #2"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:6852 ../../src/wxMaxima.cpp:8183
+#: ../../src/MaximaCommandMenus.cpp:1371 ../../src/MaximaCommandMenus.cpp:1755
+#: ../../src/dialogs/ConfigDialogue.cpp:541
+#: ../../src/sidebars/VariablesPane.cpp:54
 msgid "Variable"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:6530 ../../src/wxMaxima.cpp:6536
-#: ../../src/wxMaxima.cpp:8568
+#: ../../src/wizards/DrawWiz.cpp:61 ../../src/wizards/DrawWiz.cpp:166
+msgid "Variable for the x value"
+msgstr ""
+
+#: ../../src/wizards/DrawWiz.cpp:78 ../../src/wizards/DrawWiz.cpp:181
+msgid "Variable for the y value"
+msgstr ""
+
+#: ../../src/wizards/DrawWiz.cpp:198
+msgid "Variable for the z value"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:1586 ../../src/MaximaCommandMenus.cpp:3050
+#: ../../src/MaximaCommandMenus.cpp:3056
+#: ../../src/wizards/ActualValuesStorageWiz.cpp:48
 #, fuzzy
 msgid "Variable name"
 msgstr "舊變數："
 
-#: ../../src/wxMaximaFrame.cpp:1085
+#: ../../src/wxMaximaFrame.cpp:1119
 #, fuzzy
 msgid "Variable name, not contents..."
 msgstr "舊變數："
 
-#: ../../src/wxMaxima.cpp:7157 ../../src/wxMaxima.cpp:7675
+#: ../../src/MaximaCommandMenus.cpp:4029 ../../src/MaximaCommandMenus.cpp:4547
 #, fuzzy
 msgid "Variable name:"
 msgstr "舊變數："
 
-#: ../../src/wxMaxima.cpp:7752 ../../src/wxMaxima.cpp:7766
+#: ../../src/MaximaCommandMenus.cpp:933 ../../src/MaximaCommandMenus.cpp:947
 #, fuzzy
 msgid "Variable(s)"
 msgstr "變數："
 
-#: ../../src/wxMaxima.cpp:7849 ../../src/wxMaxima.cpp:7901
-#: ../../src/wxMaxima.cpp:9012 ../../src/wxMaxima.cpp:10057
+#: ../../src/MaximaCommandMenus.cpp:266 ../../src/MaximaCommandMenus.cpp:1030
+#: ../../src/MaximaCommandMenus.cpp:1082 ../../src/MaximaCommandMenus.cpp:3546
 msgid "Variable(s):"
 msgstr "變數："
 
-#: ../../src/wxMaxima.cpp:7714 ../../src/wxMaxima.cpp:7725
-#: ../../src/wxMaxima.cpp:7777 ../../src/wxMaxima.cpp:8934
-#: ../../src/wxMaxima.cpp:8941 ../../src/wxMaxima.cpp:8952
-#: ../../src/wxMaxima.cpp:8977 ../../src/wxMaxima.cpp:8982
-#: ../../src/wxMaxima.cpp:9063 ../../src/wxMaxima.cpp:10039
+#: ../../src/MaximaCommandMenus.cpp:185 ../../src/MaximaCommandMenus.cpp:195
+#: ../../src/MaximaCommandMenus.cpp:206 ../../src/MaximaCommandMenus.cpp:231
+#: ../../src/MaximaCommandMenus.cpp:236 ../../src/MaximaCommandMenus.cpp:317
+#: ../../src/MaximaCommandMenus.cpp:958 ../../src/MaximaCommandMenus.cpp:3528
+#: ../../src/wizards/IntegrateWiz.cpp:36 ../../src/wizards/LimitWiz.cpp:32
+#: ../../src/wizards/Plot2dWiz.cpp:45 ../../src/wizards/Plot2dWiz.cpp:55
+#: ../../src/wizards/Plot2dWiz.cpp:496 ../../src/wizards/Plot3dWiz.cpp:34
+#: ../../src/wizards/Plot3dWiz.cpp:43 ../../src/wizards/SeriesWiz.cpp:33
+#: ../../src/wizards/SumWiz.cpp:34
 msgid "Variable:"
 msgstr "變數："
 
-#: ../../src/wxMaximaFrame.cpp:277 ../../src/wxMaximaFrame.cpp:720
+#: ../../src/wxMaximaFrame.cpp:298 ../../src/wxMaximaFrame.cpp:755
 msgid "Variables"
 msgstr "變數"
 
-#: ../../src/wxMaxima.cpp:9043 ../../src/wxMaxima.cpp:9593
+#: ../../src/MaximaCommandMenus.cpp:297 ../../src/MaximaCommandMenus.cpp:1833
+#: ../../src/wizards/SystemWiz.cpp:72
 msgid "Variables:"
 msgstr "變數："
 
-#: ../../src/WXMXformat.cpp:337
+#: ../../src/sidebars/StatSidebar.cpp:58
+msgid "Variance..."
+msgstr "變異數..."
+
+#: ../../src/WXMXformat.cpp:339
 msgid "Verified that we are able to read the whole .zip archive we produced."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:836
+#: ../../src/dialogs/ConfigDialogue.cpp:232
+msgid "Vietnamese"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:870
 msgid "View"
 msgstr ""
 
-#: ../../src/Autocomplete.cpp:235
+#: ../../src/Autocomplete.cpp:305
 msgid "Waiting for m_addFiles_backgroundThread to finish"
 msgstr ""
 
-#: ../../src/Autocomplete.cpp:122 ../../src/Autocomplete.cpp:240
+#: ../../src/Autocomplete.cpp:154 ../../src/Autocomplete.cpp:310
 msgid "Waiting for m_addSymbols_backgroundThread to finish"
 msgstr ""
 
-#: ../../src/MaximaManual.cpp:533
-msgid "Waiting for the Manual anchors background task."
-msgstr ""
-
-#: ../../src/MaximaManual.cpp:562
+#: ../../src/MaximaManual.cpp:586
 msgid "Waiting for the thread that parses the maxima manual to finish"
 msgstr ""
 
-#: ../../src/MathParser.cpp:1229 ../../src/wxMaxima.cpp:3296
-#: ../../src/wxMaxima.cpp:3308 ../../src/wxMaxima.cpp:4613
-#: ../../src/wxMaxima.cpp:4703 ../../src/wxMaxima.cpp:4840
+#: ../../src/dialogs/ConfigDialogue.cpp:1410
+msgid "Warn if an inactive window is idle"
+msgstr ""
+
+#: ../../src/MathParser.cpp:1343 ../../src/MaximaFileIO.cpp:536
+#: ../../src/MaximaProcessManager.cpp:1100
+#: ../../src/MaximaResponseReader.cpp:361 ../../src/wxMaxima.cpp:1585
 msgid "Warning"
 msgstr "警告"
 
-#: ../../src/wxMaximaFrame.cpp:1556
+#: ../../src/wxMaximaFrame.cpp:1593
 #, fuzzy
 msgid "Warning:"
 msgstr "警告"
 
-#: ../../src/Dirstructure.cpp:72
+#: ../../src/Dirstructure.cpp:73
 #, c-format
 msgid ""
 "Warning: Cannot create %s, the directory maxima keeps configuration, user packages and caches in.\n"
 "Make sure that your system's home directory is set up correctly"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1546
+#: ../../src/cells/GroupCell.cpp:400 ../../src/cells/GroupCell.cpp:406
+msgid "Warning: Lookalike chars: "
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1583
 msgid "Warning: No test if the argument of the log is complex, positive or negative"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:5063
+#: ../../src/dialogs/BinaryNameCtrl.cpp:76
+msgid ""
+"We weren't searching for the location of wxMaxima!\n"
+"\n"
+"Please enter the path to the program again."
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:3603 ../../src/MaximaCommandMenus.cpp:3613
+msgid "WebP (*.webp)|*.webp|"
+msgstr ""
+
+#: ../../src/wxMaxima.cpp:1871
 msgid "Welcome to wxMaxima"
 msgstr "歡迎使用 wxMaxima"
 
-#: ../../src/wxMaxima.cpp:8583
+#: ../../src/MaximaCommandMenus.cpp:1601
 msgid "What to do:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1058
+#: ../../src/dialogs/TipOfTheDay.cpp:134
+msgid "When applying functions with one argument from menus, the default argument is '%'. To apply the function to some other value, select it in the document before executing a menu command."
+msgstr "當您從功能表使用只有一個引數的函數時，預設的引數是「%」。欲使用其他的值作為引數，請在執行功能表命令前從文件中選取該值。"
+
+#: ../../src/wxMaximaFrame.cpp:1092
 msgid "When to invoke the lisp compiler's debugger"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7046
+#: ../../src/MaximaCommandMenus.cpp:3918
 msgid "While loop"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1063
+#: ../../src/wxMaximaFrame.cpp:1097
 msgid "While loop..."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:5673
+#: ../../src/dialogs/TipOfTheDay.cpp:243
+msgid "While wxMaxima is programmed mostly in C++, it also uses some Lisp code. You can help to improve wxMaxima, if you have knowledge of Common Lisp."
+msgstr ""
+
+#: ../../src/MaximaFileIO.cpp:780
 msgid "Whole document (*.wxmx)|*.wxmx|The input, readable by load() (maxima > 5.38) (*.wxm)|*.wxm|All Files (*.*)|*"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:210
+#: ../../src/wxMaxima.cpp:309
 msgid "Will try to generate a stack backtrace, if the program ever crashes"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:6920
+#: ../../src/dialogs/ConfigDialogue.cpp:280
+msgid "Worksheet"
+msgstr ""
+
+#: ../../src/MaximaResponseReader.cpp:117
+#, c-format
+msgid "Worksheet export of type \"%s\" is not supported yet."
+msgstr ""
+
+#: ../../src/worksheet/Worksheet.cpp:4911
 msgid "Worksheet got activated"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:6840
+#: ../../src/worksheet/Worksheet.cpp:4843
 msgid "Worksheet got the mouse focus"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:7191 ../../src/Worksheet.cpp:7279
+#: ../../src/sidebars/PerformanceSidebar.cpp:47
+msgid "Worksheet repaints:"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:428
+msgid "Wrap equations exported by the \"copy as LaTeX\" feature between \\[ and \\] as equation markers"
+msgstr ""
+
+#: ../../src/worksheet/Worksheet.cpp:5200
 msgid "Wrapped search"
 msgstr ""
 
-#: ../../src/WXMXformat.cpp:282
+#: ../../src/WXMXformat.cpp:284
 msgid "Wrote all image and gnuplot files to the zip archive"
 msgstr ""
 
-#: ../../src/WXMXformat.cpp:272
+#: ../../src/WXMXformat.cpp:274
 msgid "Wrote the XML representation of the document to the zip archive"
 msgstr ""
 
-#: ../../src/WXMXformat.cpp:116
+#: ../../src/WXMXformat.cpp:117
 msgid "Wrote the mimetype info"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:11147
-#, fuzzy, c-format
+#: ../../src/wizards/DrawWiz.cpp:942 ../../src/wizards/DrawWiz.cpp:949
+#: ../../src/wizards/DrawWiz.cpp:961 ../../src/wizards/DrawWiz.cpp:974
+#: ../../src/wizards/DrawWiz.cpp:977
+msgid "X"
+msgstr ""
+
+#: ../../src/MathParser.cpp:1279
+msgid "XML nesting limit exceeded"
+msgstr ""
+
+#: ../../src/sidebars/GreekSidebar.cpp:191
+msgid "Xi"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:728
+#, fuzzy
+msgid "Yes"
+msgstr "是"
+
+#: ../../src/dialogs/TipOfTheDay.cpp:64
+msgid "You can access the last output using the variable '%'. You can access the output of previous commands using variables '%on' where n is the number of output."
+msgstr "您可以使用「%」存取最後一筆輸出。您也可以使用「%on」(n是輸出的編號)來存取先前命令的輸出。"
+
+#: ../../src/dialogs/TipOfTheDay.cpp:118
+msgid "You can evaluate your whole document by using 'Cell->Evaluate All Cells' menu command or the appropriate key shortcut. The cells will be evaluated in the order they appear in the document."
+msgstr "您可以使用「單元(C)」->「評算所有單元」功能表命令或該相對應的快捷鍵評算您的文件中的所有單元。這些單元會依照它們在文件中出現的順序評算。"
+
+#: ../../src/dialogs/TipOfTheDay.cpp:98
+#, fuzzy
+msgid "You can get help on a Maxima function by selecting or clicking on the function name and pressing F1. wxMaxima will search the help index for the selection or the word under the cursor."
+msgstr "您可以透過選取或點擊函數名並按 F1 取得 Maxima 函數的說明。wxMaxima 會在說明的索引中搜尋所選區域。"
+
+#: ../../src/dialogs/TipOfTheDay.cpp:92
+msgid "You can hide output part of cells by clicking in the triangle on the left side of cells. This works on text cells also."
+msgstr "您可以透過點擊單元左側的小三角形來隱藏單元的輸出部分。文字單元中也有同樣的功能。"
+
+#: ../../src/dialogs/TipOfTheDay.cpp:81
+#, fuzzy
+msgid "You can insert different types of 'cells' in wxMaxima documents using the 'Cell' menu. Note that only 'input cells' can be evaluated, while others are used for commenting and structuring your calculations."
+msgstr "您可以使用「編輯(E)」->「單元(C)」功能表在 wxMaxima 文件中插入不同種類的「單元」。請注意：只有「輸入單元」可以被評算，其他種類的單元是用來註解或組織您的計算。"
+
+#: ../../src/dialogs/TipOfTheDay.cpp:112
+msgid "You can select multiple cells either with a mouse - click'n'drag from between cells or from a cell bracket on the left - or with a keyboard - hold down Shift while moving the horizontal cursor - and then operate on selection. This comes in handy when you want to delete or evaluate multiple cells."
+msgstr "您可以透過滑鼠(在單元之間或左側的單元框拖曳)或鍵盤(在移動水平游標時按住Shift鍵)選取多個單元，然後對所選區域操作。這在您想要刪除或評算多個單元時很有用。"
+
+#: ../../src/dialogs/TipOfTheDay.cpp:232
 msgid ""
-"You have version %s. The newest version source code is available for is %s.\n"
+"You found a bug in wxMaxima? Please report it at https://github.com/wxMaxima-developers/wxmaxima/issues\n"
+"A mathematical bug is maybe a bug in Maxima (the backend), which can be reported at https://sourceforge.net/p/maxima/bugs/\n"
+"Please check, before, if the bug was not already reported."
+msgstr ""
+
+#: ../../src/dialogs/TipOfTheDay.cpp:238
+msgid "You got an idea for an improvement of wxMaxima? Great! Please submit your idea at https://github.com/wxMaxima-developers/wxmaxima/issues. "
+msgstr ""
+
+#: ../../src/wxMaxima.cpp:3404 ../../src/wxMaxima.cpp:3458
+#, c-format
+msgid ""
+"You have version %s. The newest wxMaxima release is %s.\n"
 "\n"
 "Select OK to visit the wxMaxima webpage."
 msgstr ""
-"您的版本是 %s ，最新的版本是 %s 。\n"
-"\n"
-"按「確認」至 wxMaxima 首頁。"
 
-#: ../../src/wxMaxima.cpp:11202
+#: ../../src/wxMaxima.cpp:3508
 msgid "Your changes will be lost if you don't save them."
 msgstr "如果您未儲存，您所做的所有修改將遺失。"
 
-#: ../../src/wxMaxima.cpp:11156
+#: ../../src/wxMaxima.cpp:3412 ../../src/wxMaxima.cpp:3466
 msgid "Your version of wxMaxima is up to date."
 msgstr "您的 wxMaxima 是最新版本"
 
-#: ../../src/wxMaximaFrame.cpp:805
+#: ../../src/sidebars/GreekSidebar.cpp:183
+msgid "Zeta"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:842
 #, fuzzy
 msgid "Zoom &In\tCtrl++"
 msgstr "放大(&I)\tAlt+I"
 
-#: ../../src/wxMaximaFrame.cpp:806
+#: ../../src/wxMaximaFrame.cpp:843
 #, fuzzy
 msgid "Zoom Ou&t\tCtrl+-"
 msgstr "縮小(&T)\tAlt+O"
 
-#: ../../src/wxMaximaFrame.cpp:805
+#: ../../src/wxMaximaFrame.cpp:842
 msgid "Zoom in 10%"
 msgstr "將顯示比例放大 10%"
 
-#: ../../src/wxMaximaFrame.cpp:806
+#: ../../src/wxMaximaFrame.cpp:843
 msgid "Zoom out 10%"
 msgstr "將顯示比例縮小 10%"
 
-#: ../../src/wxMaxima.cpp:10915 ../../src/wxMaximaFrame.cpp:187
+#: ../../src/wxMaxima.cpp:3204 ../../src/wxMaximaFrame.cpp:201
 msgid "[ unsaved ]"
 msgstr "[ 未儲存 ]"
 
-#: ../../src/wxMaxima.cpp:10920
+#: ../../src/wxMaxima.cpp:3206
 msgid "[ unsaved* ]"
 msgstr "[ 未儲存* ]"
 
-#: ../../src/Worksheet.cpp:5278
-#, c-format
-msgid "_%d.gif\"  alt=\"Animated Diagram\" loading=\"lazy\" style=\"max-width:90%%;\">\n"
+#: ../../src/wizards/DrawWiz.cpp:819 ../../src/wizards/DrawWiz.cpp:825
+msgid "[[x_1,x_2,...],[y_1,y_2,...]]"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:5484
-#, c-format
-msgid "_%d.gif\" alt=\"Animated Diagram\" style=\"max-width:90%%;\" loading=\"lazy\">"
+#: ../../src/wizards/DrawWiz.cpp:814
+msgid "[x_1, x_2,...] or [x_1, x_2,...],[y_1, y_2,...] or matrix([x_1,y_1],[x_2,y_2],...)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1690
+#: ../../src/wizards/ListSortWiz.cpp:46
+msgid "a<b (Maxima default)"
+msgstr ""
+
+#: ../../src/sidebars/GreekSidebar.cpp:151
+msgid "alpha"
+msgstr ""
+
+#: ../../src/sidebars/SymbolsSidebar.cpp:95
+#, fuzzy
+msgid "and"
+msgstr "展開"
+
+#: ../../src/wizards/MatWiz.cpp:160
+msgid "antisymmetric"
+msgstr "反對稱"
+
+#: ../../src/wxMaximaFrame.cpp:1727
 #, fuzzy
 msgid "apply function to each element"
 msgstr "套用函數至串列"
 
-#: ../../src/wxMaximaFrame.cpp:739
+#: ../../src/wxMaximaFrame.cpp:776
 msgid "as 1D ASCII"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:742
+#: ../../src/wxMaximaFrame.cpp:779
 msgid "as ASCII Art"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:745
+#: ../../src/wxMaximaFrame.cpp:782
 msgid "as ASCII+Unicode Art"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1680
+#: ../../src/wxMaximaFrame.cpp:1717
 msgid "as storage for actual values for variables"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1139
+#: ../../src/sidebars/GreekSidebar.cpp:152
+msgid "beta"
+msgstr ""
+
+#: ../../src/wizards/LimitWiz.cpp:42
+msgid "both sides"
+msgstr "雙邊"
+
+#: ../../src/wxMaximaFrame.cpp:1173
 msgid "char to Ascii code..."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7836
+#: ../../src/sidebars/GreekSidebar.cpp:172
+msgid "chi"
+msgstr ""
+
+#: ../../src/MaximaFileIO.cpp:318
+#, c-format
+msgid "content.xml exceeds the sanity limit of %zu bytes; the file may be corrupt or a decompression bomb."
+msgstr ""
+
+#: ../../src/wizards/Plot2dWiz.cpp:70 ../../src/wizards/Plot2dWiz.cpp:372
+#: ../../src/wizards/Plot3dWiz.cpp:61 ../../src/wizards/Plot3dWiz.cpp:358
+msgid "default"
+msgstr "預設值"
+
+#: ../../src/sidebars/GreekSidebar.cpp:154
+msgid "delta"
+msgstr ""
+
+#: ../../src/wizards/MatWiz.cpp:159
+msgid "diagonal"
+msgstr "對角"
+
+#: ../../src/cells/FracCell.cpp:73
+msgid "diff(): Cannot find the multiplication sign I should hide"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:1017
 msgid "diff(x,t)="
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1064 ../../src/wxMaximaFrame.cpp:1702
+#: ../../src/wxMaximaFrame.cpp:1098 ../../src/wxMaximaFrame.cpp:1739
 msgid "do for each element"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:2027
+#: ../../src/sidebars/SymbolsSidebar.cpp:92
+msgid "empty"
+msgstr ""
+
+#: ../../src/sidebars/GreekSidebar.cpp:155
+#, fuzzy
+msgid "epsilon"
+msgstr "Epsilon:"
+
+#: ../../src/sidebars/SymbolsSidebar.cpp:100
+msgid "equivalent"
+msgstr ""
+
+#: ../../src/sidebars/GreekSidebar.cpp:157
+msgid "eta"
+msgstr ""
+
+#: ../../src/worksheet/WorksheetContextMenu.cpp:799
 msgid "ev() shall evaluate this automatically"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7130
+#: ../../src/sidebars/SymbolsSidebar.cpp:88
+msgid "exists"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:4002
 #, fuzzy
 msgid "expression:"
 msgstr "數式："
 
-#: ../../src/Worksheet.cpp:2025
+#: ../../src/worksheet/WorksheetContextMenu.cpp:797
 msgid "f(x) stays f(x) even if the value of f(x) is computable"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7204 ../../src/wxMaxima.cpp:7209
+#: ../../src/dialogs/ConfigDialogue.cpp:467
+msgid ""
+"false=Don't generate subscripts\n"
+"true=Automatically convert underscores to subscript markers if the would-be subscript is a number or a single letter\n"
+"all=_ marks subscripts."
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:4076 ../../src/MaximaCommandMenus.cpp:4081
 #, fuzzy
 msgid "filename:"
 msgstr "舊變數："
 
-#: ../../src/wxMaximaFrame.cpp:1674
+#: ../../src/wxMaximaFrame.cpp:1711
 #, fuzzy
 msgid "from a list"
 msgstr "產生串列"
 
-#: ../../src/wxMaximaFrame.cpp:1671
+#: ../../src/wxMaximaFrame.cpp:1708
 msgid "from a rule"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1685
+#: ../../src/wxMaximaFrame.cpp:1722
 #, fuzzy
 msgid "from function arguments"
 msgstr "函數名"
 
-#: ../../src/wxMaximaFrame.cpp:1669
+#: ../../src/wxMaximaFrame.cpp:1706
 msgid "from individual elements"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8210 ../../src/wxMaxima.cpp:8553
+#: ../../src/MaximaCommandMenus.cpp:1400 ../../src/MaximaCommandMenus.cpp:1566
 #, fuzzy
 msgid "function"
 msgstr "函數"
 
-#: ../../src/wxMaximaFrame.cpp:747
+#: ../../src/sidebars/GreekSidebar.cpp:153
+msgid "gamma"
+msgstr ""
+
+#: ../../src/wizards/MatWiz.cpp:159
+msgid "general"
+msgstr "一般"
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1630
+msgid "gnuplot: Without command console"
+msgstr ""
+
+#: ../../src/sidebars/SymbolsSidebar.cpp:118
+#, fuzzy
+msgid "greater than or equal"
+msgstr "子章節單元"
+
+#: ../../src/sidebars/SymbolsSidebar.cpp:87
+#, fuzzy
+msgid "in"
+msgstr "尋找"
+
+#: ../../src/wxMaximaFrame.cpp:784
 msgid "in 2D"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8554
+#: ../../src/wizards/Plot2dWiz.cpp:70 ../../src/wizards/Plot2dWiz.cpp:198
+#: ../../src/wizards/Plot2dWiz.cpp:372 ../../src/wizards/Plot2dWiz.cpp:402
+#: ../../src/wizards/Plot3dWiz.cpp:61 ../../src/wizards/Plot3dWiz.cpp:194
+#: ../../src/wizards/Plot3dWiz.cpp:358 ../../src/wizards/Plot3dWiz.cpp:386
+msgid "inline"
+msgstr "隨文字顯示"
+
+#: ../../src/sidebars/SymbolsSidebar.cpp:104
+#, fuzzy
+msgid "intersection"
+msgstr "方向："
+
+#: ../../src/sidebars/GreekSidebar.cpp:159
+msgid "iota"
+msgstr ""
+
+#: ../../src/sidebars/GreekSidebar.cpp:160
+msgid "kappa"
+msgstr ""
+
+#: ../../src/sidebars/GreekSidebar.cpp:161
+msgid "lambda"
+msgstr ""
+
+#: ../../src/wizards/LimitWiz.cpp:42
+msgid "left"
+msgstr "左"
+
+#: ../../src/sidebars/SymbolsSidebar.cpp:117
+#, fuzzy
+msgid "less or equal"
+msgstr "子章節單元"
+
+#: ../../src/MaximaCommandMenus.cpp:1567
 #, fuzzy
 msgid "list"
 msgstr "產生串列"
 
-#: ../../src/wxMaximaFrame.cpp:1405
+#: ../../src/wizards/Plot2dWiz.cpp:54 ../../src/wizards/Plot2dWiz.cpp:64
+msgid "logscale"
+msgstr "對數尺度"
+
+#: ../../src/wizards/DrawWiz.cpp:822
+msgid "matrix([x_1,x_2,...],[y_1,y_2,...])"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1439
 msgid "max(abs(A(i,j))) (complex)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1404
+#: ../../src/wxMaximaFrame.cpp:1438
 msgid "max(abs(A(i,j))) (real)"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8046
+#: ../../src/sidebars/GreekSidebar.cpp:162
+msgid "mu"
+msgstr ""
+
+#: ../../src/sidebars/SymbolsSidebar.cpp:120
+#, fuzzy
+msgid "much greater than"
+msgstr "子章節單元"
+
+#: ../../src/sidebars/SymbolsSidebar.cpp:119
+msgid "much less than"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:1232
 #, fuzzy
 msgid "m×n Matrix A:"
 msgstr "矩陣："
 
-#: ../../src/wxMaxima.cpp:7378 ../../src/wxMaxima.cpp:8527
-#: ../../src/wxMaxima.cpp:8533
+#: ../../src/MaximaCommandMenus.cpp:1538 ../../src/MaximaCommandMenus.cpp:1544
+#: ../../src/MaximaCommandMenus.cpp:4250
 #, fuzzy
 msgid "n:"
 msgstr "尋找"
 
-#: ../../src/Worksheet.cpp:2000
+#: ../../src/sidebars/SymbolsSidebar.cpp:112
+msgid "nabla sign"
+msgstr ""
+
+#: ../../src/sidebars/SymbolsSidebar.cpp:98
+msgid "nand"
+msgstr ""
+
+#: ../../src/worksheet/WorksheetContextMenu.cpp:772
 msgid "nary: f(x, f(y,z)) = foo(x,y,z)"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:2024
+#: ../../src/sidebars/SymbolsSidebar.cpp:99
+#, fuzzy
+msgid "nor"
+msgstr "否"
+
+#: ../../src/sidebars/SymbolsSidebar.cpp:102
+#, fuzzy
+msgid "not"
+msgstr "否"
+
+#: ../../src/sidebars/SymbolsSidebar.cpp:116
+msgid "not bytewise identical"
+msgstr ""
+
+#: ../../src/sidebars/SymbolsSidebar.cpp:108
+msgid "not subset"
+msgstr ""
+
+#: ../../src/sidebars/SymbolsSidebar.cpp:107
+msgid "not subset or equal"
+msgstr ""
+
+#: ../../src/worksheet/WorksheetContextMenu.cpp:796
 msgid "noun: Not evaluated by default"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1710
+#: ../../src/wxMaximaFrame.cpp:1747
 #, fuzzy
 msgid "nth"
 msgstr "否"
 
-#: ../../src/Worksheet.cpp:2021
+#: ../../src/sidebars/GreekSidebar.cpp:163
+msgid "nu"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:1233
+msgid "n×1 Matrix b:"
+msgstr ""
+
+#: ../../src/sidebars/GreekSidebar.cpp:174
+msgid "omega"
+msgstr ""
+
+#: ../../src/sidebars/GreekSidebar.cpp:165
+msgid "omicron"
+msgstr ""
+
+#: ../../src/sidebars/SymbolsSidebar.cpp:96
+msgid "or"
+msgstr ""
+
+#: ../../src/worksheet/WorksheetContextMenu.cpp:793
 msgid "outative: f(2*x) = 2*f(x)"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7440 ../../src/wxMaxima.cpp:7445
-#: ../../src/wxMaxima.cpp:7455
+#: ../../src/cells/TextCell.cpp:260
+msgid "part() or the [] operator was used in order to extract the nth element of something that was less than n elements long."
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:4312 ../../src/MaximaCommandMenus.cpp:4317
+#: ../../src/MaximaCommandMenus.cpp:4327
 msgid "part:"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8942
+#: ../../src/sidebars/SymbolsSidebar.cpp:111
+#, fuzzy
+msgid "partial sign"
+msgstr "部分分式"
+
+#: ../../src/sidebars/GreekSidebar.cpp:171
+msgid "phi"
+msgstr ""
+
+#: ../../src/sidebars/GreekSidebar.cpp:166
+msgid "pi"
+msgstr ""
+
+#: ../../src/sidebars/SymbolsSidebar.cpp:101
+msgid "plus or minus"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:196
 #, fuzzy
 msgid "point:"
 msgstr "點："
 
-#: ../../src/wxMaxima.cpp:7740
+#: ../../src/MaximaCommandMenus.cpp:921
 #, fuzzy
 msgid "precision:"
 msgstr "精確度"
 
-#: ../../src/wxMaxima.cpp:7255
+#: ../../src/graphical_io/Printout.cpp:95
+#, c-format
+msgid "printOut: Setting the page size to (%li,%li)"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:4127
 #, fuzzy
 msgid "printf"
 msgstr "列印"
 
-#: ../../src/wxMaximaFrame.cpp:1108
+#: ../../src/wxMaximaFrame.cpp:1142
 #, fuzzy
 msgid "printf..."
 msgstr "微分..."
 
-#: ../../src/wxMaxima.cpp:8650
+#: ../../src/sidebars/SymbolsSidebar.cpp:115
+msgid "proportional to"
+msgstr ""
+
+#: ../../src/sidebars/GreekSidebar.cpp:173
+msgid "psi"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:642
 msgid "radcan() is a powerful tools for simplification trigonometric functions but needs to be taken with care: If a function has more than one branch radcan uses the one that looks like it would fit best, not necessarily the one that makes sense for the problem that resulted in the Expression that is to be simplified."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8731
+#: ../../src/MaximaCommandMenus.cpp:726
 msgid "ratsubst works like subst, but it knows some basic maths, if needed."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1111
+#: ../../src/wxMaximaFrame.cpp:1145
 #, fuzzy
 msgid "readbyte..."
 msgstr "積分..."
 
-#: ../../src/wxMaximaFrame.cpp:1110
+#: ../../src/wxMaximaFrame.cpp:1144
 #, fuzzy
 msgid "readchar..."
 msgstr "圓餅圖..."
 
-#: ../../src/wxMaximaFrame.cpp:1109
+#: ../../src/wxMaximaFrame.cpp:1143
 #, fuzzy
 msgid "readline..."
 msgstr "變異數..."
 
-#: ../../src/wxMaxima.cpp:10018
+#: ../../src/cells/TextCell.cpp:264
+msgid "rest() tried to drop more entries from a list than the list was long."
+msgstr ""
+
+#: ../../src/sidebars/GreekSidebar.cpp:167
+msgid "rho"
+msgstr ""
+
+#: ../../src/wizards/LimitWiz.cpp:42
+msgid "right"
+msgstr "右"
+
+#: ../../src/wizards/DrawWiz.cpp:310
+msgid "secondary x axis label"
+msgstr ""
+
+#: ../../src/wizards/DrawWiz.cpp:315
+msgid "secondary x range (automatic if incomplete)"
+msgstr ""
+
+#: ../../src/wizards/DrawWiz.cpp:325
+msgid "secondary y axis label"
+msgstr ""
+
+#: ../../src/wizards/DrawWiz.cpp:330
+msgid "secondary y range (automatic if incomplete)"
+msgstr ""
+
+#: ../../src/sidebars/GreekSidebar.cpp:168
+msgid "sigma"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:3507
 msgid ""
 "solve() will solve a list of equations only if for n independent equations there are n variables to solve to.\n"
 "If only one result variable is of interest the other result variables can be used to to tell solve() which variables to eliminate from the solution\n"
 "solve() searches for a global solution. If a problem has different solutions depending on the range its variables are in one way to successfully use solve() is to use solve() to eliminate variables one by one and to manually choose which of the solutions solve() found matches the current problem."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7745
+#: ../../src/MaximaCommandMenus.cpp:926
 msgid ""
 "solve() will solve a list of equations only if for n independent equations there are n variables to solve to.\n"
 "If only one result variable is of interest the other result variables solve needs to do its work can be used to tell solve() which variables to eliminate in the solution for the interesting variable."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7784
+#: ../../src/MaximaCommandMenus.cpp:965
 msgid ""
 "solves an equation of the form\n"
 "    'diff(y,t) = -y;"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7789
+#: ../../src/sidebars/SymbolsSidebar.cpp:81
+msgid "sqrt (needs parenthesis for its argument to work as a Maxima command)"
+msgstr ""
+
+#: ../../src/sidebars/SymbolsSidebar.cpp:106
+#, fuzzy
+msgid "subset"
+msgstr "子章節"
+
+#: ../../src/sidebars/SymbolsSidebar.cpp:105
+#, fuzzy
+msgid "subset or equal"
+msgstr "子章節單元"
+
+#: ../../src/wizards/MatWiz.cpp:160
+msgid "symmetric"
+msgstr "對稱"
+
+#: ../../src/MaximaCommandMenus.cpp:970
 msgid "t:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1075
+#: ../../src/sidebars/GreekSidebar.cpp:169
+msgid "tau"
+msgstr ""
+
+#: ../../src/cells/TextCell.cpp:340
+msgid ""
+"the [] operator tried to extract an element of a list, a matrix, an equation or an array. But instead of an integer number something was used whose numerical value is unknown or not an integer.\n"
+"Floating-point numbers are bound to contain small rounding errors and therefore in most cases don't work as an array index thatneeds to be an exact integer number."
+msgstr ""
+
+#: ../../src/wizards/DrawWiz.cpp:725
+#, fuzzy
+msgid "the x and the y coordinate."
+msgstr "y 座標，以逗號分隔"
+
+#: ../../src/wizards/DrawWiz.cpp:729
+msgid "the x, the y and the z coordinate."
+msgstr ""
+
+#: ../../src/sidebars/SymbolsSidebar.cpp:89
+msgid "there is no"
+msgstr ""
+
+#: ../../src/sidebars/GreekSidebar.cpp:158
+msgid "theta"
+msgstr ""
+
+#: ../../src/sidebars/SymbolsSidebar.cpp:78
+msgid "to the power of 2"
+msgstr ""
+
+#: ../../src/sidebars/SymbolsSidebar.cpp:79
+msgid "to the power of 3"
+msgstr ""
+
+#: ../../src/sidebars/SymbolsSidebar.cpp:103
+msgid "union"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1109
 msgid "unnamed function (lambda)..."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:11190
+#: ../../src/wxMaxima.cpp:3496
 msgid "unsaved"
 msgstr "未儲存"
 
-#: ../../src/wxMaxima.cpp:5667 ../../src/wxMaxima.cpp:6114
-#: ../../src/wxMaximaFrame.cpp:189
+#: ../../src/MaximaCommandMenus.cpp:2270 ../../src/MaximaFileIO.cpp:774
+#: ../../src/wxMaximaFrame.cpp:203
 msgid "untitled"
 msgstr "未命名"
 
-#: ../../src/wxMaximaFrame.cpp:1700
+#: ../../src/sidebars/GreekSidebar.cpp:170
+#, fuzzy
+msgid "upsilon"
+msgstr "Epsilon:"
+
+#: ../../src/wxMaximaFrame.cpp:1737
 #, fuzzy
 msgid "use as function arguments"
 msgstr "函數名"
 
-#: ../../src/wxMaximaFrame.cpp:1696
+#: ../../src/wxMaximaFrame.cpp:1733
 msgid "use the actual values stored"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1112
+#: ../../src/dialogs/ConfigDialogue.cpp:1633
+msgid "wgnuplot: Steals the mouse focus during plotting"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1146
 msgid "writebyte..."
 msgstr ""
 
-#: ../../src/main.cpp:509
+#: ../../src/dialogs/AboutDialog.cpp:64 ../../src/main.cpp:796
 msgid "wxMaxima"
 msgstr ""
 
-#: ../../src/main.cpp:516
+#: ../../src/main.cpp:805
 #, fuzzy, c-format
 msgid "wxMaxima %ld"
 msgstr "wxMaxima %s "
 
-#: ../../src/wxMaxima.cpp:10913 ../../src/wxMaxima.cpp:10918
-#: ../../src/wxMaxima.cpp:10929 ../../src/wxMaxima.cpp:10934
-#: ../../src/wxMaximaFrame.cpp:185
+#: ../../src/wxMaxima.cpp:3193 ../../src/wxMaximaFrame.cpp:199
 #, fuzzy, c-format
 msgid "wxMaxima %s (%s) "
 msgstr "wxMaxima %s "
 
-#: ../../src/wxMaxima.cpp:4490
+#: ../../src/dialogs/DiffFrame.cpp:352
+msgid "wxMaxima Diff Viewer"
+msgstr ""
+
+#: ../../src/dialogs/TipOfTheDay.cpp:159
+msgid "wxMaxima can be made to execute commands at every start-up by placing them in a text file with the name wxmaxima.rc in the user directory. This directory can be found by typing maxima_userdir;"
+msgstr ""
+
+#: ../../src/MaximaFileIO.cpp:398
 msgid "wxMaxima cannot read the xml contents of "
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2546
+#: ../../src/dialogs/ConfigDialogue.cpp:142
+#: ../../src/dialogs/ConfigDialogue.cpp:311
+msgid "wxMaxima configuration"
+msgstr "wxMaxima 設定"
+
+#: ../../src/MaximaProcessManager.cpp:211
 msgid ""
 "wxMaxima could not start a server.\n"
 "\n"
@@ -8373,82 +12710,202 @@ msgid ""
 "enabled, that no internet safety appliance is configured to intercept creation of servers even if said server only accepts connections from local application (maxima insists on the graphical frontend acting as a server it can connect on over a local socket) and try again!"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:5285
+#: ../../src/dialogs/TipOfTheDay.cpp:127
+msgid "wxMaxima dialogs set default values for inputs entries, one of which is '%'. If you have made a selection in your document, the selection will be used instead of '%'."
+msgstr "wxMaxima 對話框會設定輸入內容為預設值，其中一種是 \"%\"。如果您已經在您的文件中作選取，則這個選取內容將會取代 \"%\"。"
+
+#: ../../src/MaximaCommandMenus.cpp:4604
 msgid "wxMaxima document"
 msgstr "wxMaxima 文件"
 
-#: ../../src/wxMaxima.cpp:4162 ../../src/wxMaxima.cpp:4221
-#: ../../src/wxMaxima.cpp:4230
+#: ../../src/MaximaCommandMenus.cpp:2241
+msgid "wxMaxima document (*.wxm, *.wxmx)|*.wxm;*.wxmx"
+msgstr "wxMaxima 文件 (*.wxm, *.wxmx)|*.wxm;*.wxmx"
+
+#: ../../src/MaximaFileIO.cpp:63 ../../src/MaximaFileIO.cpp:120
+#: ../../src/MaximaFileIO.cpp:129
 msgid "wxMaxima encountered an error loading "
 msgstr "wxMaxima 發生讀取錯誤"
 
-#: ../../src/wxMaximaFrame.cpp:1881
+#: ../../src/wxMaximaFrame.cpp:1918
 msgid "wxMaxima help"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1465 ../../src/Worksheet.cpp:1839
+#: ../../src/dialogs/AboutDialog.cpp:41
+#, fuzzy
+msgid "wxMaxima is a cross-platform graphical user interface for the computer algebra system Maxima based on wxWidgets.\n"
+msgstr "wxMaxima 是基於 wxWidgets ，為電腦代數系統 Maxima 的圖形使用界面。"
+
+#: ../../src/wxMaxima.cpp:2854
+#, c-format
+msgid ""
+"wxMaxima is now the .wxmx diff tool for:%s\n"
+"\n"
+"Open a .wxmx file's \"Diff\" in TortoiseSVN/TortoiseGit to compare it side by side."
+msgstr ""
+
+#: ../../src/dialogs/TipOfTheDay.cpp:240
+msgid "wxMaxima is programmed in C++ using the wxWidgets toolkit and uses CMake as build system. You can contribute to wxMaxima, if you have some knowledge with this environment."
+msgstr ""
+
+#: ../../src/dialogs/TipOfTheDay.cpp:228
+msgid "wxMaxima needs more developers. It is an open source project where you can contribute. Join the wxMaxima development at: https://github.com/wxMaxima-developers/wxmaxima"
+msgstr ""
+
+#: ../../src/dialogs/TipOfTheDay.cpp:224
+msgid "wxMaxima needs more translators. We do not speak every language. Help us to translate wxMaxima and the manual to your language. Join the wxMaxima development at: https://github.com/wxMaxima-developers/wxmaxima"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:407
+msgid "wxMaxima normally stores the gnuplot sources for every plot made using draw() in order to be able to open plots interactively in gnuplot later. This setting defines the limit [in Megabytes per plot] for this feature."
+msgstr ""
+
+#: ../../src/dialogs/TipOfTheDay.cpp:172
+msgid ""
+"wxMaxima provides the \"table_form\" command that shows lists in an alternative form. One example would be:\n"
+"\n"
+"table_form([1,2,3,4,5]);"
+msgstr ""
+
+#: ../../src/worksheet/WorksheetContextMenu.cpp:236
+#: ../../src/worksheet/WorksheetContextMenu.cpp:611
 msgid "wxMaxima remembers answers from the last run and is able to automatically send them to maxima, if requested"
 msgstr ""
 
-#: ../../src/Worksheet.cpp:1470 ../../src/Worksheet.cpp:1844
+#: ../../src/worksheet/WorksheetContextMenu.cpp:241
+#: ../../src/worksheet/WorksheetContextMenu.cpp:616
 msgid "wxMaxima remembers answers from the last run and is able to offer them as the default answer"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1896
+#: ../../src/dialogs/ConfigDialogue.cpp:481
+msgid "wxMaxima remembers the answers to maxima's questions. If this checkbox is set it automatically offers to enter the last answer to this question the user has input."
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1933
 #, fuzzy
 msgid "wxMaxima shows help in a browser"
 msgstr "找不到檔案"
 
-#: ../../src/wxMaximaFrame.cpp:1894
+#: ../../src/wxMaximaFrame.cpp:1931
 #, fuzzy
 msgid "wxMaxima shows help in the sidebar"
 msgstr "找不到檔案"
 
-#: ../../src/wxMaximaFrame.cpp:111
+#: ../../src/dialogs/ConfigDialogue.cpp:1095
+#, fuzzy
+msgid "wxMaxima startup file location: "
+msgstr "開始動畫"
+
+#: ../../src/wxMaximaFrame.cpp:119
 #, c-format
 msgid "wxMaxima version %s"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1954
+#: ../../src/worksheet/Worksheet.cpp:6164
+msgid "wxMaxima worksheet"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1997
 #, fuzzy
 msgid "wxMaxima's ChangeLog"
 msgstr "wxMaxima 圖示"
 
-#: ../../src/wxMaximaFrame.cpp:1952
+#: ../../src/wxMaximaFrame.cpp:1995
 msgid "wxMaxima's license"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:144
+#: ../../src/wxMaximaFrame.cpp:152
 msgid "wxWidgets is using GTK 2"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:142
+#: ../../src/wxMaximaFrame.cpp:150
 msgid "wxWidgets is using GTK 3"
 msgstr ""
 
-#: ../../src/WXMXformat.cpp:367
+#: ../../src/WXMXformat.cpp:369
 msgid "wxmx file saved"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8375
+#: ../../src/MaximaResponseReader.cpp:104
+msgid "wxworksheettohtml/totex: no target file name was given."
+msgstr ""
+
+#: ../../src/wxMaxima.cpp:2204
+#, c-format
+msgid "wxworksheettohtml: could not write \"%s\"."
+msgstr ""
+
+#: ../../src/wxMaxima.cpp:2178
+#, c-format
+msgid "wxworksheettohtml: unknown flavor \"%s\"; using native MathML. Known flavors: mathml, mathjax, svg, bitmap."
+msgstr ""
+
+#: ../../src/wxMaxima.cpp:2246
+#, c-format
+msgid "wxworksheettotex: could not write \"%s\"."
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:709
+msgid "x"
+msgstr ""
+
+#: ../../src/wizards/DrawWiz.cpp:266
+msgid "x axis label"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:2021
 msgid "x direction [in multiples of the tick frequency]"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:4500 ../../src/wxMaxima.cpp:4643
+#: ../../src/wizards/DrawWiz.cpp:269
+msgid "x range (automatic if incomplete)"
+msgstr ""
+
+#: ../../src/sidebars/GreekSidebar.cpp:164
+msgid "xi"
+msgstr ""
+
+#: ../../src/MaximaFileIO.cpp:408 ../../src/MaximaFileIO.cpp:566
 msgid "xml contained in the file claims not to be a wxMaxima worksheet. "
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:8376
+#: ../../src/sidebars/SymbolsSidebar.cpp:97
+#, fuzzy
+msgid "xor"
+msgstr "匯出"
+
+#: ../../src/wizards/DrawWiz.cpp:279
+msgid "y axis label"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:2022
 msgid "y direction [in multiples of the tick frequency]"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:7789
+#: ../../src/wizards/DrawWiz.cpp:282
+msgid "y range (automatic if incomplete)"
+msgstr ""
+
+#: ../../src/MaximaCommandMenus.cpp:970
 msgid "y:"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:2
-msgid "# The wxMaxima user manual"
+#: ../../src/wizards/DrawWiz.cpp:294
+msgid "z axis label"
+msgstr ""
+
+#: ../../src/wizards/DrawWiz.cpp:298
+msgid "z range (automatic if incomplete)"
+msgstr ""
+
+#: ../../src/sidebars/GreekSidebar.cpp:156
+msgid "zeta"
+msgstr ""
+
+#. type: Title #
+#: ../../info/wxmaxima.md:1
+#, no-wrap
+msgid "The wxMaxima user manual"
 msgstr ""
 
 #. type: Plain text
@@ -8461,24 +12918,16 @@ msgstr ""
 msgid "![wxMaxima logo](./wxMaximaLogo.png){ id=img_wxMaximaLogo }"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:7 ../../info/wxmaxima.md:425
-#: ../../info/wxmaxima.md:880 ../../info/wxmaxima.md:1090
-#: ../../info/wxmaxima.md:1137 ../../info/wxmaxima.md:1161
+#. type: Title #
+#: ../../info/wxmaxima.md:9
 #, no-wrap
-msgid "______________________________________________________________________\n"
+msgid "Introduction to wxMaxima"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:10
-#, fuzzy
-#| msgid "Welcome to wxMaxima"
-msgid "# Introduction to wxMaxima"
-msgstr "歡迎使用 wxMaxima"
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:12
-msgid "## _Maxima_ and wxMaxima"
+#. type: Title ##
+#: ../../info/wxmaxima.md:11
+#, no-wrap
+msgid "_Maxima_ and wxMaxima"
 msgstr ""
 
 #. type: Plain text
@@ -8491,12 +12940,11 @@ msgstr ""
 msgid "A computer algebra system (CAS) like _Maxima_ fits into this framework. A CAS can provide the logic behind an arbitrary precision calculator application or it can do automatic transforms of formulas in the background of a bigger system (e.g., [Sage](https://www.sagemath.org/)). Alternatively, it can be used directly as a free-standing system. _Maxima_ can be accessed via a command line. Often, however, an interface like _wxMaxima_ proves a more efficient way to access the software, especially for newcomers."
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:18
-#, fuzzy
-#| msgid "&Maxima"
-msgid "### _Maxima_"
-msgstr "Maxima(&M)"
+#. type: Title ###
+#: ../../info/wxmaxima.md:17
+#, no-wrap
+msgid "_Maxima_"
+msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:20
@@ -8510,15 +12958,15 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:24
-msgid "Extensive documentation for _Maxima_ is [available in the internet](https://maxima.sourceforge.io/documentation.html). Part of this documentation is also available in wxMaxima’s help menu. Pressing the Help key (on most systems the <kbd>F1</kbd> key) causes _wxMaxima_’s context-sensitive help feature to automatically jump to _Maxima_’s manual page for the command at the cursor."
+#, no-wrap
+msgid "Extensive documentation for _Maxima_ is  [available in the internet](https://maxima.sourceforge.io/documentation.html). Part of this documentation is also available in wxMaxima’s help menu. Pressing the Help key (on most systems the <kbd>F1</kbd> key) causes _wxMaxima_’s context-sensitive help feature to automatically jump to _Maxima_’s manual page for the command at the cursor.\n"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:26
-#, fuzzy
-#| msgid "&Maxima"
-msgid "### WxMaxima"
-msgstr "Maxima(&M)"
+#. type: Title ###
+#: ../../info/wxmaxima.md:25
+#, no-wrap
+msgid "WxMaxima"
+msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:28
@@ -8535,9 +12983,10 @@ msgstr ""
 msgid "The calculations that are entered in _wxMaxima_ are performed by the _Maxima_ command-line tool in the background."
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:34
-msgid "## Workbook basics"
+#. type: Title ##
+#: ../../info/wxmaxima.md:33
+#, no-wrap
+msgid "Workbook basics"
 msgstr ""
 
 #. type: Plain text
@@ -8545,9 +12994,10 @@ msgstr ""
 msgid "Much of _wxMaxima_ is self-explaining, but some details require attention. [This site](https://wxMaxima-developers.github.io/wxmaxima/help.html) contains a number of workbooks that address various aspects of _wxMaxima_. Working through some of these (particularly the \"10 minute _(wx)Maxima_ tutorial\") will increase one’s familiarity with both the content of _Maxima_ and the use of _wxMaxima_ to interact with _Maxima_. This manual concentrates on describing aspects of _wxMaxima_ that are not likely to be self-evident and that might not be covered in the online material."
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:38
-msgid "### The workbook approach"
+#. type: Title ###
+#: ../../info/wxmaxima.md:37
+#, no-wrap
+msgid "The workbook approach"
 msgstr ""
 
 #. type: Plain text
@@ -8585,12 +13035,11 @@ msgstr ""
 msgid "![Example of different wxMaxima cells](./cell-example.png){ id=img_cell-example }"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:54
-#, fuzzy
-#| msgid "Merge Cells"
-msgid "### Cells"
-msgstr "合併單元"
+#. type: Title ###
+#: ../../info/wxmaxima.md:53
+#, no-wrap
+msgid "Cells"
+msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:56
@@ -8646,9 +13095,10 @@ msgstr ""
 msgid "\"`/*`\" marks the start of the comment, \"`*/`\" the end."
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:71
-msgid "### Horizontal and vertical cursors"
+#. type: Title ###
+#: ../../info/wxmaxima.md:70
+#, no-wrap
+msgid "Horizontal and vertical cursors"
 msgstr ""
 
 #. type: Plain text
@@ -8673,7 +13123,8 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:80
-msgid "When you start wxMaxima, you will only see the blinking horizontal cursor. If you start typing, a math cell will be automatically created and the cursor will change to a regular vertical one (you will see a right arrow as \"prompt\", after the Math cell is evaluated (<kbd>CTRL</kbd>+<kbd>ENTER</kbd>), you will see the labels, e.g. `(%i1)`, `(%o1)`)."
+#, no-wrap
+msgid "When you start wxMaxima, you will only see the blinking horizontal cursor. If you start typing, a math cell will be automatically created and the cursor will change to a regular vertical one (you will see a right arrow as \"prompt\", after the Math cell is evaluated (<kbd>CTRL</kbd>+<kbd>ENTER</kbd>), you will see the labels, e.g. `(%i1)`, `(%o1)`).\n"
 msgstr ""
 
 #. type: Plain text
@@ -8696,24 +13147,28 @@ msgstr ""
 msgid "![(blinking) horizontal cursor between cells](./horizontal-cursor-between-cells.png){ id=img_horizontal_cursor_between_cells }"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:90
-msgid "### Sending cells to Maxima"
+#. type: Title ###
+#: ../../info/wxmaxima.md:89
+#, no-wrap
+msgid "Sending cells to Maxima"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:92
-msgid "The command in a code cell is executed once by pressing <kbd>CTRL</kbd>+<kbd>ENTER</kbd>, <kbd>SHIFT</kbd>+<kbd>ENTER</kbd> or the <kbd>ENTER</kbd> key on the keypad. The _wxMaxima_ default is to enter commands when either <kbd>CTRL</kbd>+<kbd>ENTER</kbd> or <kbd>SHIFT</kbd>+<kbd>ENTER</kbd> is entered, but _wxMaxima_ can be configured to execute commands in response to <kbd>ENTER</kbd>."
+#, no-wrap
+msgid "The command in a code cell is executed once by pressing <kbd>CTRL</kbd>+<kbd>ENTER</kbd>, <kbd>SHIFT</kbd>+<kbd>ENTER</kbd> or the <kbd>ENTER</kbd> key on the keypad. The _wxMaxima_ default is to enter commands when either <kbd>CTRL</kbd>+<kbd>ENTER</kbd> or <kbd>SHIFT</kbd>+<kbd>ENTER</kbd> is entered, but _wxMaxima_ can be configured to execute commands in response to <kbd>ENTER</kbd>.\n"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:94
-msgid "### Command autocompletion"
+#. type: Title ###
+#: ../../info/wxmaxima.md:93
+#, no-wrap
+msgid "Command autocompletion"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:96
-msgid "_WxMaxima_ contains an autocompletion feature that is triggered via the menu (Cell/Complete Word) or alternatively by pressing the key combination <kbd>CTRL</kbd>+<kbd>SPACE</kbd>. The autocompletion is context-sensitive. For example, if activated within a unit specification for ezUnits it will offer a list of applicable units."
+#, no-wrap
+msgid "_WxMaxima_ contains an autocompletion feature that is triggered via the menu (Cell/Complete Word) or alternatively by pressing the key combination <kbd>CTRL</kbd>+<kbd>SPACE</kbd>. The autocompletion is context-sensitive. For example, if activated within a unit specification for ezUnits it will offer a list of applicable units.\n"
 msgstr ""
 
 #. type: Plain text
@@ -8723,14 +13178,15 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:100
-msgid "Besides completing a file name, a unit name, or the current command or variable name, the autocompletion is able to show a template for most of the commands indicating the type (and meaning) of the parameters this program expects. To activate this feature press <kbd>SHIFT</kbd>+<kbd>CTRL</kbd>+<kbd>SPACE</kbd> or select the respective menu item (Cell/Show Template)."
+#, no-wrap
+msgid "Besides completing a file name, a unit name, or the current command or variable name, the autocompletion is able to show a template for most of the commands indicating the type (and meaning) of the parameters this program expects. To activate this feature press <kbd>SHIFT</kbd>+<kbd>CTRL</kbd>+<kbd>SPACE</kbd> or select the respective menu item (Cell/Show Template).\n"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:102
-#, fuzzy
-msgid "#### Greek characters"
-msgstr "希臘字母"
+#. type: Title ####
+#: ../../info/wxmaxima.md:101
+#, no-wrap
+msgid "Greek characters"
+msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:104
@@ -8786,9 +13242,10 @@ msgstr ""
 msgid "You can also use the \"Greek letters\"-sidebar to enter the Greek letters."
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:134
-msgid "##### Attention: Lookalike characters"
+#. type: Title #####
+#: ../../info/wxmaxima.md:133
+#, no-wrap
+msgid "Attention: Lookalike characters"
 msgstr ""
 
 #. type: Plain text
@@ -8874,12 +13331,14 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:203
-msgid "If a special symbol isn’t in the list, it is possible to input arbitrary Unicode characters by pressing <kbd>ESC</kbd> \\[number of the character (hexadecimal)\\] <kbd>ESC</kbd>. Additionally the \"symbols\" sidebar has a right-click menu that allow to display a list of all available Unicode symbols one can add to this toolbar or to the worksheet."
+#, no-wrap
+msgid "If a special symbol isn’t in the list, it is possible to input arbitrary Unicode characters by pressing <kbd>ESC</kbd> \\[number of the character (hexadecimal)\\] <kbd>ESC</kbd>. Additionally the \"symbols\" sidebar has a right-click menu that allow to display a list of all available Unicode symbols one can add to this toolbar or to the worksheet.\n"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:205
-msgid "<kbd>ESC</kbd><kbd>6</kbd><kbd>1</kbd><kbd>ESC</kbd> therefore results in an `a`."
+#, no-wrap
+msgid "<kbd>ESC</kbd><kbd>6</kbd><kbd>1</kbd><kbd>ESC</kbd> therefore results in an `a`.\n"
 msgstr ""
 
 #. type: Plain text
@@ -8889,12 +13348,16 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:210
-msgid "It may be the case that e.g. Greek characters or mathematical symbols are not included in the selected font, then they can not be displayed.  To solve that problem, select other fonts (using: Edit -> Configure -> Style)."
+#, no-wrap
+msgid ""
+"It may be the case that e.g. Greek characters or mathematical symbols are not included in the selected font, then they can not be displayed.\n"
+"To solve that problem, select other fonts (using: Edit -> Configure -> Style).\n"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:212
-msgid "### Unicode replacement"
+#. type: Title ###
+#: ../../info/wxmaxima.md:211
+#, no-wrap
+msgid "Unicode replacement"
 msgstr ""
 
 #. type: Plain text
@@ -8917,9 +13380,10 @@ msgstr ""
 msgid "It is recommended to use **Maxima code** (not these Unicode code points) in input cells (Rationale: (a) it might be possible, that the used font for math input does not contain them; (b) if you save the document as `wxm`-file, it is usually readable by (command line) Maxima, but these changes will of course not work in command line Maxima); but they may occur, if you cut&paste a formula from another document."
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:223
-msgid "### Side Panes"
+#. type: Title ###
+#: ../../info/wxmaxima.md:222
+#, no-wrap
+msgid "Side Panes"
 msgstr ""
 
 #. type: Plain text
@@ -8942,9 +13406,10 @@ msgstr ""
 msgid "![Increase or decrease headings in the TOC side pane](./Sidepane-TOC-convert-headings.png){ id=Sidepane-TOC-convert-headings }"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:234
-msgid "### MathML output"
+#. type: Title ###
+#: ../../info/wxmaxima.md:233
+#, no-wrap
+msgid "MathML output"
 msgstr ""
 
 #. type: Plain text
@@ -8952,9 +13417,10 @@ msgstr ""
 msgid "Several word processors and similar programs either recognize [MathML](https://www.w3.org/Math/) input and automatically insert it as an editable 2D equation - or (like LibreOffice) have an equation editor that offers an “import MathML from clipboard” feature. Others support RTF maths. _WxMaxima_, therefore, offers several entries in the right-click menu."
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:238
-msgid "### Markdown support"
+#. type: Title ###
+#: ../../info/wxmaxima.md:237
+#, no-wrap
+msgid "Markdown support"
 msgstr ""
 
 #. type: Plain text
@@ -8962,11 +13428,10 @@ msgstr ""
 msgid "_WxMaxima_ offers a set of standard [Markdown](https://en.wikipedia.org/wiki/Markdown) conventions that don’t collide with mathematical notation. One of these elements is bullet lists."
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:250
+#. type: Fenced code block (text)
+#: ../../info/wxmaxima.md:241
 #, no-wrap
 msgid ""
-"```text\n"
 "Ordinary text\n"
 " * One item, indentation level 1\n"
 " * Another item at indentation level 1\n"
@@ -8974,37 +13439,47 @@ msgid ""
 "   * A second item at the second indentation level\n"
 " * A third item at the first indentation level\n"
 "Ordinary text\n"
-"```\n"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:252
-msgid "_WxMaxima_ will recognize text starting with `>` chars as block quotes:"
+#, no-wrap
+msgid "_WxMaxima_ will recognize text starting with `>` chars as block quotes:\n"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:260
-msgid "```text Ordinary text > quote quote quote quote > quote quote quote quote > quote quote quote quote Ordinary text ```"
+#. type: Fenced code block (text)
+#: ../../info/wxmaxima.md:253
+#, no-wrap
+msgid ""
+"Ordinary text\n"
+"> quote quote quote quote\n"
+"> quote quote quote quote\n"
+"> quote quote quote quote\n"
+"Ordinary text\n"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:262
-msgid "_WxMaxima_’s TeX and HTML output will also recognize `=>` and replace it by the corresponding Unicode sign:"
+#, no-wrap
+msgid "_WxMaxima_’s TeX and HTML output will also recognize `=>` and replace it by the corresponding Unicode sign:\n"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:266
-msgid "```text cogito => sum.  ```"
+#. type: Fenced code block (text)
+#: ../../info/wxmaxima.md:263
+#, no-wrap
+msgid "cogito => sum.\n"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:268
-msgid "Other symbols the HTML and TeX export will recognize are `<=` and `>=` for comparisons, a double-pointed double arrow (`<=>`), single-headed arrows (`<->`, `->` and `<-`) and `+/-` as the respective sign. For TeX output also `<<` and `>>` are recognized."
+#, no-wrap
+msgid "Other symbols the HTML and TeX export will recognize are `<=` and `>=` for comparisons, a double-pointed double arrow (`<=>`), single-headed arrows (`<->`, `->` and `<-`) and `+/-` as the respective sign. For TeX output also `<<` and `>>` are recognized.\n"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:270
-msgid "### Hotkeys"
+#. type: Title ###
+#: ../../info/wxmaxima.md:269
+#, no-wrap
+msgid "Hotkeys"
 msgstr ""
 
 #. type: Plain text
@@ -9027,9 +13502,10 @@ msgstr ""
 msgid "<kbd>SHIFT</kbd>+<kbd>SPACE</kbd> inserts a non-breaking space."
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:278
-msgid "### Raw TeX in the TeX export"
+#. type: Title ###
+#: ../../info/wxmaxima.md:277
+#, no-wrap
+msgid "Raw TeX in the TeX export"
 msgstr ""
 
 #. type: Plain text
@@ -9037,20 +13513,21 @@ msgstr ""
 msgid "If a text cell begins with `TeX:` the TeX export contains the literal text that follows the `TeX:` marker. Using this feature allows the entry of TeX markup within the _wxMaxima_ workbook."
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:282
-#, fuzzy
-msgid "## File Formats"
-msgstr "找不到檔案"
+#. type: Title ##
+#: ../../info/wxmaxima.md:281
+#, no-wrap
+msgid "File Formats"
+msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:284
 msgid "The material that is developed in a _wxMaxima_ session can be stored for later use in any of three ways:"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:286
-msgid "### .mac"
+#. type: Title ###
+#: ../../info/wxmaxima.md:285
+#, no-wrap
+msgid ".mac"
 msgstr ""
 
 #. type: Plain text
@@ -9078,14 +13555,18 @@ msgstr ""
 msgid "You can be use `.mac` files for writing your own library of macros. But since they don’t contain enough structural information they cannot be read back as a _wxMaxima_ session."
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:299
-msgid "### .wxm"
+#. type: Title ###
+#: ../../info/wxmaxima.md:298
+#, no-wrap
+msgid ".wxm"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:302
-msgid "`.wxm` files contain the worksheet except for _Maxima_’s output. On Maxima versions >5.38 they can be read using _Maxima_’s `load()` function just as .mac files. Well - mostly. Questions (like `asksign(x)`) are problematic, as the answer is written in the `.wxm` file (so that it can be suggested after loading), but that can Maxima not evaluate.  You can prevent Maxima from asking questions by using `assume()` to declare some properties, Maxima wants to know."
+#, no-wrap
+msgid ""
+"`.wxm` files contain the worksheet except for _Maxima_’s output. On Maxima versions >5.38 they can be read using _Maxima_’s `load()` function just as .mac files. Well - mostly. Questions (like `asksign(x)`) are problematic, as the answer is written in the `.wxm` file (so that it can be suggested after loading), but that can Maxima not evaluate.\n"
+"You can prevent Maxima from asking questions by using `assume()` to declare some properties, Maxima wants to know.\n"
 msgstr ""
 
 #. type: Plain text
@@ -9093,9 +13574,10 @@ msgstr ""
 msgid "With this plain-text format, it sometimes is unavoidable that worksheets that use new features are not downwards-compatible with older versions of _wxMaxima_."
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:306
-msgid "#### File format of wxm files"
+#. type: Title ####
+#: ../../info/wxmaxima.md:305
+#, no-wrap
+msgid "File format of wxm files"
 msgstr ""
 
 #. type: Plain text
@@ -9108,9 +13590,12 @@ msgstr ""
 msgid "It starts with the following comment:"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:315
-msgid "```maxima /* [wxMaxima batch file version 1] [ DO NOT EDIT BY HAND! ]*/ /* [ Created with wxMaxima version 24.02.2_DevelopmentSnapshot ] */ ```"
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:311
+#, no-wrap
+msgid ""
+"/* [wxMaxima batch file version 1] [ DO NOT EDIT BY HAND! ]*/\n"
+"/* [ Created with wxMaxima version 24.02.2_DevelopmentSnapshot ] */\n"
 msgstr ""
 
 #. type: Plain text
@@ -9118,15 +13603,13 @@ msgstr ""
 msgid "And then the cells follow, encoded as Maxima comments, e.g. a section cell:"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:323
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:318
 #, no-wrap
 msgid ""
-"```maxima\n"
 "/* [wxMaxima: section start ]\n"
 "Title of the section\n"
 "   [wxMaxima: section end   ] */\n"
-"```\n"
 msgstr ""
 
 #. type: Plain text
@@ -9134,16 +13617,14 @@ msgstr ""
 msgid "or (in a Math cell the input is of course *not* commented out (the output is not saved in a `wxm` file)):"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:332
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:326
 #, no-wrap
 msgid ""
-"```maxima\n"
 "/* [wxMaxima: input   start ] */\n"
 "f(x):=x^2+1$\n"
 "f(2);\n"
 "/* [wxMaxima: input   end   ] */\n"
-"```\n"
 msgstr ""
 
 #. type: Plain text
@@ -9151,16 +13632,14 @@ msgstr ""
 msgid "Images are [Base64 encoded](https://en.wikipedia.org/wiki/Base64) with the image type as first line):"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:341
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:335
 #, no-wrap
 msgid ""
-"```maxima\n"
 "/* [wxMaxima: image   start ]\n"
 "jpg\n"
 "[very chaotic looking character sequence]\n"
 "   [wxMaxima: image   end   ] */\n"
-"```\n"
 msgstr ""
 
 #. type: Plain text
@@ -9168,13 +13647,10 @@ msgstr ""
 msgid "A page break is just one line containing:"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:347
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:344
 #, no-wrap
-msgid ""
-"```maxima\n"
-"/* [wxMaxima: page break    ] */\n"
-"```\n"
+msgid "/* [wxMaxima: page break    ] */\n"
 msgstr ""
 
 #. type: Plain text
@@ -9182,20 +13658,19 @@ msgstr ""
 msgid "And folded cells marked by:"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:355
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:350
 #, no-wrap
 msgid ""
-"```maxima\n"
 "/* [wxMaxima: fold    start ] */\n"
 "...\n"
 "/* [wxMaxima: fold    end   ] */\n"
-"```\n"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:357
-msgid "### .wxmx"
+#. type: Title ###
+#: ../../info/wxmaxima.md:356
+#, no-wrap
+msgid ".wxmx"
 msgstr ""
 
 #. type: Plain text
@@ -9203,9 +13678,10 @@ msgstr ""
 msgid "This XML-based file format saves the complete worksheet including things like the zoom factor and the watchlist. It is the preferred file format."
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:361
-msgid "#### File format of wxmx files"
+#. type: Title ####
+#: ../../info/wxmaxima.md:360
+#, no-wrap
+msgid "File format of wxmx files"
 msgstr ""
 
 #. type: Plain text
@@ -9243,9 +13719,10 @@ msgstr ""
 msgid "So, if something goes wrong, you can unzip a wxMaxima document (maybe rename it before to a `zip`-file), maybe make changes in the `content.xml` file with a text editor, or replace an broken image, zip the files again, probably rename the `zip` to a `wxmx`-file - and you get another modified `wxmx`-file."
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:375
-msgid "## Configuration options"
+#. type: Title ##
+#: ../../info/wxmaxima.md:374
+#, no-wrap
+msgid "Configuration options"
 msgstr ""
 
 #. type: Plain text
@@ -9268,9 +13745,10 @@ msgstr ""
 msgid "![wxMaxima configuration 1](./wxMaxima_configuration_001.png){ id=img_wxMaxima_configuration_001 }"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:384
-msgid "### Default animation framerate"
+#. type: Title ###
+#: ../../info/wxmaxima.md:383
+#, no-wrap
+msgid "Default animation framerate"
 msgstr ""
 
 #. type: Plain text
@@ -9278,9 +13756,10 @@ msgstr ""
 msgid "The animation framerate that is used for new animations is kept in the variable `wxanimate_framerate`. The initial value this variable will contain in a new worksheet can be changed using the configuration dialogue."
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:388
-msgid "### Default plot size for new _maxima_ sessions"
+#. type: Title ###
+#: ../../info/wxmaxima.md:387
+#, no-wrap
+msgid "Default plot size for new _maxima_ sessions"
 msgstr ""
 
 #. type: Plain text
@@ -9293,26 +13772,23 @@ msgstr ""
 msgid "In order to set the plot size of a single graph only use the following notation can be used that sets a variable’s value for one command only:"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:401
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:393
 #, no-wrap
 msgid ""
-"```maxima\n"
 "wxdraw2d(\n"
 "   explicit(\n"
 "       x^2,\n"
 "       x,-5,5\n"
 "   )\n"
 "), wxplot_size=[480,480]$\n"
-"```\n"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:403
-#, fuzzy
-#| msgid "Set fixed font in text controls."
-msgid "### Match parenthesis in text controls"
-msgstr "在文字控制項中使用等寬字型"
+#. type: Title ###
+#: ../../info/wxmaxima.md:402
+#, no-wrap
+msgid "Match parenthesis in text controls"
+msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:405
@@ -9329,9 +13805,10 @@ msgstr ""
 msgid "If text is selected if any of these keys is pressed the selected text will be put between the matched signs."
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:410
-msgid "### Don’t save the worksheet automatically"
+#. type: Title ###
+#: ../../info/wxmaxima.md:409
+#, no-wrap
+msgid "Don’t save the worksheet automatically"
 msgstr ""
 
 #. type: Plain text
@@ -9354,14 +13831,18 @@ msgstr ""
 msgid "And the file will automatically be saved every 3 minutes."
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:419
-msgid "### Where is the configuration saved?"
+#. type: Title ###
+#: ../../info/wxmaxima.md:418
+#, no-wrap
+msgid "Where is the configuration saved?"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:422
-msgid "If you are using Unix/Linux, the configuration information will be saved in a file `.wxMaxima` in your home directory (if you are using wxWidgets \\< 3.1.1), or `.config/wxMaxima.conf` ((XDG-Standard) if wxWidgets >= 3.1.1 is used). You can retrieve the wxWidgets version from the command `wxbuild_info();` or by using the menu option Help->About. [wxWidgets](https://www.wxwidgets.org/) is the cross-platform GUI library, which is the base for _wxMaxima_ (therefore the `wx` in the name).  (Since the filename starts with a dot, `.wxMaxima` or `.config` will be hidden)."
+#, no-wrap
+msgid ""
+"If you are using Unix/Linux, the configuration information will be saved in a file `.wxMaxima` in your home directory (if you are using wxWidgets \\< 3.1.1), or `.config/wxMaxima.conf` ((XDG-Standard) if wxWidgets >= 3.1.1 is used). You can retrieve the wxWidgets version from the command `wxbuild_info();` or by using the menu option Help->About. [wxWidgets](https://www.wxwidgets.org/) is the cross-platform GUI library, which is the base for _wxMaxima_ (therefore the `wx` in the name).\n"
+"(Since the filename starts with a dot, `.wxMaxima` or `.config` will be hidden).\n"
 msgstr ""
 
 #. type: Plain text
@@ -9369,9 +13850,10 @@ msgstr ""
 msgid "If you are using Windows, the configuration will be stored in the registry. You will find the entries for _wxMaxima_ at the following position in the registry: `HKEY_CURRENT_USER\\Software\\wxMaxima`"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:428
-msgid "# Extensions to _Maxima_"
+#. type: Title #
+#: ../../info/wxmaxima.md:427
+#, no-wrap
+msgid "Extensions to _Maxima_"
 msgstr ""
 
 #. type: Plain text
@@ -9379,12 +13861,11 @@ msgstr ""
 msgid "_WxMaxima_ is primarily a graphical user interface for _Maxima_. As such, its main purpose is to pass along commands to _Maxima_ and to report the results of executing those commands. In some cases, however, _wxMaxima_ adds functionality to _Maxima_. _WxMaxima_’s ability to generate reports by exporting a workbook’s contents to HTML and LaTeX files has been mentioned. This section considers some ways that _wxMaxima_ enhances the inclusion of graphics in a session."
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:432
-#, fuzzy
-#| msgid "Show defined variables"
-msgid "## Subscripted variables"
-msgstr "顯示已定義的變數"
+#. type: Title ##
+#: ../../info/wxmaxima.md:431
+#, no-wrap
+msgid "Subscripted variables"
+msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:434
@@ -9428,12 +13909,14 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:449
-msgid "You can use the menu \"View->Autosubscript\" to set these values."
+#, no-wrap
+msgid "You can use the menu \"View->Autosubscript\" to set these values.\n"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:451
-msgid "## User feedback in the status bar"
+#. type: Title ##
+#: ../../info/wxmaxima.md:450
+#, no-wrap
+msgid "User feedback in the status bar"
 msgstr ""
 
 #. type: Plain text
@@ -9441,11 +13924,10 @@ msgstr ""
 msgid "Long-running commands can provide user feedback in the status bar. This user feedback is replaced by any new feedback that is placed there (allowing to use it as a progress indicator) and is deleted as soon as the current command sent to _Maxima_ is finished. It is safe to use `wxstatusbar()` even in libraries that might be used with plain _Maxima_ (as opposed to _wxMaxima_): If _wxMaxima_ isn’t present the `wxstatusbar()` command will just be left unevaluated."
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:464
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:454
 #, no-wrap
 msgid ""
-"```maxima\n"
 "for i:1 thru 10 do (\n"
 "    /* Tell the user how far we got */\n"
 "    wxstatusbar(concat(\"Pass \",i)),\n"
@@ -9454,12 +13936,12 @@ msgid ""
 "    /* program execution (here: for 3 seconds) */\n"
 "    ?sleep(3)\n"
 ")$\n"
-"```\n"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:466
-msgid "## Exporting the worksheet from within Maxima"
+#. type: Title ##
+#: ../../info/wxmaxima.md:465
+#, no-wrap
+msgid "Exporting the worksheet from within Maxima"
 msgstr ""
 
 #. type: Plain text
@@ -9467,9 +13949,12 @@ msgstr ""
 msgid "The command `wxworksheettohtml()` exports the current worksheet to an HTML file from within a running _Maxima_ session, which is convenient for scripted or batch export. Like `wxstatusbar()` it is safe to use in code that might also run in plain (console) _Maxima_: if _wxMaxima_ isn’t present the command is simply left unevaluated."
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:473
-msgid "```maxima wxworksheettohtml(\"report.html\")$ wxworksheettohtml(\"report.html\", flavor=\"svg\", wxmx=true)$ ```"
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:469
+#, no-wrap
+msgid ""
+"wxworksheettohtml(\"report.html\")$\n"
+"wxworksheettohtml(\"report.html\", flavor=\"svg\", wxmx=true)$\n"
 msgstr ""
 
 #. type: Plain text
@@ -9497,9 +13982,12 @@ msgstr ""
 msgid "The companion command `wxworksheettotex()` exports to a LaTeX (`.tex`) file the same way:"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:489
-msgid "```maxima wxworksheettotex(\"report.tex\")$ wxworksheettotex(\"report.tex\", documentclass=\"report\", documentclassoptions=\"12pt,a4paper\")$ ```"
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:485
+#, no-wrap
+msgid ""
+"wxworksheettotex(\"report.tex\")$\n"
+"wxworksheettotex(\"report.tex\", documentclass=\"report\", documentclassoptions=\"12pt,a4paper\")$\n"
 msgstr ""
 
 #. type: Plain text
@@ -9517,9 +14005,10 @@ msgstr ""
 msgid "Support for `wxworksheettopdf()` is planned."
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:498
-msgid "## Plotting"
+#. type: Title ##
+#: ../../info/wxmaxima.md:497
+#, no-wrap
+msgid "Plotting"
 msgstr ""
 
 #. type: Plain text
@@ -9527,9 +14016,10 @@ msgstr ""
 msgid "Plotting (having fundamentally to do with graphics) is a place where a graphical user interface will have to provide some extensions to the original program."
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:502
-msgid "### Embedding a plot into the worksheet"
+#. type: Title ###
+#: ../../info/wxmaxima.md:501
+#, no-wrap
+msgid "Embedding a plot into the worksheet"
 msgstr ""
 
 #. type: Plain text
@@ -9571,9 +14061,10 @@ msgstr ""
 msgid "If you got problems with one of these functions, please check, if the problem exists in the the Maxima function too (e.g. you got an error with `wxplot2d()`, check the same plot in the Maxima command `plot2d()` (which opens the plot in a separate Window)). If the problem does not disappear, it is most likely a Maxima issue and should be reported in the [Maxima bugtracker](https://sourceforge.net/p/maxima/bugs/). Or maybe a Gnuplot issue."
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:526
-msgid "### Making embedded plots bigger or smaller"
+#. type: Title ###
+#: ../../info/wxmaxima.md:525
+#, no-wrap
+msgid "Making embedded plots bigger or smaller"
 msgstr ""
 
 #. type: Plain text
@@ -9581,11 +14072,10 @@ msgstr ""
 msgid "As noted above, the configure dialog provides a way to change the default size plots created which sets the starting value of `wxplot_size`. The plotting routines of _wxMaxima_ respect this variable that specifies the size of a plot in pixels. It can always be queried or used to set the size of the following plots:"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:538
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:529
 #, no-wrap
 msgid ""
-"```maxima\n"
 "wxplot_size:[1200,800]$\n"
 "wxdraw2d(\n"
 "    explicit(\n"
@@ -9593,7 +14083,6 @@ msgid ""
 "        x,1,10\n"
 "    )\n"
 ")$\n"
-"```\n"
 msgstr ""
 
 #. type: Plain text
@@ -9601,18 +14090,16 @@ msgstr ""
 msgid "If the size of only one plot is to be changed _Maxima_ provides a canonical way to change an attribute only for the current cell. In this usage the specification `wxplot_size = [value1, value2]` is appended to the `wxdraw2d( )` command, and is not part of the `wxdraw2d` command."
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:549
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:541
 #, no-wrap
 msgid ""
-"```maxima\n"
 "wxdraw2d(\n"
 "    explicit(\n"
 "        sin(x),\n"
 "        x,1,10\n"
 "    )\n"
 "),wxplot_size=[1600,800]$\n"
-"```\n"
 msgstr ""
 
 #. type: Plain text
@@ -9620,9 +14107,10 @@ msgstr ""
 msgid "Setting the size of embedded plot with `wxplot_size` works for embedded plots using e.g. `wxplot`, `wxdraw`, `wxcontour_plot` and `wximplicit_plot` commands and for embedded animations with `with_slider_draw` and `wxanimate` commands."
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:553
-msgid "### Better quality plots"
+#. type: Title ###
+#: ../../info/wxmaxima.md:552
+#, no-wrap
+msgid "Better quality plots"
 msgstr ""
 
 #. type: Plain text
@@ -9630,9 +14118,10 @@ msgstr ""
 msgid "_Gnuplot_ doesn’t seem to provide a portable way of determining whether it supports the high-quality bitmap output that the Cairo library provides. On systems where _Gnuplot_ is compiled to use this library the pngCairo option from the configuration menu (that can be overridden by the variable `wxplot_pngcairo`) enables support for antialiasing and additional line styles. If `wxplot_pngCairo` is set without _Gnuplot_ supporting this the result will be error messages instead of graphics."
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:557
-msgid "### Opening embedded plots in interactive _Gnuplot_ windows"
+#. type: Title ###
+#: ../../info/wxmaxima.md:556
+#, no-wrap
+msgid "Opening embedded plots in interactive _Gnuplot_ windows"
 msgstr ""
 
 #. type: Plain text
@@ -9640,9 +14129,10 @@ msgstr ""
 msgid "If a plot was generated using the `wxdraw`-type commands (`wxplot2d` and `wxplot3d` isn’t supported by this feature) and the file size of the underlying _Gnuplot_ project isn’t way too high _wxMaxima_ offers a right-click menu that allows to open the plot in an interactive _Gnuplot_ window."
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:561
-msgid "### Opening Gnuplot’s command console in `plot` windows"
+#. type: Title ###
+#: ../../info/wxmaxima.md:560
+#, no-wrap
+msgid "Opening Gnuplot’s command console in `plot` windows"
 msgstr ""
 
 #. type: Plain text
@@ -9650,9 +14140,10 @@ msgstr ""
 msgid "On MS Windows, there are two Gnuplot programs, `gnuplot.exe` and `wgnuplot.exe`.  You can configure, which command should be used using the configuration menu. `wgnuplot.exe` offers the possibility to open a console window, where _gnuplot_ commands can be entered into, `gnuplot.exe` does not offer this possibility. Unfortunately, `wgnuplot.exe` causes _Gnuplot_ to \"steal\" the keyboard focus for a short time every time a plot is prepared."
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:566
-msgid "### Embedding animations into the spreadsheet"
+#. type: Title ###
+#: ../../info/wxmaxima.md:565
+#, no-wrap
+msgid "Embedding animations into the spreadsheet"
 msgstr ""
 
 #. type: Plain text
@@ -9665,11 +14156,10 @@ msgstr ""
 msgid "The first two arguments for `with_slider_draw` are the name of the variable that is stepped between the plots and a list of the values of these variable. The arguments that follow are the ordinary arguments for `wxdraw2d`:"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:581
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:571
 #, no-wrap
 msgid ""
-"```maxima\n"
 "with_slider_draw(\n"
 "    f,[1,2,3,4,5,6,7,10],\n"
 "    title=concat(\"f=\",f,\"Hz\"),\n"
@@ -9678,7 +14168,6 @@ msgid ""
 "        x,0,1\n"
 "    ),grid=true\n"
 ");\n"
-"```\n"
 msgstr ""
 
 #. type: Plain text
@@ -9686,11 +14175,10 @@ msgstr ""
 msgid "The same functionality for 3D plots is accessible as `with_slider_draw3d`, which allows for rotating 3d plots:"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:600
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:584
 #, no-wrap
 msgid ""
-"```maxima\n"
 "wxanimate_autoplay:true;\n"
 "wxanimate_framerate:20;\n"
 "with_slider_draw3d(\n"
@@ -9705,7 +14193,6 @@ msgid ""
 "        y,-π,π\n"
 "    )\n"
 ")$\n"
-"```\n"
 msgstr ""
 
 #. type: Plain text
@@ -9713,11 +14200,10 @@ msgstr ""
 msgid "If the general shape of the plot is what matters it might suffice to move the plot just a little bit in order to make its 3D nature available to the intuition:"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:619
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:603
 #, no-wrap
 msgid ""
-"```maxima\n"
 "wxanimate_autoplay:true;\n"
 "wxanimate_framerate:20;\n"
 "with_slider_draw3d(\n"
@@ -9732,7 +14218,6 @@ msgid ""
 "        y,-2*π,2*π\n"
 "    )\n"
 ")$\n"
-"```\n"
 msgstr ""
 
 #. type: Plain text
@@ -9755,14 +14240,12 @@ msgstr ""
 msgid "Normally the animations are played back or exported with the frame rate chosen in the configuration of _wxMaxima_. To set the speed at an individual animation is played back the variable `wxanimate_framerate` can be used:"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:631
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:627
 #, no-wrap
 msgid ""
-"```maxima\n"
 "wxanimate(a, 10,\n"
 "    sin(a*x), [x,-5,5]), wxanimate_framerate=6$\n"
-"```\n"
 msgstr ""
 
 #. type: Plain text
@@ -9770,11 +14253,10 @@ msgstr ""
 msgid "The animation functions use _Maxima_’s `makelist` command and therefore share the pitfall that the slider variable’s value is substituted into the expression only if the variable is directly visible in the expression. Therefore the following example will fail:"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:643
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:634
 #, no-wrap
 msgid ""
-"```maxima\n"
 "f:sin(a*x);\n"
 "with_slider_draw(\n"
 "    a,makelist(i/2,i,1,10),\n"
@@ -9782,7 +14264,6 @@ msgid ""
 "    grid=true,\n"
 "    explicit(f,x,0,10)\n"
 ")$\n"
-"```\n"
 msgstr ""
 
 #. type: Plain text
@@ -9790,11 +14271,10 @@ msgstr ""
 msgid "If _Maxima_ is explicitly asked to substitute the slider’s value plotting works fine instead:"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:658
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:646
 #, no-wrap
 msgid ""
-"```maxima\n"
 "f:sin(a*x);\n"
 "with_slider_draw(\n"
 "    b,makelist(i/2,i,1,10),\n"
@@ -9805,12 +14285,12 @@ msgid ""
 "        x,0,10\n"
 "    )\n"
 ")$\n"
-"```\n"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:660
-msgid "### Opening multiple plots in contemporaneous windows"
+#. type: Title ###
+#: ../../info/wxmaxima.md:659
+#, no-wrap
+msgid "Opening multiple plots in contemporaneous windows"
 msgstr ""
 
 #. type: Plain text
@@ -9818,24 +14298,20 @@ msgstr ""
 msgid "While not being provided by _wxMaxima_ this feature of _Maxima_ (on setups that support it) sometimes comes in handily. The following example comes from a post from Mario Rodriguez to the _Maxima_ mailing list:"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:665
-msgid "```maxima load(draw);"
-msgstr ""
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:668
-msgid "/* Parabola in window #1 */ draw2d(terminal=[wxt,1],explicit(x^2,x,-1,1));"
-msgstr ""
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:671
-msgid "/* Parabola in window #2 */ draw2d(terminal=[wxt,2],explicit(x^2,x,-1,1));"
-msgstr ""
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:675
-msgid "/* Paraboloid in window #3 */ draw3d(terminal=[wxt,3],explicit(x^2+y^2,x,-1,1,y,-1,1)); ```"
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:663
+#, no-wrap
+msgid ""
+"load(draw);\n"
+"\n"
+"/* Parabola in window #1 */\n"
+"draw2d(terminal=[wxt,1],explicit(x^2,x,-1,1));\n"
+"\n"
+"/* Parabola in window #2 */\n"
+"draw2d(terminal=[wxt,2],explicit(x^2,x,-1,1));\n"
+"\n"
+"/* Paraboloid in window #3 */\n"
+"draw3d(terminal=[wxt,3],explicit(x^2+y^2,x,-1,1,y,-1,1));\n"
 msgstr ""
 
 #. type: Plain text
@@ -9843,11 +14319,10 @@ msgstr ""
 msgid "Plotting multiple plots in the same window is possible, too (the same is possible in command line Maxima with the standard `draw()` command):"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:688
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:678
 #, no-wrap
 msgid ""
-"```maxima\n"
 "wxdraw(\n"
 "  gr2d(\n"
 "    key=\"sin (x)\",grid=[2,2],\n"
@@ -9856,22 +14331,17 @@ msgid ""
 "    key=\"cos (x)\",grid=[2,2],\n"
 "    explicit(cos(x),x,0,2*%pi))\n"
 ");\n"
-"```\n"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:690
-msgid "### The \"Plot using draw\" side pane"
+#. type: Title ###
+#: ../../info/wxmaxima.md:689
+#, no-wrap
+msgid "The \"Plot using draw\" side pane"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:692
 msgid "The \"Plot using draw\" sidebar hides a simple code generator that allows generating scenes that make use of some of the flexibility of the _draw_ package _maxima_ comes with."
-msgstr ""
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:694
-msgid "#### 2D"
 msgstr ""
 
 #. type: Plain text
@@ -9885,30 +14355,19 @@ msgid "One helpful feature of the 2D button is that it allows to set up the scen
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:700
-msgid "#### 3D"
-msgstr ""
-
-#. type: Plain text
 #: ../../info/wxmaxima.md:702
 msgid "Generates the skeleton of a `draw()` command that draws a 3D scene. If neither a 2D nor a 3D scene is set up, all of the other buttons set up a 2D scene that contains the command the button generates."
 msgstr ""
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:704
-#, fuzzy
-#| msgid "Expression"
-msgid "#### Expression"
-msgstr "數式"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:706
 msgid "Appends a standard plot of an expression like `sin(x)`, `x*sin(x)` or `x^2+2*x-4` to the `draw()` command the cursor currently is in. If there is no draw command a 2D scene with the plot is generated. Each scene can be filled with any number of plots."
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:708
-msgid "#### Implicit plot"
+#. type: Title ####
+#: ../../info/wxmaxima.md:707
+#, no-wrap
+msgid "Implicit plot"
 msgstr ""
 
 #. type: Plain text
@@ -9917,31 +14376,13 @@ msgid "Tries to find all points an expression like `y=sin(x)`, `y*sin(x)=3` or `
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:712
-#, fuzzy
-#| msgid "Parametric plot"
-msgid "#### Parametric plot"
-msgstr "參數式繪圖"
-
-#. type: Plain text
 #: ../../info/wxmaxima.md:714
 msgid "Steps a variable from a lower limit to an upper limit and uses two expressions like `t*sin(t)` and `t*cos(t)` for generating the x, y (and in 3D plots also z) coordinates of a curve that is put into the current draw command."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:716
-#, fuzzy
-msgid "#### Points"
-msgstr "點："
-
-#. type: Plain text
 #: ../../info/wxmaxima.md:718
 msgid "Draws many points that can optionally be joined. The coordinates of the points are taken from a list of lists, a 2D array or one list or array for each axis."
-msgstr ""
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:720
-msgid "#### Diagram title"
 msgstr ""
 
 #. type: Plain text
@@ -9950,18 +14391,8 @@ msgid "Draws a title on the upper end of the diagram,"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:724
-msgid "#### Axis"
-msgstr ""
-
-#. type: Plain text
 #: ../../info/wxmaxima.md:726
 msgid "Sets up the axis."
-msgstr ""
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:728
-msgid "#### Contour"
 msgstr ""
 
 #. type: Plain text
@@ -9970,19 +14401,14 @@ msgid "(Only for 3D plots): Adds contour lines similar to the ones one can find 
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:732
-#, fuzzy
-msgid "#### Plot name"
-msgstr "串列："
-
-#. type: Plain text
 #: ../../info/wxmaxima.md:734
 msgid "Adds a legend entry showing the next plot’s name to the legend of the diagram. An empty name disables generating legend entries for the following plots."
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:736
-msgid "#### Line colour"
+#. type: Title ####
+#: ../../info/wxmaxima.md:735
+#, no-wrap
+msgid "Line colour"
 msgstr ""
 
 #. type: Plain text
@@ -9990,9 +14416,10 @@ msgstr ""
 msgid "Sets the line colour for the following plots the current draw command contains."
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:740
-msgid "#### Fill colour"
+#. type: Title ####
+#: ../../info/wxmaxima.md:739
+#, no-wrap
+msgid "Fill colour"
 msgstr ""
 
 #. type: Plain text
@@ -10001,19 +14428,8 @@ msgid "Sets the fill colour for the following plots the current draw command con
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:744
-#, fuzzy
-msgid "#### Grid"
-msgstr "格線："
-
-#. type: Plain text
 #: ../../info/wxmaxima.md:746
 msgid "Pops up a wizard that allows to set up grid lines."
-msgstr ""
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:748
-msgid "#### Accuracy"
 msgstr ""
 
 #. type: Plain text
@@ -10021,9 +14437,10 @@ msgstr ""
 msgid "Allows to select an adequate point in the speed vs. accuracy tradeoff that is part of any plot program."
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:752
-msgid "### Modify font and font size for plots"
+#. type: Title ###
+#: ../../info/wxmaxima.md:751
+#, no-wrap
+msgid "Modify font and font size for plots"
 msgstr ""
 
 #. type: Plain text
@@ -10031,16 +14448,14 @@ msgstr ""
 msgid "Especially when you use a high resolution display, the default font size might be very small. For the `draw`-based commands, you can set the font / font size using options like `font=...`, `font_size=...`, e.g.:"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:761
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:755
 #, no-wrap
 msgid ""
-"~~~maxima\n"
 "wxdraw2d(\n"
 "     font=\"Helvetica\",\n"
 "     font_size=30,\n"
 "     explicit(sin(x),x,1,10));\n"
-"~~~\n"
 msgstr ""
 
 #. type: Plain text
@@ -10048,14 +14463,12 @@ msgstr ""
 msgid "For the `plot`-commands (e.g. `wxplot2d`, `wxplot3d`) font sizes and fonts can be set using the `gnuplot_preamble` command, e.g.:"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:768
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:764
 #, no-wrap
 msgid ""
-"~~~maxima\n"
 "wxplot2d(sin(x),[x,1,10],\n"
 "         [gnuplot_preamble, \"set tics font \\\"Arial, 30\\\"; set xlabel font \\\",20\\\"; set ylabel font \\\",20\\\";\"]);\n"
-"~~~\n"
 msgstr ""
 
 #. type: Plain text
@@ -10068,9 +14481,10 @@ msgstr ""
 msgid "Read the Maxima and Gnuplot documentation for further information.  Note: Gnuplot seems to have issues with larger font sizes, see [wxMaxima issue 1966](https://github.com/wxMaxima-developers/wxmaxima/issues/1966)."
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:775
-msgid "## Embedding graphics"
+#. type: Title ##
+#: ../../info/wxmaxima.md:774
+#, no-wrap
+msgid "Embedding graphics"
 msgstr ""
 
 #. type: Plain text
@@ -10078,14 +14492,16 @@ msgstr ""
 msgid "If the `.wxmx` file format is being used embedding files in a _wxMaxima_ project can be done as easily as per drag-and-drop. But sometimes (for example if an image’s contents might change later on in a session) it is better to tell the file to load the image on evaluation:"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:781
-msgid "```maxima show_image(\"man.png\"); ```"
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:778
+#, no-wrap
+msgid "show_image(\"man.png\");\n"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:783
-msgid "## Startup files"
+#. type: Title ##
+#: ../../info/wxmaxima.md:782
+#, no-wrap
+msgid "Startup files"
 msgstr ""
 
 #. type: Plain text
@@ -10113,303 +14529,340 @@ msgstr ""
 msgid "These files are in the Maxima user directory (usually `%USERPROFILE%/maxima` in Windows, `$HOME/.maxima` otherwise). The location can be found out with the command: `maxima_userdir;`"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:794
-#, fuzzy
-msgid "## Special variables wx..."
-msgstr "刪除變數"
+#. type: Title ##
+#: ../../info/wxmaxima.md:793
+#, no-wrap
+msgid "Special variables wx..."
+msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:805
+#: ../../info/wxmaxima.md:811
 msgid "`wxsubscripts` tells _Maxima_ if it should convert variable names that contain an underscore (`R_150` or the like) into subscripted variables. See `wxdeclare_subscript` for details which variable names are automatically converted."
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:805
+#: ../../info/wxmaxima.md:811
 msgid "`wxfilename`: This variable contains the name of the file currently opened in _wxMaxima_."
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:805
+#: ../../info/wxmaxima.md:811
 msgid "`wxdirname`: This variable contains the name the directory, in which the file currently opened in _wxMaxima_ is."
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:805
+#: ../../info/wxmaxima.md:811
 msgid "`wxplot_pngcairo` tells whether _wxMaxima_ tries to use _Gnuplot_’s pngcairo terminal that provides more line styles and a better overall graphics quality."
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:805
+#: ../../info/wxmaxima.md:811
 msgid "`wxplot_size` defines the resolution of embedded plots."
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:805
+#: ../../info/wxmaxima.md:811
 msgid "`wxchangedir`: On most operating systems _wxMaxima_ automatically sets _Maxima_’s working directory to the directory of the current file. This allows file I/O (e.g. by `read_matrix`) to work without specifying the whole path to the file that has to be read or written. On Windows this feature sometimes causes error messages and therefore can be set to `false` from the config dialogue."
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:805
+#: ../../info/wxmaxima.md:811
 msgid "`wxanimate_framerate`: The number of frames per second the following animations have to be played back with."
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:805
+#: ../../info/wxmaxima.md:811
 msgid "`wxanimate_autoplay`: Automatically play animations by default?"
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:805
+#: ../../info/wxmaxima.md:811
 msgid "`wxmaximaversion`: Returns the version number of _wxMaxima_."
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:805
+#: ../../info/wxmaxima.md:811
 msgid "`wxwidgetsversion`: Returns the wxWidgets version _wxMaxima_ is using."
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:807
-msgid "## Pretty-printing 2D output"
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:811
+msgid "`wxdirs`: A struct holding the paths _wxMaxima_ itself uses, since these differ by maintainer, distribution and operating system:"
+msgstr ""
+
+#. type: Bullet: '  - '
+#: ../../info/wxmaxima.md:811
+msgid "`wxdirs@userconfdir`: The directory the user's configuration is stored in. Same directory as `maxima_userdir` (see above) - both point at the same place, `wxdirs@userconfdir` is only useful if that is more convenient to reach from a `.mac` file than the Maxima-side variable."
+msgstr ""
+
+#. type: Bullet: '  - '
+#: ../../info/wxmaxima.md:811
+msgid "`wxdirs@datadir`: The directory _wxMaxima_'s own data (icons, the built-in autocompletion list, ...) is installed in."
+msgstr ""
+
+#. type: Bullet: '  - '
+#: ../../info/wxmaxima.md:811
+msgid "`wxdirs@helpdir`: The directory the offline copy of this manual is installed in."
+msgstr ""
+
+#. type: Bullet: '  - '
+#: ../../info/wxmaxima.md:811
+msgid "`wxdirs@localedir`: The directory _wxMaxima_'s translation files are installed in."
+msgstr ""
+
+#. type: Bullet: '  - '
+#: ../../info/wxmaxima.md:811
+msgid "`wxdirs@maximalocation`: The path to the _Maxima_ executable _wxMaxima_ is configured to start."
+msgstr ""
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:812
+#, no-wrap
+msgid "Pretty-printing 2D output"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:809
+#: ../../info/wxmaxima.md:815
 msgid "The function `table_form()` displays a 2D list in a form that is more readable than the output from _Maxima_’s default output routine. The input is a list of one or more lists. Like the \"print\" command, this command displays output even when ended with a dollar sign. Ending the command with a semicolon results in the same table along with a \"done\" statement."
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:818
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:816
 #, no-wrap
 msgid ""
-"```maxima\n"
 "table_form(\n"
 "    [\n"
 "        [1,2],\n"
 "        [3,4]\n"
 "    ]\n"
 ")$\n"
-"```\n"
-msgstr ""
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:820
-msgid "As the next example shows, the lists that are assembled by the `table_form` command can be created before the command is executed."
-msgstr ""
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:822
-msgid "![A third table example](./MatrixTableExample.png){ id=img_MatrixTableExample }"
-msgstr ""
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:824
-msgid "Also, because a matrix is a list of lists, matrices can be converted to tables in a similar fashion."
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:826
-msgid "![Another table_form example](./SecondTableExample.png){ id=img_SecondTableExample }"
+msgid "As the next example shows, the lists that are assembled by the `table_form` command can be created before the command is executed."
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:828
-msgid "The function `wx_matrix()` is a wrapper for Maxima's `matrix()` command that allows for more flexible formatting of matrices in wxMaxima:"
+msgid "![A third table example](./MatrixTableExample.png){ id=img_MatrixTableExample }"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:830
+msgid "Also, because a matrix is a list of lists, matrices can be converted to tables in a similar fashion."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:832
+msgid "![Another table_form example](./SecondTableExample.png){ id=img_SecondTableExample }"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:834
+msgid "The function `wx_matrix()` is a wrapper for Maxima's `matrix()` command that allows for more flexible formatting of matrices in wxMaxima:"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:836
 #, no-wrap
 msgid "**`wx_matrix( <matrix>, [options] )`**\n"
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:835
+#: ../../info/wxmaxima.md:841
 msgid "**`lines=true`**: Draws internal separator lines between the cells. This is required to visually separate headings from data."
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:835
+#: ../../info/wxmaxima.md:841
 msgid "**`rownames=true`**: Tells wxMaxima that the first column of the matrix contains labels."
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:835
+#: ../../info/wxmaxima.md:841
 msgid "**`colnames=true`**: Tells wxMaxima that the first row of the matrix contains labels."
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:835
+#: ../../info/wxmaxima.md:841
 msgid "**`parenstyle=<style>`**: Sets the type of parenthesis or brackets to draw around the matrix. Supported styles are: `round` `()`, `square` `[]`, `angled` `<>`, `straight` `||`, or `none`."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:837
+#: ../../info/wxmaxima.md:843
 #, fuzzy
 #| msgid "Example"
 msgid "Example:"
 msgstr "範例"
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:842
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:844
 #, no-wrap
 msgid ""
-"```maxima\n"
 "wx_matrix(matrix([\"Name\", \"Value\"], [\"X\", 10], [\"Y\", 20]),\n"
 "          lines=true, rownames=true, colnames=true, parenstyle=square);\n"
-"```\n"
+msgstr ""
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:849
+#, no-wrap
+msgid "Bug reporting"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:844
-msgid "## Bug reporting"
-msgstr ""
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:846
+#: ../../info/wxmaxima.md:852
 msgid "_WxMaxima_ provides a few functions that gather bug reporting information about the current system:"
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:849
+#: ../../info/wxmaxima.md:855
 msgid "`wxbuild_info()` gathers information about the currently running version of _wxMaxima_"
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:849
+#: ../../info/wxmaxima.md:855
 msgid "`wxbug_report()` tells how and where to file bugs"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:851
-msgid "## Marking output being drawn in red"
-msgstr ""
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:854
-msgid "_Maxima_’s `box()` command causes _wxMaxima_ to print its argument with a red foreground, if the second argument to the command is the text `highlight`."
-msgstr ""
-
-#. type: Plain text
+#. type: Title ##
 #: ../../info/wxmaxima.md:856
-#, fuzzy
-msgid "## Output rendering."
-msgstr "字串"
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:858
-msgid "With `set_display()` one can set, how wxMaxima will render the output."
+#, no-wrap
+msgid "Marking output being drawn in red"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:860
+msgid "_Maxima_’s `box()` command causes _wxMaxima_ to print its argument with a red foreground, if the second argument to the command is the text `highlight`."
+msgstr ""
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:861
+#, no-wrap
+msgid "Output rendering."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:864
+msgid "With `set_display()` one can set, how wxMaxima will render the output."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:866
 msgid "`set_display('xml)` is the default value. Here Maxima speaks to wxMaxima using an (machine readable) XML-dialect (can be seen in the \"Raw XML sidebar\") and outputs the resulting formulas nicely rendered, e.g. pretty Matrices, Square root signs, fractions, etc."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:863
-msgid "<!--- Currently that does not work as it should, the line with the output label is shifted right (issue: #2006) --> `set_display('ascii)` causes wxMaxima to output formulas as in command line Maxima - as ASCII-Art."
-msgstr ""
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:865
-msgid "`set_display('none)` causes 'one-line' ASCII results - the same as the command line Maxima command `display2d:false;` does."
-msgstr ""
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:867
-msgid "# Help menu"
-msgstr ""
-
-#. type: Plain text
 #: ../../info/wxmaxima.md:869
-msgid "WxMaxima’s help menu provides access to the Maxima and wxMaxima manual, tips, some example worksheets and in command line Maxima included demos (the `demo()` command)."
+#, no-wrap
+msgid ""
+"<!--- Currently that does not work as it should, the line with the output label is shifted right (issue: #2006) -->\n"
+"`set_display('ascii)` causes wxMaxima to output formulas as in command line Maxima - as ASCII-Art.\n"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:871
-msgid "Please notice, that the demos write:"
+msgid "`set_display('none)` causes 'one-line' ASCII results - the same as the command line Maxima command `display2d:false;` does."
+msgstr ""
+
+#. type: Title #
+#: ../../info/wxmaxima.md:872
+#, no-wrap
+msgid "Help menu"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:875
-msgid "~~~text At the ’_’ prompt, type ’;’ and <enter> to proceed with the demonstration.  ~~~"
+msgid "WxMaxima’s help menu provides access to the Maxima and wxMaxima manual, tips, some example worksheets and in command line Maxima included demos (the `demo()` command)."
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:877
-msgid "That is valid for command-line Maxima, however in wxMaxima by default it is necessary to continue the demonstration with: <kbd>CTRL</kbd>+<kbd>ENTER</kbd>"
+msgid "Please notice, that the demos write:"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:879
-msgid "(That can be configured in the Configure->Worksheet->\"Hotkeys for sending commands to Maxima\" menu.)"
+#. type: Fenced code block (text)
+#: ../../info/wxmaxima.md:878
+#, no-wrap
+msgid "At the ’_’ prompt, type ’;’ and <enter> to proceed with the demonstration.\n"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:883
-msgid "# Troubleshooting"
+#, no-wrap
+msgid "That is valid for command-line Maxima, however in wxMaxima by default it is necessary to continue the demonstration with: <kbd>CTRL</kbd>+<kbd>ENTER</kbd>\n"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:885
-#, fuzzy
-msgid "## Cannot connect to _Maxima_"
-msgstr ""
-"\n"
-"未連線"
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:887
-msgid "Since _Maxima_ (the program that does the actual mathematics) and _wxMaxima_ (providing the easy-to-use user interface) are separate programs that communicate by the means of a local network connection. Therefore the most probable cause is that this connection is somehow not working. For example, a firewall could be set up in a way that it doesn’t just prevent unauthorized connections from the internet (and perhaps intercept some connections to the internet, too), but also blocks inter-process-communication inside the same computer. Note that since _Maxima_ is being run by a Lisp processor the process communication that is blocked does not necessarily have to be named \"maxima\". Common names of the program that opens the network connection would be sbcl, gcl, ccl, lisp.exe, or similar names."
+#, no-wrap
+msgid "(That can be configured in the Configure->Worksheet->\"Hotkeys for sending commands to Maxima\" menu.)\n"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:889
-msgid "On Unix computers another possible reason would be that the loopback network that provides network connections between two programs in the same computer isn’t properly configured."
+#. type: Title #
+#: ../../info/wxmaxima.md:888
+#, no-wrap
+msgid "Troubleshooting"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:891
-msgid "## How to save data from a broken .wxmx file"
+#. type: Title ##
+#: ../../info/wxmaxima.md:890
+#, no-wrap
+msgid "Cannot connect to _Maxima_"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:893
-msgid "Internally most modern XML-based formats are ordinary zip files. _WxMaxima_ doesn’t turn on compression, so the contents of `.wxmx` files can be viewed in any text editor."
+msgid "Since _Maxima_ (the program that does the actual mathematics) and _wxMaxima_ (providing the easy-to-use user interface) are separate programs that communicate by the means of a local network connection. Therefore the most probable cause is that this connection is somehow not working. For example, a firewall could be set up in a way that it doesn’t just prevent unauthorized connections from the internet (and perhaps intercept some connections to the internet, too), but also blocks inter-process-communication inside the same computer. Note that since _Maxima_ is being run by a Lisp processor the process communication that is blocked does not necessarily have to be named \"maxima\". Common names of the program that opens the network connection would be sbcl, gcl, ccl, lisp.exe, or similar names."
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:895
-msgid "If the zip signature at the end of the file is still intact after renaming a broken `.wxmx` file to `.zip` most operating systems will provide a way to extract any portion of the information that is stored inside it. This can be done when there is a need of recovering the original image files from a text processor document. If the zip signature isn’t intact that does not need to be the end of the world: If _wxMaxima_ during saving detected that something went wrong there will be a `.wxmx~` file whose contents might help."
+msgid "On Unix computers another possible reason would be that the loopback network that provides network connections between two programs in the same computer isn’t properly configured."
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:897
-msgid "And even if there isn’t such a file: The `.wxmx` file is a container format and the XML portion is stored uncompressed. It it is possible to rename the `.wxmx` file to a `.txt` file and to use a text editor to recover the XML portion of the file’s contents (it starts with `<?xml version=\"1.0\" encoding=\"UTF-8\"?>` and ends with `</wxMaximaDocument>`. Before and after that text you will see some unreadable binary contents in the text editor)."
+#. type: Title ##
+#: ../../info/wxmaxima.md:896
+#, no-wrap
+msgid "How to save data from a broken .wxmx file"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:899
-msgid "If a text file containing only these contents (e.g. copy and paste this text into a new file) is saved as a file ending in `.xml`, _wxMaxima_ will know how to recover the text from the document."
+msgid "Internally most modern XML-based formats are ordinary zip files. _WxMaxima_ doesn’t turn on compression, so the contents of `.wxmx` files can be viewed in any text editor."
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:901
-msgid "## I want some debug info to be displayed on the screen before my command has finished"
+msgid "If the zip signature at the end of the file is still intact after renaming a broken `.wxmx` file to `.zip` most operating systems will provide a way to extract any portion of the information that is stored inside it. This can be done when there is a need of recovering the original image files from a text processor document. If the zip signature isn’t intact that does not need to be the end of the world: If _wxMaxima_ during saving detected that something went wrong there will be a `.wxmx~` file whose contents might help."
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:903
-msgid "Normally _wxMaxima_ waits for the whole 2D formula to be transferred before it begins to typeset. This saves time for making many attempts to typeset a only partially completed equation. There is a `disp` command, though, that will provide debug output immediately and without waiting for the current _Maxima_ command to finish:"
+#, no-wrap
+msgid "And even if there isn’t such a file: The `.wxmx` file is a container format and the XML portion is stored uncompressed. It it is possible to rename the `.wxmx` file to a `.txt` file and to use a text editor to recover the XML portion of the file’s contents (it starts with `<?xml version=\"1.0\" encoding=\"UTF-8\"?>` and ends with `</wxMaximaDocument>`. Before and after that text you will see some unreadable binary contents in the text editor).\n"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:913
+#: ../../info/wxmaxima.md:905
+msgid "If a text file containing only these contents (e.g. copy and paste this text into a new file) is saved as a file ending in `.xml`, _wxMaxima_ will know how to recover the text from the document."
+msgstr ""
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:906
+#, no-wrap
+msgid "I want some debug info to be displayed on the screen before my command has finished"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:909
+msgid "Normally _wxMaxima_ waits for the whole 2D formula to be transferred before it begins to typeset. This saves time for making many attempts to typeset a only partially completed equation. There is a `disp` command, though, that will provide debug output immediately and without waiting for the current _Maxima_ command to finish:"
+msgstr ""
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:910
 #, no-wrap
 msgid ""
-"```maxima\n"
 "for i:1 thru 10 do (\n"
 "   disp(i),\n"
 "   /* (sleep n) is a Lisp function, which can be used */\n"
@@ -10417,273 +14870,285 @@ msgid ""
 "   /* program execution (here: for 3 seconds) */\n"
 "   ?sleep(3)\n"
 ")$\n"
-"```\n"
-msgstr ""
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:915
-msgid "Alternatively one can look for the `wxstatusbar()` command above."
-msgstr ""
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:917
-msgid "## Plotting only shows a closed empty envelope with an error message"
-msgstr ""
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:919
-msgid "This means that _wxMaxima_ could not read the file _Maxima_ that was supposed to instruct _Gnuplot_ to create."
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:921
+msgid "Alternatively one can look for the `wxstatusbar()` command above."
+msgstr ""
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:922
+#, no-wrap
+msgid "Plotting only shows a closed empty envelope with an error message"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:925
+msgid "This means that _wxMaxima_ could not read the file _Maxima_ that was supposed to instruct _Gnuplot_ to create."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:927
 msgid "Possible reasons for this error are:"
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:926
+#: ../../info/wxmaxima.md:932
 msgid "The plotting command is part of a third-party package like `implicit_plot` but this package was not loaded by _Maxima_’s `load()` command before trying to plot."
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:926
+#: ../../info/wxmaxima.md:932
 msgid "_Maxima_ tried to do something the currently installed version of _Gnuplot_ isn’t able to understand. In this case, a file ending in `.gnuplot` located in the directory, which _Maxima_’s variable `maxima_userdir` is pointing, contains the instructions from _Maxima_ to _Gnuplot_. Most of the time, this file’s contents therefore are helpful when debugging the problem."
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:926
+#: ../../info/wxmaxima.md:932
 msgid "Gnuplot was instructed to use the pngCairo library that provides antialiasing and additional line styles, but it was not compiled to support this possibility. Solution: Uncheck the \"Use the Cairo terminal for the plot\" checkbox in the configuration dialog and don’t set `wxplot_pngcairo` to true from _Maxima_."
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:926
+#: ../../info/wxmaxima.md:932
 msgid "Gnuplot didn’t output a valid `.png` file."
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:928
-msgid "## Plotting an animation results in “error: undefined variable”"
+#. type: Title ##
+#: ../../info/wxmaxima.md:933
+#, no-wrap
+msgid "Plotting an animation results in “error: undefined variable”"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:930
+#: ../../info/wxmaxima.md:936
 msgid "The value of the slider variable by default is only substituted into the expression that is to be plotted if it is visible there. Using a `subst` command that substitutes the slider variable into the equation to plot resolves this problem. At the end of section [Embedding animations into the spreadsheet](#embedding-animations-into-the-spreadsheet), you can see an example."
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:932
-msgid "## I lost cell content and undo doesn’t remember"
+#. type: Title ##
+#: ../../info/wxmaxima.md:937
+#, no-wrap
+msgid "I lost cell content and undo doesn’t remember"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:934
+#: ../../info/wxmaxima.md:940
 msgid "There are separate undo functions for cell operations and for changes inside of cells so chances are low that this ever happens. If it does there are several methods to recover data:"
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:939
+#: ../../info/wxmaxima.md:945
 msgid "_WxMaxima_ actually has two undo features: The global undo buffer that is active if no cell is selected and a per-cell undo buffer that is active if the cursor is inside a cell. It is worth trying to use both undo options in order to see if an old value can still be accessed."
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:939
+#: ../../info/wxmaxima.md:945
 msgid "If you still have a way to find out what label _Maxima_ has assigned to the cell just type in the cell’s label and its contents will reappear."
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:939
+#: ../../info/wxmaxima.md:945
 msgid "If you don’t: Don’t panic. In the “View” menu there is a way to show a history pane that shows all _Maxima_ commands that have been issued recently."
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:939
+#: ../../info/wxmaxima.md:945
 msgid "If nothing else helps _Maxima_ contains a replay feature:"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:943
-msgid "```maxima playback(); ```"
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:946
+#, no-wrap
+msgid "playback();\n"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:945
-msgid "## _WxMaxima_ starts up with the message “Maxima process terminated.”"
-msgstr ""
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:947
-msgid "One possible reason is that _Maxima_ cannot be found in the location that is set in the “Maxima” tab of _wxMaxima_’s configuration dialog and therefore won’t run at all. Setting the path to a working _Maxima_ binary should fix this problem."
-msgstr ""
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:949
-msgid "## Maxima is forever calculating and not responding to input"
-msgstr ""
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:951
-msgid "It is theoretically possible that _wxMaxima_ doesn’t realize that _Maxima_ has finished calculating and therefore never gets informed it can send new data to _Maxima_. If this is the case “Trigger evaluation” might resynchronize the two programs."
+#. type: Title ##
+#: ../../info/wxmaxima.md:950
+#, no-wrap
+msgid "_WxMaxima_ starts up with the message “Maxima process terminated.”"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:953
-msgid "## My SBCL-based _Maxima_ runs out of memory"
+msgid "One possible reason is that _Maxima_ cannot be found in the location that is set in the “Maxima” tab of _wxMaxima_’s configuration dialog and therefore won’t run at all. Setting the path to a working _Maxima_ binary should fix this problem."
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:955
-msgid "The Lisp compiler SBCL by default comes with a memory limit that allows it to run even on low-end computers. When compiling a big software package like Lapack or dealing with extremely big lists of equations this limit might be too low. In order to extend the limits, SBCL can be provided with the command line parameter `--dynamic-space-size` that tells SBCL how many megabytes it should reserve. A 32bit Windows-SBCL can reserve up to 999 Megabytes. A 64-bit SBCL version running on Windows can be instructed to use more than the about 1280 Megabytes compiling Lapack needs."
+#. type: Title ##
+#: ../../info/wxmaxima.md:954
+#, no-wrap
+msgid "Maxima is forever calculating and not responding to input"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:957
-msgid "One way to provide _Maxima_ (and thus SBCL) with command line parameters is the \"Additional parameters for Maxima\" field of _wxMaxima_’s configuration dialogue."
+msgid "It is theoretically possible that _wxMaxima_ doesn’t realize that _Maxima_ has finished calculating and therefore never gets informed it can send new data to _Maxima_. If this is the case “Trigger evaluation” might resynchronize the two programs."
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:959
-msgid "![sbcl memory](./sbclMemory.png){ id=img_sbclMemory }"
+#. type: Title ##
+#: ../../info/wxmaxima.md:958
+#, no-wrap
+msgid "My SBCL-based _Maxima_ runs out of memory"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:961
-msgid "## Input sometimes is sluggish/ignoring keys on Ubuntu"
+msgid "The Lisp compiler SBCL by default comes with a memory limit that allows it to run even on low-end computers. When compiling a big software package like Lapack or dealing with extremely big lists of equations this limit might be too low. In order to extend the limits, SBCL can be provided with the command line parameter `--dynamic-space-size` that tells SBCL how many megabytes it should reserve. A 32bit Windows-SBCL can reserve up to 999 Megabytes. A 64-bit SBCL version running on Windows can be instructed to use more than the about 1280 Megabytes compiling Lapack needs."
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:963
-msgid "Installing the package `ibus-gtk` should resolve this issue. See ([https://bugs.launchpad.net/ubuntu/+source/wxwidgets3.0/+bug/1421558](https://bugs.launchpad.net/ubuntu/+source/wxwidgets3.0/+bug/1421558)) for details."
+msgid "One way to provide _Maxima_ (and thus SBCL) with command line parameters is the \"Additional parameters for Maxima\" field of _wxMaxima_’s configuration dialogue."
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:965
-msgid "## _WxMaxima_ halts when _Maxima_ processes Greek characters or Umlauts"
+msgid "![sbcl memory](./sbclMemory.png){ id=img_sbclMemory }"
+msgstr ""
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:966
+#, no-wrap
+msgid "Input sometimes is sluggish/ignoring keys on Ubuntu"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:967
-msgid "If your _Maxima_ is based on SBCL the following lines have to be added to your `.sbclrc`:"
+#: ../../info/wxmaxima.md:969
+msgid "Installing the package `ibus-gtk` should resolve this issue. See ([https://bugs.launchpad.net/ubuntu/+source/wxwidgets3.0/+bug/1421558](https://bugs.launchpad.net/ubuntu/+source/wxwidgets3.0/+bug/1421558)) for details."
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:971
-msgid "```commonlisp (setf sb-impl::*default-external-format* :utf-8)  ```"
+#. type: Title ##
+#: ../../info/wxmaxima.md:970
+#, no-wrap
+msgid "_WxMaxima_ halts when _Maxima_ processes Greek characters or Umlauts"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:973
-msgid "The folder where this file has to be placed is system- and installation-specific. But any SBCL-based _Maxima_ that already has evaluated a cell in the current session will happily tell where it can be found after getting the following command:"
+msgid "If your _Maxima_ is based on SBCL the following lines have to be added to your `.sbclrc`:"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:977
-msgid "```maxima :lisp (sb-impl::userinit-pathname)  ```"
+#. type: Fenced code block (commonlisp)
+#: ../../info/wxmaxima.md:974
+#, no-wrap
+msgid "(setf sb-impl::*default-external-format* :utf-8)\n"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:979
-msgid "## Note concerning Wayland (recent Linux/BSD distributions)"
+msgid "The folder where this file has to be placed is system- and installation-specific. But any SBCL-based _Maxima_ that already has evaluated a cell in the current session will happily tell where it can be found after getting the following command:"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:982
-msgid "There seem to be issues with the Wayland Display Server and wxWidgets.  WxMaxima may be affected, e.g. that sidebars are not moveable."
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:980
+#, no-wrap
+msgid ":lisp (sb-impl::userinit-pathname)\n"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:986
-msgid "You can either disable Wayland and use X11 instead (globally)  or just tell, that wxMaxima should use the X Window System by setting: `GDK_BACKEND=x11`"
+#. type: Title ##
+#: ../../info/wxmaxima.md:984
+#, no-wrap
+msgid "Note concerning Wayland (recent Linux/BSD distributions)"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:988
+msgid "There seem to be issues with the Wayland Display Server and wxWidgets.  WxMaxima may be affected, e.g. that sidebars are not moveable."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:992
+msgid "You can either disable Wayland and use X11 instead (globally)  or just tell, that wxMaxima should use the X Window System by setting: `GDK_BACKEND=x11`"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:994
 #, fuzzy
 #| msgid "Restart Maxima"
 msgid "E.g. start wxMaxima with:"
 msgstr "重新啟動 Maxima"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:990
+#: ../../info/wxmaxima.md:996
 msgid "`GDK_BACKEND=x11 wxmaxima`"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:992
-msgid "## The menu bar disappears on KDE Plasma"
-msgstr ""
-
-#. type: Plain text
+#. type: Title ##
 #: ../../info/wxmaxima.md:997
-msgid "On some KDE Plasma installations the global menu bar disappears when clicked.  As this is a bug in the global menu proxy, the only way to avoid it is to tell that wxMaxima should use its own menu bar instead of the global one.  This is done by setting: `UBUNTU_MENUPROXY=0`"
-msgstr ""
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:1001
-msgid "Starting with version 26.05.0, wxMaxima attempts to set this variable automatically if it detects an affected system (KDE, Unity, or Ubuntu with older wxWidgets versions)."
+#, no-wrap
+msgid "The menu bar disappears on KDE Plasma"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:1003
-msgid "If the automatic fix fails, you can manually start wxMaxima with:"
-msgstr ""
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:1005
-msgid "`UBUNTU_MENUPROXY=0 wxmaxima`"
+msgid "On some KDE Plasma installations the global menu bar disappears when clicked.  As this is a bug in the global menu proxy, the only way to avoid it is to tell that wxMaxima should use its own menu bar instead of the global one.  This is done by setting: `UBUNTU_MENUPROXY=0`"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:1007
-msgid "## Why is the integrated manual browser not offered on my Windows PC?"
+msgid "Starting with version 26.05.0, wxMaxima attempts to set this variable automatically if it detects an affected system (KDE, Unity, or Ubuntu with older wxWidgets versions)."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1010
+#: ../../info/wxmaxima.md:1009
+msgid "If the automatic fix fails, you can manually start wxMaxima with:"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1011
+msgid "`UBUNTU_MENUPROXY=0 wxmaxima`"
+msgstr ""
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:1012
+#, no-wrap
+msgid "Why is the integrated manual browser not offered on my Windows PC?"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1016
 msgid "Either wxWidgets wasn’t compiled with support for Microsoft’s webview2 or Microsoft’s webview2 isn’t installed."
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:1012
-msgid "## Why is the external manual browser not working on my Linux box?"
+#. type: Title ##
+#: ../../info/wxmaxima.md:1017
+#, no-wrap
+msgid "Why is the external manual browser not working on my Linux box?"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1018
+#: ../../info/wxmaxima.md:1024
 msgid "The HTML browser might be a snap, flatpack or appimage version. All of these typically cannot access files that are installed on your local system. Another reason might be that maxima or wxMaxima is installed as a snap, flatpack or something else that doesn’t give the host system access to its contents. A third reason might be that the maxima HTML manual isn’t installed and the online one cannot be accessed."
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:1020
-msgid "## Can I make _wxMaxima_ output both image files and embedded plots at once?"
+#. type: Title ##
+#: ../../info/wxmaxima.md:1025
+#, no-wrap
+msgid "Can I make _wxMaxima_ output both image files and embedded plots at once?"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1022
+#: ../../info/wxmaxima.md:1028
 msgid "The worksheet embeds `.png files. _WxMaxima_ allows the user to specify where they should be generated:"
 msgstr ""
 
-#. type: Plain text
+#. type: Fenced code block (maxima)
 #: ../../info/wxmaxima.md:1029
 #, no-wrap
 msgid ""
-"```maxima\n"
 "wxdraw2d(\n"
 "    file_name=\"test\",  /* extension .png automatically added */\n"
 "    explicit(sin(x),x,1,10)\n"
 ");\n"
-"```\n"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1031
+#: ../../info/wxmaxima.md:1037
 msgid "If a different format is to be used, it is easier to generate the images and then import them into the worksheet again:"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:1050
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:1038
 #, no-wrap
 msgid ""
-"```maxima\n"
 "load(\"draw\");\n"
 "pngdraw(name,[contents]):=\n"
 "(\n"
@@ -10701,217 +15166,234 @@ msgid ""
 ");\n"
 "pngdraw2d(name,[contents]):=\n"
 "    pngdraw(name,gr2d(contents));\n"
-msgstr ""
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:1055
-#, no-wrap
-msgid ""
+"\n"
 "pngdraw2d(\"Test\",\n"
 "        explicit(sin(x),x,1,10)\n"
 ");\n"
-"```\n"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:1057
-msgid "## Can I set the aspect ratio of an embedded plot?"
-msgstr ""
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:1059
-msgid "Use the variable `wxplot_size`:"
+#. type: Title ##
+#: ../../info/wxmaxima.md:1062
+#, no-wrap
+msgid "Can I set the aspect ratio of an embedded plot?"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:1065
+msgid "Use the variable `wxplot_size`:"
+msgstr ""
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:1066
 #, no-wrap
 msgid ""
-"```maxima\n"
 "wxdraw2d(\n"
 "    explicit(sin(x),x,1,10)\n"
 "),wxplot_size=[1000,1000];\n"
-"```\n"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:1067
-msgid "## After upgrading to MacOS 13.1 plot and/or draw commands output error messages like"
+#. type: Title ##
+#: ../../info/wxmaxima.md:1072
+#, no-wrap
+msgid "After upgrading to MacOS 13.1 plot and/or draw commands output error messages like"
 msgstr ""
 
-#. type: Plain text
+#. type: Fenced code block (text)
 #: ../../info/wxmaxima.md:1074
-msgid "```text 1 HIToolbox 0x00007ff80cd91726 _ZN15MenuBarInstance22EnsureAutoShowObserverEv + 102 2 HIToolbox 0x00007ff80cd912b8 _ZN15MenuBarInstance14EnableAutoShowEv + 52 3 HIToolbox 0x00007ff80cd35908 SetMenuBarObscured + 408 ...  ```"
-msgstr ""
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:1076
-msgid "This might be an issue with the operating system. Disable the hiding of the menu bar (SystemSettings => Desktop & Dock => Menu Bar) might solve the issue. See [wxMaxima issue #1746](https://github.com/wxMaxima-developers/wxmaxima/issues/1746) for more information."
-msgstr ""
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:1078
-msgid "## Logging"
+#, no-wrap
+msgid ""
+"1 HIToolbox 0x00007ff80cd91726 _ZN15MenuBarInstance22EnsureAutoShowObserverEv + 102\n"
+"2 HIToolbox 0x00007ff80cd912b8 _ZN15MenuBarInstance14EnableAutoShowEv + 52\n"
+"3 HIToolbox 0x00007ff80cd35908 SetMenuBarObscured + 408\n"
+"...\n"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:1082
-msgid "Log messages might be helpful to debug problems. WxMaxima can log many events. Most log entries will be helpful for developers, especially in case of problems or bugs. If you run a \"Release\"-Build, the log windows is not shown by default, if you run a development version, it is shown by default as a second window. You can enable and disable this window using the \"View->Toggle log window\" menu entry."
+#, no-wrap
+msgid "This might be an issue with the operating system. Disable the hiding of the menu bar (SystemSettings => Desktop & Dock => Menu Bar) might solve the issue. See [wxMaxima issue #1746](https://github.com/wxMaxima-developers/wxmaxima/issues/1746) for more information.\n"
+msgstr ""
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:1083
+#, no-wrap
+msgid "Logging"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1084
+#: ../../info/wxmaxima.md:1088
+#, no-wrap
+msgid ""
+"Log messages might be helpful to debug problems. WxMaxima can log many events. Most log entries will be helpful for developers, especially in case of problems or bugs. If you run a \"Release\"-Build,\n"
+"the log windows is not shown by default, if you run a development version, it is shown by default as a second window. You can enable and disable\n"
+"this window using the \"View->Toggle log window\" menu entry.\n"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1090
 msgid "Messages are not 'lost', if the log window is not shown, if you select to show the log window later, you will see past log messages (if you did not clear the messages)."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1086
+#: ../../info/wxmaxima.md:1092
 msgid "Such messages may be helpful, when you create bug reports (or trying to find a bug by yourself)."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1089
+#: ../../info/wxmaxima.md:1095
 msgid "Log messages can (additionally) be printed to STDERR, when using the command line option \"--logtostderr\". On Windows a separate text console will be opened, as a Windows GUI application does not have the standard IO connected."
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:1093
-msgid "# FAQ"
+#. type: Title #
+#: ../../info/wxmaxima.md:1098
+#, no-wrap
+msgid "FAQ"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:1095
-msgid "## Is there a way to make more text fit on a LaTeX page?"
-msgstr ""
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:1097
-msgid "Yes. Use the [LaTeX package \"geometry\"](https://ctan.org/pkg/geometry) to specify the size of the borders."
-msgstr ""
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:1099
-msgid "You can add the following line to the LaTeX preamble (for example by using the respective field in the config dialogue (\"Export\"->\"Additional lines for the TeX preamble\"), to set borders of 1cm):"
+#. type: Title ##
+#: ../../info/wxmaxima.md:1100
+#, no-wrap
+msgid "Is there a way to make more text fit on a LaTeX page?"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:1103
-msgid "```latex \\usepackage[left=1cm,right=1cm,top=1cm,bottom=1cm]{geometry} ```"
+msgid "Yes. Use the [LaTeX package \"geometry\"](https://ctan.org/pkg/geometry) to specify the size of the borders."
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:1105
-msgid "## Is there a dark mode?"
+#, no-wrap
+msgid "You can add the following line to the LaTeX preamble (for example by using the respective field in the config dialogue (\"Export\"->\"Additional lines for the TeX preamble\"), to set borders of 1cm):\n"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:1107
-msgid "If wxWidgets is new enough, _wxMaxima_ will automatically be in dark mode if the rest of the operating system is. The worksheet itself is by default equipped with a bright background. But it can be configured otherwise. Alternatively, there is a `View/Invert worksheet brightness` menu entry that allows to quickly convert the worksheet from dark to bright and vice versa."
+#. type: Fenced code block (latex)
+#: ../../info/wxmaxima.md:1106
+#, no-wrap
+msgid "\\usepackage[left=1cm,right=1cm,top=1cm,bottom=1cm]{geometry}\n"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:1109
-msgid "## _WxMaxima_ sometimes hangs for several seconds once in the first minute"
-msgstr ""
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:1111
-msgid "_WxMaxima_ delegates some big tasks like parsing _Maxima_’s >1000-page-manual to background tasks, which normally goes totally unnoticed. At the moment the result of such a task is needed, though, it is possible that _wxMaxima_ needs to wait a couple of seconds before it can continue its work."
+#. type: Title ##
+#: ../../info/wxmaxima.md:1110
+#, no-wrap
+msgid "Is there a dark mode?"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:1113
-msgid "## Especially when testing new locale settings, a message box \"locale ’xx_YY’ can not be set\" occurs"
+msgid "If wxWidgets is new enough, _wxMaxima_ will automatically be in dark mode if the rest of the operating system is. The worksheet itself is by default equipped with a bright background. But it can be configured otherwise. Alternatively, there is a `View/Invert worksheet brightness` menu entry that allows to quickly convert the worksheet from dark to bright and vice versa."
+msgstr ""
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:1114
+#, no-wrap
+msgid "_WxMaxima_ sometimes hangs for several seconds once in the first minute"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1115
+#: ../../info/wxmaxima.md:1117
+#, no-wrap
+msgid "_WxMaxima_ delegates some big tasks like parsing _Maxima_’s >1000-page-manual to background tasks, which normally goes totally unnoticed. At the moment the result of such a task is needed, though, it is possible that _wxMaxima_ needs to wait a couple of seconds before it can continue its work.\n"
+msgstr ""
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:1118
+#, no-wrap
+msgid "Especially when testing new locale settings, a message box \"locale ’xx_YY’ can not be set\" occurs"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1121
 msgid "![Locale warning](./locale-warning.png){ id=img_locale_warning}"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1119
+#: ../../info/wxmaxima.md:1125
 msgid "(The same problem can occur with other applications too). The translations seem okay after you click on ’OK’. WxMaxima does not only use its own translations but the translations of the wxWidgets framework too."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1122
+#: ../../info/wxmaxima.md:1128
 msgid "These locales maybe not present in the system. On Ubuntu/Debian systems they can be generated using: `dpkg-reconfigure locales`"
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:1124
-msgid "## How can I use symbols for real numbers, natural numbers (ℝ, ℕ), etc.?"
-msgstr ""
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:1126
-msgid "You can find these symbols in the Unicode sidebar (search for ’double-struck capital’). But the selected font must also support these symbols. If they do not display properly, select another font."
-msgstr ""
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:1128
-msgid "## How can a Maxima script determine, if it is running under wxMaxima or command line Maxima?"
-msgstr ""
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:1130
-msgid "If wxMaxima is used, the Maxima variable `maxima_frontend` is set to `wxmaxima`. The Maxima variable `maxima_frontend_version` contains the wxMaxima version in this case."
+#. type: Title ##
+#: ../../info/wxmaxima.md:1129
+#, no-wrap
+msgid "How can I use symbols for real numbers, natural numbers (ℝ, ℕ), etc.?"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:1132
-msgid "If no frontend is used (you are using command line Maxima), these variables are `false`."
+msgid "You can find these symbols in the Unicode sidebar (search for ’double-struck capital’). But the selected font must also support these symbols. If they do not display properly, select another font."
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:1134
-msgid "## Help! I can not save my document!"
+#. type: Title ##
+#: ../../info/wxmaxima.md:1133
+#, no-wrap
+msgid "How can a Maxima script determine, if it is running under wxMaxima or command line Maxima?"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:1136
-msgid "If saving as wxmx file does not work, try saving the document as wxm file (and vice versa). And you can also try to remove all output (Menu Cell->Remove all output) and save that file, maybe some unexpected output causes issues during the save process."
+msgid "If wxMaxima is used, the Maxima variable `maxima_frontend` is set to `wxmaxima`. The Maxima variable `maxima_frontend_version` contains the wxMaxima version in this case."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1140
-#, fuzzy
-msgid "# Command-line arguments"
-msgstr "x 座標，以逗號分隔"
+#: ../../info/wxmaxima.md:1138
+msgid "If no frontend is used (you are using command line Maxima), these variables are `false`."
+msgstr ""
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:1139
+#, no-wrap
+msgid "Help! I can not save my document!"
+msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:1142
+#, no-wrap
+msgid "If saving as wxmx file does not work, try saving the document as wxm file (and vice versa). And you can also try to remove all output (Menu Cell->Remove all output) and save that file, maybe some unexpected output causes issues during the save process.\n"
+msgstr ""
+
+#. type: Title #
+#: ../../info/wxmaxima.md:1145
+#, no-wrap
+msgid "Command-line arguments"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1148
 msgid "Usually you can start programs with a graphical user interface just by clicking on a desktop icon or desktop menu entry. WxMaxima - if started from the command line - still provides some command-line switches, though."
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:1158
+#: ../../info/wxmaxima.md:1164
 msgid "`-v` or `--version`: Output the version information"
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:1158
+#: ../../info/wxmaxima.md:1164
 msgid "`-h` or `--help`: Output a short help text"
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:1158
+#: ../../info/wxmaxima.md:1164
 msgid "`-o` or `--open=<str>`: Open the filename given as an argument to this command-line switch"
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:1158
+#: ../../info/wxmaxima.md:1164
 msgid "`-e` or `--eval`: Evaluate the file after opening it."
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:1158
+#: ../../info/wxmaxima.md:1164
 msgid "`-b` or `--batch`: If the command-line opens a file all cells in this file are evaluated and the file is saved afterward. This is for example useful if the session described in the file makes _Maxima_ generate output files. Batch-processing will be stopped if _wxMaxima_ detects that _Maxima_ has output an error and will pause if _Maxima_ has a question: Mathematics is somewhat interactive by nature so a completely interaction-free batch processing cannot always be guaranteed."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1158
+#: ../../info/wxmaxima.md:1164
 #, no-wrap
 msgid ""
 "- `--logtostderr`:                 Log all \"debug messages\" sidebar messages to stderr, too.\n"
@@ -10927,44 +15409,169 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1160
+#: ../../info/wxmaxima.md:1166
 msgid "Instead of a minus, some operating systems might use a dash in front of the command-line switches."
 msgstr ""
 
-#. type: Plain text
-#: ../../info/wxmaxima.md:1164
-msgid "# About the program, contributing to wxMaxima"
-msgstr ""
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:1166
-msgid "wxMaxima is mainly developed using the programming language C++ using the [wxWidgets framework](https://www.wxwidgets.org), as build system we use [CMake](https://www.cmake.org), a small part is written in Lisp. You can contribute to wxMaxima, join the wxMaxima project at <https://github.com/wxMaxima-developers/wxmaxima>, if you have knowledge of these programming languages and want to help and contribute to the open source project wxMaxima."
-msgstr ""
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:1168
-msgid "But not only programmers are necessary! You can also contribute to wxMaxima, if you help to improve the documentation, find and report bugs (and maybe bugfixes), suggest new features, help to translate wxMaxima or the manual to your language (read the README.md in the [locale subdirectory](https://github.com/wxMaxima-developers/wxmaxima/tree/main/locales) how wxMaxima and the manual can be translated)."
-msgstr ""
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:1170
-msgid "Or answer questions of other users in the discussion forum."
+#. type: Title #
+#: ../../info/wxmaxima.md:1169
+#, no-wrap
+msgid "About the program, contributing to wxMaxima"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:1172
-msgid "The source code of wxMaxima is documented using Doxygen [here](https://wxmaxima-developers.github.io/wxmaxima/Doxygen-documentation/)."
+msgid "wxMaxima is mainly developed using the programming language C++ using the [wxWidgets framework](https://www.wxwidgets.org), as build system we use [CMake](https://www.cmake.org), a small part is written in Lisp. You can contribute to wxMaxima, join the wxMaxima project at <https://github.com/wxMaxima-developers/wxmaxima>, if you have knowledge of these programming languages and want to help and contribute to the open source project wxMaxima."
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:1174
+msgid "But not only programmers are necessary! You can also contribute to wxMaxima, if you help to improve the documentation, find and report bugs (and maybe bugfixes), suggest new features, help to translate wxMaxima or the manual to your language (read the README.md in the [locale subdirectory](https://github.com/wxMaxima-developers/wxmaxima/tree/main/locales) how wxMaxima and the manual can be translated)."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1176
+msgid "Or answer questions of other users in the discussion forum."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1178
+msgid "The source code of wxMaxima is documented using Doxygen [here](https://wxmaxima-developers.github.io/wxmaxima/Doxygen-documentation/)."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1180
 msgid "The program is nearly self-contained, so except for system libraries (and the wxWidgets library), no external dependencies (like graphic files or the Lisp part (the `wxmathML.lisp`-file) is needed, these files are included in the executable."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1175
-msgid "If you are a developer, you might want to try out a modified `wxmathML.lisp`-file without recompiling everything, one can use the command line option `--wxmathml-lisp=<str>` to use another Lisp file, not the included one."
+#: ../../info/wxmaxima.md:1181
+#, no-wrap
+msgid "If you are a developer, you might want to try out a modified `wxmathML.lisp`-file without recompiling everything, one can use the command line option `--wxmathml-lisp=<str>` to use another Lisp file, not the included one.\n"
 msgstr ""
+
+#, fuzzy
+#~ msgid "1×n Matrix b:"
+#~ msgstr "矩陣："
+
+#, fuzzy
+#~ msgid "Calculate variation"
+#~ msgstr "計算乘積"
+
+#, fuzzy
+#~ msgid "Hide All Toolbars\tAlt+Shift+-"
+#~ msgstr "全部隱藏\tAlt+Shift+-"
+
+#, fuzzy
+#~ msgid "Integrate numerically"
+#~ msgstr "Risch 積分"
+
+#, fuzzy
+#~ msgid "Load a list from a csv file"
+#~ msgstr "讀取 Maxima package 檔"
+
+#, fuzzy
+#~ msgid "Main Toolbar\tAlt+Shift+B"
+#~ msgstr "工具列\tAlt+Shift+T"
+
+#, fuzzy
+#~ msgid "Multivariate linear regression"
+#~ msgstr "線性迴歸..."
+
+#~ msgid "Parts of the document will not be loaded correctly!"
+#~ msgstr "文件的某部分將無法被正確的讀取！"
+
+#, fuzzy
+#~ msgid "Read List from csv file..."
+#~ msgstr "自檔案載入樣式"
+
+#, fuzzy, c-format
+#~ msgid ""
+#~ "You have version %s. The newest version source code is available for is %s.\n"
+#~ "\n"
+#~ "Select OK to visit the wxMaxima webpage."
+#~ msgstr ""
+#~ "您的版本是 %s ，最新的版本是 %s 。\n"
+#~ "\n"
+#~ "按「確認」至 wxMaxima 首頁。"
+
+#, fuzzy
+#~| msgid "Welcome to wxMaxima"
+#~ msgid "# Introduction to wxMaxima"
+#~ msgstr "歡迎使用 wxMaxima"
+
+#, fuzzy
+#~| msgid "&Maxima"
+#~ msgid "### _Maxima_"
+#~ msgstr "Maxima(&M)"
+
+#, fuzzy
+#~| msgid "&Maxima"
+#~ msgid "### WxMaxima"
+#~ msgstr "Maxima(&M)"
+
+#, fuzzy
+#~| msgid "Merge Cells"
+#~ msgid "### Cells"
+#~ msgstr "合併單元"
+
+#, fuzzy
+#~ msgid "#### Greek characters"
+#~ msgstr "希臘字母"
+
+#, fuzzy
+#~ msgid "## File Formats"
+#~ msgstr "找不到檔案"
+
+#, fuzzy
+#~| msgid "Set fixed font in text controls."
+#~ msgid "### Match parenthesis in text controls"
+#~ msgstr "在文字控制項中使用等寬字型"
+
+#, fuzzy
+#~| msgid "Show defined variables"
+#~ msgid "## Subscripted variables"
+#~ msgstr "顯示已定義的變數"
+
+#, fuzzy
+#~| msgid "Expression"
+#~ msgid "#### Expression"
+#~ msgstr "數式"
+
+#, fuzzy
+#~| msgid "Parametric plot"
+#~ msgid "#### Parametric plot"
+#~ msgstr "參數式繪圖"
+
+#, fuzzy
+#~ msgid "#### Points"
+#~ msgstr "點："
+
+#, fuzzy
+#~ msgid "#### Plot name"
+#~ msgstr "串列："
+
+#, fuzzy
+#~ msgid "#### Grid"
+#~ msgstr "格線："
+
+#, fuzzy
+#~ msgid "## Special variables wx..."
+#~ msgstr "刪除變數"
+
+#, fuzzy
+#~ msgid "## Output rendering."
+#~ msgstr "字串"
+
+#, fuzzy
+#~ msgid "## Cannot connect to _Maxima_"
+#~ msgstr ""
+#~ "\n"
+#~ "未連線"
+
+#, fuzzy
+#~ msgid "# Command-line arguments"
+#~ msgstr "x 座標，以逗號分隔"
 
 #, fuzzy
 #~ msgid "Killing Maxima."
@@ -11002,22 +15609,6 @@ msgstr ""
 #~ "請檢查您的網路支援，\n"
 #~ "將其開啟並再試一次！"
 
-#, fuzzy
-#~ msgid "Maxima version: "
-#~ msgstr ""
-#~ "\n"
-#~ "Maxima 版本："
-
-#, fuzzy
-#~ msgid "Maxima was compiled using: "
-#~ msgstr ""
-#~ "\n"
-#~ "Maxima 版本："
-
-#, fuzzy
-#~ msgid "wxMaxima is a cross-platform graphical user interface for the computer algebra system Maxima based on wxWidgets.\n"
-#~ msgstr "wxMaxima 是基於 wxWidgets ，為電腦代數系統 Maxima 的圖形使用界面。"
-
 #~ msgid ""
 #~ "\n"
 #~ "\n"
@@ -11033,42 +15624,8 @@ msgstr ""
 #~ msgstr "是"
 
 #, fuzzy
-#~ msgid "\"Numpad Enter\" always evaluates cells"
-#~ msgstr "按 Enter 評算單元"
-
-#~ msgid "(Use default language)"
-#~ msgstr "( 使用預設語言 )"
-
-#~ msgid "A 'horizontal cursor' was introduced in wxMaxima 0.8.0. It looks like a horizontal line between cells. It indicates where a new cell will appear if you type or paste text or execute a menu command."
-#~ msgstr "自 wxMaxima 0.8.0 版開始引進「水平游標」。它的外觀為單元之間的水平線，代表您輸入或貼上文字或執行標能表命令時新單元出現的位置。"
-
-#, fuzzy
-#~ msgid "A new document format has been introduced in wxMaxima 0.8.2 that saves not only your input and text commentaries, but also the outputs of your calculations. When saving your document, select 'Whole document (*.wxmx)' format."
-#~ msgstr "從 wxMaxima 0.8.2 版開始有新的文件格式。這種格式除了儲存您的輸入和文字註解以外，也一起儲存您的計算的輸出。請在儲存您的文件時，選擇「wxMaxima XML 文件」。"
-
-#~ msgid "Additional parameters for Maxima (e.g. -l clisp)."
-#~ msgstr "Maxima 的附加參數 (例： -l clisp)"
-
-#, fuzzy
 #~ msgid "Additional parameters for maxima"
 #~ msgstr "附加參數："
-
-#, fuzzy
-#~ msgid "All variable names"
-#~ msgstr "舊變數："
-
-#~ msgid "All|*"
-#~ msgstr "所有類型|*"
-
-#~ msgid "Ask to save untitled documents"
-#~ msgstr "詢問是否儲存未命名文件"
-
-#, fuzzy
-#~ msgid "Auto-insert closing parenthesis"
-#~ msgstr "在文字控制項中輸入時匹配括弧"
-
-#~ msgid "Barsplot..."
-#~ msgstr "長條圖..."
 
 #~ msgid "Bat files (*.bat)|*.bat|All|*"
 #~ msgstr "批次檔 (*.bat)|*.bat|所有類型|*"
@@ -11076,218 +15633,6 @@ msgstr ""
 #, fuzzy
 #~ msgid "Bat files (*.bat)|*.bat|Exe files (*.exe)||All|*"
 #~ msgstr "批次檔 (*.bat)|*.bat|所有類型|*"
-
-#~ msgid "Bold"
-#~ msgstr "粗體"
-
-#~ msgid "Boxplot..."
-#~ msgstr "箱形圖..."
-
-#, fuzzy
-#~ msgid "By default, Shift-Enter is used to evaluate commands, while Enter is used for multiline input. This behaviour can be changed in 'Edit->Configure' dialog by checking 'Enter evaluates cells'. This switches the roles of these two key commands."
-#~ msgstr "預設值使用 Shift+Enter 來開始評算，Enter 則是用來做多行輸入。這個操作方式可透過「編輯(E)」->「設定(O)」對話框中勾選「按 Enter 鍵評算單元」變更。這會交換這兩組按鍵的功能。"
-
-#~ msgid "Canonical (tr)"
-#~ msgstr "標準型式 (三角)"
-
-#~ msgid "Catalan"
-#~ msgstr "Catalan"
-
-#, fuzzy
-#~ msgid "ChangeLog"
-#~ msgstr "變數變換"
-
-#~ msgid "Choose font"
-#~ msgstr "選擇字型"
-
-#, fuzzy
-#~ msgid "Choose the %s Font"
-#~ msgstr "選擇字型"
-
-#, fuzzy
-#~ msgid "Clear the selection"
-#~ msgstr "剪下所選區域"
-
-#~ msgid "Config file (*.ini)|*.ini"
-#~ msgstr "設定檔 (*.ini)|*.ini"
-
-#, fuzzy
-#~ msgid "Convert to Heading 5"
-#~ msgstr "轉換為 Gamma 函數(&G)"
-
-#, fuzzy
-#~ msgid "Convert to Heading 6"
-#~ msgstr "轉換為 Gamma 函數(&G)"
-
-#, fuzzy
-#~ msgid "Convert to Section"
-#~ msgstr "轉換為直角座標形式(&R)"
-
-#, fuzzy
-#~ msgid "Convert to Sub-Subsection"
-#~ msgstr "插入子章節單元"
-
-#, fuzzy
-#~ msgid "Convert to Subsection"
-#~ msgstr "轉換為直角座標形式(&R)"
-
-#, fuzzy
-#~ msgid "Convert to Title"
-#~ msgstr "轉換為階乘(&F)"
-
-#~ msgid "Czech"
-#~ msgstr "Czech"
-
-#~ msgid "Danish"
-#~ msgstr "Danish"
-
-#, fuzzy
-#~ msgid "Default port for communication with wxMaxima:"
-#~ msgstr "供 Maxima 與 wxMaxima 溝通的預設埠"
-
-#~ msgid "Deviation..."
-#~ msgstr "偏差..."
-
-#~ msgid "Diff..."
-#~ msgstr "微分..."
-
-#, fuzzy
-#~ msgid "Display"
-#~ msgstr "切換計算時間顯示(&T)"
-
-#, fuzzy
-#~ msgid "Display all digits"
-#~ msgstr "用於顯示的演算法"
-
-#~ msgid "English"
-#~ msgstr "English"
-
-#~ msgid "Enter Matrix..."
-#~ msgstr "輸入矩陣..."
-
-#, fuzzy
-#~ msgid "Enter adds newlines, Ctrl+Enter evaluates cells"
-#~ msgstr "按 Enter 評算單元"
-
-#, fuzzy
-#~ msgid "Enter evaluates cells, Ctrl+Enter adds newlines"
-#~ msgstr "按 Enter 評算單元"
-
-#~ msgid "Enter the path to the Maxima executable."
-#~ msgstr "輸入可執行 Maxima 的路徑"
-
-#, fuzzy
-#~ msgid "Environment variables for maxima"
-#~ msgstr "附加參數："
-
-#, fuzzy
-#~ msgid "Epsilon"
-#~ msgstr "Epsilon:"
-
-#, fuzzy
-#~ msgid "Evaluate"
-#~ msgstr "評算單元"
-
-#~ msgid "Example text"
-#~ msgstr "Example text 範例文字"
-
-#~ msgid "Expand"
-#~ msgstr "展開"
-
-#~ msgid "Expand (tr)"
-#~ msgstr "展開 (三角)"
-
-#, fuzzy
-#~ msgid "Export As"
-#~ msgstr "匯出"
-
-#, fuzzy
-#~ msgid "Export all settings"
-#~ msgstr "匯出為 TeX 失敗！"
-
-#, fuzzy
-#~ msgid "Export equations to HTML as:"
-#~ msgstr "匯出為 HTML 失敗！"
-
-#, fuzzy
-#~ msgid "Export the style settings"
-#~ msgstr "匯出為 TeX 失敗！"
-
-#, fuzzy
-#~ msgid "Exporting to .mac file failed!"
-#~ msgstr "匯出為 TeX 失敗！"
-
-#~ msgid "Factor"
-#~ msgstr "因式分解"
-
-#, fuzzy
-#~ msgid "Find:"
-#~ msgstr "尋找"
-
-#, fuzzy
-#~ msgid "Finnish"
-#~ msgstr "Danish"
-
-#~ msgid "Fixed font in text controls"
-#~ msgstr "文字控制項使用等寬字型"
-
-#~ msgid "Fonts"
-#~ msgstr "字型"
-
-#~ msgid "French"
-#~ msgstr "French"
-
-#~ msgid "German"
-#~ msgstr "German"
-
-#~ msgid "Greek"
-#~ msgstr "Greek"
-
-#, fuzzy
-#~ msgid "Hide"
-#~ msgstr "分割單元"
-
-#, fuzzy
-#~ msgid "Highlight the matching parenthesis"
-#~ msgstr "在文字控制項中輸入時匹配括弧"
-
-#~ msgid "Histogram..."
-#~ msgstr "直方圖..."
-
-#~ msgid "Horizontal cursor works like a normal cursor, but it operates on cells: press up or down arrow to move it, holding down Shift while moving will select cells, pressing backspace or delete twice will delete a cell next to it."
-#~ msgstr "水平游標就像一般游標一樣，但是它是對單元操作。按向上或向下箭頭來移動它，在移動時按住 Shift 鍵將會選擇單元，按 backspace 或 delete 鍵兩次會刪除相鄰的單元。"
-
-#~ msgid "Hungarian"
-#~ msgstr "Hungarian"
-
-#~ msgid "If your calculation is taking too long to evaluate, you can try 'Maxima->Interrupt' or 'Maxima->Restart Maxima' menu commands."
-#~ msgstr "若您的計算花費過長的時間，您可以嘗試「Maxima(M)」->「中斷(I)」或「Maxima(M)」->「重新啟動 Maxima(R)」這兩個功能表命令。"
-
-#~ msgid "Image"
-#~ msgstr "圖片"
-
-#, fuzzy
-#~ msgid "Import+Export"
-#~ msgstr "匯出"
-
-#~ msgid "Infinity"
-#~ msgstr "無限大"
-
-#, fuzzy
-#~ msgid "Integral sign"
-#~ msgstr "對數式積分"
-
-#, fuzzy
-#~ msgid "Intelligently hide cell brackets"
-#~ msgstr "作用中的單元框"
-
-#, fuzzy
-#~ msgid "Interaction"
-#~ msgstr "方向："
-
-#, fuzzy
-#~ msgid "Internal"
-#~ msgstr "積分"
 
 #~ msgid ""
 #~ "Invalid entry for Maxima program.\n"
@@ -11298,377 +15643,12 @@ msgstr ""
 #~ "\n"
 #~ "請再次輸入 Maxima 程式的所在路徑。"
 
-#~ msgid "Italian"
-#~ msgstr "Italian"
-
-#~ msgid "Italic"
-#~ msgstr "斜體"
-
-#~ msgid "Japanese"
-#~ msgstr "Japanese"
-
-#~ msgid "Keep percent sign with special symbols: %e, %i, etc."
-#~ msgstr "保留特殊符號前的百分比號，像是「%e」、「%i」等..."
-
-#~ msgid "Language used for wxMaxima GUI."
-#~ msgstr "wxMaxima 圖形介面的語言"
-
-#~ msgid "Language:"
-#~ msgstr "語言："
-
-#~ msgid "Least Squares Fit..."
-#~ msgstr "最小平方法..."
-
-#~ msgid "Limit..."
-#~ msgstr "極限..."
-
-#~ msgid "Linear Regression..."
-#~ msgstr "線性迴歸..."
-
-#, fuzzy
-#~ msgid "List of labels"
-#~ msgstr "輸入標籤"
-
-#~ msgid "Load"
-#~ msgstr "載入"
-
-#~ msgid "Load style from file"
-#~ msgstr "自檔案載入樣式"
-
-#, fuzzy
-#~ msgid "Match Case"
-#~ msgstr "以批次檔載入"
-
-#, fuzzy
-#~ msgid "Maxima Location"
-#~ msgstr "Maxima 詢問"
-
-#, fuzzy
-#~ msgid "Maxima configuration"
-#~ msgstr "wxMaxima 設定"
-
-#~ msgid "Maxima program:"
-#~ msgstr "Maxima 程式："
-
-#, fuzzy
-#~ msgid "Maxima session (*.mac)|*.mac"
-#~ msgstr "Maxima package (*.mac)|*.mac"
-
-#, fuzzy
-#~ msgid "Maxima usage"
-#~ msgstr "wxMaxima 圖示"
-
-#, fuzzy
-#~ msgid ""
-#~ "Maxima uses ':=' to define functions, e.g.:\n"
-#~ "f(x) := x^2;"
-#~ msgstr "Maxima 使用 \":\" 來設定數值 (例：\"a : 3;\")，使用 \":=\" 來定義函數 (例：\"f(x) := x^2\")。"
-
-#~ msgid "Mean Difference Test..."
-#~ msgstr "平均差檢驗..."
-
-#~ msgid "Mean Test..."
-#~ msgstr "平均值檢驗..."
-
-#~ msgid "Mean..."
-#~ msgstr "平均..."
-
-#~ msgid "Median..."
-#~ msgstr "中位數..."
-
-#, fuzzy
-#~ msgid "Misc settings"
-#~ msgstr "匯出為 TeX 失敗！"
-
-#~ msgid "Normality Test..."
-#~ msgstr "常態分布檢驗..."
-
-#~ msgid "Open a cell when Maxima expects input"
-#~ msgstr "當 Maxima 期望輸入時新增單元"
-
-#, fuzzy
-#~ msgid "Parametric Plot"
-#~ msgstr "參數式繪圖"
-
-#~ msgid "Piechart..."
-#~ msgstr "圓餅圖..."
-
-#~ msgid "Please restart wxMaxima for changes to take effect!"
-#~ msgstr "請重新啟動 wxMaxima 使變更生效！"
-
-#~ msgid "Polish"
-#~ msgstr "Polish"
-
-#~ msgid "Portuguese (Brazilian)"
-#~ msgstr "Portuguese (Brazilian)"
-
-#, fuzzy
-#~ msgid "Print Margins"
-#~ msgstr "列印"
-
-#, fuzzy
-#~ msgid "Print scale:"
-#~ msgstr "列印文件"
-
-#, fuzzy
-#~ msgid "Printout settings"
-#~ msgstr "匯出為 TeX 失敗！"
-
-#, fuzzy
-#~ msgid "Privacy settings"
-#~ msgstr "匯出為 TeX 失敗！"
-
-#, fuzzy
-#~ msgid "Product sign"
-#~ msgstr "乘積"
-
-#~ msgid "Read Matrix..."
-#~ msgstr "讀取矩陣..."
-
-#, fuzzy
-#~ msgid "Read config to file"
-#~ msgstr "儲存選取區域至檔案"
-
-#~ msgid "Rectform"
-#~ msgstr "直角坐標形式"
-
-#~ msgid "Reduce (tr)"
-#~ msgstr "縮併 (三角)"
-
-#, fuzzy
-#~ msgid "Reloading the styles from disc"
-#~ msgstr "自檔案載入樣式"
-
-#, fuzzy
-#~ msgid "Replace All"
-#~ msgstr "全部選取"
-
-#, fuzzy
-#~ msgid "Revert changes"
-#~ msgstr "重作上次的變更"
-
-#, fuzzy
-#~ msgid "Right"
-#~ msgstr "右"
-
-#~ msgid "Russian"
-#~ msgstr "Russian"
-
-#, fuzzy
-#~ msgid "Save config to file"
-#~ msgstr "儲存選取區域至檔案"
-
-#~ msgid "Save style to file"
-#~ msgstr "將樣式儲存至檔案"
-
-#~ msgid "Scatterplot..."
-#~ msgstr "散布圖..."
-
-#, fuzzy
-#~ msgid "Select"
-#~ msgstr "所選區域"
-
 #~ msgid "Select Maxima program"
 #~ msgstr "選擇 Maxima 程式"
 
 #, fuzzy
-#~ msgid "Selecting a part of an output and right-clicking on the selection will bring up a menu with convenient functions that will operate on the selection."
-#~ msgstr "選取輸出並點擊右鍵會顯示功能表，其中含有一些供您方便操作所選區域的函數。"
-
-#, fuzzy
-#~ msgid "Show labels:"
-#~ msgstr "顯示變數(&V)"
-
-#~ msgid "Show long expressions in wxMaxima document."
-#~ msgstr "在 wxMaxima 文件中顯示長的數式"
-
-#, fuzzy
-#~ msgid "Show long expressions:"
-#~ msgstr "顯示長的數式"
-
-#, fuzzy
 #~ msgid "Show section numbers"
 #~ msgstr "顯示函數(&F)"
-
-#, fuzzy
-#~ msgid "Simple"
-#~ msgstr "樣本："
-
-#~ msgid "Simplify"
-#~ msgstr "化簡"
-
-#~ msgid "Simplify (r)"
-#~ msgstr "化簡根式"
-
-#~ msgid "Simplify (tr)"
-#~ msgstr "化簡 (三角)"
-
-#, fuzzy
-#~ msgid "Since wxMaxima 0.8.2 you can also insert images into your documents. Use 'Cell->Insert Image...' menu command."
-#~ msgstr "自 wxMaxima 0.8.2 版開始您可以使用「單元(C)」->「插入圖片...」功能表在文件中插入圖片。請注意：若您希望將圖片與文件一起儲存，您必須將您的文件儲存為 「wxMaxima XML 文件」。"
-
-#~ msgid "Solve ODE..."
-#~ msgstr "解常微分方程..."
-
-#~ msgid "Spanish"
-#~ msgstr "Spanish"
-
-#, fuzzy
-#~ msgid "Standard Options"
-#~ msgstr "選項"
-
-#~ msgid "Style"
-#~ msgstr "樣式"
-
-#~ msgid "Styles"
-#~ msgstr "樣式"
-
-#~ msgid "Subsample..."
-#~ msgstr "子樣本..."
-
-#~ msgid "Subst..."
-#~ msgstr "代換"
-
-#, fuzzy
-#~ msgid "Text Only"
-#~ msgstr "文字單元"
-
-#~ msgid "The default port used for communication between Maxima and wxMaxima."
-#~ msgstr "供 Maxima 與 wxMaxima 溝通的預設埠"
-
-#~ msgid "Title, section and subsection cells can be folded to hide their contents. To fold or unfold, click in the square next to the cell. If you shift-click, all sublevels of that cell will also fold/unfold."
-#~ msgstr "標題單元、章節單元和子章節單元可被折疊並隱藏它們的內容。欲折疊或取消折疊，點擊該單元左側的小正方形。如果您按住 Shift 鍵並點擊小正方形，所有該單元中的子單元也會跟著折疊或取消折疊。"
-
-#~ msgid "To plot in polar coordinates, select 'set polar' in the Options entry for Plot2d dialog. You can also plot in spherical and cylindrical coordinates in 3D."
-#~ msgstr "欲在極座標上繪圖，在二維繪圖對話視窗的「選項」中選擇 \"set polar\" 。您也可以在三維繪圖中在球座標或柱座標上繪圖。"
-
-#, fuzzy
-#~ msgid "To put parentheses around an expression, select it, and press '(' or ')' depending on where you want the cursor to appear afterwards."
-#~ msgstr "欲在數式外側加上括號，請先選取它，再依照您想要游標出現的位置按「(」或「)」。"
-
-#~ msgid "To save the size and position of wxMaxima windows between session, use 'Edit->Configure' dialog."
-#~ msgstr "欲儲存工作階段之間 wxMaxima 視窗的大小及位置，請從「編輯(E)」->「設定(O)」變更。"
-
-#, fuzzy
-#~ msgid "To start using wxMaxima right away, start typing your command. An input cell should appear. Then press Shift-Enter to evaluate your command."
-#~ msgstr "欲立即使用 wxMaxima，請開始輸入命令，此時應該會出現一個輸入單元，然後按 Shift+Enter 鍵評算您的命令。"
-
-#, fuzzy
-#~ msgid "Top"
-#~ msgstr "到："
-
-#~ msgid "Ukrainian"
-#~ msgstr "Ukrainian"
-
-#, fuzzy
-#~ msgid "Upsilon"
-#~ msgstr "Epsilon:"
-
-#~ msgid "Use centered dot character for multiplication"
-#~ msgstr "用圓點符號表示乘法"
-
-#, fuzzy
-#~ msgid "Value"
-#~ msgstr "值："
-
-#~ msgid "Variance..."
-#~ msgstr "變異數..."
-
-#~ msgid "When applying functions with one argument from menus, the default argument is '%'. To apply the function to some other value, select it in the document before executing a menu command."
-#~ msgstr "當您從功能表使用只有一個引數的函數時，預設的引數是「%」。欲使用其他的值作為引數，請在執行功能表命令前從文件中選取該值。"
-
-#, fuzzy
-#~ msgid "Yes"
-#~ msgstr "是"
-
-#~ msgid "You can access the last output using the variable '%'. You can access the output of previous commands using variables '%on' where n is the number of output."
-#~ msgstr "您可以使用「%」存取最後一筆輸出。您也可以使用「%on」(n是輸出的編號)來存取先前命令的輸出。"
-
-#~ msgid "You can evaluate your whole document by using 'Cell->Evaluate All Cells' menu command or the appropriate key shortcut. The cells will be evaluated in the order they appear in the document."
-#~ msgstr "您可以使用「單元(C)」->「評算所有單元」功能表命令或該相對應的快捷鍵評算您的文件中的所有單元。這些單元會依照它們在文件中出現的順序評算。"
-
-#, fuzzy
-#~ msgid "You can get help on a Maxima function by selecting or clicking on the function name and pressing F1. wxMaxima will search the help index for the selection or the word under the cursor."
-#~ msgstr "您可以透過選取或點擊函數名並按 F1 取得 Maxima 函數的說明。wxMaxima 會在說明的索引中搜尋所選區域。"
-
-#~ msgid "You can hide output part of cells by clicking in the triangle on the left side of cells. This works on text cells also."
-#~ msgstr "您可以透過點擊單元左側的小三角形來隱藏單元的輸出部分。文字單元中也有同樣的功能。"
-
-#, fuzzy
-#~ msgid "You can insert different types of 'cells' in wxMaxima documents using the 'Cell' menu. Note that only 'input cells' can be evaluated, while others are used for commenting and structuring your calculations."
-#~ msgstr "您可以使用「編輯(E)」->「單元(C)」功能表在 wxMaxima 文件中插入不同種類的「單元」。請注意：只有「輸入單元」可以被評算，其他種類的單元是用來註解或組織您的計算。"
-
-#~ msgid "You can select multiple cells either with a mouse - click'n'drag from between cells or from a cell bracket on the left - or with a keyboard - hold down Shift while moving the horizontal cursor - and then operate on selection. This comes in handy when you want to delete or evaluate multiple cells."
-#~ msgstr "您可以透過滑鼠(在單元之間或左側的單元框拖曳)或鍵盤(在移動水平游標時按住Shift鍵)選取多個單元，然後對所選區域操作。這在您想要刪除或評算多個單元時很有用。"
-
-#, fuzzy
-#~ msgid "and"
-#~ msgstr "展開"
-
-#, fuzzy
-#~ msgid "epsilon"
-#~ msgstr "Epsilon:"
-
-#, fuzzy
-#~ msgid "greater than or equal"
-#~ msgstr "子章節單元"
-
-#, fuzzy
-#~ msgid "in"
-#~ msgstr "尋找"
-
-#, fuzzy
-#~ msgid "intersection"
-#~ msgstr "方向："
-
-#, fuzzy
-#~ msgid "less or equal"
-#~ msgstr "子章節單元"
-
-#, fuzzy
-#~ msgid "much greater than"
-#~ msgstr "子章節單元"
-
-#, fuzzy
-#~ msgid "nor"
-#~ msgstr "否"
-
-#, fuzzy
-#~ msgid "not"
-#~ msgstr "否"
-
-#, fuzzy
-#~ msgid "partial sign"
-#~ msgstr "部分分式"
-
-#, fuzzy
-#~ msgid "subset"
-#~ msgstr "子章節"
-
-#, fuzzy
-#~ msgid "subset or equal"
-#~ msgstr "子章節單元"
-
-#, fuzzy
-#~ msgid "upsilon"
-#~ msgstr "Epsilon:"
-
-#~ msgid "wxMaxima configuration"
-#~ msgstr "wxMaxima 設定"
-
-#~ msgid "wxMaxima dialogs set default values for inputs entries, one of which is '%'. If you have made a selection in your document, the selection will be used instead of '%'."
-#~ msgstr "wxMaxima 對話框會設定輸入內容為預設值，其中一種是 \"%\"。如果您已經在您的文件中作選取，則這個選取內容將會取代 \"%\"。"
-
-#, fuzzy
-#~ msgid "wxMaxima startup file location: "
-#~ msgstr "開始動畫"
-
-#, fuzzy
-#~ msgid "xor"
-#~ msgstr "匯出"
-
-#~ msgid "Direction:"
-#~ msgstr "方向："
 
 #, fuzzy
 #~ msgid "Lisp files (*.lisp)|*.lisp|All|*"
@@ -11763,9 +15743,6 @@ msgstr ""
 
 #~ msgid "At value"
 #~ msgstr "定點設值"
-
-#~ msgid "BC2"
-#~ msgstr "邊界條件(二階)"
 
 #~ msgid "Char poly"
 #~ msgstr "特徵多項式"
@@ -11873,184 +15850,11 @@ msgstr ""
 #~ msgid "Save panes layout between sessions."
 #~ msgstr "儲存工作階段間的窗格配置"
 
-#, fuzzy
-#~ msgid " samples"
-#~ msgstr "範例"
-
-#, fuzzy
-#~ msgid " times"
-#~ msgstr "次數："
-
-#~ msgid "&Definite integration"
-#~ msgstr "定積分(&D)"
-
-#~ msgid "&Nusum"
-#~ msgstr "使用 Nusum(&N)"
-
-#~ msgid "&Rational"
-#~ msgstr "有理式(&R)"
-
-#~ msgid "&Special"
-#~ msgstr "特殊(&S)"
-
-#~ msgid "&Taylor series"
-#~ msgstr "Taylor 級數(&T)"
-
-#~ msgid "&pm3d"
-#~ msgstr "pm3d(&P)"
-
-#~ msgid "- Infinity"
-#~ msgstr "負無限大"
-
-#, fuzzy
-#~ msgid "A function f(a,b), named"
-#~ msgstr "函數名"
-
-#, fuzzy
-#~ msgid "A page break"
-#~ msgstr "換頁符號"
-
-#, fuzzy
-#~ msgid "A static plot"
-#~ msgstr "參數式繪圖"
-
-#, fuzzy
-#~ msgid "A sub-subsection heading"
-#~ msgstr "子章節單元"
-
-#, fuzzy
-#~ msgid "A subsection heading"
-#~ msgstr "子章節單元"
-
-#~ msgid "Browse"
-#~ msgstr "瀏覽"
-
-#~ msgid "Choose new plot format:"
-#~ msgstr "選擇新的繪圖格式："
-
-#~ msgid "Comma separated x coordinates"
-#~ msgstr "x 座標，以逗號分隔"
-
-#~ msgid "Comma separated y coordinates"
-#~ msgstr "y 座標，以逗號分隔"
-
-#~ msgid "Constant"
-#~ msgstr "常數"
-
-#, fuzzy
-#~ msgid "Data format"
-#~ msgstr "繪圖格式"
-
-#~ msgid "Depth:"
-#~ msgstr "深度："
-
-#~ msgid "Discrete plot"
-#~ msgstr "離散繪圖"
-
 #~ msgid "Equation %d:"
 #~ msgstr "方程式 %d："
 
-#~ msgid "Figure %d:"
-#~ msgstr "圖 %d:"
-
 #~ msgid "File:"
 #~ msgstr "檔案："
-
-#~ msgid "Format:"
-#~ msgstr "格式："
-
-#, fuzzy
-#~ msgid "Frame counter end"
-#~ msgstr "找不到檔案"
-
-#~ msgid "Grid:"
-#~ msgstr "格線："
-
-#~ msgid "Method:"
-#~ msgstr "方法："
-
-#~ msgid "New value:"
-#~ msgstr "新值："
-
-#~ msgid "Old value:"
-#~ msgstr "舊值："
-
-#~ msgid "Options:"
-#~ msgstr "選項："
-
-#, fuzzy
-#~ msgid "Plot an explicit expression"
-#~ msgstr "求數式的極限"
-
-#~ msgid "Plot to file:"
-#~ msgstr "繪圖存檔："
-
-#, fuzzy
-#~ msgid "Point type:"
-#~ msgstr "點："
-
-#, fuzzy
-#~ msgid "Reuse last"
-#~ msgstr "產生串列"
-
-#~ msgid "Save plot to file"
-#~ msgstr "儲存繪圖至檔案"
-
-#~ msgid "Special"
-#~ msgstr "特殊"
-
-#, fuzzy
-#~ msgid "Start value of the parameter"
-#~ msgstr "將最後的計算結果以浮點數 (float) 表示"
-
-#~ msgid "Ticks:"
-#~ msgstr "描繪密度："
-
-#, fuzzy
-#~ msgid "Type in text"
-#~ msgstr "複製為圖片"
-
-#~ msgid "Use Gosper algorithm"
-#~ msgstr "使用 Gosper 演算法"
-
-#~ msgid "antisymmetric"
-#~ msgstr "反對稱"
-
-#~ msgid "both sides"
-#~ msgstr "雙邊"
-
-#~ msgid "default"
-#~ msgstr "預設值"
-
-#~ msgid "diagonal"
-#~ msgstr "對角"
-
-#~ msgid "general"
-#~ msgstr "一般"
-
-#~ msgid "inline"
-#~ msgstr "隨文字顯示"
-
-#~ msgid "left"
-#~ msgstr "左"
-
-#~ msgid "logscale"
-#~ msgstr "對數尺度"
-
-#~ msgid "symmetric"
-#~ msgstr "對稱"
-
-#, fuzzy
-#~ msgid "the x and the y coordinate."
-#~ msgstr "y 座標，以逗號分隔"
-
-#, fuzzy
-#~ msgid "Complex infinity."
-#~ msgstr "複數化簡(&C)"
-
-#, fuzzy
-#~ msgid "The inverse laplace transform."
-#~ msgstr "反 Laplace 變換(&R)..."
 
 #~ msgid "Greek constants"
 #~ msgstr "希臘字母"
@@ -12098,9 +15902,6 @@ msgstr ""
 #~ msgstr ""
 #~ "\n"
 #~ "Lisp 版本："
-
-#~ msgid "wxMaxima document (*.wxm, *.wxmx)|*.wxm;*.wxmx"
-#~ msgstr "wxMaxima 文件 (*.wxm, *.wxmx)|*.wxm;*.wxmx"
 
 #~ msgid "&Interrupt\tCtrl+."
 #~ msgstr "中斷(&I)\tCtrl+."

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -265,6 +265,22 @@ add_test(
     COMMAND "${CMAKE_CURRENT_BINARY_DIR}/check-translations.sh"
 )
 
+# Check that no translatable string can go missing the way ~7000 of them once
+# did: the xgettext glob in locales/wxMaxima/CMakeLists.txt was flat src/*, so
+# everything under src/cells, src/wizards, src/dialogs and src/sidebars was
+# absent from wxMaxima.pot for years without a single warning anywhere.
+# The POT drift check in CI cannot see this -- it regenerates the POT and diffs
+# it, and a broken glob truncates both sides identically. A CMake script rather
+# than a shell helper so it runs on Windows CI too, and it needs neither a build
+# nor gettext.
+add_test(
+    NAME check-pot-coverage
+    COMMAND "${CMAKE_COMMAND}"
+            "-DSOURCE_DIR=${CMAKE_SOURCE_DIR}"
+            -P "${CMAKE_CURRENT_SOURCE_DIR}/check-pot-coverage.cmake"
+)
+set_property(TEST check-pot-coverage APPEND PROPERTY LABELS unittest)
+
 add_test(
     NAME multiple_batch_files
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/automatic_test_files

--- a/test/check-pot-coverage.cmake
+++ b/test/check-pot-coverage.cmake
@@ -1,0 +1,132 @@
+# Guard against translatable strings becoming invisible to xgettext.
+#
+# locales/wxMaxima/CMakeLists.txt feeds xgettext an explicit glob. It used to be
+# a flat src/*.cpp;src/*.h, which meant every string under src/cells, src/wizards,
+# src/dialogs and src/sidebars was silently missing from wxMaxima.pot -- and from
+# there, missing from every catalogue. That cost about 7000 translations before
+# anyone noticed, because nothing in the build ever complains: xgettext is
+# perfectly happy to extract from a shorter file list.
+#
+# The existing wxMaxima.pot drift check in CI cannot catch this. It regenerates
+# the POT and diffs it against the committed one -- but a broken glob produces
+# the same truncated POT on both sides, so the diff is empty and the check
+# passes while the strings stay lost.
+#
+# Two assertions, both cheap and neither needing a build or gettext:
+#
+#   1. Every source file under src/ is at a depth the glob actually reaches.
+#      This is the exact regression: the day someone adds src/cells/foo/Bar.cpp,
+#      the two-level glob stops covering it.
+#   2. Every source file that contains a _("...") marker is referenced by the
+#      committed POT. This catches the same class of loss coming from a
+#      direction the depth rule cannot see, e.g. a new file extension.
+#
+# Run standalone with:
+#   cmake -DSOURCE_DIR=<repo> -P test/check-pot-coverage.cmake
+
+if(NOT SOURCE_DIR)
+  message(FATAL_ERROR "check-pot-coverage: SOURCE_DIR must be set")
+endif()
+
+set(pot "${SOURCE_DIR}/locales/wxMaxima/wxMaxima.pot")
+if(NOT EXISTS "${pot}")
+  message(FATAL_ERROR "check-pot-coverage: ${pot} not found")
+endif()
+
+# --- 1. depth: keep this list in step with POT_SOURCE_FILES in ---------------
+#        locales/wxMaxima/CMakeLists.txt.
+file(GLOB_RECURSE all_sources RELATIVE "${SOURCE_DIR}"
+     "${SOURCE_DIR}/src/*.cpp" "${SOURCE_DIR}/src/*.h")
+file(GLOB covered_abs
+     "${SOURCE_DIR}/src/*.cpp" "${SOURCE_DIR}/src/*.h"
+     "${SOURCE_DIR}/src/*/*.cpp" "${SOURCE_DIR}/src/*/*.h")
+set(covered "")
+foreach(f IN LISTS covered_abs)
+  file(RELATIVE_PATH rel "${SOURCE_DIR}" "${f}")
+  list(APPEND covered "${rel}")
+endforeach()
+
+set(too_deep "")
+foreach(f IN LISTS all_sources)
+  if(NOT f IN_LIST covered)
+    list(APPEND too_deep "${f}")
+  endif()
+endforeach()
+
+if(too_deep)
+  string(REPLACE ";" "\n    " pretty "${too_deep}")
+  message(FATAL_ERROR
+    "These source files are nested deeper than the POT glob reaches, so every\n"
+    "translatable string in them is invisible to xgettext and will never appear\n"
+    "in any translation catalogue:\n    ${pretty}\n\n"
+    "Fix: add the matching pattern (e.g. src/*/*/*.cpp and src/*/*/*.h) to both\n"
+    "POT_SOURCE_FILES_REL and POT_SOURCE_FILES in locales/wxMaxima/CMakeLists.txt,\n"
+    "and to the covered list in test/check-pot-coverage.cmake.")
+endif()
+
+# --- 2. marker coverage -----------------------------------------------------
+file(STRINGS "${pot}" pot_refs REGEX "^#: ")
+set(referenced "")
+foreach(line IN LISTS pot_refs)
+  string(REPLACE "#: " "" line "${line}")
+  string(REPLACE " " ";" refs "${line}")
+  foreach(ref IN LISTS refs)
+    string(REGEX REPLACE ":[0-9]+$" "" ref "${ref}")
+    string(REGEX REPLACE "^\\.\\./\\.\\./" "" ref "${ref}")
+    list(APPEND referenced "${ref}")
+  endforeach()
+endforeach()
+list(REMOVE_DUPLICATES referenced)
+
+set(missing "")
+foreach(f IN LISTS all_sources)
+  if(f IN_LIST referenced)
+    continue()
+  endif()
+  # Strip comments before looking for the marker: a commented-out _("...") is
+  # not a string xgettext should have found. src/Notification.cpp is exactly
+  # this case and must not be reported.
+  file(STRINGS "${SOURCE_DIR}/${f}" lines)
+  set(in_block FALSE)
+  set(found FALSE)
+  foreach(line IN LISTS lines)
+    if(in_block)
+      if(line MATCHES "\\*/")
+        string(REGEX REPLACE "^.*\\*/" "" line "${line}")
+        set(in_block FALSE)
+      else()
+        continue()
+      endif()
+    endif()
+    string(REGEX REPLACE "/\\*.*\\*/" "" line "${line}")
+    if(line MATCHES "/\\*")
+      string(REGEX REPLACE "/\\*.*$" "" line "${line}")
+      set(in_block TRUE)
+    endif()
+    string(REGEX REPLACE "//.*$" "" line "${line}")
+    if(line MATCHES "_\\(\"")
+      set(found TRUE)
+      break()
+    endif()
+  endforeach()
+  if(found)
+    list(APPEND missing "${f}")
+  endif()
+endforeach()
+
+if(missing)
+  string(REPLACE ";" "\n    " pretty "${missing}")
+  message(FATAL_ERROR
+    "These files contain translatable _(\"...\") strings but are not referenced\n"
+    "by locales/wxMaxima/wxMaxima.pot, so their strings reach no translator:\n"
+    "    ${pretty}\n\n"
+    "Either the POT is stale (run 'cmake --build build --target update-locale'\n"
+    "and commit the result) or the xgettext glob in\n"
+    "locales/wxMaxima/CMakeLists.txt does not reach these files.")
+endif()
+
+list(LENGTH all_sources n_src)
+list(LENGTH referenced n_ref)
+message(STATUS
+  "check-pot-coverage: ${n_src} source files, all within the POT glob; "
+  "${n_ref} referenced by the POT.")


### PR DESCRIPTION
`locales/wxMaxima/CMakeLists.txt` globbed only `src/*.cpp` and `src/*.h`, so every string in a source subdirectory was invisible to xgettext and silently absent from `wxMaxima.pot`. 03b16f2d8 fixed the glob when it created `src/worksheet/`, but the blast radius is far older:

| directory | invisible since |
|---|---|
| `src/cells`, `src/wizards`, `src/graphical_io` | **2020-08-05** |
| `src/sidebars`, `src/dialogs` | 2024-01 |

1032 msgids in the current POT come only from such files.

### Nothing came back on its own

`msgmerge` normally demotes a vanished msgid to an obsolete `#~` entry and revives it when the string returns. For the catalogues nobody has re-merged since (`nb`, `pt_BR`, `sq`, `zh_CN`, `zh_TW`) that safety net held — they still carry 324–966 obsolete entries each. Every actively synced catalogue has **exactly zero**, so the entries were pruned rather than demoted, and the translations were only still reachable through git history.

### The measured cost

In the mature catalogues, strings from top-level sources are 79–91% translated while subdirectory strings sat at **13–15%**. These were real translations, not strings nobody had got to: `"&Definite integration"` had been `"&Bestimmtes Integral"` since long before `src/wizards` existed.

### How they were recovered

The newest historic revision of each catalogue that still had a translation, refilling **exact msgid matches only**, so a restored string is precisely what a translator once wrote. Restored unfuzzied: an exact msgid match means the English is unchanged, and a fuzzy entry would not be used at runtime, which would defeat the point.

Two mechanisms, because two situations:

- **17 catalogues** already had the entries, empty. Filled in place: no reordering, no header rewrite, no refreshed line-number comments, so the diff is exactly one changed line per restored string.
- **`nb`, `pt_BR`, `zh_CN`, `zh_TW`** were frozen at 2327 msgids against a 3290-msgid POT: the entries were not empty, they were *absent*, and no in-place fill can reach an entry that does not exist. Those needed a real `msgmerge` — hence their large diffs. It also revives 527 of `zh_CN`'s obsolete entries. The compendium handed to `msgmerge` was filtered to the subdirectory msgids alone, so the scope stays identical to the in-place pass.

That `msgmerge` passes `--previous`, matching what `update-locale` does since 00ba34121: without it, `msgmerge` silently discards the `#| msgid` comments that tell a translator what a fuzzy entry used to say — 212 of them in `zh_CN` alone. Verified afterwards that no entry kept its fuzzy status while losing its `#|`, and that entries leaving the active section land in the obsolete one rather than being deleted.

`sq` is deliberately untouched: it would have gained 963 entries and not one translation.

### The guard

The POT-drift check in CI cannot catch this class of bug — it regenerates the POT and diffs it, and a broken glob truncates both sides identically. The new `check-pot-coverage` ctest asserts that every source file sits at a depth the glob reaches, and that every file containing a `_("...")` marker is referenced by the committed POT. Verified in both directions: passes as-is, fails when a `src/cells/deep/` file or an unreferenced string is planted.

All 50 catalogues pass `msgfmt -c`. `wxMaxima.pot` is **not** regenerated: a fresh xgettext run produces zero msgid drift against the committed file.

```
ca +312  cs +130  da +104  de +633  el +123  es +589  fi +171  fr +143
gl +280  hu +647  it +637  ja +211  kab +178 nb +144  pl +154  pt_BR +140
ru +657  tr +525  uk +656  zh_CN +510  zh_TW +139
```

⚠️ **Before merging:** these catalogues are Crowdin-synced, and Crowdin appears to be what pruned the entries. Unless the restore also reaches Crowdin, the next sync can undo it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q65eoSF1N7jzjdTHpBsq4Z