### PR TITLE
Restore 464 translations wiped by a Crowdin sync race, fix check-pot-coverage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -560,6 +560,49 @@ tried without rebuilding.
   (a `ctest`, needs neither a build nor gettext) now fails the build if any
   source file sits deeper than the glob reaches, or if a file containing a
   `_("...")` marker is unreferenced by the committed POT.
+- **A Crowdin sync can silently wipe existing translations if it's built from
+  a stale base -- confirmed twice now (2026-08-05 and 2026-08-10), both times
+  around the same subdir-glob restoration work above, and both times a plain
+  git merge, not a Crowdin misconfiguration found so far.** The second
+  incident: PR #2241 ("Restore 7083 translations the flat `src/*` gettext
+  glob had dropped") merged at 19:59:43; Crowdin's own `l10n_main2` branch
+  (a long-lived branch it force-pushes to repeatedly, see PRs #2187/#2199/
+  #2239/#2244) had already branched off main at 19:55:40 -- 4 minutes
+  *before* #2241 -- and didn't re-sync before its own PR #2244 merged 30
+  minutes later. Confirmed directly from the commit graph, not inferred:
+  `git merge-base <l10n_main2 tip> <main-before-#2241>` equals that
+  pre-#2241 commit exactly, i.e. Crowdin's new per-language commits were
+  still parented on the stale base. The result once merged: a plain 3-way
+  git merge doesn't understand PO-file semantics, so wherever Crowdin's
+  diff and the restore's diff touched entries in the same file without a
+  textual line conflict, whichever side's hunk landed could silently win --
+  in this case, largely Crowdin's older, translation-poorer version. Net
+  effect measured with `polib` (msgid+msgctxt keyed diff, not
+  `msgfmt --statistics` counts alone, since those can't tell "a translation
+  reverted to worse text" from "line-wrapping changed"): 464 translations
+  across 16 languages went from non-empty to empty, and *zero* went the
+  other way -- a real regression, not translator churn. Recovered with a
+  surgical text-level patch (locate each entry's own line range via
+  `polib`'s `.linenum` in both the pre-regression and current file
+  independently, splice only the `msgstr` block, leave everything else
+  byte-identical) -- reusing `polib`'s own serializer to resave the whole
+  file was tried first and rejected: it reformats every line's wrapping,
+  turning a 464-line fix into a ~200KB diff across 16 files that would have
+  buried the actual change completely. If this happens a third time, the
+  fix is on the Crowdin project side (a webhook trigger that also
+  re-syncs sources immediately before generating its PR, not just before
+  the languages it already had), not on wxMaxima's own git handling -- ask
+  Crowdin support directly, since this session cannot access Crowdin's
+  own dashboard/API to confirm the exact trigger without credentials.
+- **`test/check-pot-coverage.cmake` needs `cmake_policy(SET CMP0057 NEW)`
+  explicitly.** It runs in script mode (`cmake -P`), which does not inherit
+  the top-level `CMakeLists.txt`'s policy settings -- without this line,
+  `if(NOT f IN_LIST covered)` hard-errors with "Unknown arguments
+  specified" on every invocation, on any CMake version, confirmed against a
+  clean `main` checkout (not something introduced by unrelated local
+  changes). `IN_LIST` needs CMP0057 set to `NEW` to be recognized as an
+  operator at all in `if()`; the default/OLD behavior predates that
+  operator's existence.
 - **Don't drop `--previous` from `msgmerge`.** It is what keeps the
   `#| msgid` comment recording what a fuzzy entry used to say, which is how a
   translator works out *why* something went fuzzy (`00ba34121`). A plain

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,15 @@
 # Current development version
 
+- Restored 464 UI/manual translations across 16 languages (Catalan, Czech,
+  Danish, German, Greek, Spanish, Finnish, French, Galician, Hungarian,
+  Italian, Kabyle, Polish, Russian, Turkish, Ukrainian) that a Crowdin sync
+  had wiped to empty. The Crowdin export that produced this had branched a
+  few minutes before an unrelated PR restored translations for source files
+  under `src/`'s subdirectories, then merged half an hour later without
+  ever picking up that change -- a race, not a Crowdin misconfiguration
+  found so far. Also fixed a CMake policy bug in the just-added
+  `check-pot-coverage` CI guard (script mode doesn't inherit the top-level
+  policy settings, so its `IN_LIST` check unconditionally errored out).
 - Equations exported as SVG now carry their text form, so a screen reader can
   read them out instead of announcing an anonymous picture (GH #2230). Both
   the HTML export's equation images and the SVG that "Copy as SVG" puts on the

--- a/locales/wxMaxima/ca.po
+++ b/locales/wxMaxima/ca.po
@@ -63,11 +63,11 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1571
 msgid "      -X '--dynamic-space-size <int>'"
-msgstr ""
+msgstr "      -X '--dynamic-space-size <int>'"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1551
 msgid "      -l <name>"
-msgstr ""
+msgstr "      -l <name>"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1557
 msgid "      -u <versionnumber>"
@@ -434,7 +434,7 @@ msgstr "Integració &numèrica"
 
 #: ../../src/wizards/SumWiz.cpp:44
 msgid "&Nusum"
-msgstr ""
+msgstr "&Nusum"
 
 #: ../../src/main.cpp:700
 msgid "&Open\tCtrl+O"
@@ -608,7 +608,7 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:77
 msgid "1/2"
-msgstr ""
+msgstr "1/2"
 
 #: ../../src/sidebars/DrawSidebar.cpp:45
 msgid "2D"
@@ -1291,7 +1291,7 @@ msgstr ""
 
 #: ../../src/wizards/BC2Wiz.cpp:59
 msgid "BC2"
-msgstr ""
+msgstr "BC2"
 
 #: ../../src/MaximaManual.cpp:559
 msgid "Background task that compiles the Manual anchors scheduled."
@@ -1342,7 +1342,7 @@ msgstr "A més a més de la funcionalitat de desfer global que està activada qu
 
 #: ../../src/sidebars/GreekSidebar.cpp:179
 msgid "Beta"
-msgstr ""
+msgstr "Beta"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1898
 msgid "Bitmap"
@@ -1921,7 +1921,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:199
 msgid "Chi"
-msgstr ""
+msgstr "Chi"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:189
 msgid "Chinese (Simplified)"
@@ -2408,7 +2408,7 @@ msgstr ""
 #: ../../src/wizards/IntegrateWiz.cpp:208 ../../src/wizards/LimitWiz.cpp:133
 #: ../../src/wizards/SeriesWiz.cpp:105
 msgid "Constant"
-msgstr ""
+msgstr "Constant"
 
 #: ../../src/MaximaCommandMenus.cpp:1102
 msgid "Construct a fraction"
@@ -2882,7 +2882,7 @@ msgstr ""
 
 #: ../../src/worksheet/Worksheet.cpp:6125
 msgid "Cursor"
-msgstr ""
+msgstr "Cursor"
 
 #: ../../src/Styles.cpp:126
 msgid "Cursor color"
@@ -3099,7 +3099,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:181
 msgid "Delta"
-msgstr ""
+msgstr "Delta"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:110
 #: ../../src/worksheet/WorksheetContextMenu.cpp:558
@@ -3643,7 +3643,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:182
 msgid "Epsilon"
-msgstr ""
+msgstr "Epsilon"
 
 #: ../../src/MaximaCommandMenus.cpp:299
 msgid "Epsilon:"
@@ -3736,7 +3736,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:184
 msgid "Eta"
-msgstr ""
+msgstr "Eta"
 
 #: ../../src/sidebars/TableOfContents.cpp:513
 msgid "Evaluate"
@@ -4537,7 +4537,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2047
 msgid "Fonts"
-msgstr ""
+msgstr "Fonts"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:442
 msgid "For each Text-, Sectioning or code cell wxMaxima can display a bracket showing the extend of the cell and allowing to fold it. This setting now tells if this bracket is to be printed, as well."
@@ -4565,7 +4565,7 @@ msgstr ""
 
 #: ../../src/wizards/Plot2dWiz.cpp:69 ../../src/wizards/Plot3dWiz.cpp:60
 msgid "Format:"
-msgstr ""
+msgstr "Format:"
 
 #: ../../src/worksheet/Worksheet.cpp:301 ../../src/wxMaxima.cpp:3584
 msgid "Forwarding the keyboard focus to a text control"
@@ -4717,7 +4717,7 @@ msgstr "Galleg"
 
 #: ../../src/sidebars/GreekSidebar.cpp:180
 msgid "Gamma"
-msgstr ""
+msgstr "Gamma"
 
 #: ../../src/wxMaximaFrame.cpp:320
 msgid "General Math"
@@ -5670,7 +5670,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:186
 msgid "Iota"
-msgstr ""
+msgstr "Iota"
 
 #: ../../src/MaximaCommandMenus.cpp:4210
 msgid "Is Char 1 greater than Char2, if case is ignored?"
@@ -5858,11 +5858,11 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:210
 msgid "Kabyle"
-msgstr ""
+msgstr "Kabyle"
 
 #: ../../src/sidebars/GreekSidebar.cpp:187
 msgid "Kappa"
-msgstr ""
+msgstr "Kappa"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:864
 #, c-format
@@ -6926,7 +6926,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:189
 msgid "Mu"
-msgstr ""
+msgstr "Mu"
 
 #: ../../src/wxMaximaFrame.cpp:1390
 msgid "Multiplication, exponent and similar"
@@ -7188,7 +7188,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:190
 msgid "Nu"
-msgstr ""
+msgstr "Nu"
 
 #: ../../src/MaximaCommandMenus.cpp:177
 msgid "Num. deg:"
@@ -7348,11 +7348,11 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:201
 msgid "Omega"
-msgstr ""
+msgstr "Omega"
 
 #: ../../src/sidebars/GreekSidebar.cpp:192
 msgid "Omicron"
-msgstr ""
+msgstr "Omicron"
 
 #: ../../src/wxMaximaFrame.cpp:1093
 msgid "On all errors"
@@ -7631,11 +7631,11 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:198
 msgid "Phi"
-msgstr ""
+msgstr "Phi"
 
 #: ../../src/sidebars/GreekSidebar.cpp:193
 msgid "Pi"
-msgstr ""
+msgstr "Pi"
 
 #: ../../src/sidebars/StatSidebar.cpp:94
 msgid "Piechart..."
@@ -7987,7 +7987,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:200
 msgid "Psi"
-msgstr ""
+msgstr "Psi"
 
 #: ../../src/wxMaximaFrame.cpp:1792
 msgid "Push"
@@ -8569,7 +8569,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:194
 msgid "Rho"
-msgstr ""
+msgstr "Rho"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2015
 msgid "Right"
@@ -9358,7 +9358,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:195
 msgid "Sigma"
-msgstr ""
+msgstr "Sigma"
 
 #: ../../src/dialogs/FindReplacePane.cpp:88
 msgid "Simple"
@@ -10039,7 +10039,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:196
 msgid "Tau"
-msgstr ""
+msgstr "Tau"
 
 #: ../../src/MaximaCommandMenus.cpp:181
 msgid "Taylor series"
@@ -10496,7 +10496,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:185
 msgid "Theta"
-msgstr ""
+msgstr "Theta"
 
 #: ../../src/dialogs/LicenseDialog.cpp:85
 msgid "Third-party notices"
@@ -11384,7 +11384,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:191
 msgid "Xi"
-msgstr ""
+msgstr "Xi"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:728
 msgid "Yes"
@@ -11440,7 +11440,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:183
 msgid "Zeta"
-msgstr ""
+msgstr "Zeta"
 
 #: ../../src/wxMaximaFrame.cpp:846
 msgid "Zoom &In\tCtrl++"
@@ -11480,7 +11480,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:151
 msgid "alpha"
-msgstr ""
+msgstr "alpha"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:95
 msgid "and"
@@ -11512,7 +11512,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:152
 msgid "beta"
-msgstr ""
+msgstr "beta"
 
 #: ../../src/wizards/LimitWiz.cpp:42
 msgid "both sides"
@@ -11524,7 +11524,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:172
 msgid "chi"
-msgstr ""
+msgstr "chi"
 
 #: ../../src/MaximaFileIO.cpp:318
 #, c-format
@@ -11538,11 +11538,11 @@ msgstr "pre-determinat"
 
 #: ../../src/sidebars/GreekSidebar.cpp:154
 msgid "delta"
-msgstr ""
+msgstr "delta"
 
 #: ../../src/wizards/MatWiz.cpp:159
 msgid "diagonal"
-msgstr ""
+msgstr "diagonal"
 
 #: ../../src/cells/FracCell.cpp:73
 msgid "diff(): Cannot find the multiplication sign I should hide"
@@ -11562,15 +11562,15 @@ msgstr "buit"
 
 #: ../../src/sidebars/GreekSidebar.cpp:155
 msgid "epsilon"
-msgstr ""
+msgstr "epsilon"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:100
 msgid "equivalent"
-msgstr ""
+msgstr "equivalent"
 
 #: ../../src/sidebars/GreekSidebar.cpp:157
 msgid "eta"
-msgstr ""
+msgstr "eta"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:799
 msgid "ev() shall evaluate this automatically"
@@ -11620,11 +11620,11 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:153
 msgid "gamma"
-msgstr ""
+msgstr "gamma"
 
 #: ../../src/wizards/MatWiz.cpp:159
 msgid "general"
-msgstr ""
+msgstr "general"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1630
 msgid "gnuplot: Without command console"
@@ -11655,15 +11655,15 @@ msgstr "intersecció"
 
 #: ../../src/sidebars/GreekSidebar.cpp:159
 msgid "iota"
-msgstr ""
+msgstr "iota"
 
 #: ../../src/sidebars/GreekSidebar.cpp:160
 msgid "kappa"
-msgstr ""
+msgstr "kappa"
 
 #: ../../src/sidebars/GreekSidebar.cpp:161
 msgid "lambda"
-msgstr ""
+msgstr "lambda"
 
 #: ../../src/wizards/LimitWiz.cpp:42
 msgid "left"
@@ -11695,7 +11695,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:162
 msgid "mu"
-msgstr ""
+msgstr "mu"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:120
 msgid "much greater than"
@@ -11720,7 +11720,7 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:98
 msgid "nand"
-msgstr ""
+msgstr "nand"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:772
 msgid "nary: f(x, f(y,z)) = foo(x,y,z)"
@@ -11728,11 +11728,11 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:99
 msgid "nor"
-msgstr ""
+msgstr "nor"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:102
 msgid "not"
-msgstr ""
+msgstr "not"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:116
 msgid "not bytewise identical"
@@ -11756,7 +11756,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:163
 msgid "nu"
-msgstr ""
+msgstr "nu"
 
 #: ../../src/MaximaCommandMenus.cpp:1233
 msgid "n×1 Matrix b:"
@@ -11764,15 +11764,15 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:174
 msgid "omega"
-msgstr ""
+msgstr "omega"
 
 #: ../../src/sidebars/GreekSidebar.cpp:165
 msgid "omicron"
-msgstr ""
+msgstr "omicron"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:96
 msgid "or"
-msgstr ""
+msgstr "or"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:793
 msgid "outative: f(2*x) = 2*f(x)"
@@ -11793,11 +11793,11 @@ msgstr "símbol parcial"
 
 #: ../../src/sidebars/GreekSidebar.cpp:171
 msgid "phi"
-msgstr ""
+msgstr "phi"
 
 #: ../../src/sidebars/GreekSidebar.cpp:166
 msgid "pi"
-msgstr ""
+msgstr "pi"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:101
 msgid "plus or minus"
@@ -11830,7 +11830,7 @@ msgstr "proporcional a "
 
 #: ../../src/sidebars/GreekSidebar.cpp:173
 msgid "psi"
-msgstr ""
+msgstr "psi"
 
 #: ../../src/MaximaCommandMenus.cpp:642
 msgid "radcan() is a powerful tools for simplification trigonometric functions but needs to be taken with care: If a function has more than one branch radcan uses the one that looks like it would fit best, not necessarily the one that makes sense for the problem that resulted in the Expression that is to be simplified."
@@ -11858,7 +11858,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:167
 msgid "rho"
-msgstr ""
+msgstr "rho"
 
 #: ../../src/wizards/LimitWiz.cpp:42
 msgid "right"
@@ -11882,7 +11882,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:168
 msgid "sigma"
-msgstr ""
+msgstr "sigma"
 
 #: ../../src/MaximaCommandMenus.cpp:3507
 msgid "solve() will solve a list of equations only if for n independent equations there are n variables to solve to.\n"
@@ -11922,7 +11922,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:169
 msgid "tau"
-msgstr ""
+msgstr "tau"
 
 #: ../../src/cells/TextCell.cpp:340
 msgid "the [] operator tried to extract an element of a list, a matrix, an equation or an array. But instead of an integer number something was used whose numerical value is unknown or not an integer.\n"
@@ -11943,7 +11943,7 @@ msgstr "no hi ha"
 
 #: ../../src/sidebars/GreekSidebar.cpp:158
 msgid "theta"
-msgstr ""
+msgstr "theta"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:78
 msgid "to the power of 2"
@@ -11972,7 +11972,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:170
 msgid "upsilon"
-msgstr ""
+msgstr "upsilon"
 
 #: ../../src/wxMaximaFrame.cpp:1741
 msgid "use as function arguments"
@@ -12155,7 +12155,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:709
 msgid "x"
-msgstr ""
+msgstr "x"
 
 #: ../../src/wizards/DrawWiz.cpp:266
 msgid "x axis label"
@@ -12171,7 +12171,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:164
 msgid "xi"
-msgstr ""
+msgstr "xi"
 
 #: ../../src/MaximaFileIO.cpp:408 ../../src/MaximaFileIO.cpp:566
 msgid "xml contained in the file claims not to be a wxMaxima worksheet. "
@@ -12179,7 +12179,7 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:97
 msgid "xor"
-msgstr ""
+msgstr "xor"
 
 #: ../../src/wizards/DrawWiz.cpp:279
 msgid "y axis label"
@@ -12207,7 +12207,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:156
 msgid "zeta"
-msgstr ""
+msgstr "zeta"
 
 #. type: Title #
 #: ../../info/wxmaxima.md:1

--- a/locales/wxMaxima/cs.po
+++ b/locales/wxMaxima/cs.po
@@ -63,11 +63,11 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1571
 msgid "      -X '--dynamic-space-size <int>'"
-msgstr ""
+msgstr "      -X '--dynamic-space-size <int>'"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1551
 msgid "      -l <name>"
-msgstr ""
+msgstr "      -l <name>"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1557
 msgid "      -u <versionnumber>"
@@ -490,7 +490,7 @@ msgstr "&Řešit..."
 
 #: ../../src/wizards/Plot2dWiz.cpp:42
 msgid "&Special"
-msgstr ""
+msgstr "&Special"
 
 #: ../../src/wizards/LimitWiz.cpp:45
 msgid "&Taylor series"
@@ -514,7 +514,7 @@ msgstr ""
 
 #: ../../src/wizards/Plot3dWiz.cpp:79
 msgid "&pm3d"
-msgstr ""
+msgstr "&pm3d"
 
 #: ../../src/cells/AnimationCell.cpp:475
 msgid "(Animation)"
@@ -608,7 +608,7 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:77
 msgid "1/2"
-msgstr ""
+msgstr "1/2"
 
 #: ../../src/sidebars/DrawSidebar.cpp:45
 msgid "2D"
@@ -1291,7 +1291,7 @@ msgstr ""
 
 #: ../../src/wizards/BC2Wiz.cpp:59
 msgid "BC2"
-msgstr ""
+msgstr "BC2"
 
 #: ../../src/MaximaManual.cpp:559
 msgid "Background task that compiles the Manual anchors scheduled."
@@ -5056,7 +5056,7 @@ msgstr ""
 
 #: ../../src/sidebars/StatSidebar.cpp:85
 msgid "Histogram..."
-msgstr ""
+msgstr "Histogram..."
 
 #: ../../src/wxMaximaFrame.cpp:250
 msgid "History"
@@ -9898,7 +9898,7 @@ msgstr ""
 
 #: ../../src/sidebars/MathSidebar.cpp:59
 msgid "Subst..."
-msgstr ""
+msgstr "Subst..."
 
 #: ../../src/MaximaCommandMenus.cpp:715 ../../src/MaximaCommandMenus.cpp:3550
 #: ../../src/MaximaCommandMenus.cpp:4560 ../../src/wizards/SubstituteWiz.cpp:53

--- a/locales/wxMaxima/da.po
+++ b/locales/wxMaxima/da.po
@@ -514,7 +514,7 @@ msgstr ""
 
 #: ../../src/wizards/Plot3dWiz.cpp:79
 msgid "&pm3d"
-msgstr ""
+msgstr "&pm3d"
 
 #: ../../src/cells/AnimationCell.cpp:475
 msgid "(Animation)"
@@ -1291,7 +1291,7 @@ msgstr ""
 
 #: ../../src/wizards/BC2Wiz.cpp:59
 msgid "BC2"
-msgstr ""
+msgstr "BC2"
 
 #: ../../src/MaximaManual.cpp:559
 msgid "Background task that compiles the Manual anchors scheduled."
@@ -4565,7 +4565,7 @@ msgstr ""
 
 #: ../../src/wizards/Plot2dWiz.cpp:69 ../../src/wizards/Plot3dWiz.cpp:60
 msgid "Format:"
-msgstr ""
+msgstr "Format:"
 
 #: ../../src/worksheet/Worksheet.cpp:301 ../../src/wxMaxima.cpp:3584
 msgid "Forwarding the keyboard focus to a text control"
@@ -11542,7 +11542,7 @@ msgstr ""
 
 #: ../../src/wizards/MatWiz.cpp:159
 msgid "diagonal"
-msgstr ""
+msgstr "diagonal"
 
 #: ../../src/cells/FracCell.cpp:73
 msgid "diff(): Cannot find the multiplication sign I should hide"

--- a/locales/wxMaxima/de.po
+++ b/locales/wxMaxima/de.po
@@ -53,23 +53,23 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1569
 msgid "      -X \"--control-stack-size <int>\""
-msgstr ""
+msgstr "      -X \"--control-stack-size <int>\""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1568
 msgid "      -X \"--dynamic-space-size <int>\""
-msgstr ""
+msgstr "      -X \"--dynamic-space-size <int>\""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1572
 msgid "      -X '--control-stack-size <int>'"
-msgstr ""
+msgstr "      -X '--control-stack-size <int>'"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1571
 msgid "      -X '--dynamic-space-size <int>'"
-msgstr ""
+msgstr "      -X '--dynamic-space-size <int>'"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1551
 msgid "      -l <name>"
-msgstr ""
+msgstr "      -l <name>"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1557
 msgid "      -u <versionnumber>"
@@ -587,7 +587,7 @@ msgstr "(f(x),x,y) mit Singularitäten und Unstetigkeiten"
 #: ../../src/wizards/DrawWiz.cpp:303 ../../src/wizards/DrawWiz.cpp:320
 #: ../../src/wizards/DrawWiz.cpp:335
 msgid "-"
-msgstr ""
+msgstr "-"
 
 #: ../../src/wizards/IntegrateWiz.cpp:192
 #: ../../src/wizards/IntegrateWiz.cpp:202
@@ -595,7 +595,7 @@ msgstr ""
 #: ../../src/wizards/IntegrateWiz.cpp:217 ../../src/wizards/LimitWiz.cpp:132
 #: ../../src/wizards/LimitWiz.cpp:142
 msgid "- Infinity"
-msgstr ""
+msgstr "- Infinity"
 
 #: ../../src/MaximaOutputAppender.cpp:116
 msgid "... [suppressed additional lines as the output is longer than allowed in the wxMaxima configuration] "
@@ -611,11 +611,11 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:77
 msgid "1/2"
-msgstr ""
+msgstr "1/2"
 
 #: ../../src/sidebars/DrawSidebar.cpp:45
 msgid "2D"
-msgstr ""
+msgstr "2D"
 
 #: ../../src/wxMaximaFrame.cpp:1350
 msgid "2D Array to Matrix..."
@@ -639,7 +639,7 @@ msgstr ""
 
 #: ../../src/sidebars/DrawSidebar.cpp:49
 msgid "3D"
-msgstr ""
+msgstr "3D"
 
 #: ../../src/wxMaxima.cpp:1836
 #, c-format
@@ -1349,11 +1349,11 @@ msgstr "wxMaxima bietet zwei Funktionen, die Änderungen rückgängig machen kö
 
 #: ../../src/sidebars/GreekSidebar.cpp:179
 msgid "Beta"
-msgstr ""
+msgstr "Beta"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1898
 msgid "Bitmap"
-msgstr ""
+msgstr "Bitmap"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1273
 msgid "Bitmap scale for export:"
@@ -1928,7 +1928,7 @@ msgstr "Prüft, ob Sie eine aktuelle Version von wxMaxima erhältlich ist."
 
 #: ../../src/sidebars/GreekSidebar.cpp:199
 msgid "Chi"
-msgstr ""
+msgstr "Chi"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:189
 msgid "Chinese (Simplified)"
@@ -2889,7 +2889,7 @@ msgstr ""
 
 #: ../../src/worksheet/Worksheet.cpp:6125
 msgid "Cursor"
-msgstr ""
+msgstr "Cursor"
 
 #: ../../src/Styles.cpp:126
 msgid "Cursor color"
@@ -3106,7 +3106,7 @@ msgstr "Trennzeichen:"
 
 #: ../../src/sidebars/GreekSidebar.cpp:181
 msgid "Delta"
-msgstr ""
+msgstr "Delta"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:110
 #: ../../src/worksheet/WorksheetContextMenu.cpp:558
@@ -3650,7 +3650,7 @@ msgstr "Umgebungsvariablen für Maxima:"
 
 #: ../../src/sidebars/GreekSidebar.cpp:182
 msgid "Epsilon"
-msgstr ""
+msgstr "Epsilon"
 
 #: ../../src/MaximaCommandMenus.cpp:299
 msgid "Epsilon:"
@@ -3745,7 +3745,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:184
 msgid "Eta"
-msgstr ""
+msgstr "Eta"
 
 #: ../../src/sidebars/TableOfContents.cpp:513
 msgid "Evaluate"
@@ -4582,7 +4582,7 @@ msgstr "For Schleife..."
 
 #: ../../src/wizards/Plot2dWiz.cpp:69 ../../src/wizards/Plot3dWiz.cpp:60
 msgid "Format:"
-msgstr ""
+msgstr "Format:"
 
 #: ../../src/worksheet/Worksheet.cpp:301 ../../src/wxMaxima.cpp:3584
 msgid "Forwarding the keyboard focus to a text control"
@@ -4734,7 +4734,7 @@ msgstr "Galicisch"
 
 #: ../../src/sidebars/GreekSidebar.cpp:180
 msgid "Gamma"
-msgstr ""
+msgstr "Gamma"
 
 #: ../../src/wxMaximaFrame.cpp:320
 msgid "General Math"
@@ -4904,7 +4904,7 @@ msgstr "Eine exakte Zahl schätzen, die diese Gleitkommazahl sein könnte"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1215
 msgid "HTML"
-msgstr ""
+msgstr "HTML"
 
 #: ../../src/MaximaCommandMenus.cpp:2279
 msgid "HTML file (*.html)|*.html|maxima batch file (*.mac)|*.mac|LaTeX file (*.tex)|*.tex"
@@ -5356,7 +5356,7 @@ msgstr ""
 #: ../../src/wizards/IntegrateWiz.cpp:215 ../../src/wizards/LimitWiz.cpp:132
 #: ../../src/wizards/LimitWiz.cpp:140
 msgid "Infinity"
-msgstr ""
+msgstr "Infinity"
 
 #: ../../src/wxMaximaFrame.cpp:1990
 msgid "Info about Maxima build"
@@ -5690,7 +5690,7 @@ msgstr "Inverse Laplacet&ransformation ..."
 
 #: ../../src/sidebars/GreekSidebar.cpp:186
 msgid "Iota"
-msgstr ""
+msgstr "Iota"
 
 #: ../../src/MaximaCommandMenus.cpp:4210
 msgid "Is Char 1 greater than Char2, if case is ignored?"
@@ -5882,7 +5882,7 @@ msgstr "Kabylisch"
 
 #: ../../src/sidebars/GreekSidebar.cpp:187
 msgid "Kappa"
-msgstr ""
+msgstr "Kappa"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:864
 #, c-format
@@ -5915,7 +5915,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1166
 msgid "LaTeX"
-msgstr ""
+msgstr "LaTeX"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1199
 msgid "LaTeX: Place exponents after, instead above subscripts"
@@ -6456,7 +6456,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:281
 msgid "Maxima"
-msgstr ""
+msgstr "Maxima"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1433
 msgid "Maxima Location"
@@ -6859,7 +6859,7 @@ msgstr "Mittelwert:"
 
 #: ../../src/sidebars/StatSidebar.cpp:55
 msgid "Median..."
-msgstr ""
+msgstr "Median..."
 
 #: ../../src/wxMaximaFrame.cpp:1965
 msgid "Memoizing"
@@ -6979,7 +6979,7 @@ msgstr "Name von x:"
 
 #: ../../src/wizards/MatWiz.cpp:163
 msgid "Name:"
-msgstr ""
+msgstr "Name:"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:216
 msgid "Nepali"
@@ -7369,7 +7369,7 @@ msgstr "Alte Variable:"
 
 #: ../../src/sidebars/GreekSidebar.cpp:201
 msgid "Omega"
-msgstr ""
+msgstr "Omega"
 
 #: ../../src/sidebars/GreekSidebar.cpp:192
 msgid "Omicron"
@@ -7652,11 +7652,11 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:198
 msgid "Phi"
-msgstr ""
+msgstr "Phi"
 
 #: ../../src/sidebars/GreekSidebar.cpp:193
 msgid "Pi"
-msgstr ""
+msgstr "Pi"
 
 #: ../../src/sidebars/StatSidebar.cpp:94
 msgid "Piechart..."
@@ -8008,7 +8008,7 @@ msgstr "Programmblock ohne lokale Variablen..."
 
 #: ../../src/sidebars/GreekSidebar.cpp:200
 msgid "Psi"
-msgstr ""
+msgstr "Psi"
 
 #: ../../src/wxMaximaFrame.cpp:1792
 msgid "Push"
@@ -8231,7 +8231,7 @@ msgstr "Nicht gespeicherte Dateien wiederherstellen"
 
 #: ../../src/sidebars/MathSidebar.cpp:56
 msgid "Rectform"
-msgstr ""
+msgstr "Rectform"
 
 #: ../../src/wxMaximaFrame.cpp:1681
 msgid "Recursive Substitute..."
@@ -8590,7 +8590,7 @@ msgstr "Änderungen rückgängig machen"
 
 #: ../../src/sidebars/GreekSidebar.cpp:194
 msgid "Rho"
-msgstr ""
+msgstr "Rho"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2015
 msgid "Right"
@@ -9381,7 +9381,7 @@ msgstr "Seitenleisten"
 
 #: ../../src/sidebars/GreekSidebar.cpp:195
 msgid "Sigma"
-msgstr ""
+msgstr "Sigma"
 
 #: ../../src/dialogs/FindReplacePane.cpp:88
 msgid "Simple"
@@ -10062,7 +10062,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:196
 msgid "Tau"
-msgstr ""
+msgstr "Tau"
 
 #: ../../src/MaximaCommandMenus.cpp:181
 msgid "Taylor series"
@@ -10523,7 +10523,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:185
 msgid "Theta"
-msgstr ""
+msgstr "Theta"
 
 #: ../../src/dialogs/LicenseDialog.cpp:85
 msgid "Third-party notices"
@@ -11406,7 +11406,7 @@ msgstr "Mimetype Information geschrieben"
 #: ../../src/wizards/DrawWiz.cpp:961 ../../src/wizards/DrawWiz.cpp:974
 #: ../../src/wizards/DrawWiz.cpp:977
 msgid "X"
-msgstr ""
+msgstr "X"
 
 #: ../../src/MathParser.cpp:1279
 msgid "XML nesting limit exceeded"
@@ -11414,7 +11414,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:191
 msgid "Xi"
-msgstr ""
+msgstr "Xi"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:728
 msgid "Yes"
@@ -11470,7 +11470,7 @@ msgstr "Ihre wxMaxima Version ist aktuell."
 
 #: ../../src/sidebars/GreekSidebar.cpp:183
 msgid "Zeta"
-msgstr ""
+msgstr "Zeta"
 
 #: ../../src/wxMaximaFrame.cpp:846
 msgid "Zoom &In\tCtrl++"
@@ -11498,7 +11498,7 @@ msgstr "[ nicht gespeichert* ]"
 
 #: ../../src/wizards/DrawWiz.cpp:819 ../../src/wizards/DrawWiz.cpp:825
 msgid "[[x_1,x_2,...],[y_1,y_2,...]]"
-msgstr ""
+msgstr "[[x_1,x_2,...],[y_1,y_2,...]]"
 
 #: ../../src/wizards/DrawWiz.cpp:814
 msgid "[x_1, x_2,...] or [x_1, x_2,...],[y_1, y_2,...] or matrix([x_1,y_1],[x_2,y_2],...)"
@@ -11511,7 +11511,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:151
 msgid "alpha"
-msgstr ""
+msgstr "alpha"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:95
 msgid "and"
@@ -11543,7 +11543,7 @@ msgstr "als Speicher für die konkreten Inhalte von Variablen"
 
 #: ../../src/sidebars/GreekSidebar.cpp:152
 msgid "beta"
-msgstr ""
+msgstr "beta"
 
 #: ../../src/wizards/LimitWiz.cpp:42
 msgid "both sides"
@@ -11555,7 +11555,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:172
 msgid "chi"
-msgstr ""
+msgstr "chi"
 
 #: ../../src/MaximaFileIO.cpp:318
 #, c-format
@@ -11569,11 +11569,11 @@ msgstr "Standard"
 
 #: ../../src/sidebars/GreekSidebar.cpp:154
 msgid "delta"
-msgstr ""
+msgstr "delta"
 
 #: ../../src/wizards/MatWiz.cpp:159
 msgid "diagonal"
-msgstr ""
+msgstr "diagonal"
 
 #: ../../src/cells/FracCell.cpp:73
 msgid "diff(): Cannot find the multiplication sign I should hide"
@@ -11593,7 +11593,7 @@ msgstr "Leere Menge"
 
 #: ../../src/sidebars/GreekSidebar.cpp:155
 msgid "epsilon"
-msgstr ""
+msgstr "epsilon"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:100
 msgid "equivalent"
@@ -11601,7 +11601,7 @@ msgstr "Äquivalent"
 
 #: ../../src/sidebars/GreekSidebar.cpp:157
 msgid "eta"
-msgstr ""
+msgstr "eta"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:799
 msgid "ev() shall evaluate this automatically"
@@ -11651,7 +11651,7 @@ msgstr "Funktion"
 
 #: ../../src/sidebars/GreekSidebar.cpp:153
 msgid "gamma"
-msgstr ""
+msgstr "gamma"
 
 #: ../../src/wizards/MatWiz.cpp:159
 msgid "general"
@@ -11686,15 +11686,15 @@ msgstr "Schnittmenge"
 
 #: ../../src/sidebars/GreekSidebar.cpp:159
 msgid "iota"
-msgstr ""
+msgstr "iota"
 
 #: ../../src/sidebars/GreekSidebar.cpp:160
 msgid "kappa"
-msgstr ""
+msgstr "kappa"
 
 #: ../../src/sidebars/GreekSidebar.cpp:161
 msgid "lambda"
-msgstr ""
+msgstr "lambda"
 
 #: ../../src/wizards/LimitWiz.cpp:42
 msgid "left"
@@ -11714,7 +11714,7 @@ msgstr "Logarithmische Skala"
 
 #: ../../src/wizards/DrawWiz.cpp:822
 msgid "matrix([x_1,x_2,...],[y_1,y_2,...])"
-msgstr ""
+msgstr "matrix([x_1,x_2,...],[y_1,y_2,...])"
 
 #: ../../src/wxMaximaFrame.cpp:1443
 msgid "max(abs(A(i,j))) (complex)"
@@ -11795,7 +11795,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:174
 msgid "omega"
-msgstr ""
+msgstr "omega"
 
 #: ../../src/sidebars/GreekSidebar.cpp:165
 msgid "omicron"
@@ -11824,11 +11824,11 @@ msgstr "Symbol für partielle Ableitung"
 
 #: ../../src/sidebars/GreekSidebar.cpp:171
 msgid "phi"
-msgstr ""
+msgstr "phi"
 
 #: ../../src/sidebars/GreekSidebar.cpp:166
 msgid "pi"
-msgstr ""
+msgstr "pi"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:101
 msgid "plus or minus"
@@ -11861,7 +11861,7 @@ msgstr "Proportional zu"
 
 #: ../../src/sidebars/GreekSidebar.cpp:173
 msgid "psi"
-msgstr ""
+msgstr "psi"
 
 #: ../../src/MaximaCommandMenus.cpp:642
 msgid "radcan() is a powerful tools for simplification trigonometric functions but needs to be taken with care: If a function has more than one branch radcan uses the one that looks like it would fit best, not necessarily the one that makes sense for the problem that resulted in the Expression that is to be simplified."
@@ -11889,7 +11889,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:167
 msgid "rho"
-msgstr ""
+msgstr "rho"
 
 #: ../../src/wizards/LimitWiz.cpp:42
 msgid "right"
@@ -11913,7 +11913,7 @@ msgstr "Der Bereich für die 2. y-Achse (automatisch, wenn leer)"
 
 #: ../../src/sidebars/GreekSidebar.cpp:168
 msgid "sigma"
-msgstr ""
+msgstr "sigma"
 
 #: ../../src/MaximaCommandMenus.cpp:3507
 msgid "solve() will solve a list of equations only if for n independent equations there are n variables to solve to.\n"
@@ -11955,7 +11955,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:169
 msgid "tau"
-msgstr ""
+msgstr "tau"
 
 #: ../../src/cells/TextCell.cpp:340
 msgid "the [] operator tried to extract an element of a list, a matrix, an equation or an array. But instead of an integer number something was used whose numerical value is unknown or not an integer.\n"
@@ -11976,7 +11976,7 @@ msgstr "Es existiert kein"
 
 #: ../../src/sidebars/GreekSidebar.cpp:158
 msgid "theta"
-msgstr ""
+msgstr "theta"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:78
 msgid "to the power of 2"
@@ -12188,7 +12188,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:709
 msgid "x"
-msgstr ""
+msgstr "x"
 
 #: ../../src/wizards/DrawWiz.cpp:266
 msgid "x axis label"
@@ -12204,7 +12204,7 @@ msgstr "Der Bereich für die x-Achse (automatisch, wenn leer)"
 
 #: ../../src/sidebars/GreekSidebar.cpp:164
 msgid "xi"
-msgstr ""
+msgstr "xi"
 
 #: ../../src/MaximaFileIO.cpp:408 ../../src/MaximaFileIO.cpp:566
 msgid "xml contained in the file claims not to be a wxMaxima worksheet. "
@@ -12240,7 +12240,7 @@ msgstr "Der Bereich für die z-Achse (automatisch, wenn leer)"
 
 #: ../../src/sidebars/GreekSidebar.cpp:156
 msgid "zeta"
-msgstr ""
+msgstr "zeta"
 
 #. type: Title #
 #: ../../info/wxmaxima.md:1

--- a/locales/wxMaxima/el.po
+++ b/locales/wxMaxima/el.po
@@ -1291,7 +1291,7 @@ msgstr ""
 
 #: ../../src/wizards/BC2Wiz.cpp:59
 msgid "BC2"
-msgstr ""
+msgstr "BC2"
 
 #: ../../src/MaximaManual.cpp:559
 msgid "Background task that compiles the Manual anchors scheduled."
@@ -11647,7 +11647,7 @@ msgstr ""
 #: ../../src/wizards/Plot3dWiz.cpp:61 ../../src/wizards/Plot3dWiz.cpp:194
 #: ../../src/wizards/Plot3dWiz.cpp:358 ../../src/wizards/Plot3dWiz.cpp:386
 msgid "inline"
-msgstr ""
+msgstr "inline"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:104
 msgid "intersection"

--- a/locales/wxMaxima/es.po
+++ b/locales/wxMaxima/es.po
@@ -53,19 +53,19 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1569
 msgid "      -X \"--control-stack-size <int>\""
-msgstr ""
+msgstr "      -X \"--control-stack-size <int>\""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1568
 msgid "      -X \"--dynamic-space-size <int>\""
-msgstr ""
+msgstr "      -X \"--dynamic-space-size <int>\""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1572
 msgid "      -X '--control-stack-size <int>'"
-msgstr ""
+msgstr "      -X '--control-stack-size <int>'"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1571
 msgid "      -X '--dynamic-space-size <int>'"
-msgstr ""
+msgstr "      -X '--dynamic-space-size <int>'"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1551
 msgid "      -l <name>"
@@ -517,7 +517,7 @@ msgstr ""
 
 #: ../../src/wizards/Plot3dWiz.cpp:79
 msgid "&pm3d"
-msgstr ""
+msgstr "&pm3d"
 
 #: ../../src/cells/AnimationCell.cpp:475
 msgid "(Animation)"
@@ -587,7 +587,7 @@ msgstr "(f(x),x,y) con singularidades+descontinuidades"
 #: ../../src/wizards/DrawWiz.cpp:303 ../../src/wizards/DrawWiz.cpp:320
 #: ../../src/wizards/DrawWiz.cpp:335
 msgid "-"
-msgstr ""
+msgstr "-"
 
 #: ../../src/wizards/IntegrateWiz.cpp:192
 #: ../../src/wizards/IntegrateWiz.cpp:202
@@ -615,7 +615,7 @@ msgstr "½"
 
 #: ../../src/sidebars/DrawSidebar.cpp:45
 msgid "2D"
-msgstr ""
+msgstr "2D"
 
 #: ../../src/wxMaximaFrame.cpp:1350
 msgid "2D Array to Matrix..."
@@ -639,7 +639,7 @@ msgstr ""
 
 #: ../../src/sidebars/DrawSidebar.cpp:49
 msgid "3D"
-msgstr ""
+msgstr "3D"
 
 #: ../../src/wxMaxima.cpp:1836
 #, c-format
@@ -1346,7 +1346,7 @@ msgstr "Junto con la funcionalidad habitual de deshacer que está activa cuando 
 
 #: ../../src/sidebars/GreekSidebar.cpp:179
 msgid "Beta"
-msgstr ""
+msgstr "Beta"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1898
 msgid "Bitmap"
@@ -2886,7 +2886,7 @@ msgstr ""
 
 #: ../../src/worksheet/Worksheet.cpp:6125
 msgid "Cursor"
-msgstr ""
+msgstr "Cursor"
 
 #: ../../src/Styles.cpp:126
 msgid "Cursor color"
@@ -3103,7 +3103,7 @@ msgstr "Delimitador:"
 
 #: ../../src/sidebars/GreekSidebar.cpp:181
 msgid "Delta"
-msgstr ""
+msgstr "Delta"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:110
 #: ../../src/worksheet/WorksheetContextMenu.cpp:558
@@ -3742,7 +3742,7 @@ msgstr "Escape a todos los caracteres especiales en una cadena. El resultado es 
 
 #: ../../src/sidebars/GreekSidebar.cpp:184
 msgid "Eta"
-msgstr ""
+msgstr "Eta"
 
 #: ../../src/sidebars/TableOfContents.cpp:513
 msgid "Evaluate"
@@ -4731,7 +4731,7 @@ msgstr "gallego"
 
 #: ../../src/sidebars/GreekSidebar.cpp:180
 msgid "Gamma"
-msgstr ""
+msgstr "Gamma"
 
 #: ../../src/wxMaximaFrame.cpp:320
 msgid "General Math"
@@ -4901,7 +4901,7 @@ msgstr "Adivina un número exacto que pudo ser dicho por este flotante"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1215
 msgid "HTML"
-msgstr ""
+msgstr "HTML"
 
 #: ../../src/MaximaCommandMenus.cpp:2279
 msgid "HTML file (*.html)|*.html|maxima batch file (*.mac)|*.mac|LaTeX file (*.tex)|*.tex"
@@ -5687,7 +5687,7 @@ msgstr "T&ransformada inversa de Laplace…"
 
 #: ../../src/sidebars/GreekSidebar.cpp:186
 msgid "Iota"
-msgstr ""
+msgstr "Iota"
 
 #: ../../src/MaximaCommandMenus.cpp:4210
 msgid "Is Char 1 greater than Char2, if case is ignored?"
@@ -5879,7 +5879,7 @@ msgstr "Kabil"
 
 #: ../../src/sidebars/GreekSidebar.cpp:187
 msgid "Kappa"
-msgstr ""
+msgstr "Kappa"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:864
 #, c-format
@@ -5912,7 +5912,7 @@ msgstr "L[inf] Normal (real)"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1166
 msgid "LaTeX"
-msgstr ""
+msgstr "LaTeX"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1199
 msgid "LaTeX: Place exponents after, instead above subscripts"
@@ -6906,7 +6906,7 @@ msgstr "Valor absoluto mínimo escrito sin exponente:"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1270
 msgid "Misc"
-msgstr ""
+msgstr "Misc"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1963
 msgid "Misc settings"
@@ -6947,7 +6947,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:189
 msgid "Mu"
-msgstr ""
+msgstr "Mu"
 
 #: ../../src/wxMaximaFrame.cpp:1390
 msgid "Multiplication, exponent and similar"
@@ -7209,7 +7209,7 @@ msgstr "Ninguna evaluación de disparador como no esté funcionando ningún proc
 
 #: ../../src/sidebars/GreekSidebar.cpp:190
 msgid "Nu"
-msgstr ""
+msgstr "Nu"
 
 #: ../../src/MaximaCommandMenus.cpp:177
 msgid "Num. deg:"
@@ -7369,7 +7369,7 @@ msgstr "Variable antigua:"
 
 #: ../../src/sidebars/GreekSidebar.cpp:201
 msgid "Omega"
-msgstr ""
+msgstr "Omega"
 
 #: ../../src/sidebars/GreekSidebar.cpp:192
 msgid "Omicron"
@@ -7656,7 +7656,7 @@ msgstr "Fi"
 
 #: ../../src/sidebars/GreekSidebar.cpp:193
 msgid "Pi"
-msgstr ""
+msgstr "Pi"
 
 #: ../../src/sidebars/StatSidebar.cpp:94
 msgid "Piechart..."
@@ -8008,7 +8008,7 @@ msgstr "Bloque del programa, ninguna variable local…"
 
 #: ../../src/sidebars/GreekSidebar.cpp:200
 msgid "Psi"
-msgstr ""
+msgstr "Psi"
 
 #: ../../src/wxMaximaFrame.cpp:1792
 msgid "Push"
@@ -9379,7 +9379,7 @@ msgstr "Barras laterales"
 
 #: ../../src/sidebars/GreekSidebar.cpp:195
 msgid "Sigma"
-msgstr ""
+msgstr "Sigma"
 
 #: ../../src/dialogs/FindReplacePane.cpp:88
 msgid "Simple"
@@ -10061,7 +10061,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:196
 msgid "Tau"
-msgstr ""
+msgstr "Tau"
 
 #: ../../src/MaximaCommandMenus.cpp:181
 msgid "Taylor series"
@@ -10532,7 +10532,7 @@ msgstr "Hubo un error en el XML que describiría el mensaje de la barra de estad
 
 #: ../../src/sidebars/GreekSidebar.cpp:185
 msgid "Theta"
-msgstr ""
+msgstr "Theta"
 
 #: ../../src/dialogs/LicenseDialog.cpp:85
 msgid "Third-party notices"
@@ -11054,7 +11054,7 @@ msgstr "Cota superior:"
 
 #: ../../src/sidebars/GreekSidebar.cpp:197
 msgid "Upsilon"
-msgstr ""
+msgstr "Upsilon"
 
 #: ../../src/wxMaximaFrame.cpp:833
 msgid "Use \"<\" and \">\" as parenthesis for matrices"
@@ -11424,7 +11424,7 @@ msgstr "Ha escrito el informe de tipo mime"
 #: ../../src/wizards/DrawWiz.cpp:961 ../../src/wizards/DrawWiz.cpp:974
 #: ../../src/wizards/DrawWiz.cpp:977
 msgid "X"
-msgstr ""
+msgstr "X"
 
 #: ../../src/MathParser.cpp:1279
 msgid "XML nesting limit exceeded"
@@ -11432,7 +11432,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:191
 msgid "Xi"
-msgstr ""
+msgstr "Xi"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:728
 msgid "Yes"
@@ -11488,7 +11488,7 @@ msgstr "La versión de wxMaxima está actualizada."
 
 #: ../../src/sidebars/GreekSidebar.cpp:183
 msgid "Zeta"
-msgstr ""
+msgstr "Zeta"
 
 #: ../../src/wxMaximaFrame.cpp:846
 msgid "Zoom &In\tCtrl++"
@@ -11560,7 +11560,7 @@ msgstr "como almacén para valores actuales desde variables"
 
 #: ../../src/sidebars/GreekSidebar.cpp:152
 msgid "beta"
-msgstr ""
+msgstr "beta"
 
 #: ../../src/wizards/LimitWiz.cpp:42
 msgid "both sides"
@@ -11586,11 +11586,11 @@ msgstr "predeterminado"
 
 #: ../../src/sidebars/GreekSidebar.cpp:154
 msgid "delta"
-msgstr ""
+msgstr "delta"
 
 #: ../../src/wizards/MatWiz.cpp:159
 msgid "diagonal"
-msgstr ""
+msgstr "diagonal"
 
 #: ../../src/cells/FracCell.cpp:73
 msgid "diff(): Cannot find the multiplication sign I should hide"
@@ -11618,7 +11618,7 @@ msgstr "equivalente"
 
 #: ../../src/sidebars/GreekSidebar.cpp:157
 msgid "eta"
-msgstr ""
+msgstr "eta"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:799
 msgid "ev() shall evaluate this automatically"
@@ -11703,15 +11703,15 @@ msgstr "intersección"
 
 #: ../../src/sidebars/GreekSidebar.cpp:159
 msgid "iota"
-msgstr ""
+msgstr "iota"
 
 #: ../../src/sidebars/GreekSidebar.cpp:160
 msgid "kappa"
-msgstr ""
+msgstr "kappa"
 
 #: ../../src/sidebars/GreekSidebar.cpp:161
 msgid "lambda"
-msgstr ""
+msgstr "lambda"
 
 #: ../../src/wizards/LimitWiz.cpp:42
 msgid "left"
@@ -11743,7 +11743,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:162
 msgid "mu"
-msgstr ""
+msgstr "mu"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:120
 msgid "much greater than"
@@ -11804,7 +11804,7 @@ msgstr "enésimo"
 
 #: ../../src/sidebars/GreekSidebar.cpp:163
 msgid "nu"
-msgstr ""
+msgstr "nu"
 
 #: ../../src/MaximaCommandMenus.cpp:1233
 msgid "n×1 Matrix b:"
@@ -11812,7 +11812,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:174
 msgid "omega"
-msgstr ""
+msgstr "omega"
 
 #: ../../src/sidebars/GreekSidebar.cpp:165
 msgid "omicron"
@@ -11845,7 +11845,7 @@ msgstr "fi"
 
 #: ../../src/sidebars/GreekSidebar.cpp:166
 msgid "pi"
-msgstr ""
+msgstr "pi"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:101
 msgid "plus or minus"
@@ -11878,7 +11878,7 @@ msgstr "proporcional a"
 
 #: ../../src/sidebars/GreekSidebar.cpp:173
 msgid "psi"
-msgstr ""
+msgstr "psi"
 
 #: ../../src/MaximaCommandMenus.cpp:642
 msgid "radcan() is a powerful tools for simplification trigonometric functions but needs to be taken with care: If a function has more than one branch radcan uses the one that looks like it would fit best, not necessarily the one that makes sense for the problem that resulted in the Expression that is to be simplified."
@@ -11974,7 +11974,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:169
 msgid "tau"
-msgstr ""
+msgstr "tau"
 
 #: ../../src/cells/TextCell.cpp:340
 msgid "the [] operator tried to extract an element of a list, a matrix, an equation or an array. But instead of an integer number something was used whose numerical value is unknown or not an integer.\n"
@@ -11995,7 +11995,7 @@ msgstr "no hay"
 
 #: ../../src/sidebars/GreekSidebar.cpp:158
 msgid "theta"
-msgstr ""
+msgstr "theta"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:78
 msgid "to the power of 2"
@@ -12024,7 +12024,7 @@ msgstr "sin título"
 
 #: ../../src/sidebars/GreekSidebar.cpp:170
 msgid "upsilon"
-msgstr ""
+msgstr "upsilon"
 
 #: ../../src/wxMaximaFrame.cpp:1741
 msgid "use as function arguments"
@@ -12207,7 +12207,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:709
 msgid "x"
-msgstr ""
+msgstr "x"
 
 #: ../../src/wizards/DrawWiz.cpp:266
 msgid "x axis label"
@@ -12223,7 +12223,7 @@ msgstr "rango x (automático si incompleto)"
 
 #: ../../src/sidebars/GreekSidebar.cpp:164
 msgid "xi"
-msgstr ""
+msgstr "xi"
 
 #: ../../src/MaximaFileIO.cpp:408 ../../src/MaximaFileIO.cpp:566
 msgid "xml contained in the file claims not to be a wxMaxima worksheet. "
@@ -12259,7 +12259,7 @@ msgstr "rango z (automático si incompleto)"
 
 #: ../../src/sidebars/GreekSidebar.cpp:156
 msgid "zeta"
-msgstr ""
+msgstr "zeta"
 
 #. type: Title #
 #: ../../info/wxmaxima.md:1

--- a/locales/wxMaxima/fi.po
+++ b/locales/wxMaxima/fi.po
@@ -608,7 +608,7 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:77
 msgid "1/2"
-msgstr ""
+msgstr "1/2"
 
 #: ../../src/sidebars/DrawSidebar.cpp:45
 msgid "2D"
@@ -1342,7 +1342,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:179
 msgid "Beta"
-msgstr ""
+msgstr "Beta"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1898
 msgid "Bitmap"
@@ -9358,7 +9358,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:195
 msgid "Sigma"
-msgstr ""
+msgstr "Sigma"
 
 #: ../../src/dialogs/FindReplacePane.cpp:88
 msgid "Simple"
@@ -11538,7 +11538,7 @@ msgstr "oletus"
 
 #: ../../src/sidebars/GreekSidebar.cpp:154
 msgid "delta"
-msgstr ""
+msgstr "delta"
 
 #: ../../src/wizards/MatWiz.cpp:159
 msgid "diagonal"
@@ -11562,7 +11562,7 @@ msgstr "tyhjä"
 
 #: ../../src/sidebars/GreekSidebar.cpp:155
 msgid "epsilon"
-msgstr ""
+msgstr "epsilon"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:100
 msgid "equivalent"
@@ -11620,7 +11620,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:153
 msgid "gamma"
-msgstr ""
+msgstr "gamma"
 
 #: ../../src/wizards/MatWiz.cpp:159
 msgid "general"
@@ -11663,7 +11663,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:161
 msgid "lambda"
-msgstr ""
+msgstr "lambda"
 
 #: ../../src/wizards/LimitWiz.cpp:42
 msgid "left"
@@ -11882,7 +11882,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:168
 msgid "sigma"
-msgstr ""
+msgstr "sigma"
 
 #: ../../src/MaximaCommandMenus.cpp:3507
 msgid "solve() will solve a list of equations only if for n independent equations there are n variables to solve to.\n"
@@ -11922,7 +11922,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:169
 msgid "tau"
-msgstr ""
+msgstr "tau"
 
 #: ../../src/cells/TextCell.cpp:340
 msgid "the [] operator tried to extract an element of a list, a matrix, an equation or an array. But instead of an integer number something was used whose numerical value is unknown or not an integer.\n"

--- a/locales/wxMaxima/fr.po
+++ b/locales/wxMaxima/fr.po
@@ -251,7 +251,7 @@ msgstr ""
 #: ../../src/worksheet/Worksheet.cpp:423
 #, c-format
 msgid "%s image, %li×%li, %li ppi"
-msgstr ""
+msgstr "%s image, %li×%li, %li ppi"
 
 #: ../../src/Autocomplete.cpp:405
 #, c-format
@@ -438,7 +438,7 @@ msgstr "Intégration &numérique"
 
 #: ../../src/wizards/SumWiz.cpp:44
 msgid "&Nusum"
-msgstr ""
+msgstr "&Nusum"
 
 #: ../../src/main.cpp:700
 msgid "&Open\tCtrl+O"
@@ -518,7 +518,7 @@ msgstr ""
 
 #: ../../src/wizards/Plot3dWiz.cpp:79
 msgid "&pm3d"
-msgstr ""
+msgstr "&pm3d"
 
 #: ../../src/cells/AnimationCell.cpp:475
 msgid "(Animation)"
@@ -1296,7 +1296,7 @@ msgstr ""
 
 #: ../../src/wizards/BC2Wiz.cpp:59
 msgid "BC2"
-msgstr ""
+msgstr "BC2"
 
 #: ../../src/MaximaManual.cpp:559
 msgid "Background task that compiles the Manual anchors scheduled."
@@ -1780,7 +1780,7 @@ msgstr "Canonique (expr. trig.)"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:188
 msgid "Catalan"
-msgstr ""
+msgstr "Catalan"
 
 #: ../../src/MaximaCommandMenus.cpp:466
 msgid "Cauchy principal value of f(x)/(x-c), finite interval"
@@ -4302,7 +4302,7 @@ msgstr "Champs :"
 #: ../../src/cells/GroupCell.cpp:2115
 #, c-format
 msgid "Figure %d:"
-msgstr ""
+msgstr "Figure %d:"
 
 #: ../../src/main.cpp:703
 msgid "File"
@@ -5224,7 +5224,7 @@ msgstr "La version en cache des ancres du manuel est ignorée."
 
 #: ../../src/sidebars/FormatSidebar.cpp:66
 msgid "Image"
-msgstr ""
+msgstr "Image"
 
 #: ../../src/Image.cpp:110
 msgid "Image data had zero length!"
@@ -9893,11 +9893,11 @@ msgstr "Structures"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:282
 msgid "Style"
-msgstr ""
+msgstr "Style"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2082
 msgid "Styles"
-msgstr ""
+msgstr "Styles"
 
 #: ../../src/sidebars/StatSidebar.cpp:112
 msgid "Subsample..."
@@ -10862,7 +10862,7 @@ msgstr "Test de Student (t-test) à 2 échantillons"
 
 #: ../../src/worksheet/Worksheet.cpp:6249
 msgid "Type"
-msgstr ""
+msgstr "Type"
 
 #: ../../src/cells/EditorCell.cpp:4550
 msgid "Type in text"
@@ -11771,7 +11771,7 @@ msgstr ""
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:772
 msgid "nary: f(x, f(y,z)) = foo(x,y,z)"
-msgstr ""
+msgstr "nary: f(x, f(y,z)) = foo(x,y,z)"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:99
 msgid "nor"

--- a/locales/wxMaxima/gl.po
+++ b/locales/wxMaxima/gl.po
@@ -434,7 +434,7 @@ msgstr "Integración &numérica"
 
 #: ../../src/wizards/SumWiz.cpp:44
 msgid "&Nusum"
-msgstr ""
+msgstr "&Nusum"
 
 #: ../../src/main.cpp:700
 msgid "&Open\tCtrl+O"
@@ -608,7 +608,7 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:77
 msgid "1/2"
-msgstr ""
+msgstr "1/2"
 
 #: ../../src/sidebars/DrawSidebar.cpp:45
 msgid "2D"
@@ -1291,7 +1291,7 @@ msgstr ""
 
 #: ../../src/wizards/BC2Wiz.cpp:59
 msgid "BC2"
-msgstr ""
+msgstr "BC2"
 
 #: ../../src/MaximaManual.cpp:559
 msgid "Background task that compiles the Manual anchors scheduled."
@@ -1342,7 +1342,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:179
 msgid "Beta"
-msgstr ""
+msgstr "Beta"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1898
 msgid "Bitmap"
@@ -2882,7 +2882,7 @@ msgstr ""
 
 #: ../../src/worksheet/Worksheet.cpp:6125
 msgid "Cursor"
-msgstr ""
+msgstr "Cursor"
 
 #: ../../src/Styles.cpp:126
 msgid "Cursor color"
@@ -3099,7 +3099,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:181
 msgid "Delta"
-msgstr ""
+msgstr "Delta"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:110
 #: ../../src/worksheet/WorksheetContextMenu.cpp:558
@@ -3736,7 +3736,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:184
 msgid "Eta"
-msgstr ""
+msgstr "Eta"
 
 #: ../../src/sidebars/TableOfContents.cpp:513
 msgid "Evaluate"
@@ -4717,7 +4717,7 @@ msgstr "Galego"
 
 #: ../../src/sidebars/GreekSidebar.cpp:180
 msgid "Gamma"
-msgstr ""
+msgstr "Gamma"
 
 #: ../../src/wxMaximaFrame.cpp:320
 msgid "General Math"
@@ -5670,7 +5670,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:186
 msgid "Iota"
-msgstr ""
+msgstr "Iota"
 
 #: ../../src/MaximaCommandMenus.cpp:4210
 msgid "Is Char 1 greater than Char2, if case is ignored?"
@@ -5862,7 +5862,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:187
 msgid "Kappa"
-msgstr ""
+msgstr "Kappa"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:864
 #, c-format
@@ -7348,7 +7348,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:201
 msgid "Omega"
-msgstr ""
+msgstr "Omega"
 
 #: ../../src/sidebars/GreekSidebar.cpp:192
 msgid "Omicron"
@@ -7635,7 +7635,7 @@ msgstr "Fi"
 
 #: ../../src/sidebars/GreekSidebar.cpp:193
 msgid "Pi"
-msgstr ""
+msgstr "Pi"
 
 #: ../../src/sidebars/StatSidebar.cpp:94
 msgid "Piechart..."
@@ -7987,7 +7987,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:200
 msgid "Psi"
-msgstr ""
+msgstr "Psi"
 
 #: ../../src/wxMaximaFrame.cpp:1792
 msgid "Push"
@@ -8234,7 +8234,7 @@ msgstr ""
 
 #: ../../src/sidebars/MathSidebar.cpp:71
 msgid "Reduce (tr)"
-msgstr ""
+msgstr "Reduce (tr)"
 
 #: ../../src/wxMaximaFrame.cpp:1636
 msgid "Reduce trigonometric expression"
@@ -9358,7 +9358,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:195
 msgid "Sigma"
-msgstr ""
+msgstr "Sigma"
 
 #: ../../src/dialogs/FindReplacePane.cpp:88
 msgid "Simple"
@@ -10039,7 +10039,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:196
 msgid "Tau"
-msgstr ""
+msgstr "Tau"
 
 #: ../../src/MaximaCommandMenus.cpp:181
 msgid "Taylor series"
@@ -10496,7 +10496,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:185
 msgid "Theta"
-msgstr ""
+msgstr "Theta"
 
 #: ../../src/dialogs/LicenseDialog.cpp:85
 msgid "Third-party notices"
@@ -11384,7 +11384,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:191
 msgid "Xi"
-msgstr ""
+msgstr "Xi"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:728
 msgid "Yes"
@@ -11440,7 +11440,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:183
 msgid "Zeta"
-msgstr ""
+msgstr "Zeta"
 
 #: ../../src/wxMaximaFrame.cpp:846
 msgid "Zoom &In\tCtrl++"
@@ -11484,7 +11484,7 @@ msgstr "alfa"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:95
 msgid "and"
-msgstr ""
+msgstr "and"
 
 #: ../../src/wizards/MatWiz.cpp:160
 msgid "antisymmetric"
@@ -11512,7 +11512,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:152
 msgid "beta"
-msgstr ""
+msgstr "beta"
 
 #: ../../src/wizards/LimitWiz.cpp:42
 msgid "both sides"
@@ -11538,11 +11538,11 @@ msgstr "predeterminado"
 
 #: ../../src/sidebars/GreekSidebar.cpp:154
 msgid "delta"
-msgstr ""
+msgstr "delta"
 
 #: ../../src/wizards/MatWiz.cpp:159
 msgid "diagonal"
-msgstr ""
+msgstr "diagonal"
 
 #: ../../src/cells/FracCell.cpp:73
 msgid "diff(): Cannot find the multiplication sign I should hide"
@@ -11570,7 +11570,7 @@ msgstr "equivalente"
 
 #: ../../src/sidebars/GreekSidebar.cpp:157
 msgid "eta"
-msgstr ""
+msgstr "eta"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:799
 msgid "ev() shall evaluate this automatically"
@@ -11620,7 +11620,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:153
 msgid "gamma"
-msgstr ""
+msgstr "gamma"
 
 #: ../../src/wizards/MatWiz.cpp:159
 msgid "general"
@@ -11655,15 +11655,15 @@ msgstr "intersección"
 
 #: ../../src/sidebars/GreekSidebar.cpp:159
 msgid "iota"
-msgstr ""
+msgstr "iota"
 
 #: ../../src/sidebars/GreekSidebar.cpp:160
 msgid "kappa"
-msgstr ""
+msgstr "kappa"
 
 #: ../../src/sidebars/GreekSidebar.cpp:161
 msgid "lambda"
-msgstr ""
+msgstr "lambda"
 
 #: ../../src/wizards/LimitWiz.cpp:42
 msgid "left"
@@ -11720,7 +11720,7 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:98
 msgid "nand"
-msgstr ""
+msgstr "nand"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:772
 msgid "nary: f(x, f(y,z)) = foo(x,y,z)"
@@ -11728,11 +11728,11 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:99
 msgid "nor"
-msgstr ""
+msgstr "nor"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:102
 msgid "not"
-msgstr ""
+msgstr "not"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:116
 msgid "not bytewise identical"
@@ -11764,7 +11764,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:174
 msgid "omega"
-msgstr ""
+msgstr "omega"
 
 #: ../../src/sidebars/GreekSidebar.cpp:165
 msgid "omicron"
@@ -11772,7 +11772,7 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:96
 msgid "or"
-msgstr ""
+msgstr "or"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:793
 msgid "outative: f(2*x) = 2*f(x)"
@@ -11797,7 +11797,7 @@ msgstr "fi"
 
 #: ../../src/sidebars/GreekSidebar.cpp:166
 msgid "pi"
-msgstr ""
+msgstr "pi"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:101
 msgid "plus or minus"
@@ -11830,7 +11830,7 @@ msgstr "proporcional a"
 
 #: ../../src/sidebars/GreekSidebar.cpp:173
 msgid "psi"
-msgstr ""
+msgstr "psi"
 
 #: ../../src/MaximaCommandMenus.cpp:642
 msgid "radcan() is a powerful tools for simplification trigonometric functions but needs to be taken with care: If a function has more than one branch radcan uses the one that looks like it would fit best, not necessarily the one that makes sense for the problem that resulted in the Expression that is to be simplified."
@@ -11882,7 +11882,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:168
 msgid "sigma"
-msgstr ""
+msgstr "sigma"
 
 #: ../../src/MaximaCommandMenus.cpp:3507
 msgid "solve() will solve a list of equations only if for n independent equations there are n variables to solve to.\n"
@@ -11922,7 +11922,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:169
 msgid "tau"
-msgstr ""
+msgstr "tau"
 
 #: ../../src/cells/TextCell.cpp:340
 msgid "the [] operator tried to extract an element of a list, a matrix, an equation or an array. But instead of an integer number something was used whose numerical value is unknown or not an integer.\n"
@@ -11943,7 +11943,7 @@ msgstr "non hai"
 
 #: ../../src/sidebars/GreekSidebar.cpp:158
 msgid "theta"
-msgstr ""
+msgstr "theta"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:78
 msgid "to the power of 2"
@@ -12155,7 +12155,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:709
 msgid "x"
-msgstr ""
+msgstr "x"
 
 #: ../../src/wizards/DrawWiz.cpp:266
 msgid "x axis label"
@@ -12171,7 +12171,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:164
 msgid "xi"
-msgstr ""
+msgstr "xi"
 
 #: ../../src/MaximaFileIO.cpp:408 ../../src/MaximaFileIO.cpp:566
 msgid "xml contained in the file claims not to be a wxMaxima worksheet. "
@@ -12179,7 +12179,7 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:97
 msgid "xor"
-msgstr ""
+msgstr "xor"
 
 #: ../../src/wizards/DrawWiz.cpp:279
 msgid "y axis label"
@@ -12207,7 +12207,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:156
 msgid "zeta"
-msgstr ""
+msgstr "zeta"
 
 #. type: Title #
 #: ../../info/wxmaxima.md:1

--- a/locales/wxMaxima/hu.po
+++ b/locales/wxMaxima/hu.po
@@ -68,7 +68,7 @@ msgstr "      -X '--dinamikus-helyméret <int>'"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1551
 msgid "      -l <name>"
-msgstr ""
+msgstr "      -l <name>"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1557
 msgid "      -u <versionnumber>"
@@ -516,7 +516,7 @@ msgstr "&Változók"
 
 #: ../../src/wizards/Plot3dWiz.cpp:79
 msgid "&pm3d"
-msgstr ""
+msgstr "&pm3d"
 
 #: ../../src/cells/AnimationCell.cpp:475
 msgid "(Animation)"
@@ -586,7 +586,7 @@ msgstr "(f(x),x,y) szingularitásokkal+diszkontinuitásokkal"
 #: ../../src/wizards/DrawWiz.cpp:303 ../../src/wizards/DrawWiz.cpp:320
 #: ../../src/wizards/DrawWiz.cpp:335
 msgid "-"
-msgstr ""
+msgstr "-"
 
 #: ../../src/wizards/IntegrateWiz.cpp:192
 #: ../../src/wizards/IntegrateWiz.cpp:202
@@ -610,11 +610,11 @@ msgstr "1 szint"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:77
 msgid "1/2"
-msgstr ""
+msgstr "1/2"
 
 #: ../../src/sidebars/DrawSidebar.cpp:45
 msgid "2D"
-msgstr ""
+msgstr "2D"
 
 #: ../../src/wxMaximaFrame.cpp:1350
 msgid "2D Array to Matrix..."
@@ -638,7 +638,7 @@ msgstr ""
 
 #: ../../src/sidebars/DrawSidebar.cpp:49
 msgid "3D"
-msgstr ""
+msgstr "3D"
 
 #: ../../src/wxMaxima.cpp:1836
 #, c-format
@@ -3102,7 +3102,7 @@ msgstr "Kiküszöbölés:"
 
 #: ../../src/sidebars/GreekSidebar.cpp:181
 msgid "Delta"
-msgstr ""
+msgstr "Delta"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:110
 #: ../../src/worksheet/WorksheetContextMenu.cpp:558
@@ -4730,7 +4730,7 @@ msgstr "Galíciai"
 
 #: ../../src/sidebars/GreekSidebar.cpp:180
 msgid "Gamma"
-msgstr ""
+msgstr "Gamma"
 
 #: ../../src/wxMaximaFrame.cpp:320
 msgid "General Math"
@@ -4900,7 +4900,7 @@ msgstr "Találj ki egy pontos számot, amit ez az úszó jelenthet"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1215
 msgid "HTML"
-msgstr ""
+msgstr "HTML"
 
 #: ../../src/MaximaCommandMenus.cpp:2279
 msgid "HTML file (*.html)|*.html|maxima batch file (*.mac)|*.mac|LaTeX file (*.tex)|*.tex"
@@ -5240,7 +5240,7 @@ msgstr ""
 
 #: ../../src/worksheet/WorksheetExport.cpp:1407
 msgid "ImageCell without image."
-msgstr ""
+msgstr "ImageCell without image."
 
 #: ../../src/sidebars/DrawSidebar.cpp:60
 msgid "Implicit Plot"
@@ -5810,7 +5810,7 @@ msgstr "Issuing the active cella's undo function"
 
 #: ../../src/worksheet/Worksheet.cpp:4251
 msgid "Issuing the worksheet's undo function"
-msgstr ""
+msgstr "Issuing the worksheet's undo function"
 
 #: ../../src/dialogs/TipOfTheDay.cpp:185
 msgid "It is possible to add custom symbols to the \"symbols\" sidebar by copying them into the respective field in the configuration dialogue."
@@ -5878,7 +5878,7 @@ msgstr "Kabil"
 
 #: ../../src/sidebars/GreekSidebar.cpp:187
 msgid "Kappa"
-msgstr ""
+msgstr "Kappa"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:864
 #, c-format
@@ -5911,7 +5911,7 @@ msgstr "L[inf] Norm (valódi)"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1166
 msgid "LaTeX"
-msgstr ""
+msgstr "LaTeX"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1199
 msgid "LaTeX: Place exponents after, instead above subscripts"
@@ -6452,7 +6452,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:281
 msgid "Maxima"
-msgstr ""
+msgstr "Maxima"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1433
 msgid "Maxima Location"
@@ -6599,7 +6599,7 @@ msgstr "A maxima eljárásának futása váratlanul megszakadt."
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1437
 msgid "Maxima program:"
-msgstr ""
+msgstr "Maxima program:"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:382
 msgid "Maxima provides no \"forget all\" command that flushes all settings a maxima session could make. wxMaxima therefore normally defaults to starting a fresh maxima process every time the worksheet is to be re-evaluated. As this needs a little bit of time this switch allows to disable this behavior."
@@ -10056,7 +10056,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:196
 msgid "Tau"
-msgstr ""
+msgstr "Tau"
 
 #: ../../src/MaximaCommandMenus.cpp:181
 msgid "Taylor series"
@@ -11408,7 +11408,7 @@ msgstr "Megírta a MIME-típus adatait"
 #: ../../src/wizards/DrawWiz.cpp:961 ../../src/wizards/DrawWiz.cpp:974
 #: ../../src/wizards/DrawWiz.cpp:977
 msgid "X"
-msgstr ""
+msgstr "X"
 
 #: ../../src/MathParser.cpp:1279
 msgid "XML nesting limit exceeded"
@@ -11500,7 +11500,7 @@ msgstr "[ mentetlen* ]"
 
 #: ../../src/wizards/DrawWiz.cpp:819 ../../src/wizards/DrawWiz.cpp:825
 msgid "[[x_1,x_2,...],[y_1,y_2,...]]"
-msgstr ""
+msgstr "[[x_1,x_2,...],[y_1,y_2,...]]"
 
 #: ../../src/wizards/DrawWiz.cpp:814
 msgid "[x_1, x_2,...] or [x_1, x_2,...],[y_1, y_2,...] or matrix([x_1,y_1],[x_2,y_2],...)"
@@ -11570,7 +11570,7 @@ msgstr "alapértelmezett"
 
 #: ../../src/sidebars/GreekSidebar.cpp:154
 msgid "delta"
-msgstr ""
+msgstr "delta"
 
 #: ../../src/wizards/MatWiz.cpp:159
 msgid "diagonal"
@@ -11652,7 +11652,7 @@ msgstr "függvény"
 
 #: ../../src/sidebars/GreekSidebar.cpp:153
 msgid "gamma"
-msgstr ""
+msgstr "gamma"
 
 #: ../../src/wizards/MatWiz.cpp:159
 msgid "general"
@@ -11691,11 +11691,11 @@ msgstr "ióta"
 
 #: ../../src/sidebars/GreekSidebar.cpp:160
 msgid "kappa"
-msgstr ""
+msgstr "kappa"
 
 #: ../../src/sidebars/GreekSidebar.cpp:161
 msgid "lambda"
-msgstr ""
+msgstr "lambda"
 
 #: ../../src/wizards/LimitWiz.cpp:42
 msgid "left"
@@ -11715,7 +11715,7 @@ msgstr "logaritmikus skála"
 
 #: ../../src/wizards/DrawWiz.cpp:822
 msgid "matrix([x_1,x_2,...],[y_1,y_2,...])"
-msgstr ""
+msgstr "matrix([x_1,x_2,...],[y_1,y_2,...])"
 
 #: ../../src/wxMaximaFrame.cpp:1443
 msgid "max(abs(A(i,j))) (complex)"
@@ -11756,7 +11756,7 @@ msgstr "negált és"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:772
 msgid "nary: f(x, f(y,z)) = foo(x,y,z)"
-msgstr ""
+msgstr "nary: f(x, f(y,z)) = foo(x,y,z)"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:99
 msgid "nor"
@@ -11957,7 +11957,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:169
 msgid "tau"
-msgstr ""
+msgstr "tau"
 
 #: ../../src/cells/TextCell.cpp:340
 msgid "the [] operator tried to extract an element of a list, a matrix, an equation or an array. But instead of an integer number something was used whose numerical value is unknown or not an integer.\n"
@@ -12192,7 +12192,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:709
 msgid "x"
-msgstr ""
+msgstr "x"
 
 #: ../../src/wizards/DrawWiz.cpp:266
 msgid "x axis label"

--- a/locales/wxMaxima/it.po
+++ b/locales/wxMaxima/it.po
@@ -53,19 +53,19 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1569
 msgid "      -X \"--control-stack-size <int>\""
-msgstr ""
+msgstr "      -X \"--control-stack-size <int>\""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1568
 msgid "      -X \"--dynamic-space-size <int>\""
-msgstr ""
+msgstr "      -X \"--dynamic-space-size <int>\""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1572
 msgid "      -X '--control-stack-size <int>'"
-msgstr ""
+msgstr "      -X '--control-stack-size <int>'"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1571
 msgid "      -X '--dynamic-space-size <int>'"
-msgstr ""
+msgstr "      -X '--dynamic-space-size <int>'"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1551
 msgid "      -l <name>"
@@ -517,7 +517,7 @@ msgstr "&Variabili"
 
 #: ../../src/wizards/Plot3dWiz.cpp:79
 msgid "&pm3d"
-msgstr ""
+msgstr "&pm3d"
 
 #: ../../src/cells/AnimationCell.cpp:475
 msgid "(Animation)"
@@ -587,7 +587,7 @@ msgstr "(f(x),x,y) con singolarità+discontinuità"
 #: ../../src/wizards/DrawWiz.cpp:303 ../../src/wizards/DrawWiz.cpp:320
 #: ../../src/wizards/DrawWiz.cpp:335
 msgid "-"
-msgstr ""
+msgstr "-"
 
 #: ../../src/wizards/IntegrateWiz.cpp:192
 #: ../../src/wizards/IntegrateWiz.cpp:202
@@ -611,11 +611,11 @@ msgstr "1 Livello"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:77
 msgid "1/2"
-msgstr ""
+msgstr "1/2"
 
 #: ../../src/sidebars/DrawSidebar.cpp:45
 msgid "2D"
-msgstr ""
+msgstr "2D"
 
 #: ../../src/wxMaximaFrame.cpp:1350
 msgid "2D Array to Matrix..."
@@ -639,7 +639,7 @@ msgstr ""
 
 #: ../../src/sidebars/DrawSidebar.cpp:49
 msgid "3D"
-msgstr ""
+msgstr "3D"
 
 #: ../../src/wxMaxima.cpp:1836
 #, c-format
@@ -1295,7 +1295,7 @@ msgstr "Asse"
 
 #: ../../src/wizards/BC2Wiz.cpp:59
 msgid "BC2"
-msgstr ""
+msgstr "BC2"
 
 #: ../../src/MaximaManual.cpp:559
 msgid "Background task that compiles the Manual anchors scheduled."
@@ -1346,11 +1346,11 @@ msgstr "Oltre alla funzionalità di annullamento globale che è attiva quando il
 
 #: ../../src/sidebars/GreekSidebar.cpp:179
 msgid "Beta"
-msgstr ""
+msgstr "Beta"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1898
 msgid "Bitmap"
-msgstr ""
+msgstr "Bitmap"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1273
 msgid "Bitmap scale for export:"
@@ -1864,7 +1864,7 @@ msgstr "Cambia variabile nell'integrale o nella somma ed elabora il risultato"
 
 #: ../../src/dialogs/ChangeLogDialog.cpp:37
 msgid "ChangeLog"
-msgstr ""
+msgstr "ChangeLog"
 
 #: ../../src/wxMaximaFrame.cpp:1064
 msgid "Changed option variables"
@@ -1925,7 +1925,7 @@ msgstr "Controlla se esiste una versione più recente di wxMaxima"
 
 #: ../../src/sidebars/GreekSidebar.cpp:199
 msgid "Chi"
-msgstr ""
+msgstr "Chi"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:189
 msgid "Chinese (Simplified)"
@@ -3103,7 +3103,7 @@ msgstr "Delimitatore:"
 
 #: ../../src/sidebars/GreekSidebar.cpp:181
 msgid "Delta"
-msgstr ""
+msgstr "Delta"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:110
 #: ../../src/worksheet/WorksheetContextMenu.cpp:558
@@ -3196,7 +3196,7 @@ msgstr ""
 
 #: ../../src/sidebars/MathSidebar.cpp:80
 msgid "Diff..."
-msgstr ""
+msgstr "Diff..."
 
 #: ../../src/dialogs/DiffFrame.cpp:308
 #, c-format
@@ -3647,7 +3647,7 @@ msgstr "Variabili ambiente per maxima"
 
 #: ../../src/sidebars/GreekSidebar.cpp:182
 msgid "Epsilon"
-msgstr ""
+msgstr "Epsilon"
 
 #: ../../src/MaximaCommandMenus.cpp:299
 msgid "Epsilon:"
@@ -3743,7 +3743,7 @@ msgstr "Escapes all special characters in a string. The result is a regex that m
 
 #: ../../src/sidebars/GreekSidebar.cpp:184
 msgid "Eta"
-msgstr ""
+msgstr "Eta"
 
 #: ../../src/sidebars/TableOfContents.cpp:513
 msgid "Evaluate"
@@ -4732,7 +4732,7 @@ msgstr "Galiziano"
 
 #: ../../src/sidebars/GreekSidebar.cpp:180
 msgid "Gamma"
-msgstr ""
+msgstr "Gamma"
 
 #: ../../src/wxMaximaFrame.cpp:320
 msgid "General Math"
@@ -4902,7 +4902,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1215
 msgid "HTML"
-msgstr ""
+msgstr "HTML"
 
 #: ../../src/MaximaCommandMenus.cpp:2279
 msgid "HTML file (*.html)|*.html|maxima batch file (*.mac)|*.mac|LaTeX file (*.tex)|*.tex"
@@ -5685,7 +5685,7 @@ msgstr "T&rasformata inversa di Laplace..."
 
 #: ../../src/sidebars/GreekSidebar.cpp:186
 msgid "Iota"
-msgstr ""
+msgstr "Iota"
 
 #: ../../src/MaximaCommandMenus.cpp:4210
 msgid "Is Char 1 greater than Char2, if case is ignored?"
@@ -5877,7 +5877,7 @@ msgstr "Cabile"
 
 #: ../../src/sidebars/GreekSidebar.cpp:187
 msgid "Kappa"
-msgstr ""
+msgstr "Kappa"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:864
 #, c-format
@@ -5910,7 +5910,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1166
 msgid "LaTeX"
-msgstr ""
+msgstr "LaTeX"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1199
 msgid "LaTeX: Place exponents after, instead above subscripts"
@@ -6451,7 +6451,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:281
 msgid "Maxima"
-msgstr ""
+msgstr "Maxima"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1433
 msgid "Maxima Location"
@@ -6942,7 +6942,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:189
 msgid "Mu"
-msgstr ""
+msgstr "Mu"
 
 #: ../../src/wxMaximaFrame.cpp:1390
 msgid "Multiplication, exponent and similar"
@@ -7204,7 +7204,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:190
 msgid "Nu"
-msgstr ""
+msgstr "Nu"
 
 #: ../../src/MaximaCommandMenus.cpp:177
 msgid "Num. deg:"
@@ -7364,11 +7364,11 @@ msgstr "Vecchia variabile:"
 
 #: ../../src/sidebars/GreekSidebar.cpp:201
 msgid "Omega"
-msgstr ""
+msgstr "Omega"
 
 #: ../../src/sidebars/GreekSidebar.cpp:192
 msgid "Omicron"
-msgstr ""
+msgstr "Omicron"
 
 #: ../../src/wxMaximaFrame.cpp:1093
 msgid "On all errors"
@@ -7647,11 +7647,11 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:198
 msgid "Phi"
-msgstr ""
+msgstr "Phi"
 
 #: ../../src/sidebars/GreekSidebar.cpp:193
 msgid "Pi"
-msgstr ""
+msgstr "Pi"
 
 #: ../../src/sidebars/StatSidebar.cpp:94
 msgid "Piechart..."
@@ -8003,7 +8003,7 @@ msgstr "Blocco programma, senza variabili locali..."
 
 #: ../../src/sidebars/GreekSidebar.cpp:200
 msgid "Psi"
-msgstr ""
+msgstr "Psi"
 
 #: ../../src/wxMaximaFrame.cpp:1792
 msgid "Push"
@@ -8585,7 +8585,7 @@ msgstr "Annulla modifiche"
 
 #: ../../src/sidebars/GreekSidebar.cpp:194
 msgid "Rho"
-msgstr ""
+msgstr "Rho"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2015
 msgid "Right"
@@ -8842,7 +8842,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1914
 msgid "Scalable Vector Graphics (svg)"
-msgstr ""
+msgstr "Scalable Vector Graphics (svg)"
 
 #: ../../src/MaximaCommandMenus.cpp:3596
 msgid "Scalable Vector image (*.svg)|*.svg|Compressed Scalable Vector Image (*.svgz)|*.svgz|PNG image (*.png)|*.png|JPEG image (*.jpg)|*.jpg|GIF image (*.gif)|*.gif|Windows bitmap (*.bmp)|*.bmp|"
@@ -9374,7 +9374,7 @@ msgstr "Barre laterali"
 
 #: ../../src/sidebars/GreekSidebar.cpp:195
 msgid "Sigma"
-msgstr ""
+msgstr "Sigma"
 
 #: ../../src/dialogs/FindReplacePane.cpp:88
 msgid "Simple"
@@ -10055,7 +10055,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:196
 msgid "Tau"
-msgstr ""
+msgstr "Tau"
 
 #: ../../src/MaximaCommandMenus.cpp:181
 msgid "Taylor series"
@@ -10519,7 +10519,7 @@ msgstr "C'è stato un errore nell'XML che doveva descrivere il messaggio della b
 
 #: ../../src/sidebars/GreekSidebar.cpp:185
 msgid "Theta"
-msgstr ""
+msgstr "Theta"
 
 #: ../../src/dialogs/LicenseDialog.cpp:85
 msgid "Third-party notices"
@@ -11032,7 +11032,7 @@ msgstr "Intorno alto:"
 
 #: ../../src/sidebars/GreekSidebar.cpp:197
 msgid "Upsilon"
-msgstr ""
+msgstr "Upsilon"
 
 #: ../../src/wxMaximaFrame.cpp:833
 msgid "Use \"<\" and \">\" as parenthesis for matrices"
@@ -11402,7 +11402,7 @@ msgstr "Scritte le informazioni sul tipo mime"
 #: ../../src/wizards/DrawWiz.cpp:961 ../../src/wizards/DrawWiz.cpp:974
 #: ../../src/wizards/DrawWiz.cpp:977
 msgid "X"
-msgstr ""
+msgstr "X"
 
 #: ../../src/MathParser.cpp:1279
 msgid "XML nesting limit exceeded"
@@ -11410,7 +11410,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:191
 msgid "Xi"
-msgstr ""
+msgstr "Xi"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:728
 msgid "Yes"
@@ -11466,7 +11466,7 @@ msgstr "L'attuale versione di wxMaxima è aggiornata."
 
 #: ../../src/sidebars/GreekSidebar.cpp:183
 msgid "Zeta"
-msgstr ""
+msgstr "Zeta"
 
 #: ../../src/wxMaximaFrame.cpp:846
 msgid "Zoom &In\tCtrl++"
@@ -11494,7 +11494,7 @@ msgstr "[ non salvato* ]"
 
 #: ../../src/wizards/DrawWiz.cpp:819 ../../src/wizards/DrawWiz.cpp:825
 msgid "[[x_1,x_2,...],[y_1,y_2,...]]"
-msgstr ""
+msgstr "[[x_1,x_2,...],[y_1,y_2,...]]"
 
 #: ../../src/wizards/DrawWiz.cpp:814
 msgid "[x_1, x_2,...] or [x_1, x_2,...],[y_1, y_2,...] or matrix([x_1,y_1],[x_2,y_2],...)"
@@ -11510,7 +11510,7 @@ msgstr "alfa"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:95
 msgid "and"
-msgstr ""
+msgstr "and"
 
 #: ../../src/wizards/MatWiz.cpp:160
 msgid "antisymmetric"
@@ -11538,7 +11538,7 @@ msgstr "come contenitore dei valori correnti delle variabili"
 
 #: ../../src/sidebars/GreekSidebar.cpp:152
 msgid "beta"
-msgstr ""
+msgstr "beta"
 
 #: ../../src/wizards/LimitWiz.cpp:42
 msgid "both sides"
@@ -11550,7 +11550,7 @@ msgstr "da carattere a codice ASCII.."
 
 #: ../../src/sidebars/GreekSidebar.cpp:172
 msgid "chi"
-msgstr ""
+msgstr "chi"
 
 #: ../../src/MaximaFileIO.cpp:318
 #, c-format
@@ -11564,7 +11564,7 @@ msgstr "predefinito"
 
 #: ../../src/sidebars/GreekSidebar.cpp:154
 msgid "delta"
-msgstr ""
+msgstr "delta"
 
 #: ../../src/wizards/MatWiz.cpp:159
 msgid "diagonal"
@@ -11588,7 +11588,7 @@ msgstr "vuoto"
 
 #: ../../src/sidebars/GreekSidebar.cpp:155
 msgid "epsilon"
-msgstr ""
+msgstr "epsilon"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:100
 msgid "equivalent"
@@ -11596,7 +11596,7 @@ msgstr "equivalente"
 
 #: ../../src/sidebars/GreekSidebar.cpp:157
 msgid "eta"
-msgstr ""
+msgstr "eta"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:799
 msgid "ev() shall evaluate this automatically"
@@ -11646,7 +11646,7 @@ msgstr "funzione"
 
 #: ../../src/sidebars/GreekSidebar.cpp:153
 msgid "gamma"
-msgstr ""
+msgstr "gamma"
 
 #: ../../src/wizards/MatWiz.cpp:159
 msgid "general"
@@ -11662,7 +11662,7 @@ msgstr "maggiore o uguale"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:87
 msgid "in"
-msgstr ""
+msgstr "in"
 
 #: ../../src/wxMaximaFrame.cpp:788
 msgid "in 2D"
@@ -11681,15 +11681,15 @@ msgstr "intersezione"
 
 #: ../../src/sidebars/GreekSidebar.cpp:159
 msgid "iota"
-msgstr ""
+msgstr "iota"
 
 #: ../../src/sidebars/GreekSidebar.cpp:160
 msgid "kappa"
-msgstr ""
+msgstr "kappa"
 
 #: ../../src/sidebars/GreekSidebar.cpp:161
 msgid "lambda"
-msgstr ""
+msgstr "lambda"
 
 #: ../../src/wizards/LimitWiz.cpp:42
 msgid "left"
@@ -11721,7 +11721,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:162
 msgid "mu"
-msgstr ""
+msgstr "mu"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:120
 msgid "much greater than"
@@ -11746,7 +11746,7 @@ msgstr "simbolo nabla"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:98
 msgid "nand"
-msgstr ""
+msgstr "nand"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:772
 msgid "nary: f(x, f(y,z)) = foo(x,y,z)"
@@ -11754,11 +11754,11 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:99
 msgid "nor"
-msgstr ""
+msgstr "nor"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:102
 msgid "not"
-msgstr ""
+msgstr "not"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:116
 msgid "not bytewise identical"
@@ -11782,7 +11782,7 @@ msgstr "n-esimo"
 
 #: ../../src/sidebars/GreekSidebar.cpp:163
 msgid "nu"
-msgstr ""
+msgstr "nu"
 
 #: ../../src/MaximaCommandMenus.cpp:1233
 msgid "n×1 Matrix b:"
@@ -11790,15 +11790,15 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:174
 msgid "omega"
-msgstr ""
+msgstr "omega"
 
 #: ../../src/sidebars/GreekSidebar.cpp:165
 msgid "omicron"
-msgstr ""
+msgstr "omicron"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:96
 msgid "or"
-msgstr ""
+msgstr "or"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:793
 msgid "outative: f(2*x) = 2*f(x)"
@@ -11819,11 +11819,11 @@ msgstr "segno parziale"
 
 #: ../../src/sidebars/GreekSidebar.cpp:171
 msgid "phi"
-msgstr ""
+msgstr "phi"
 
 #: ../../src/sidebars/GreekSidebar.cpp:166
 msgid "pi"
-msgstr ""
+msgstr "pi"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:101
 msgid "plus or minus"
@@ -11856,7 +11856,7 @@ msgstr "proporzionale a"
 
 #: ../../src/sidebars/GreekSidebar.cpp:173
 msgid "psi"
-msgstr ""
+msgstr "psi"
 
 #: ../../src/MaximaCommandMenus.cpp:642
 msgid "radcan() is a powerful tools for simplification trigonometric functions but needs to be taken with care: If a function has more than one branch radcan uses the one that looks like it would fit best, not necessarily the one that makes sense for the problem that resulted in the Expression that is to be simplified."
@@ -11884,7 +11884,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:167
 msgid "rho"
-msgstr ""
+msgstr "rho"
 
 #: ../../src/wizards/LimitWiz.cpp:42
 msgid "right"
@@ -11908,7 +11908,7 @@ msgstr "campo y secondario (automatico se incompleto)"
 
 #: ../../src/sidebars/GreekSidebar.cpp:168
 msgid "sigma"
-msgstr ""
+msgstr "sigma"
 
 #: ../../src/MaximaCommandMenus.cpp:3507
 msgid "solve() will solve a list of equations only if for n independent equations there are n variables to solve to.\n"
@@ -11951,7 +11951,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:169
 msgid "tau"
-msgstr ""
+msgstr "tau"
 
 #: ../../src/cells/TextCell.cpp:340
 msgid "the [] operator tried to extract an element of a list, a matrix, an equation or an array. But instead of an integer number something was used whose numerical value is unknown or not an integer.\n"
@@ -11972,7 +11972,7 @@ msgstr "non c'è"
 
 #: ../../src/sidebars/GreekSidebar.cpp:158
 msgid "theta"
-msgstr ""
+msgstr "theta"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:78
 msgid "to the power of 2"
@@ -12001,7 +12001,7 @@ msgstr "senzanome"
 
 #: ../../src/sidebars/GreekSidebar.cpp:170
 msgid "upsilon"
-msgstr ""
+msgstr "upsilon"
 
 #: ../../src/wxMaximaFrame.cpp:1741
 msgid "use as function arguments"
@@ -12184,7 +12184,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:709
 msgid "x"
-msgstr ""
+msgstr "x"
 
 #: ../../src/wizards/DrawWiz.cpp:266
 msgid "x axis label"
@@ -12200,7 +12200,7 @@ msgstr "campo x (automatico se incompleto)"
 
 #: ../../src/sidebars/GreekSidebar.cpp:164
 msgid "xi"
-msgstr ""
+msgstr "xi"
 
 #: ../../src/MaximaFileIO.cpp:408 ../../src/MaximaFileIO.cpp:566
 msgid "xml contained in the file claims not to be a wxMaxima worksheet. "
@@ -12208,7 +12208,7 @@ msgstr "l'xml contenuto nel file dichiara di non essere un foglio di lavoro wxMa
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:97
 msgid "xor"
-msgstr ""
+msgstr "xor"
 
 #: ../../src/wizards/DrawWiz.cpp:279
 msgid "y axis label"
@@ -12236,7 +12236,7 @@ msgstr "campo z (automatico se incompleto)"
 
 #: ../../src/sidebars/GreekSidebar.cpp:156
 msgid "zeta"
-msgstr ""
+msgstr "zeta"
 
 #. type: Title #
 #: ../../info/wxmaxima.md:1

--- a/locales/wxMaxima/kab.po
+++ b/locales/wxMaxima/kab.po
@@ -63,11 +63,11 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1571
 msgid "      -X '--dynamic-space-size <int>'"
-msgstr ""
+msgstr "      -X '--dynamic-space-size <int>'"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1551
 msgid "      -l <name>"
-msgstr ""
+msgstr "      -l <name>"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1557
 msgid "      -u <versionnumber>"
@@ -434,7 +434,7 @@ msgstr "Intégration &numérique"
 
 #: ../../src/wizards/SumWiz.cpp:44
 msgid "&Nusum"
-msgstr ""
+msgstr "&Nusum"
 
 #: ../../src/main.cpp:700
 msgid "&Open\tCtrl+O"
@@ -514,7 +514,7 @@ msgstr ""
 
 #: ../../src/wizards/Plot3dWiz.cpp:79
 msgid "&pm3d"
-msgstr ""
+msgstr "&pm3d"
 
 #: ../../src/cells/AnimationCell.cpp:475
 msgid "(Animation)"
@@ -1291,7 +1291,7 @@ msgstr ""
 
 #: ../../src/wizards/BC2Wiz.cpp:59
 msgid "BC2"
-msgstr ""
+msgstr "BC2"
 
 #: ../../src/MaximaManual.cpp:559
 msgid "Background task that compiles the Manual anchors scheduled."
@@ -1342,7 +1342,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:179
 msgid "Beta"
-msgstr ""
+msgstr "Beta"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1898
 msgid "Bitmap"
@@ -3099,7 +3099,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:181
 msgid "Delta"
-msgstr ""
+msgstr "Delta"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:110
 #: ../../src/worksheet/WorksheetContextMenu.cpp:558
@@ -3736,7 +3736,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:184
 msgid "Eta"
-msgstr ""
+msgstr "Eta"
 
 #: ../../src/sidebars/TableOfContents.cpp:513
 msgid "Evaluate"
@@ -4295,7 +4295,7 @@ msgstr ""
 #: ../../src/cells/GroupCell.cpp:2115
 #, c-format
 msgid "Figure %d:"
-msgstr ""
+msgstr "Figure %d:"
 
 #: ../../src/main.cpp:703
 msgid "File"
@@ -5207,7 +5207,7 @@ msgstr ""
 
 #: ../../src/sidebars/FormatSidebar.cpp:66
 msgid "Image"
-msgstr ""
+msgstr "Image"
 
 #: ../../src/Image.cpp:110
 msgid "Image data had zero length!"
@@ -5862,7 +5862,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:187
 msgid "Kappa"
-msgstr ""
+msgstr "Kappa"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:864
 #, c-format
@@ -7631,11 +7631,11 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:198
 msgid "Phi"
-msgstr ""
+msgstr "Phi"
 
 #: ../../src/sidebars/GreekSidebar.cpp:193
 msgid "Pi"
-msgstr ""
+msgstr "Pi"
 
 #: ../../src/sidebars/StatSidebar.cpp:94
 msgid "Piechart..."
@@ -7987,7 +7987,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:200
 msgid "Psi"
-msgstr ""
+msgstr "Psi"
 
 #: ../../src/wxMaximaFrame.cpp:1792
 msgid "Push"
@@ -8569,7 +8569,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:194
 msgid "Rho"
-msgstr ""
+msgstr "Rho"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2015
 msgid "Right"
@@ -9358,7 +9358,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:195
 msgid "Sigma"
-msgstr ""
+msgstr "Sigma"
 
 #: ../../src/dialogs/FindReplacePane.cpp:88
 msgid "Simple"
@@ -10039,7 +10039,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:196
 msgid "Tau"
-msgstr ""
+msgstr "Tau"
 
 #: ../../src/MaximaCommandMenus.cpp:181
 msgid "Taylor series"
@@ -10496,7 +10496,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:185
 msgid "Theta"
-msgstr ""
+msgstr "Theta"
 
 #: ../../src/dialogs/LicenseDialog.cpp:85
 msgid "Third-party notices"
@@ -11384,7 +11384,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:191
 msgid "Xi"
-msgstr ""
+msgstr "Xi"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:728
 msgid "Yes"
@@ -11440,7 +11440,7 @@ msgstr "Lqem inek n wxMaximar d aneggaru."
 
 #: ../../src/sidebars/GreekSidebar.cpp:183
 msgid "Zeta"
-msgstr ""
+msgstr "Zeta"
 
 #: ../../src/wxMaximaFrame.cpp:846
 msgid "Zoom &In\tCtrl++"
@@ -11480,7 +11480,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:151
 msgid "alpha"
-msgstr ""
+msgstr "alpha"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:95
 msgid "and"
@@ -11512,7 +11512,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:152
 msgid "beta"
-msgstr ""
+msgstr "beta"
 
 #: ../../src/wizards/LimitWiz.cpp:42
 msgid "both sides"
@@ -11538,7 +11538,7 @@ msgstr "par défaut"
 
 #: ../../src/sidebars/GreekSidebar.cpp:154
 msgid "delta"
-msgstr ""
+msgstr "delta"
 
 #: ../../src/wizards/MatWiz.cpp:159
 msgid "diagonal"
@@ -11570,7 +11570,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:157
 msgid "eta"
-msgstr ""
+msgstr "eta"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:799
 msgid "ev() shall evaluate this automatically"
@@ -11793,7 +11793,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:171
 msgid "phi"
-msgstr ""
+msgstr "phi"
 
 #: ../../src/sidebars/GreekSidebar.cpp:166
 msgid "pi"
@@ -11830,7 +11830,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:173
 msgid "psi"
-msgstr ""
+msgstr "psi"
 
 #: ../../src/MaximaCommandMenus.cpp:642
 msgid "radcan() is a powerful tools for simplification trigonometric functions but needs to be taken with care: If a function has more than one branch radcan uses the one that looks like it would fit best, not necessarily the one that makes sense for the problem that resulted in the Expression that is to be simplified."
@@ -11858,7 +11858,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:167
 msgid "rho"
-msgstr ""
+msgstr "rho"
 
 #: ../../src/wizards/LimitWiz.cpp:42
 msgid "right"
@@ -11922,7 +11922,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:169
 msgid "tau"
-msgstr ""
+msgstr "tau"
 
 #: ../../src/cells/TextCell.cpp:340
 msgid "the [] operator tried to extract an element of a list, a matrix, an equation or an array. But instead of an integer number something was used whose numerical value is unknown or not an integer.\n"
@@ -11943,7 +11943,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:158
 msgid "theta"
-msgstr ""
+msgstr "theta"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:78
 msgid "to the power of 2"
@@ -12155,7 +12155,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:709
 msgid "x"
-msgstr ""
+msgstr "x"
 
 #: ../../src/wizards/DrawWiz.cpp:266
 msgid "x axis label"
@@ -12171,7 +12171,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:164
 msgid "xi"
-msgstr ""
+msgstr "xi"
 
 #: ../../src/MaximaFileIO.cpp:408 ../../src/MaximaFileIO.cpp:566
 msgid "xml contained in the file claims not to be a wxMaxima worksheet. "
@@ -12207,7 +12207,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:156
 msgid "zeta"
-msgstr ""
+msgstr "zeta"
 
 #. type: Title #
 #: ../../info/wxmaxima.md:1

--- a/locales/wxMaxima/pl.po
+++ b/locales/wxMaxima/pl.po
@@ -434,7 +434,7 @@ msgstr "Całkowanie &numeryczne"
 
 #: ../../src/wizards/SumWiz.cpp:44
 msgid "&Nusum"
-msgstr ""
+msgstr "&Nusum"
 
 #: ../../src/main.cpp:700
 msgid "&Open\tCtrl+O"
@@ -514,7 +514,7 @@ msgstr ""
 
 #: ../../src/wizards/Plot3dWiz.cpp:79
 msgid "&pm3d"
-msgstr ""
+msgstr "&pm3d"
 
 #: ../../src/cells/AnimationCell.cpp:475
 msgid "(Animation)"
@@ -4565,7 +4565,7 @@ msgstr ""
 
 #: ../../src/wizards/Plot2dWiz.cpp:69 ../../src/wizards/Plot3dWiz.cpp:60
 msgid "Format:"
-msgstr ""
+msgstr "Format:"
 
 #: ../../src/worksheet/Worksheet.cpp:301 ../../src/wxMaxima.cpp:3584
 msgid "Forwarding the keyboard focus to a text control"
@@ -5056,7 +5056,7 @@ msgstr ""
 
 #: ../../src/sidebars/StatSidebar.cpp:85
 msgid "Histogram..."
-msgstr ""
+msgstr "Histogram..."
 
 #: ../../src/wxMaximaFrame.cpp:250
 msgid "History"
@@ -6583,7 +6583,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1437
 msgid "Maxima program:"
-msgstr ""
+msgstr "Maxima program:"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:382
 msgid "Maxima provides no \"forget all\" command that flushes all settings a maxima session could make. wxMaxima therefore normally defaults to starting a fresh maxima process every time the worksheet is to be re-evaluated. As this needs a little bit of time this switch allows to disable this behavior."

--- a/locales/wxMaxima/ru.po
+++ b/locales/wxMaxima/ru.po
@@ -54,23 +54,23 @@ msgstr "\n"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1569
 msgid "      -X \"--control-stack-size <int>\""
-msgstr ""
+msgstr "      -X \"--control-stack-size <int>\""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1568
 msgid "      -X \"--dynamic-space-size <int>\""
-msgstr ""
+msgstr "      -X \"--dynamic-space-size <int>\""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1572
 msgid "      -X '--control-stack-size <int>'"
-msgstr ""
+msgstr "      -X '--control-stack-size <int>'"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1571
 msgid "      -X '--dynamic-space-size <int>'"
-msgstr ""
+msgstr "      -X '--dynamic-space-size <int>'"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1551
 msgid "      -l <name>"
-msgstr ""
+msgstr "      -l <name>"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1557
 msgid "      -u <versionnumber>"
@@ -518,7 +518,7 @@ msgstr "&Переменные"
 
 #: ../../src/wizards/Plot3dWiz.cpp:79
 msgid "&pm3d"
-msgstr ""
+msgstr "&pm3d"
 
 #: ../../src/cells/AnimationCell.cpp:475
 msgid "(Animation)"
@@ -588,7 +588,7 @@ msgstr "(f(x),x,y) с сингулярностями и разрывами"
 #: ../../src/wizards/DrawWiz.cpp:303 ../../src/wizards/DrawWiz.cpp:320
 #: ../../src/wizards/DrawWiz.cpp:335
 msgid "-"
-msgstr ""
+msgstr "-"
 
 #: ../../src/wizards/IntegrateWiz.cpp:192
 #: ../../src/wizards/IntegrateWiz.cpp:202
@@ -612,11 +612,11 @@ msgstr "1 уровень"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:77
 msgid "1/2"
-msgstr ""
+msgstr "1/2"
 
 #: ../../src/sidebars/DrawSidebar.cpp:45
 msgid "2D"
-msgstr ""
+msgstr "2D"
 
 #: ../../src/wxMaximaFrame.cpp:1350
 msgid "2D Array to Matrix..."
@@ -640,7 +640,7 @@ msgstr ""
 
 #: ../../src/sidebars/DrawSidebar.cpp:49
 msgid "3D"
-msgstr ""
+msgstr "3D"
 
 #: ../../src/wxMaxima.cpp:1836
 #, c-format
@@ -1296,7 +1296,7 @@ msgstr "Ось"
 
 #: ../../src/wizards/BC2Wiz.cpp:59
 msgid "BC2"
-msgstr ""
+msgstr "BC2"
 
 #: ../../src/MaximaManual.cpp:559
 msgid "Background task that compiles the Manual anchors scheduled."
@@ -4902,7 +4902,7 @@ msgstr "Подсчёт точного числа, которое может об
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1215
 msgid "HTML"
-msgstr ""
+msgstr "HTML"
 
 #: ../../src/MaximaCommandMenus.cpp:2279
 msgid "HTML file (*.html)|*.html|maxima batch file (*.mac)|*.mac|LaTeX file (*.tex)|*.tex"
@@ -5913,7 +5913,7 @@ msgstr "Норма L[inf] (вещественная)"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1166
 msgid "LaTeX"
-msgstr ""
+msgstr "LaTeX"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1199
 msgid "LaTeX: Place exponents after, instead above subscripts"
@@ -6456,7 +6456,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:281
 msgid "Maxima"
-msgstr ""
+msgstr "Maxima"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1433
 msgid "Maxima Location"
@@ -8848,7 +8848,7 @@ msgstr "Сохранение выполнено успешно, но пропа�
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1914
 msgid "Scalable Vector Graphics (svg)"
-msgstr ""
+msgstr "Scalable Vector Graphics (svg)"
 
 #: ../../src/MaximaCommandMenus.cpp:3596
 msgid "Scalable Vector image (*.svg)|*.svg|Compressed Scalable Vector Image (*.svgz)|*.svgz|PNG image (*.png)|*.png|JPEG image (*.jpg)|*.jpg|GIF image (*.gif)|*.gif|Windows bitmap (*.bmp)|*.bmp|"
@@ -11424,7 +11424,7 @@ msgstr "Записана информация о типе MIME"
 #: ../../src/wizards/DrawWiz.cpp:961 ../../src/wizards/DrawWiz.cpp:974
 #: ../../src/wizards/DrawWiz.cpp:977
 msgid "X"
-msgstr ""
+msgstr "X"
 
 #: ../../src/MathParser.cpp:1279
 msgid "XML nesting limit exceeded"
@@ -11516,7 +11516,7 @@ msgstr "[ не сохранено* ]"
 
 #: ../../src/wizards/DrawWiz.cpp:819 ../../src/wizards/DrawWiz.cpp:825
 msgid "[[x_1,x_2,...],[y_1,y_2,...]]"
-msgstr ""
+msgstr "[[x_1,x_2,...],[y_1,y_2,...]]"
 
 #: ../../src/wizards/DrawWiz.cpp:814
 msgid "[x_1, x_2,...] or [x_1, x_2,...],[y_1, y_2,...] or matrix([x_1,y_1],[x_2,y_2],...)"
@@ -11731,7 +11731,7 @@ msgstr "логарифм. масштаб"
 
 #: ../../src/wizards/DrawWiz.cpp:822
 msgid "matrix([x_1,x_2,...],[y_1,y_2,...])"
-msgstr ""
+msgstr "matrix([x_1,x_2,...],[y_1,y_2,...])"
 
 #: ../../src/wxMaximaFrame.cpp:1443
 msgid "max(abs(A(i,j))) (complex)"
@@ -11772,7 +11772,7 @@ msgstr "не-и"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:772
 msgid "nary: f(x, f(y,z)) = foo(x,y,z)"
-msgstr ""
+msgstr "nary: f(x, f(y,z)) = foo(x,y,z)"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:99
 msgid "nor"
@@ -12209,7 +12209,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:709
 msgid "x"
-msgstr ""
+msgstr "x"
 
 #: ../../src/wizards/DrawWiz.cpp:266
 msgid "x axis label"

--- a/locales/wxMaxima/tr.po
+++ b/locales/wxMaxima/tr.po
@@ -435,7 +435,7 @@ msgstr "&Numerik İntegral"
 
 #: ../../src/wizards/SumWiz.cpp:44
 msgid "&Nusum"
-msgstr ""
+msgstr "&Nusum"
 
 #: ../../src/main.cpp:700
 msgid "&Open\tCtrl+O"
@@ -585,7 +585,7 @@ msgstr ""
 #: ../../src/wizards/DrawWiz.cpp:303 ../../src/wizards/DrawWiz.cpp:320
 #: ../../src/wizards/DrawWiz.cpp:335
 msgid "-"
-msgstr ""
+msgstr "-"
 
 #: ../../src/wizards/IntegrateWiz.cpp:192
 #: ../../src/wizards/IntegrateWiz.cpp:202
@@ -609,7 +609,7 @@ msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:77
 msgid "1/2"
-msgstr ""
+msgstr "1/2"
 
 #: ../../src/sidebars/DrawSidebar.cpp:45
 msgid "2D"
@@ -1343,11 +1343,11 @@ msgstr "İmleç hücreler arasında olduğunda geri alma işlemi yapılabildiği
 
 #: ../../src/sidebars/GreekSidebar.cpp:179
 msgid "Beta"
-msgstr ""
+msgstr "Beta"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1898
 msgid "Bitmap"
-msgstr ""
+msgstr "Bitmap"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1273
 msgid "Bitmap scale for export:"
@@ -1922,7 +1922,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:199
 msgid "Chi"
-msgstr ""
+msgstr "Chi"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:189
 msgid "Chinese (Simplified)"
@@ -3100,7 +3100,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:181
 msgid "Delta"
-msgstr ""
+msgstr "Delta"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:110
 #: ../../src/worksheet/WorksheetContextMenu.cpp:558
@@ -3644,7 +3644,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:182
 msgid "Epsilon"
-msgstr ""
+msgstr "Epsilon"
 
 #: ../../src/MaximaCommandMenus.cpp:299
 msgid "Epsilon:"
@@ -3737,7 +3737,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:184
 msgid "Eta"
-msgstr ""
+msgstr "Eta"
 
 #: ../../src/sidebars/TableOfContents.cpp:513
 msgid "Evaluate"
@@ -4574,7 +4574,7 @@ msgstr ""
 
 #: ../../src/wizards/Plot2dWiz.cpp:69 ../../src/wizards/Plot3dWiz.cpp:60
 msgid "Format:"
-msgstr ""
+msgstr "Format:"
 
 #: ../../src/worksheet/Worksheet.cpp:301 ../../src/wxMaxima.cpp:3584
 msgid "Forwarding the keyboard focus to a text control"
@@ -4726,7 +4726,7 @@ msgstr "Galiçyaca"
 
 #: ../../src/sidebars/GreekSidebar.cpp:180
 msgid "Gamma"
-msgstr ""
+msgstr "Gamma"
 
 #: ../../src/wxMaximaFrame.cpp:320
 msgid "General Math"
@@ -5065,7 +5065,7 @@ msgstr ""
 
 #: ../../src/sidebars/StatSidebar.cpp:85
 msgid "Histogram..."
-msgstr ""
+msgstr "Histogram..."
 
 #: ../../src/wxMaximaFrame.cpp:250
 msgid "History"
@@ -5679,7 +5679,7 @@ msgstr "Ters Laplace Dönüşümü..."
 
 #: ../../src/sidebars/GreekSidebar.cpp:186
 msgid "Iota"
-msgstr ""
+msgstr "Iota"
 
 #: ../../src/MaximaCommandMenus.cpp:4210
 msgid "Is Char 1 greater than Char2, if case is ignored?"
@@ -5871,7 +5871,7 @@ msgstr "Berberi dili"
 
 #: ../../src/sidebars/GreekSidebar.cpp:187
 msgid "Kappa"
-msgstr ""
+msgstr "Kappa"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:864
 #, c-format
@@ -6056,7 +6056,7 @@ msgstr ""
 
 #: ../../src/sidebars/MathSidebar.cpp:86
 msgid "Limit..."
-msgstr ""
+msgstr "Limit..."
 
 #: ../../src/sidebars/DrawSidebar.cpp:88
 msgid "Line color"
@@ -6445,7 +6445,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:281
 msgid "Maxima"
-msgstr ""
+msgstr "Maxima"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1433
 msgid "Maxima Location"
@@ -7358,7 +7358,7 @@ msgstr "Eski Değişken:"
 
 #: ../../src/sidebars/GreekSidebar.cpp:201
 msgid "Omega"
-msgstr ""
+msgstr "Omega"
 
 #: ../../src/sidebars/GreekSidebar.cpp:192
 msgid "Omicron"
@@ -7641,11 +7641,11 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:198
 msgid "Phi"
-msgstr ""
+msgstr "Phi"
 
 #: ../../src/sidebars/GreekSidebar.cpp:193
 msgid "Pi"
-msgstr ""
+msgstr "Pi"
 
 #: ../../src/sidebars/StatSidebar.cpp:94
 msgid "Piechart..."
@@ -7997,7 +7997,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:200
 msgid "Psi"
-msgstr ""
+msgstr "Psi"
 
 #: ../../src/wxMaximaFrame.cpp:1792
 msgid "Push"
@@ -8579,7 +8579,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:194
 msgid "Rho"
-msgstr ""
+msgstr "Rho"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:2015
 msgid "Right"
@@ -9368,7 +9368,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:195
 msgid "Sigma"
-msgstr ""
+msgstr "Sigma"
 
 #: ../../src/dialogs/FindReplacePane.cpp:88
 msgid "Simple"
@@ -10049,7 +10049,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:196
 msgid "Tau"
-msgstr ""
+msgstr "Tau"
 
 #: ../../src/MaximaCommandMenus.cpp:181
 msgid "Taylor series"
@@ -11020,7 +11020,7 @@ msgstr "Üst Sınır:"
 
 #: ../../src/sidebars/GreekSidebar.cpp:197
 msgid "Upsilon"
-msgstr ""
+msgstr "Upsilon"
 
 #: ../../src/wxMaximaFrame.cpp:833
 msgid "Use \"<\" and \">\" as parenthesis for matrices"
@@ -11389,7 +11389,7 @@ msgstr ""
 #: ../../src/wizards/DrawWiz.cpp:961 ../../src/wizards/DrawWiz.cpp:974
 #: ../../src/wizards/DrawWiz.cpp:977
 msgid "X"
-msgstr ""
+msgstr "X"
 
 #: ../../src/MathParser.cpp:1279
 msgid "XML nesting limit exceeded"
@@ -11397,7 +11397,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:191
 msgid "Xi"
-msgstr ""
+msgstr "Xi"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:728
 msgid "Yes"
@@ -11454,7 +11454,7 @@ msgstr "Kullandığınız wxMaxima günceldir."
 
 #: ../../src/sidebars/GreekSidebar.cpp:183
 msgid "Zeta"
-msgstr ""
+msgstr "Zeta"
 
 #: ../../src/wxMaximaFrame.cpp:846
 msgid "Zoom &In\tCtrl++"
@@ -11482,7 +11482,7 @@ msgstr "[Kaydedilmemiş*]"
 
 #: ../../src/wizards/DrawWiz.cpp:819 ../../src/wizards/DrawWiz.cpp:825
 msgid "[[x_1,x_2,...],[y_1,y_2,...]]"
-msgstr ""
+msgstr "[[x_1,x_2,...],[y_1,y_2,...]]"
 
 #: ../../src/wizards/DrawWiz.cpp:814
 msgid "[x_1, x_2,...] or [x_1, x_2,...],[y_1, y_2,...] or matrix([x_1,y_1],[x_2,y_2],...)"
@@ -11526,7 +11526,7 @@ msgstr "değişkenler için gerçek değerler için depo olarak"
 
 #: ../../src/sidebars/GreekSidebar.cpp:152
 msgid "beta"
-msgstr ""
+msgstr "beta"
 
 #: ../../src/wizards/LimitWiz.cpp:42
 msgid "both sides"
@@ -11552,7 +11552,7 @@ msgstr "varsayılan"
 
 #: ../../src/sidebars/GreekSidebar.cpp:154
 msgid "delta"
-msgstr ""
+msgstr "delta"
 
 #: ../../src/wizards/MatWiz.cpp:159
 msgid "diagonal"
@@ -11576,7 +11576,7 @@ msgstr "boş"
 
 #: ../../src/sidebars/GreekSidebar.cpp:155
 msgid "epsilon"
-msgstr ""
+msgstr "epsilon"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:100
 msgid "equivalent"
@@ -11584,7 +11584,7 @@ msgstr "denk"
 
 #: ../../src/sidebars/GreekSidebar.cpp:157
 msgid "eta"
-msgstr ""
+msgstr "eta"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:799
 msgid "ev() shall evaluate this automatically"
@@ -11677,7 +11677,7 @@ msgstr "kappa harfi"
 
 #: ../../src/sidebars/GreekSidebar.cpp:161
 msgid "lambda"
-msgstr ""
+msgstr "lambda"
 
 #: ../../src/wizards/LimitWiz.cpp:42
 msgid "left"
@@ -11697,7 +11697,7 @@ msgstr "log ölçeği"
 
 #: ../../src/wizards/DrawWiz.cpp:822
 msgid "matrix([x_1,x_2,...],[y_1,y_2,...])"
-msgstr ""
+msgstr "matrix([x_1,x_2,...],[y_1,y_2,...])"
 
 #: ../../src/wxMaximaFrame.cpp:1443
 msgid "max(abs(A(i,j))) (complex)"
@@ -11734,7 +11734,7 @@ msgstr "nabla işareti"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:98
 msgid "nand"
-msgstr ""
+msgstr "nand"
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:772
 msgid "nary: f(x, f(y,z)) = foo(x,y,z)"
@@ -11778,7 +11778,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:174
 msgid "omega"
-msgstr ""
+msgstr "omega"
 
 #: ../../src/sidebars/GreekSidebar.cpp:165
 msgid "omicron"
@@ -11807,11 +11807,11 @@ msgstr "kısmi türev  işareti"
 
 #: ../../src/sidebars/GreekSidebar.cpp:171
 msgid "phi"
-msgstr ""
+msgstr "phi"
 
 #: ../../src/sidebars/GreekSidebar.cpp:166
 msgid "pi"
-msgstr ""
+msgstr "pi"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:101
 msgid "plus or minus"
@@ -11844,7 +11844,7 @@ msgstr "'e ile doğru orantılı"
 
 #: ../../src/sidebars/GreekSidebar.cpp:173
 msgid "psi"
-msgstr ""
+msgstr "psi"
 
 #: ../../src/MaximaCommandMenus.cpp:642
 msgid "radcan() is a powerful tools for simplification trigonometric functions but needs to be taken with care: If a function has more than one branch radcan uses the one that looks like it would fit best, not necessarily the one that makes sense for the problem that resulted in the Expression that is to be simplified."
@@ -11896,7 +11896,7 @@ msgstr "ikincil y aralığı (eksikse otomatik)"
 
 #: ../../src/sidebars/GreekSidebar.cpp:168
 msgid "sigma"
-msgstr ""
+msgstr "sigma"
 
 #: ../../src/MaximaCommandMenus.cpp:3507
 msgid "solve() will solve a list of equations only if for n independent equations there are n variables to solve to.\n"
@@ -11937,7 +11937,7 @@ msgstr ""
 
 #: ../../src/sidebars/GreekSidebar.cpp:169
 msgid "tau"
-msgstr ""
+msgstr "tau"
 
 #: ../../src/cells/TextCell.cpp:340
 msgid "the [] operator tried to extract an element of a list, a matrix, an equation or an array. But instead of an integer number something was used whose numerical value is unknown or not an integer.\n"
@@ -11958,7 +11958,7 @@ msgstr "bulunmuyor"
 
 #: ../../src/sidebars/GreekSidebar.cpp:158
 msgid "theta"
-msgstr ""
+msgstr "theta"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:78
 msgid "to the power of 2"
@@ -11987,7 +11987,7 @@ msgstr "başlıksız"
 
 #: ../../src/sidebars/GreekSidebar.cpp:170
 msgid "upsilon"
-msgstr ""
+msgstr "upsilon"
 
 #: ../../src/wxMaximaFrame.cpp:1741
 msgid "use as function arguments"
@@ -12170,7 +12170,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:709
 msgid "x"
-msgstr ""
+msgstr "x"
 
 #: ../../src/wizards/DrawWiz.cpp:266
 msgid "x axis label"
@@ -12186,7 +12186,7 @@ msgstr "x aralığı (eksikse otomatik)"
 
 #: ../../src/sidebars/GreekSidebar.cpp:164
 msgid "xi"
-msgstr ""
+msgstr "xi"
 
 #: ../../src/MaximaFileIO.cpp:408 ../../src/MaximaFileIO.cpp:566
 msgid "xml contained in the file claims not to be a wxMaxima worksheet. "
@@ -12194,7 +12194,7 @@ msgstr "dosyada bulunan xml, bir wxMaxima çalışma sayfası olmamasını talep
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:97
 msgid "xor"
-msgstr ""
+msgstr "xor"
 
 #: ../../src/wizards/DrawWiz.cpp:279
 msgid "y axis label"
@@ -12222,7 +12222,7 @@ msgstr "z aralığı (eksikse otomatik)"
 
 #: ../../src/sidebars/GreekSidebar.cpp:156
 msgid "zeta"
-msgstr ""
+msgstr "zeta"
 
 #. type: Title #
 #: ../../info/wxmaxima.md:1

--- a/locales/wxMaxima/uk.po
+++ b/locales/wxMaxima/uk.po
@@ -517,7 +517,7 @@ msgstr "З&мінні"
 
 #: ../../src/wizards/Plot3dWiz.cpp:79
 msgid "&pm3d"
-msgstr ""
+msgstr "&pm3d"
 
 #: ../../src/cells/AnimationCell.cpp:475
 msgid "(Animation)"
@@ -587,7 +587,7 @@ msgstr "(f(x),x,y) із сингулярностями і розривами"
 #: ../../src/wizards/DrawWiz.cpp:303 ../../src/wizards/DrawWiz.cpp:320
 #: ../../src/wizards/DrawWiz.cpp:335
 msgid "-"
-msgstr ""
+msgstr "-"
 
 #: ../../src/wizards/IntegrateWiz.cpp:192
 #: ../../src/wizards/IntegrateWiz.cpp:202
@@ -611,7 +611,7 @@ msgstr "1 рівень"
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:77
 msgid "1/2"
-msgstr ""
+msgstr "1/2"
 
 #: ../../src/sidebars/DrawSidebar.cpp:45
 msgid "2D"
@@ -1295,7 +1295,7 @@ msgstr "Вісь"
 
 #: ../../src/wizards/BC2Wiz.cpp:59
 msgid "BC2"
-msgstr ""
+msgstr "BC2"
 
 #: ../../src/MaximaManual.cpp:559
 msgid "Background task that compiles the Manual anchors scheduled."
@@ -4901,7 +4901,7 @@ msgstr "Вгадати точне число, яке могло б бути пр
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1215
 msgid "HTML"
-msgstr ""
+msgstr "HTML"
 
 #: ../../src/MaximaCommandMenus.cpp:2279
 msgid "HTML file (*.html)|*.html|maxima batch file (*.mac)|*.mac|LaTeX file (*.tex)|*.tex"
@@ -5912,7 +5912,7 @@ msgstr "Норма L[inf] (дійсна)"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1166
 msgid "LaTeX"
-msgstr ""
+msgstr "LaTeX"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1199
 msgid "LaTeX: Place exponents after, instead above subscripts"
@@ -6455,7 +6455,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:281
 msgid "Maxima"
-msgstr ""
+msgstr "Maxima"
 
 #: ../../src/dialogs/ConfigDialogue.cpp:1433
 msgid "Maxima Location"
@@ -11415,7 +11415,7 @@ msgstr "Записано дані щодо типу MIME"
 #: ../../src/wizards/DrawWiz.cpp:961 ../../src/wizards/DrawWiz.cpp:974
 #: ../../src/wizards/DrawWiz.cpp:977
 msgid "X"
-msgstr ""
+msgstr "X"
 
 #: ../../src/MathParser.cpp:1279
 msgid "XML nesting limit exceeded"
@@ -11507,7 +11507,7 @@ msgstr "[ не збережено* ]"
 
 #: ../../src/wizards/DrawWiz.cpp:819 ../../src/wizards/DrawWiz.cpp:825
 msgid "[[x_1,x_2,...],[y_1,y_2,...]]"
-msgstr ""
+msgstr "[[x_1,x_2,...],[y_1,y_2,...]]"
 
 #: ../../src/wizards/DrawWiz.cpp:814
 msgid "[x_1, x_2,...] or [x_1, x_2,...],[y_1, y_2,...] or matrix([x_1,y_1],[x_2,y_2],...)"
@@ -11722,7 +11722,7 @@ msgstr "логарифмічна шкала"
 
 #: ../../src/wizards/DrawWiz.cpp:822
 msgid "matrix([x_1,x_2,...],[y_1,y_2,...])"
-msgstr ""
+msgstr "matrix([x_1,x_2,...],[y_1,y_2,...])"
 
 #: ../../src/wxMaximaFrame.cpp:1443
 msgid "max(abs(A(i,j))) (complex)"
@@ -12198,7 +12198,7 @@ msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:709
 msgid "x"
-msgstr ""
+msgstr "x"
 
 #: ../../src/wizards/DrawWiz.cpp:266
 msgid "x axis label"

--- a/test/check-pot-coverage.cmake
+++ b/test/check-pot-coverage.cmake
@@ -28,6 +28,12 @@ if(NOT SOURCE_DIR)
   message(FATAL_ERROR "check-pot-coverage: SOURCE_DIR must be set")
 endif()
 
+# Script mode (cmake -P) doesn't inherit the top-level CMakeLists.txt's policy
+# settings, so IN_LIST below needs this set explicitly -- without it CMake
+# falls back to the pre-3.3 OLD behavior, where if() doesn't know IN_LIST at
+# all, and errors out on it as a bare unquoted argument list.
+cmake_policy(SET CMP0057 NEW)
+
 set(pot "${SOURCE_DIR}/locales/wxMaxima/wxMaxima.pot")
 if(NOT EXISTS "${pot}")
   message(FATAL_ERROR "check-pot-coverage: ${pot} not found")


### PR DESCRIPTION
## Summary

### Translation loss from a Crowdin sync race

PR #2244 ("New Crowdin updates", the `l10n_main2` branch) merged into `main` at 19:59:43+30min, but its branch had last synced from `main` at 19:55:40 — only 4 minutes **before** PR #2241 ("Restore 7083 translations the flat `src/*` gettext glob had dropped") landed. Confirmed directly from the commit graph, not inferred:

```
git merge-base <l10n_main2 tip that became #2244> <main tip right after #2239, the previous Crowdin merge>
```

equals that pre-#2241 commit exactly — Crowdin's new per-language commits were parented on a base that predates the restore. When #2244 then merged into a `main` that had since moved on, a plain 3-way git merge (which has no concept of PO-file semantics) combined both diffs, and wherever they touched the same file without a *textual* line conflict, whichever side's hunk landed silently won.

Measured precisely with `polib` (a `msgid`+`msgctxt`-keyed diff, not `msgfmt --statistics` counts, since those can't distinguish "reverted to worse text" from "line-wrapping changed"): **464 translations across 16 languages went from non-empty to empty, and zero went the other way** — an unambiguous regression, not translator churn:

```
ca: 64  cs: 8   da: 4   de: 63  el: 2   es: 48  fi: 9   fr: 11
gl: 42  hu: 26  it: 72  kab: 32 pl: 5   ru: 20  tr: 47  uk: 11
```

This isn't the first time either — a stale local branch from 2026-08-05, `recover-crowdin-translations` ("Recover UI translations wiped by Crowdin's initial project sync"), shows the same failure mode already happened once before around this same subdir-glob restoration work. Worth raising with Crowdin support directly if it recurs; this session has no Crowdin API access to inspect their sync/webhook configuration.

**Fix**: restored each wiped entry's exact pre-regression text via a surgical, per-entry text-level patch — locate each entry's own line range independently in both the pre-regression and current file (via `polib`'s `.linenum`), then splice in only the `msgstr` block, leaving everything else byte-identical. Round-tripping the whole file through `polib`'s own serializer was tried first and rejected: it reformats every line's wrapping, which would have turned this 464-line fix into ~200KB of unreadable diff noise across 16 files. The actual diff here is exactly 464 lines changed, one per restored entry.

### `check-pot-coverage.cmake` CMake policy bug

While verifying the above, `check-pot-coverage` (the CI guard from #2241) was failing the full test suite — turned out to be unrelated to translations: the script runs in `cmake -P` script mode, which does not inherit the top-level `CMakeLists.txt`'s policy settings, so its `if(... IN_LIST ...)` check needs `cmake_policy(SET CMP0057 NEW)` set explicitly. Confirmed this fails identically on a clean, unrelated checkout of `main` — not something this PR's translation changes caused, just caught along the way.

## Test plan

- [x] `ninja` builds cleanly, `.mo` compilation succeeds for all 16 restored `.po` files (`msgfmt --check` clean on each)
- [x] Confirmed zero remaining lost entries and zero text mismatches against the pre-regression state (scripted `polib` comparison)
- [x] Full `ctest` suite: 226/226 passing (including the now-fixed `check-pot-coverage`)
- [x] `wxMaxima.pot` untouched — this is purely translation-content restoration, no source-string changes


---
_Generated by [Claude Code](https://claude.ai/code/session_011iszcZR49S3QXrTKUQjiu6)_