### PR TITLE
Carry an equation's text inside the PNG we export it as (GH #2231)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,12 @@
   found so far. Also fixed a CMake policy bug in the just-added
   `check-pot-coverage` CI guard (script mode doesn't inherit the top-level
   policy settings, so its `IN_LIST` check unconditionally errored out).
+- Equations saved as PNG now carry their text form inside the image file
+  (GH #2231), so the maths travels with the picture: a screen reader can read
+  out what the image shows, and anyone who finds the file later - or a search
+  index that looks at it - can tell what is in it instead of seeing an
+  anonymous graphic. Needs wxWidgets 3.3.1 or newer; with an older wxWidgets
+  the exported PNG is unchanged.
 - Equations exported as SVG now carry their text form, so a screen reader can
   read them out instead of announcing an anonymous picture (GH #2230). Both
   the HTML export's equation images and the SVG that "Copy as SVG" puts on the

--- a/src/graphical_io/BitmapOut.cpp
+++ b/src/graphical_io/BitmapOut.cpp
@@ -28,6 +28,8 @@
 #include "BitmapOut.h"
 #include "cells/Cell.h"
 #include <wx/clipbrd.h>
+// wxIMAGE_OPTION_PNG_DESCRIPTION
+#include <wx/imagpng.h>
 
 #define BM_FULL_WIDTH 1000
 
@@ -129,6 +131,18 @@ wxSize BitmapOut::ToFile(const wxString &file) {
   wxImage img = m_bmp.ConvertToImage();
   int resolution = m_cmn.GetScreenConfig().GetRecalcDC()->GetPPI().x;
   img.SetOption(wxIMAGE_OPTION_RESOLUTION, resolution * m_cmn.GetScale());
+
+#if wxCHECK_VERSION(3, 3, 1)
+  // A PNG of an equation is just pixels: nothing in it says what the maths is,
+  // so a screen reader meeting one has nothing to announce and anyone finding
+  // the file later has no idea what it holds. wxWidgets 3.3.1 and up can write
+  // PNG text chunks, so carry the equation's text form along inside the file
+  // itself. Only PNG has somewhere to put this - the .bmp/.xpm/.jpg branches
+  // below simply have no such chunk, and older wxWidgets ignores the option.
+  const wxString description = OutCommon::AccessibleText(m_tree.get());
+  if (!description.IsEmpty())
+    img.SetOption(wxIMAGE_OPTION_PNG_DESCRIPTION, description);
+#endif
 
   bool success = false;
   if (file.EndsWith(wxS(".bmp")))

--- a/src/graphical_io/OutCommon.cpp
+++ b/src/graphical_io/OutCommon.cpp
@@ -65,6 +65,27 @@ wxString MakeTempFilename(const wxString &prefix) {
 
 } // namespace
 
+wxString OutCommon::AccessibleText(const Cell *tree) {
+  if (!tree)
+    return {};
+
+  const wxString text = tree->ListToString();
+  wxString label;
+  label.reserve(text.length());
+  bool pendingSpace = false;
+  for (const wxUniChar c : text) {
+    if (wxIsspace(c))
+      pendingSpace = true;
+    else {
+      if (pendingSpace && !label.IsEmpty())
+        label += wxS(' ');
+      pendingSpace = false;
+      label += c;
+    }
+  }
+  return label;
+}
+
 OutCommon::OutCommon(const Configuration * const *configuration, const wxString &filename,
                      int fullWidth, double scale)
     : m_tempFilename(MakeTempFilename(wxS("wxmaxima_size_"))),

--- a/src/graphical_io/OutCommon.h
+++ b/src/graphical_io/OutCommon.h
@@ -58,6 +58,29 @@ public:
   //! file the data was saved in.
   std::unique_ptr<DataObject> GetDataObject(const wxDataFormat &format);
 
+  /*! The plain-text form of a cell list, for use as an accessible label
+
+    Exported maths is a picture: an SVG draws it as anonymous paths, a PNG as
+    pixels, and either way a screen reader has nothing to announce unless we
+    hand it the text. This is the one place that text is derived, so the SVG's
+    <title>/aria-label and the PNG's Description chunk cannot drift apart.
+
+    The text is what ListToString() gives - the same rendering the clipboard
+    and the .wxm exporter use, so what is spoken matches what copying the cell
+    as text would give.
+
+    Every run of whitespace collapses to a single space. 2-D ASCII-art maths
+    pads its lines with long space runs and tabs to keep fraction bars and
+    matrices aligned; that alignment is meaningless once the text is spoken
+    rather than drawn, and leaving it in makes the label a stuttering mess.
+    Line breaks go for the same reason: the result is a single label, not a
+    document.
+
+    \param tree The cell list that was rendered, or null.
+    \return The label, or an empty string if there is nothing to describe.
+  */
+  static wxString AccessibleText(const Cell *tree);
+
   /*! Constructs the instance of the helper, temporarily overriding the
    * configuration.
    *

--- a/src/graphical_io/SVGout.cpp
+++ b/src/graphical_io/SVGout.cpp
@@ -72,37 +72,6 @@ wxSize Svgout::Render(std::unique_ptr<Cell> &&tree) {
   return m_size;
 }
 
-wxString Svgout::AccessibleText() const {
-  if (!m_tree)
-    return {};
-
-  // The same plain-text rendering the clipboard and the .wxm exporter use, so
-  // a screen reader hears exactly what a sighted user would get by copying the
-  // cell as text.
-  //
-  // Every run of whitespace collapses to a single space. 2-D ASCII-art maths
-  // (TS_ASCIIMATHS) pads its lines with long runs of spaces and tabs to keep
-  // fraction bars and matrices aligned; that alignment is meaningless once the
-  // text is spoken rather than drawn, and left in it makes the label a
-  // stuttering mess. The line breaks have to go for the same reason: this ends
-  // up in an SVG <title>/aria-label, which is a single label, not a document.
-  const wxString text = m_tree->ListToString();
-  wxString label;
-  label.reserve(text.length());
-  bool pendingSpace = false;
-  for (const wxUniChar c : text) {
-    if (wxIsspace(c))
-      pendingSpace = true;
-    else {
-      if (pendingSpace && !label.IsEmpty())
-        label += wxS(' ');
-      pendingSpace = false;
-      label += c;
-    }
-  }
-  return label;
-}
-
 bool Svgout::Layout() {
   if (!m_cmn.PrepareLayout(m_tree.get()))
     return false;
@@ -116,7 +85,7 @@ bool Svgout::Layout() {
   // announce. Older wxWidgets simply produces the same SVG as before -- note
   // that the label is computed inside the guard too, so it cannot become an
   // unused variable there.
-  const wxString text = AccessibleText();
+  const wxString text = OutCommon::AccessibleText(m_tree.get());
   wxSVGFileDC dc(m_cmn.GetFilename(), size.x, size.y, 20 * m_cmn.GetScale(),
                  text);
 #else

--- a/src/graphical_io/SVGout.h
+++ b/src/graphical_io/SVGout.h
@@ -60,14 +60,6 @@ public:
   std::unique_ptr<wxCustomDataObject> GetDataObject();
 
 private:
-  /*! The plain-text form of the rendered cells, for use as an accessible label
-
-    Empty if there is nothing to render. Line breaks are folded into spaces:
-    the result is used as a single SVG <title>/aria-label, which is a label,
-    not a document.
-  */
-  wxString AccessibleText() const;
-
   std::unique_ptr<Cell> m_tree;
   OutCommon m_cmn;
   wxSVGFileDC m_recalculationDc;

--- a/test/unit_tests/test_WorksheetExport.cpp
+++ b/test/unit_tests/test_WorksheetExport.cpp
@@ -394,6 +394,66 @@ static void RequireSvgIsLabelled(const wxString &htmlDir) {
 #endif
 }
 
+/*! Every exported equation PNG must carry its text form inside the file.
+
+  A PNG of an equation is just pixels: a screen reader meeting one has nothing
+  to announce, and anyone finding the file later cannot tell what it holds.
+  BitmapOut therefore sets wxIMAGE_OPTION_PNG_DESCRIPTION (GH #2231), which
+  wxWidgets 3.3.1 and up writes as a PNG text chunk keyed "Description".
+
+  The chunks are walked rather than the bytes searched, so a stray
+  "Description" inside the compressed image data cannot make this pass by
+  accident. wxWidgets writes iTXt (UTF-8); tEXt is accepted too so this does
+  not break if that ever changes - hence skipping any run of NULs after the
+  keyword, which covers iTXt's compression/language fields and tEXt's absence
+  of them alike.
+
+  Guarded on the wxWidgets version exactly like the code under test.
+*/
+static void RequireBitmapsDescribed(const wxString &htmlDir) {
+#if wxCHECK_VERSION(3, 3, 1)
+  const wxString imgDir = htmlDir + wxS("/doc_htmlimg");
+  wxArrayString pngs;
+  wxDir::GetAllFiles(imgDir, &pngs, wxS("doc_*.png"), wxDIR_FILES);
+  REQUIRE(pngs.GetCount() > 0);
+  static const std::string keyword("Description\0", 12);
+  for (const wxString &png : pngs) {
+    INFO("equation bitmap: " << png.ToStdString());
+    const std::string bytes = ReadBinaryFile(png);
+    REQUIRE(bytes.size() > 8);
+    bool described = false;
+    for (size_t pos = 8; pos + 12 <= bytes.size();) {
+      const unsigned char *const p =
+        reinterpret_cast<const unsigned char *>(bytes.data()) + pos;
+      const size_t len = (static_cast<size_t>(p[0]) << 24) |
+                         (static_cast<size_t>(p[1]) << 16) |
+                         (static_cast<size_t>(p[2]) << 8) |
+                         static_cast<size_t>(p[3]);
+      const std::string type = bytes.substr(pos + 4, 4);
+      if (pos + 12 + len > bytes.size())
+        break;
+      if ((type == "iTXt" || type == "tEXt") && len > keyword.size()) {
+        const std::string body = bytes.substr(pos + 8, len);
+        if (body.compare(0, keyword.size(), keyword) == 0) {
+          size_t textStart = keyword.size();
+          while (textStart < body.size() && body[textStart] == '\0')
+            ++textStart;
+          // The description must actually say something.
+          REQUIRE(textStart < body.size());
+          described = true;
+        }
+      }
+      if (type == "IEND")
+        break;
+      pos += 12 + len;
+    }
+    REQUIRE(described);
+  }
+#else
+  wxUnusedVar(htmlDir);
+#endif
+}
+
 static void RequireBitmapsNotClipped(const wxString &htmlDir) {
   const wxString imgDir = htmlDir + wxS("/doc_htmlimg");
   wxArrayString pngs;
@@ -518,8 +578,11 @@ SCENARIO("HTML export succeeds, is deterministic and contains the document") {
         RequireImgSrcsExist(html, dir1);
       // The bitmap flavor must not clip equations to a corner of the canvas
       // (a BitmapScale double-magnification regression, see helper).
-      if (eq.format == Configuration::bitmap)
+      if (eq.format == Configuration::bitmap) {
         RequireBitmapsNotClipped(dir1);
+        // ...and must say what maths they show (see helper).
+        RequireBitmapsDescribed(dir1);
+      }
       // The svg flavor must label its equations for screen readers (see
       // helper); an unlabelled SVG is an anonymous picture to them.
       if (eq.format == Configuration::svg)


### PR DESCRIPTION
Closes #2231.

A PNG of an equation is just pixels. A screen reader meeting one has nothing to announce, and anyone who finds the file later — or a search index that looks at it — cannot tell what maths it holds.

wxWidgets 3.3.1 and up can write PNG text chunks, so `BitmapOut` now sets `wxIMAGE_OPTION_PNG_DESCRIPTION` when it saves, right beside the resolution it already sets. wxWidgets writes it as an `iTXt` chunk keyed `Description`:

```
IHDR (13 bytes)
sBIT (3 bytes)
pHYs (9 bytes)
iTXt: b'Description\x00\x00\x00\x00\x00(%o11) 2 ExportNetAsciiArt x + 1 ...'
IDAT ...
```

### Scope

Only PNG gets this: the `.bmp` / `.xpm` / `.jpg` branches have nowhere to put it, and older wxWidgets ignores the option. The LaTeX animation-frame export is deliberately untouched too — it writes out already-rendered animation frames rather than freshly drawn maths, so a description there would be describing the wrong thing.

### One shared source of truth

The description is the same string the SVG export (#2243) uses as its `aria-label`, and that the HTML export already writes as the `<img>` `alt` attribute. Three separate answers to "how do we describe an exported equation" is exactly the thing that rots, so the derivation moves out of `Svgout` into **`OutCommon::AccessibleText()`** — now the single place that turns a cell list into a spoken label: `ListToString()` with every run of whitespace folded to one space, because 2-D ASCII-art padding is meaningless once the text is spoken rather than drawn.

### Test

`test_WorksheetExport` gains `RequireBitmapsDescribed`. It walks the PNG chunk structure rather than searching the raw bytes, so a stray `Description` inside the compressed image data cannot make it pass by accident, and it accepts `tEXt` as well as the `iTXt` wxWidgets currently writes.

Which chunk that is was **read off a real exported file rather than assumed** — `tEXt` was the obvious guess, and would have been wrong.

Verified red before the fix and green after; `WorksheetClipboard` and `WXMXRoundtrip` stay green.

> Note: to build this (or `main`) with clang you also need #2247 — `main` currently fails on an unused lambda capture. That fix is deliberately not included here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q65eoSF1N7jzjdTHpBsq4Z