### PR TITLE
Make the LaTeX exporter's mode handling and preamble readable

### DIFF
--- a/src/cells/GroupCell.cpp
+++ b/src/cells/GroupCell.cpp
@@ -1376,8 +1376,39 @@ wxString GroupCell::ToTeXCodeCell(const wxString &imgDir, const wxString &filena
     if (imgCounter == NULL)
       str += wxS("\\definecolor{labelcolor}{RGB}{100,0,0}\n");
 
+    // The output is a run of cells that each need to be typeset in math mode,
+    // in a verbatim block or in neither, so walking it means opening and
+    // closing those two modes from half a dozen places. These keep that
+    // markup in one place - and idempotent, so a caller can just ask for the
+    // mode it needs.
     bool mathMode = false;
     bool asciiArt = false;
+    auto openMath = [&str, &mathMode]() {
+      if (mathMode)
+        return;
+      str += wxS("\\[\\displaystyle ");
+      mathMode = true;
+    };
+    auto closeMath = [&str, &mathMode]() {
+      if (!mathMode)
+        return;
+      // Some invisible dummy content that keeps TeX happy if the equation
+      // would otherwise end up empty.
+      str += wxS("\\mbox{}\n\\]");
+      mathMode = false;
+    };
+    auto openVerbatim = [&str, &asciiArt]() {
+      if (asciiArt)
+        return;
+      str += wxS("\n\\begin{verbatim}\n");
+      asciiArt = true;
+    };
+    auto closeVerbatim = [&str, &asciiArt]() {
+      if (!asciiArt)
+        return;
+      str += wxS("\\end{verbatim}\n");
+      asciiArt = false;
+    };
 
     auto const outputDrawList = OnDrawList(m_output.get());
     for (auto it = outputDrawList.begin(), listEnd = outputDrawList.end();
@@ -1392,10 +1423,8 @@ wxString GroupCell::ToTeXCodeCell(const wxString &imgDir, const wxString &filena
       const bool isAsciiArt = (tmp.GetTextStyle() == TS_ASCIIMATHS);
 
       // Anything that isn't another art line ends the block.
-      if (asciiArt && !isAsciiArt) {
-        str += wxS("\\end{verbatim}\n");
-        asciiArt = false;
-      }
+      if (!isAsciiArt)
+        closeVerbatim();
 
       if (tmp.GetType() == MC_TYPE_IMAGE) {
         str << ToTeXImage(&tmp, imgDir, filename, imgCounter);
@@ -1407,14 +1436,8 @@ wxString GroupCell::ToTeXCodeCell(const wxString &imgDir, const wxString &filena
         else
           str << anim;
       } else if (isAsciiArt) {
-        if (mathMode) {
-          str += wxS("\\mbox{}\n\\]");
-          mathMode = false;
-        }
-        if (!asciiArt) {
-          str += wxS("\n\\begin{verbatim}\n");
-          asciiArt = true;
-        }
+        closeMath();
+        openVerbatim();
         // ToString() gives the art back as characters (it also undoes the
         // unicode minus the parser substitutes for "-", which is what keeps
         // fraction bars printable under pdfTeX) and appends the line break the
@@ -1434,22 +1457,16 @@ wxString GroupCell::ToTeXCodeCell(const wxString &imgDir, const wxString &filena
           ++peek;
           const Cell *const next = peek;
           if (next && (next->GetTextStyle() == TS_ASCIIMATHS)) {
-            if (mathMode) {
-              str += wxS("\\mbox{}\n\\]");
-              mathMode = false;
-            }
+            closeMath();
             wxString label = tmp.GetValue();
             label.Trim(true).Trim(false);
             str += wxS("\n\\noindent\\textcolor{labelcolor}{\\texttt{") +
               TexEscapePlainText(label) + wxS("}}\n");
             break;
           }
-          if (mathMode)
-            str += wxS("\\mbox{}\\]\n\\[\\displaystyle ");
-          else {
-            str += wxS("\\[\\displaystyle ");
-            mathMode = true;
-          }
+          // A label starts an equation of its own: end the one before it.
+          closeMath();
+          openMath();
           str += tmp.ToTeX() + wxS("\n");
           break;
         }
@@ -1461,31 +1478,22 @@ wxString GroupCell::ToTeXCodeCell(const wxString &imgDir, const wxString &filena
           // Non-math output (a string, a message, a warning or an error) is
           // emitted as LaTeX text, not forced through the math renderer: it is
           // prose, and wrapping a sentence in \[...\] produced garbled output.
-          if (mathMode) {
-            str += wxS("\\mbox{}\n\\]");
-            mathMode = false;
-          }
+          closeMath();
           str += TexEscapeOutputCell(tmp.ToTeX()) + wxS("\n");
           break;
 
         default:
-          if (!mathMode) {
-            str += wxS("\\[\\displaystyle ");
-            mathMode = true;
-          }
+          openMath();
           str += tmp.ToTeX();
           break;
         }
       }
     }
 
-    if (asciiArt)
-      str += wxS("\\end{verbatim}\n");
-
+    closeVerbatim();
     if (mathMode) {
-      // Some invisible dummy content that keeps TeX happy if there really is
-      // no output to display.
-      str += wxS("\\mbox{}\n\\]\n%%%%%%%%%%%%%%%%");
+      closeMath();
+      str += wxS("\n%%%%%%%%%%%%%%%%");
     }
   } else
     str += wxS("\n\n\\noindent%\n");

--- a/src/worksheet/WorksheetExport.cpp
+++ b/src/worksheet/WorksheetExport.cpp
@@ -696,25 +696,25 @@ void WriteTeXPreamble(wxTextOutputStream &output, Configuration *configuration) 
       "]{" + configuration->Documentclass() + "}\n\n";
   // cppcheck-suppress unknownMacro
   output << wxS("%% Created with wxMaxima " WXMAXIMA_VERSION "\n\n");
-  output << wxS("\\setlength{\\parskip}{\\medskipamount}\n");
-  output << wxS("\\setlength{\\parindent}{0pt}\n");
-  output << wxS("\\usepackage{iftex}\n");
-  output << wxS("\\ifPDFTeX\n");
-  output << wxS("  % PDFLaTeX or LaTeX \n");
-  output << wxS("  \\usepackage[utf8]{inputenc}\n");
-  output << wxS("  \\usepackage[T1]{fontenc}\n");
-  output << wxS("  \\DeclareUnicodeCharacter{00B5}{\\ensuremath{\\mu}}\n");
-  output << wxS("\\else\n");
-  output << wxS("  %  XeLaTeX or LuaLaTeX\n");
-  output << wxS("  \\usepackage{fontspec}\n");
-  output << wxS("\\fi\n");
-
-  // The following line loads all code needed in order to include graphics.
-  output << wxS("\\usepackage{graphicx}\n");
-  // Lets \animategraphics embed the frames of an animation as a real animation
+  // graphicx loads all the code needed in order to include graphics; animate
+  // lets \animategraphics embed the frames of an animation as a real animation
   // that plays in PDF viewers supporting it (and shows the first frame in the
   // rest).
-  output << wxS("\\usepackage{animate}\n");
+  output << wxS(R"TEX(\setlength{\parskip}{\medskipamount}
+\setlength{\parindent}{0pt}
+\usepackage{iftex}
+\ifPDFTeX
+  % PDFLaTeX or LaTeX
+  \usepackage[utf8]{inputenc}
+  \usepackage[T1]{fontenc}
+  \DeclareUnicodeCharacter{00B5}{\ensuremath{\mu}}
+\else
+  %  XeLaTeX or LuaLaTeX
+  \usepackage{fontspec}
+\fi
+\usepackage{graphicx}
+\usepackage{animate}
+)TEX");
 
   // Carries the worksheet itself inside the PDF as a file attachment, so the
   // document and the session that produced it cannot be separated. attachfile2
@@ -723,62 +723,52 @@ void WriteTeXPreamble(wxTextOutputStream &output, Configuration *configuration) 
   // something to attach, so nobody needs the package otherwise.
   if (configuration->ExportContainsWXMX())
     output << wxS("\\usepackage{attachfile2}\n");
-  // We want to color the labels and text cells. The following line adds the
-  // necessary logic for this to TeX.
-  output << wxS("\\usepackage{color}\n");
-  output << wxS("\\usepackage[leqno]{amsmath}\n");
+  // color: we want to color the labels and text cells.
+  output << wxS(R"TEX(\usepackage{color}
+\usepackage[leqno]{amsmath}
+)TEX");
   // On the modern Unicode engines (XeLaTeX/LuaLaTeX) unicode-math lets the
   // document typeset arbitrary Unicode maths directly -- so a symbol wxMaxima
   // doesn't translate to a LaTeX command still renders instead of vanishing or
   // breaking the build. It must be loaded after amsmath, and only there (pdfTeX
   // has no Unicode-math font machinery; it keeps the inputenc path above).
-  output << wxS("\\ifPDFTeX\\else\n");
-  output << wxS("  \\usepackage{unicode-math}\n");
-  output << wxS("\\fi\n");
+  output << wxS(R"TEX(\ifPDFTeX\else
+  \usepackage{unicode-math}
+\fi
+)TEX");
 
-  // We want to shrink pictures the user has included if they are
-  // higher or wider than the page.
-  output << wxS("\\usepackage{ifthen}\n");
-  output << wxS("\\newsavebox{\\picturebox}\n");
-  output << wxS("\\newlength{\\pictureboxwidth}\n");
-  output << wxS("\\newlength{\\pictureboxheight}\n");
-  output << wxS("\\newcommand{\\includeimage}[1]{\n");
-  output << wxS("    \\savebox{\\picturebox}{\\includegraphics{#1}}\n");
-  output << wxS(
-                "    \\settoheight{\\pictureboxheight}{\\usebox{\\picturebox}}\n");
-  output << wxS(
-                "    \\settowidth{\\pictureboxwidth}{\\usebox{\\picturebox}}\n");
-  output << wxS(
-                "    \\ifthenelse{\\lengthtest{\\pictureboxwidth > .95\\linewidth}}\n");
-  output << wxS("    {\n");
-  output << wxS("        "
-                "\\includegraphics[width=.95\\linewidth,height=.80\\textheight,"
-                "keepaspectratio]{#1}\n");
-  output << wxS("    }\n");
-  output << wxS("    {\n");
-  output << wxS(
-                "        "
-                "\\ifthenelse{\\lengthtest{\\pictureboxheight>.80\\textheight}}\n");
-  output << wxS("        {\n");
-  output << wxS("            "
-                "\\includegraphics[width=.95\\linewidth,height=.80\\textheight,"
-                "keepaspectratio]{#1}\n");
-  output << wxS("            \n");
-  output << wxS("        }\n");
-  output << wxS("        {\n");
-  output << wxS("            \\includegraphics{#1}\n");
-  output << wxS("        }\n");
-  output << wxS("    }\n");
-  output << wxS("}\n");
-  output << wxS("\\newlength{\\thislabelwidth}\n");
+  // \includeimage shrinks a picture the user has included if it is higher or
+  // wider than the page, and \abs is an operator for abs commands that are long
+  // enough to be broken into lines.
+  output << wxS(R"TEX(\usepackage{ifthen}
+\newsavebox{\picturebox}
+\newlength{\pictureboxwidth}
+\newlength{\pictureboxheight}
+\newcommand{\includeimage}[1]{
+    \savebox{\picturebox}{\includegraphics{#1}}
+    \settoheight{\pictureboxheight}{\usebox{\picturebox}}
+    \settowidth{\pictureboxwidth}{\usebox{\picturebox}}
+    \ifthenelse{\lengthtest{\pictureboxwidth > .95\linewidth}}
+    {
+        \includegraphics[width=.95\linewidth,height=.80\textheight,keepaspectratio]{#1}
+    }
+    {
+        \ifthenelse{\lengthtest{\pictureboxheight>.80\textheight}}
+        {
+            \includegraphics[width=.95\linewidth,height=.80\textheight,keepaspectratio]{#1}
 
-  // Define an "abs" operator for abs commands that are long enough to be broken
-  // into lines.
-  output << wxS("\\DeclareMathOperator{\\abs}{abs}\n");
+        }
+        {
+            \includegraphics{#1}
+        }
+    }
+}
+\newlength{\thislabelwidth}
+\DeclareMathOperator{\abs}{abs}
 
-  output << wxS("\n");
-  output << wxS("\\definecolor{labelcolor}{RGB}{100,0,0}\n");
-  output << wxS("\n");
+\definecolor{labelcolor}{RGB}{100,0,0}
+
+)TEX");
 
   // Add an eventual preamble requested by the user.
   wxString texPreamble = configuration->TexPreamble();


### PR DESCRIPTION
Two readability changes to the TeX export path. No user-visible behaviour intended.

### `ToTeXCodeCell`

It walks the output cells deciding, per cell, whether each belongs in math mode, in a verbatim block, or in neither. Opening and closing those two modes was written out longhand in six different places, each an `if (mathMode) { emit; flag = false; }` that the reader has to re-verify every time.

They are now four idempotent lambdas — `openMath` / `closeMath` / `openVerbatim` / `closeVerbatim` — so a call site simply asks for the mode it needs and the flag bookkeeping lives in one spot.

### `WriteTeXPreamble`

It emitted its preamble as a column of forty-odd `output << wxS("...\n")` lines, in which the LaTeX being generated was almost impossible to read past the quoting. The contiguous runs become raw string literals, so the preamble reads as the LaTeX it actually is.

### One deliberate byte-level difference

The `TS_LABEL` branch used to emit `\mbox{}\]\n\[` where the shared `closeMath()` + `openMath()` pair emits `\mbox{}\n\]\[`. The newline moves from after the closing `\]` to before it — whitespace between display-math delimiters either way, so the typeset result is identical, and in exchange all four close sites now emit the same thing.

### Note on the rebase

Rebased onto a25740cf0, which rewrote this same loop to compute the draw list instead of storing `m_nextToDraw`: the label lookahead uses the iterator peek that commit introduced, since `GetNextToDraw()` no longer exists.

Verified green: `WorksheetExport` (which exports the whole corpus twice and requires the two runs to be byte-identical), `IntegralToTeX`, `WXMRoundtrip`, `LayoutInvariants`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q65eoSF1N7jzjdTHpBsq4Z