### PR TITLE
Label exported SVG equations so screen readers can read them (GH #2230)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,11 @@
 # Current development version
 
+- Equations exported as SVG now carry their text form, so a screen reader can
+  read them out instead of announcing an anonymous picture (GH #2230). Both
+  the HTML export's equation images and the SVG that "Copy as SVG" puts on the
+  clipboard are affected: the file is given a title, and the drawing is marked
+  up as mathematics with the equation's text as its label. Needs wxWidgets
+  3.3.3 or newer; with an older wxWidgets the exported SVG is unchanged.
 - Evaluating a folded section no longer unfolds it just because an error
   happened somewhere inside (GH #1952). Folding a time-consuming or
   no-longer-relevant calculation down to one line, so the worksheet stays

--- a/src/graphical_io/SVGout.cpp
+++ b/src/graphical_io/SVGout.cpp
@@ -72,6 +72,37 @@ wxSize Svgout::Render(std::unique_ptr<Cell> &&tree) {
   return m_size;
 }
 
+wxString Svgout::AccessibleText() const {
+  if (!m_tree)
+    return {};
+
+  // The same plain-text rendering the clipboard and the .wxm exporter use, so
+  // a screen reader hears exactly what a sighted user would get by copying the
+  // cell as text.
+  //
+  // Every run of whitespace collapses to a single space. 2-D ASCII-art maths
+  // (TS_ASCIIMATHS) pads its lines with long runs of spaces and tabs to keep
+  // fraction bars and matrices aligned; that alignment is meaningless once the
+  // text is spoken rather than drawn, and left in it makes the label a
+  // stuttering mess. The line breaks have to go for the same reason: this ends
+  // up in an SVG <title>/aria-label, which is a single label, not a document.
+  const wxString text = m_tree->ListToString();
+  wxString label;
+  label.reserve(text.length());
+  bool pendingSpace = false;
+  for (const wxUniChar c : text) {
+    if (wxIsspace(c))
+      pendingSpace = true;
+    else {
+      if (pendingSpace && !label.IsEmpty())
+        label += wxS(' ');
+      pendingSpace = false;
+      label += c;
+    }
+  }
+  return label;
+}
+
 bool Svgout::Layout() {
   if (!m_cmn.PrepareLayout(m_tree.get()))
     return false;
@@ -79,14 +110,40 @@ bool Svgout::Layout() {
   // Let's switch to a DC of the right size for our object.
   auto size = m_cmn.GetSize();
   auto *config = m_cmn.GetConfiguration();
+#if wxCHECK_VERSION(3, 3, 3)
+  // wxWidgets 3.3.3 and up let us name the document, which turns the whole
+  // file from an anonymous picture into something a screen reader can
+  // announce. Older wxWidgets simply produces the same SVG as before -- note
+  // that the label is computed inside the guard too, so it cannot become an
+  // unused variable there.
+  const wxString text = AccessibleText();
+  wxSVGFileDC dc(m_cmn.GetFilename(), size.x, size.y, 20 * m_cmn.GetScale(),
+                 text);
+#else
   wxSVGFileDC dc(m_cmn.GetFilename(), size.x, size.y, 20 * m_cmn.GetScale());
+#endif
   m_cmn.SetRecalculationContext(&dc);
 #if wxCHECK_VERSION(3, 1, 0)
   dc.SetBitmapHandler(new wxSVGBitmapEmbedHandler());
 #endif
 
   config->SetRecalcContext(dc);
+#if wxCHECK_VERSION(3, 3, 3)
+  {
+    // role="math" tells assistive technology that this group is an equation
+    // rather than decoration, and aria-label carries its text form. The group
+    // has to be closed before dc goes out of scope, hence the extra block:
+    // wxSVGAccessibleGroup emits the closing </g> from its destructor.
+    wxSVGAttributes attributes;
+    attributes.Role(wxS("math"));
+    if (!text.IsEmpty())
+      attributes.AriaLabel(text);
+    wxSVGAccessibleGroup group(dc, attributes);
+    m_cmn.Draw(m_tree.get());
+  }
+#else
   m_cmn.Draw(m_tree.get());
+#endif
   config->UnsetContext();
   // std::cerr<<"cfg1="<<config<<", cfg2="<<m_tree.get()->GetConfiguration()<<"\n";
   // std::cerr<<"LayoutEnd\n";

--- a/src/graphical_io/SVGout.h
+++ b/src/graphical_io/SVGout.h
@@ -60,6 +60,14 @@ public:
   std::unique_ptr<wxCustomDataObject> GetDataObject();
 
 private:
+  /*! The plain-text form of the rendered cells, for use as an accessible label
+
+    Empty if there is nothing to render. Line breaks are folded into spaces:
+    the result is used as a single SVG <title>/aria-label, which is a label,
+    not a document.
+  */
+  wxString AccessibleText() const;
+
   std::unique_ptr<Cell> m_tree;
   OutCommon m_cmn;
   wxSVGFileDC m_recalculationDc;

--- a/test/unit_tests/test_WorksheetExport.cpp
+++ b/test/unit_tests/test_WorksheetExport.cpp
@@ -359,6 +359,41 @@ static void RequireImgSrcsExist(const wxString &html, const wxString &htmlDir) {
   "1", a comma) legitimately leave more slack, so only the non-blank check
   applies to them.
 */
+/*! Every exported equation SVG must be labelled for assistive technology.
+
+  An <img> pointing at an SVG is an opaque picture to a screen reader: the
+  maths inside it is drawn as anonymous paths, so without a label the reader
+  announces nothing useful. wxWidgets 3.3.3 gives wxSVGFileDC a document
+  <title> and accessible groups, and Svgout uses both (GH #2230): the document
+  is titled with the equation's text form, and the drawing is wrapped in a
+  role="math" group carrying the same text as aria-label.
+
+  Guarded on the wxWidgets version exactly like the code under test, so on an
+  older wxWidgets this simply doesn't apply rather than failing.
+*/
+static void RequireSvgIsLabelled(const wxString &htmlDir) {
+#if wxCHECK_VERSION(3, 3, 3)
+  const wxString imgDir = htmlDir + wxS("/doc_htmlimg");
+  wxArrayString svgs;
+  wxDir::GetAllFiles(imgDir, &svgs, wxS("*.svg"), wxDIR_FILES);
+  REQUIRE(svgs.GetCount() > 0);
+  for (const wxString &svg : svgs) {
+    INFO("equation svg: " << svg.ToStdString());
+    const wxString xml = ReadTextFile(svg);
+    REQUIRE(xml.Contains(wxS("role=\"math\"")));
+    REQUIRE(xml.Contains(wxS("aria-label=\"")));
+    REQUIRE(xml.Contains(wxS("<title>")));
+    // The label must not be empty, and must not have been left as the raw
+    // multi-line ASCII-art text: it is spoken, so Svgout folds whitespace.
+    REQUIRE_FALSE(xml.Contains(wxS("aria-label=\"\"")));
+    REQUIRE_FALSE(xml.Contains(wxS("<title></title>")));
+    REQUIRE_FALSE(xml.Contains(wxS("aria-label=\"  ")));
+  }
+#else
+  wxUnusedVar(htmlDir);
+#endif
+}
+
 static void RequireBitmapsNotClipped(const wxString &htmlDir) {
   const wxString imgDir = htmlDir + wxS("/doc_htmlimg");
   wxArrayString pngs;
@@ -485,6 +520,10 @@ SCENARIO("HTML export succeeds, is deterministic and contains the document") {
       // (a BitmapScale double-magnification regression, see helper).
       if (eq.format == Configuration::bitmap)
         RequireBitmapsNotClipped(dir1);
+      // The svg flavor must label its equations for screen readers (see
+      // helper); an unlabelled SVG is an anonymous picture to them.
+      if (eq.format == Configuration::svg)
+        RequireSvgIsLabelled(dir1);
       // Both MathML flavors emit native <math> with the label beside it as
       // HTML. MathML Core dropped <mlabeledtr>, so it must never appear.
       if (eq.format == Configuration::mathML ||


### PR DESCRIPTION
Closes #2230.

An `<img>` pointing at an SVG is an opaque picture to assistive technology: the maths inside is drawn as anonymous paths, so a screen reader meeting an exported equation announces nothing useful. wxWidgets 3.3.3 added the two pieces needed to fix that — a document title on `wxSVGFileDC`, and accessible groups that emit a `<g>` with ARIA attributes — so `Svgout` now uses both.

The document is titled with the equation's text form, and the drawing is wrapped in a group carrying `role="math"` plus that same text as `aria-label`: the role tells assistive technology this is an equation rather than decoration, and the label is what actually gets spoken. This reaches both users of `Svgout` — the HTML export's equation images and "Copy as SVG".

```xml
<title>(%o11) x^2 + 1 / x</title>
<g aria-label="(%o11) x^2 + 1 / x" role="math">
```

### Where the label comes from

`ListToString()`, the same plain-text rendering the clipboard and the `.wxm` exporter use — so what is spoken matches what copying the cell as text would give, and, in the HTML export, matches the `alt` text already emitted on the `<img>`. No second source of truth.

### Whitespace is folded

2-D ASCII-art maths pads its lines with long space runs and tabs to keep fraction bars and matrices aligned; that alignment carries no meaning once the text is spoken, and left in it makes the label a stuttering mess. Line breaks go for the same reason: the result is a single label, not a document. (Found by dumping real exported SVGs rather than assuming.)

### Version gating

Everything is behind `wxCHECK_VERSION(3, 3, 3)`, **including the computation of the label itself**, so on an older wxWidgets nothing changes and no variable is left unused for `-Wall -Wextra` to complain about.

### Test

`test_WorksheetExport` gains `RequireSvgIsLabelled`, asserting every exported `.svg` carries `role="math"`, a non-empty `aria-label` and a non-empty `<title>`. Verified **red before the fix and green after**; `WorksheetClipboard`, which drives the same class, stays green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q65eoSF1N7jzjdTHpBsq4Z