### PR TITLE
Fix main not compiling with clang: drop an unused lambda capture

### DIFF
--- a/src/wxMaxima.cpp
+++ b/src/wxMaxima.cpp
@@ -2636,7 +2636,7 @@ void wxMaxima::OnTimerEvent(wxTimerEvent &event) {
       // another event handler is still in flight; no modal dialogs directly
       // inside event handlers (see the similar CallAfter()s in
       // MaximaProcessManager.cpp/StartMaxima()).
-      CallAfter([this, command] {
+      CallAfter([command] {
 #if defined(__WXOSX__)
         LoggingMessageBox(
           wxString::Format(


### PR DESCRIPTION
`main` does not currently compile with clang:

```
src/wxMaxima.cpp:2639:18: error: lambda capture 'this' is not used
                                 [-Werror,-Wunused-lambda-capture]
      CallAfter([this, command] {
```

d3af3a093 added a `CallAfter()` lambda capturing both `this` and `command`, but its body only ever calls `LoggingMessageBox()` — a **free** function (`dialogs/LoggingMessageDialog.h` declares it `extern int LoggingMessageBox(...)`), in the `__WXOSX__` branch and the other one alike. So `this` is captured and never used, and `-Werror` turns that into a build stop.

The fix captures only what the lambda uses. `command` stays captured **by value**, as it must: the whole point of the `CallAfter()` is that the message box appears after the current event handler returns, by which time the local `wxString` is gone.

### Why CI didn't catch this, which is the part worth keeping in mind

`-Wunused-lambda-capture` is a clang warning; gcc has no equivalent. The Ubuntu jobs build with gcc, so they cannot see this at all. Anything built with clang — a development machine set up this way, and the sanitizer toolchain — simply cannot compile `main` until it is fixed.

So a green Linux CI is not evidence that the tree builds with clang. If that gap is worth closing, a clang build job would be the way; happy to open a separate issue for it if you want one.

Verified: a full rebuild (304 steps, `-Wall -Werror -Wextra`, clang 21) is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q65eoSF1N7jzjdTHpBsq4Z