### PR TITLE
Let the sidebars be minimized, not just closed (GH #2229)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,13 @@
 # Current development version
 
+- Sidebars can now be minimized, not just closed (GH #2229). A minimized
+  sidebar collapses into a small strip at the edge of the window and comes
+  back, in the same place and at the same size, when you click it there - so a
+  sidebar you only need occasionally no longer costs you either its screen
+  space or its position. Closing a sidebar still works exactly as before.
+  Needs wxWidgets 3.3.2 or newer; with an older wxWidgets the sidebars are
+  unchanged.
+
 - Restored 464 UI/manual translations across 16 languages (Catalan, Czech,
   Danish, German, Greek, Spanish, Finnish, French, Galician, Hungarian,
   Italian, Kabyle, Polish, Russian, Turkish, Ukrainian) that a Crowdin sync

--- a/src/wxMaximaFrame.cpp
+++ b/src/wxMaximaFrame.cpp
@@ -430,6 +430,19 @@ wxMaximaFrame::wxMaximaFrame(wxWindow *parent, int id,
               .LeftDockable(true)
               .RightDockable(true)
               .PaneBorder(true);
+#if wxCHECK_VERSION(3, 3, 2)
+          // A sidebar can be closed, but closing it forgets where it was.
+          // wxWidgets 3.3.2 and up can minimize a pane instead: it collapses
+          // to a small toolbar-like handle and comes back where it was, which
+          // is what you want for a sidebar you only need now and then. Set
+          // after the chain above rather than inside it, so the whole common
+          // block stays one statement on every wxWidgets version.
+          if(
+             (paneId != EventIDs::menu_pane_console) &&
+             (paneId != EventIDs::menu_pane_toolbar)
+             )
+            m_manager.GetPane(name).MinimizeButton(true);
+#endif
           // Give the pane's window an accessible name: without it a screen
           // reader announces every sidebar as an unnamed "panel". The default
           // wxWindowAccessible reports the window's label as its name.


### PR DESCRIPTION
Closes #2229.

Closing a sidebar throws away where it was and how big it was. wxWidgets 3.3.2 added `wxAuiPaneInfo::MinimizeButton()`, which offers the gentler alternative: the pane collapses into a small strip at the edge of the window and comes back in the same place when clicked there — what you want for a sidebar you only need occasionally.

The button appears on all 14 sidebars:

> `Greek Lett… — ×`  `Mathemati… — ×`  `Plot using — ×`

### Where it's applied, and what's excluded

In the loop that already applies the common sidebar properties **after** `LoadPerspective()` — the one place that deliberately runs after the saved perspective is read, so a stale saved layout cannot leave a sidebar without the new button.

The worksheet and the toolbar are excluded, with the same condition as the block above it. That isn't cosmetic: `wxAuiManager::MinimizePane()` asserts on panes without a minimize button and refuses centre panes outright, so offering the button on the worksheet would be offering something that cannot work.

### Nothing else needed to cope with a minimized sidebar

Worth spelling out, because it looks like it should need work — @gunterkoenigsmann asked specifically whether invoking a wizard with the wizard sidebar minimized would bring it back.

It does, for free. A minimized pane is **not a separate state**: `MinimizePane()` calls `paneInfo.Hide()` and adds an entry to a min-dock strip, and wx's own handler for clicking that entry is just

```cpp
if (pane->IsShown()) m_mgr.MinimizePane(*pane);
else                 pane->Show();
m_mgr.Update();
```

which is exactly what `ShowPane()` and `ShowWizardPane()` already do. So invoking a wizard, or opening the variables/unicode/help sidebar from the menu, restores it from minimized with no new code.

⚠️ **A trap for later:** `wxAuiManager::RestorePane()` is *not* the way to undo this despite the name. It is the counterpart to `MaximizePane()` and rewrites **every** pane's hidden state from `savedHiddenState`, which would silently reshuffle all the other sidebars.

### On the Find dialogue

The other half of the original request — Ctrl+F with the find sidebar minimized — turns out not to apply: there is no find sidebar. `Ctrl+F` opens `m_findDialog`, a separate dialog window, and there is no `menu_pane_find`. That is now its own issue, #2249.

### Verification

The GUI screenshot confirms the button on every sidebar and not on the worksheet. 43 of 45 unit tests pass; the two that don't (`SqrtCell`, `ImgCell`) fail only because that run has `DISPLAY` unset, and pass under `xvfb-run`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q65eoSF1N7jzjdTHpBsq4Z