### PR TITLE
Let the compiler catch unused instances of our value classes (GH #2232)

### DIFF
--- a/src/Compat.h
+++ b/src/Compat.h
@@ -20,14 +20,18 @@
 //  SPDX-License-Identifier: GPL-2.0+
 
 /*! \file
-  Small C++ standard-library compatibility shims.
+  Small compatibility shims for older toolchains and older wxWidgets.
 
   wxMaxima targets C++20 but aims to keep building on toolchains a few years
   behind. This header provides minimal fall-backs for std features that may be
   missing there: std::jthread / std::stop_token / std::stop_source, and
   std::ranges::contains. These were historically carried in Version.h; they live
-  here now because they have nothing to do with the version and are pure,
-  CMake-independent C++ (so this header is a plain committed file, not generated).
+  here now because they have nothing to do with the version and are
+  CMake-independent (so this header is a plain committed file, not generated).
+
+  It also carries the same kind of fall-back for wxWidgets macros that only
+  exist in newer wxWidgets than the 3.0.5 we still support - currently
+  wxWARN_UNUSED, see its documentation at the bottom of this file.
 */
 
 #ifndef WXM_COMPAT_H
@@ -88,4 +92,28 @@ namespace ranges {
     }
 #endif
 }
+
+/*! \def wxWARN_UNUSED
+  Marks a class whose unused instances are a bug.
+
+  It expands to __attribute__((warn_unused)), which makes the compiler report a
+  local variable of that type that is never used. Plain -Wunused-variable
+  cannot do that on its own: as soon as a type has a non-trivial constructor or
+  destructor the compiler must assume the object exists for its side effects,
+  so it stops warning - which is exactly why a dead `Style style;` or
+  `MaximaTokenizer::Token token;` can sit unnoticed.
+
+  wxWidgets defines it itself from 3.2.7 on. This no-op fallback keeps wxMaxima
+  building against the older wxWidgets it still supports (3.0.5, see AGENTS.md).
+
+  The <wx/defs.h> include above the guard is load-bearing: without it this
+  header could be reached first, define the macro empty, and then wxWidgets'
+  own "#ifndef wxWARN_UNUSED" would decline to redefine it - silently turning
+  the attribute off on the very compilers that support it.
+*/
+#include <wx/defs.h>
+#ifndef wxWARN_UNUSED
+#define wxWARN_UNUSED
+#endif
+
 #endif // WXM_COMPAT_H

--- a/src/MaximaTokenizer.h
+++ b/src/MaximaTokenizer.h
@@ -30,6 +30,7 @@
 #include <wx/string.h>
 #include <wx/arrstr.h>
 #include "precomp.h"
+#include "Compat.h"   // wxWARN_UNUSED
 #include "cells/TextStyle.h"
 #include "Configuration.h"
 #include <unordered_map>
@@ -58,7 +59,10 @@ public:
   MaximaTokenizer(const wxString &commands, const Configuration * const configuration);
 
   //! A maxima code snippet from this tokenizer
-  class Token
+  // A token is a value: it holds the text and its style and does nothing
+  // else, so an unused one is dead code. The wxString member makes it
+  // non-trivial, so only this attribute can catch that.
+  class wxWARN_UNUSED Token
   {
   public:
     Token() = default;

--- a/src/cells/FontAttribs.h
+++ b/src/cells/FontAttribs.h
@@ -53,6 +53,7 @@
 #ifndef WXMAXIMA_FONTATTRIBS_H
 #define WXMAXIMA_FONTATTRIBS_H
 
+#include "Compat.h"   // wxWARN_UNUSED
 #include "EnumWrapper.h"
 #include <wx/font.h>
 #include <wx/version.h>
@@ -93,7 +94,8 @@ using AFontWeight = EnumWrapper<wxFontWeight, int16_t, wxFONTWEIGHT_NORMAL>;
  *
  * To check if a font size is null, use IsNull(), or its inverse IsValid().
  */
-class AFontSize final
+// A font size is a value: an AFontSize nobody reads is dead code.
+class wxWARN_UNUSED AFontSize final
 {
   constexpr static float Size_Unit = 0.05f;
 

--- a/src/cells/TextStyle.h
+++ b/src/cells/TextStyle.h
@@ -40,6 +40,7 @@
 #include <wx/settings.h>
 #include <cstdint>
 #include <functional>
+#include "Compat.h"   // wxWARN_UNUSED
 #include "FontAttribs.h"
 #include "FontVariantCache.h"
 #include <unordered_map>
@@ -59,7 +60,10 @@ static constexpr uint32_t MAKE_RGB(uint32_t r, uint32_t g, uint32_t b)
  * for fonts with this font name.
  *
  */
-class Style final
+// A style is a value: constructing one and never asking it anything is dead
+// code. Its user-provided copy constructor makes it non-trivial, which is
+// exactly the case plain -Wunused-variable stops warning about.
+class wxWARN_UNUSED Style final
 {
 public:
   Style();


### PR DESCRIPTION
Closes #2232.

wxWidgets marks its own value classes — `wxPoint`, `wxSize`, `wxRect`, `wxColour`, `wxDateTime`, `wxArrayString` — with `wxWARN_UNUSED`, i.e. `__attribute__((warn_unused))`.

It exists because `-Wunused-variable` goes quiet as soon as a type has a non-trivial constructor or destructor: from then on the compiler must assume the object exists for its side effects, so a dead local of that type is never reported. For a pure value that assumption is wrong, and the dead code sits there unnoticed.

wxMaxima has value classes of exactly that shape, so they get the same treatment:

- **`Style`** — its user-provided copy constructor makes it non-trivial
- **`MaximaTokenizer::Token`** — holds a `wxString`
- **`AFontSize`**

Deliberately no wider than that. The attribute only earns its keep on types where an unused instance is meaningless, and it would be actively wrong on anything whose constructor or destructor *is* the point — an RAII guard, or a `CellPtr`, whose construction registers with the observed cell.

### The fallback, and a trap worth knowing about

wxWidgets only defines `wxWARN_UNUSED` from 3.2.7 on and we still support 3.0.5, so `Compat.h` (which already carries this kind of shim) gets a no-op fallback.

The `#include <wx/defs.h>` above that fallback is **load-bearing**: without it, `Compat.h` could be reached first, define the macro empty, and then wxWidgets' own `#ifndef wxWARN_UNUSED` would decline to redefine it — silently disabling the attribute on precisely the compilers that support it.

### On the name

The issue asks for `wxNO_UNUSED_VARIABLES`, which does not exist in wxWidgets. `wxWARN_UNUSED` is the macro that does what the issue describes.

### Verification

An attribute that quietly does nothing is worse than no attribute, so this was checked both ways:

- A probe declaring one unused local of each of the three types produces three `-Wunused-variable` diagnostics that were **absent beforehand**.
- A full rebuild — 359 steps, with `-Wall -Werror -Wextra` as CI uses — is **clean**, so no existing dead locals of these types were hiding anywhere.

That means this is prophylactic rather than a bug fix, and there is no NEWS.md entry because nothing user-visible changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q65eoSF1N7jzjdTHpBsq4Z