### PR TITLE
Distil the project knowledge that only lived in one agent's notes

### DIFF
--- a/.claude/skills/wxmaxima-architecture/SKILL.md
+++ b/.claude/skills/wxmaxima-architecture/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: wxmaxima-architecture
+description: Where wxMaxima's code lives and why - the friend-class decomposition of the wxMaxima god class, the Worksheet document/view split, CellPointers, and the recipe for peeling another cluster off safely. Use when looking for where a piece of functionality lives, when a class feels too big, or before starting any extraction/refactor of wxMaxima.cpp, Worksheet.cpp or Configuration.
+---
+
+# wxMaxima's architecture, and how it got that way
+
+Two classes used to hold almost everything: `wxMaxima` (the app/frame) and
+`Worksheet` (the document view). Both have been decomposed in behaviour-
+preserving slices. This is where things ended up, and the recipe for doing the
+next one without breaking anything.
+
+## Where functionality lives now
+
+`wxMaxima` keeps the frame and the glue; the clusters were peeled into **friend
+classes** (declared in `wxMaxima.h`), each owning one concern:
+
+| Class | Owns |
+|---|---|
+| `MaximaProcessManager` | spawn / kill / connect, the data pump, gnuplot children |
+| `MaximaEvaluator` | the evaluation queue driver and the command protocol |
+| `MaximaResponseReader` | the incoming-XML handlers and their dispatch maps |
+| `MaximaFileIO` | worksheet open/save (`.wxm`, `.wxmx`, `.mac`), autosave |
+| `MaximaCommandMenus` | the bound menu handlers |
+| `MaximaIPC`, `MaximaOutputAppender` | IPC, output appending |
+
+So: **look in the friend class before `wxMaxima.cpp`.** The god class went from
+~11,100 lines to ~3,700 this way.
+
+`Worksheet` was split along a different axis - document state versus view - into
+`WorksheetDocument`, `WorksheetLayout` (see the `wxmaxima-layout` skill),
+`WorksheetExport`, `WorksheetSearch`, `WorksheetEvalQueue` and
+`WorksheetContextMenu`. What remains in `Worksheet.cpp` is genuinely
+view/OS-native: input handling, painting, accessibility, autocomplete,
+clipboard. **That arc is closed**; don't go looking for more of the same shape
+there without a new reason.
+
+## The extraction recipe
+
+Both arcs used the same method, and it works:
+
+1. **Map first, cut second.** Write down the cluster's members, its callers, and
+   its coupling in three directions (up to the wx view, down to the cell tree,
+   sideways to `Configuration`) *before* moving a line. Most of the risk is in
+   coupling you did not notice.
+2. **Small slices, each green.** Move one coherent group at a time, build and
+   test between slices. Never one big move.
+3. **Friend class, not inheritance.** Keeps the private state reachable during
+   the transition without inventing accessors you will regret.
+4. **Behaviour-preserving means byte-identical where you can measure it.** The
+   export cluster had `test_WorksheetExport` dump its whole output tree so the
+   before/after could be `diff -r`'d. Build that lever *first* if the cluster
+   has any serialisable output.
+
+### Gotchas that actually bit
+
+- **`sed`-style bulk renames are the main hazard.** A local variable that merely
+  *looks* like a member (`m_something`) gets wrongly prefixed; qualified callers
+  (`->foo()`, `.foo()`) need hand-fixing; a scoped name like
+  `wxMaxima::m_exitCode` needs its own pass. Read every hunk.
+- **`CallAfter` and `Close` need the real `wxEvtHandler`.** In an extracted
+  class that is `m_wxMaxima`, not `this` - the friend class is not an event
+  handler.
+- **Event binds** from an extracted class use the functor form.
+- **Relinking is slow.** Expect a long build between slices; budget for it.
+
+## CellPointers, and the split that is *not* what it looks like
+
+Cells reach the shared pointers (selection, active cell, last-clicked, ...)
+through `Configuration`, not through `Worksheet`. So separating document from
+view state there is an **internal `CellPointers` reorganisation**, not a
+relocation into `WorksheetDocument`. The selection alone is ~189 call sites; do
+it last, if at all.
+
+## Long-lived references: `CellPtr`, always
+
+Anything holding a `Cell`/`GroupCell` beyond the current call - undo/redo, the
+evaluation queue, the selection, sidebars, a cached "last clicked" - **must**
+use `CellPtr<...>`, which nulls itself when the cell dies. A raw `Cell *` is
+fine only within a single function or event. This is also in AGENTS.md because
+it is the single easiest way to introduce a use-after-free here.
+
+## EditorCell
+
+Split in slices 1-4 and 6; slices 5 and 7 (relocating Maxima-code-only state
+onto a `CodeEditorCell`) are deliberately **deferred** as the risky ones. Soft
+line breaks live in a side table (`m_softBreaks`), *not* as `\r` characters in
+the content - that representation change killed a whole bug family where soft
+breaks leaked into copy/paste as hard newlines. Do not reintroduce in-string
+break markers.
+
+## Related
+
+`wxmaxima-layout` for the geometry pipeline. AGENTS.md's "Key Subsystems Map"
+for the one-paragraph version.

--- a/.claude/skills/wxmaxima-export/SKILL.md
+++ b/.claude/skills/wxmaxima-export/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: wxmaxima-export
+description: How wxMaxima turns worksheets into HTML, LaTeX, images and .wxmx/.wxm - the equation-rendering flavours, the single source of accessible label text, the round-trip guarantees, and the traps (double scaling, ASCII-art alignment, forward-compatible XML). Use when touching WorksheetExport, the graphical_io classes, ToXML/MathParser, or any exporter.
+---
+
+# Exporting worksheets
+
+Every exporter shares two obligations: it must be **deterministic** (exporting
+the same document twice yields byte-identical output) and it must not **lose**
+anything it cannot reproduce.
+
+## The pieces
+
+- `src/worksheet/WorksheetExport.cpp` - HTML, LaTeX, MAC, RTF, and the
+  selection-to-string converters.
+- `src/graphical_io/` - `BitmapOut` (PNG/BMP/XPM/JPEG), `Svgout`, `EMFout`,
+  `Printout`, and `OutCommon`, which holds what they share.
+- `Cell::ToXML()` / `MathParser` - the `.wxmx` `content.xml` round trip.
+
+HTML equations have several flavours (`Configuration::htmlExportFormat`): native
+MathML, MathML+MathJax fill-in, bitmap and SVG. Each is a separate code path, so
+a change to "the HTML export" usually needs checking in all four -
+`test_WorksheetExport` loops over them for exactly this reason.
+
+## Accessible labels have ONE source
+
+An exported equation is a picture: an SVG draws it as anonymous paths, a PNG as
+pixels. Screen readers get nothing unless we hand them the text.
+
+`OutCommon::AccessibleText(const Cell *tree)` is the single place that derives
+it - `ListToString()` with every run of whitespace folded to one space. All of
+these must agree, and do, because they call it:
+
+- the SVG document `<title>` and its `role="math"` group's `aria-label`
+- the PNG's `Description` text chunk (written as `iTXt`, not `tEXt`)
+- the HTML export's `<img alt="...">`
+
+Whitespace folding is not cosmetic: 2-D ASCII-art maths pads its lines with long
+space runs and tabs to keep fraction bars aligned, which is meaningless once the
+text is spoken and makes the label a stuttering mess.
+
+## Traps
+
+- **Double scaling.** `BitmapOut::Layout()` once called `CreateScaled(size,
+  scale)` *and* `SetUserScale(scale)`, magnifying everything twice - at the
+  default 3x zoom only the upper-left third of an equation survived. Allocate
+  the canvas at the already-scaled device size and let `SetUserScale` do the
+  magnification, once. Suspect this shape whenever something is exactly 2x or
+  3x wrong.
+- **ASCII-art must stay verbatim.** `TS_ASCIIMATHS` output only reads correctly
+  if its column alignment survives, so the LaTeX exporter emits a run of art
+  lines as one `verbatim` block rather than as an equation, and the HTML export
+  deliberately keeps it as an image rather than as text.
+- **Forward compatibility is mandatory.** `ToXML()` implementations MUST include
+  `GetXMLFlags()` output in the opening tag, so attributes written by a *newer*
+  wxMaxima survive a round trip through an older one. Any attribute you handle
+  manually must also be added to `MathParser`'s filter list, or it gets emitted
+  twice.
+- **Shortened tags.** Some cells serialise under abbreviated names (`LimitCell`
+  → `<lm>`). Check `MathParser.cpp` before assuming a tag name.
+- **Temp files for DC-based formats.** `wxSVGFileDC`/EMF only write to a real
+  path, so clipboard rendering needs a temp file - `OutCommon::PrivateTempDir()`
+  puts it in a mode-0700 directory rather than the shared system temp, closing a
+  symlink-swap window.
+
+## The safety nets
+
+- `test_WorksheetExport` exports a rich corpus through **every** exporter
+  **twice** and requires the two trees to be byte-identical - which is also the
+  lever that made the export-cluster extraction reviewable. Set
+  `WXM_EXPORT_DUMP_DIR=<dir>` to keep the output and `diff -r` two revisions.
+  It normalises the two things that legitimately differ between runs: wxSVG's
+  process-global image ids, and zip entry timestamps in `.wxmx`.
+- `test_WXMRoundtrip` / `test_WXMXRoundtrip` - `.wxm` byte round trip and
+  `content.xml` parse/serialise idempotency. A cell class that loses information
+  in `ToXML()`/`MathParser` shows up as a non-fixed-point here.
+- Image assertions live alongside: bitmaps must not be clipped, SVGs must be
+  labelled, PNGs must carry a description.
+
+When adding an exporter feature, add the assertion to the existing loop rather
+than a new test - it already has the corpus, the two-run determinism check and
+the per-flavour iteration.

--- a/.claude/skills/wxmaxima-layout/SKILL.md
+++ b/.claude/skills/wxmaxima-layout/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: wxmaxima-layout
+description: How wxMaxima lays the worksheet out - the schedule/recalculate/resize pipeline in WorksheetLayout, the invariants that layout bugs keep violating, and the recurring bug shapes (stale widths, parens too narrow, repaint storms, a group that won't grow). Use when touching Recalculate/Reposition/Draw, cell geometry, scrolling, or when something renders at the wrong size or the wrong time.
+---
+
+# The wxMaxima layout engine
+
+Everything about how a worksheet turns into pixels. Read this before changing
+anything that computes a size or a position: the same handful of mistakes have
+caused most of the layout bugs in this codebase, and they are all invisible at
+the call site.
+
+## The pipeline
+
+`WorksheetLayout` (`src/worksheet/WorksheetLayout.{h,cpp}`) owns the whole
+thing, behind a narrow view interface so it can be driven with no `Worksheet`
+window at all (which is what `test_WorksheetLayout` does).
+
+| Phase | Entry point | What it does |
+|---|---|---|
+| SCHEDULE | `RequestRecalculation(start)` / `RequestFullRecalculation()` | Marks a group dirty and moves the resume point. **Lays nothing out.** |
+| EXECUTE | `RecalculateIfNeeded(timeout, timeSliceMs)` | Walks from the resume point. Per group: dirty → `Recalculate()` (sizes), else `Reposition()` (positions). |
+| SIZE | `AdjustSize()` → `GetMaxPoint()` | Reads the last cell's position, sets the virtual size and scroll rate. |
+| SCROLL | `ScheduleScrollToCell` / `ScrollToCellIfNeeded` / `ScrollToCaretIfNeeded` | |
+| CLIENT SIZE | `UpdateConfigurationClientSize()` → `Configuration::SetCanvasSize` | |
+
+Inside a single group, sizing drops into the cell-layer break pipeline
+(`Cell.cpp`): `UnBreakUpCells()` → `BreakUpCells()` → `BreakLines_List()`.
+
+The `timeout` path time-slices (50 ms by default) so a huge worksheet stays
+responsive; a cell whose layout is cancelled mid-flight is the subject of one of
+the traps below.
+
+## The four invariants
+
+**1. Scheduling is not doing.** `RequestRecalculation()` only marks work
+pending; `RecalculateIfNeeded()` performs it. Never read a size or position on
+the line after requesting a recalculation - you will read the *previous*
+layout. `AdjustSize()` deliberately defers while positions are stale, and there
+is a guard plus an assert to catch it. The name is the trap: this was called
+`Recalculate()` until 2026-07-08, so older code reads as though it were
+synchronous.
+
+**2. A composite `Recalculate()` override must recurse unconditionally.**
+About twenty composite cells (`FracCell`, `SqrtCell`, `ParenCell`, ...) once
+skipped recursing into children when they judged *themselves* unchanged. A
+child can be dirty for a reason the parent cannot see - typically a font-size
+change during partial breakup - and the parent's guard then strands it at a
+stale width. That is precisely how parentheses ended up drawn too narrow for
+their contents. Recurse every time; let each child's own changed-flag decide.
+
+**3. Cached list geometry must be stamped with the configuration counter.**
+Per-list caches (`m_listCacheCfgCnt` and friends) otherwise survive a font,
+zoom or style change and hand back widths computed under the old settings. This
+is the "stale spacing" bug family.
+
+**4. Cancelled layout must invalidate what it did not compute.** When the
+layout deadline fires mid-cell, the base `Cell::Recalculate()` has already
+marked the cell as recalculated. If the override then returns early without
+computing its widths, `NeedsRecalculation()` is false forever after and the
+cell renders at a stale or first-pass size. `MatrCell::Recalculate()` shows the
+fix: `m_width.Invalidate()` before the early return. Test-drive this with
+`Configuration::SetLayoutDeadline(0)`, which makes `IsLayoutCancelled()` true
+immediately - see the matrix scenario in `test_GroupCellLayout.cpp`.
+
+## Recurring bug shapes
+
+Recognise these before starting a fresh investigation.
+
+- **Something renders at the wrong width, and touching one cell fixes it.**
+  Layout state surviving when it should not: invariant 2, 3 or 4. The "one cell
+  heals when poked" signature specifically points at a cache or a
+  never-cleared dirty flag, not at the width formula.
+- **A `GroupCell` doesn't grow with its `EditorCell`.** Historically a stale
+  list cache plus an input-height loop that ignored the second cell on a line.
+- **Repaint storms on mouse motion.** The big one was GTK's composited overlay
+  scrollbar, plus `OnPaint` collapsing the update box, a sidebar `OnSize` that
+  re-triggered itself, and status-bar `SetLabel` churn. The performance monitor
+  has repaint counters; use them before optimising anything.
+- **Geometry read too early.** Invariant 1. Symptom: correct after the next
+  interaction, wrong on the first paint.
+
+## Testing layout without a window
+
+`test_WorksheetLayout` drives the pipeline with no `Worksheet` window.
+`test_GroupCellLayout` and `test_LayoutInvariants` cover cell-level geometry and
+the invariants above. A layout bug that can be expressed as "these sizes should
+be equal" belongs in one of those rather than in a GUI test - several of the
+bugs listed here were only pinned down once they had a windowless reproduction.
+
+For the display/`xvfb` mechanics of running GUI tests on a developer machine,
+see the `run-wxmaxima` skill; the environment traps are local, not project
+knowledge.

--- a/.claude/skills/wxmaxima-maxima-protocol/SKILL.md
+++ b/.claude/skills/wxmaxima-maxima-protocol/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: wxmaxima-maxima-protocol
+description: How wxMaxima talks to Maxima - the socket, the MathML-like XML, wxMathML.lisp, the evaluation queue, and batch mode. Use when touching Maxima.cpp, MathParser, wxMathML.lisp, the evaluation queue, --batch/--exit-on-error, or when output arrives wrong, late, or not at all.
+---
+
+# Talking to Maxima
+
+wxMaxima drives a real `maxima` subprocess over a **local TCP socket**. Maxima
+answers with a MathML-like XML dialect that `MathParser` turns into cells.
+
+## The path a result takes
+
+1. `MaximaEvaluator` sends a command (evaluation queue + command protocol).
+2. `Maxima` (`src/Maxima.cpp`) reads the socket **on a worker thread** and posts
+   `EVT_MAXIMA` events to the main thread.
+3. `MaximaResponseReader` handles the incoming tags and dispatches them.
+4. `MathParser` builds the cell tree.
+
+`src/wxMathML.lisp` is what teaches Maxima to emit that XML. It is compiled into
+the binary via CMake's bin2h - but `--wxmathml-lisp=<path>` overrides it with an
+external file, so a change can be tried **without rebuilding**. Use that while
+iterating; it saves a great deal of time on this codebase.
+
+## Chunk boundaries are not output boundaries
+
+The single most misleading property of this interface: **data arrives in
+socket/timer-sized chunks that have nothing to do with Maxima's own output
+structure.** Any logic that classifies a chunk by looking at how it *starts* is
+wrong, and will be wrong only sometimes.
+
+That is a real bug that shipped: 2-D ASCII-art maths was rendered with the label
+line in a different font from the rest, because the code decided
+monospace-vs-proportional per chunk by testing whether it began with `"(%"`. A
+block's label could land in a separate read and be misclassified. The fix was to
+make Maxima delimit the block explicitly - `wxMathML.lisp` wraps the stock ASCII
+printer in `<wxxml-asciimath>` markers via an `*alt-display2d*` hook, and
+`Maxima::ProcessData()` only fires the event once the whole tag is complete.
+
+**Rule: if you need to know what something is, make Maxima tag it. Never infer
+it from what a chunk happens to contain.**
+
+## Lisp side conventions (`wxMathML.lisp`)
+
+- `with-output-to-string`, not recursive concatenation - the latter is
+  quadratic on big outputs.
+- `unwind-protect` when modifying global state such as `$lmxchar`.
+- `(intern ...)` rather than `read-from-string` for dynamic symbols.
+- Reuse Maxima's own printers where possible (as the ASCII-art hook does) rather
+  than reimplementing them.
+
+## Escaping
+
+`Maxima::EscapeVarnameForMaxima` handles the characters that need it (`,`, `°`,
+and friends). A **leading digit** must be escaped too (`\1a`) - easy to miss,
+because it is the position that matters, not the character.
+
+## Batch mode
+
+`--batch` / `--exit-on-error` are the headless path the test suite leans on, and
+they have sharp edges that have all bitten:
+
+- An **unanswerable question** from Maxima must halt, not hang - batch mode has
+  no one to answer it. Killing Maxima immediately on that halt matters; merely
+  closing left processes behind.
+- `--exit-on-error` must not go **toothless** after a transient empty queue.
+- A **startup-config race** could silently drop queued cells.
+- A worksheet that asks an interactive question will block forever under
+  `--batch`. Either pick a non-interactive worksheet or wrap it in `timeout`.
+
+## Process lifetime
+
+`MaximaProcessManager` owns spawn/kill/connect. Two things to remember:
+
+- The Lisp process is a **grandchild**, so cleaning up needs a group kill, not
+  just killing the direct child. Orphaned `maxima` processes after an abnormal
+  wxMaxima death are this.
+- **gnuplot children count too.** An orphaned async gnuplot query holding a pipe
+  open is what made a CI test look like a teardown wedge for weeks - wxMaxima
+  had exited fine, but the pipe kept the harness waiting. The
+  `wxmaxima_no_stray_children` test guards it.
+- On Windows, restarting requires explicitly resetting the network client
+  (`m_client.reset()`) and streams in `KillMaxima`, or the socket state is
+  wrong on the next start.
+
+## Probing gnuplot
+
+Must be asynchronous (`wxEXEC_ASYNC`). A synchronous probe blocks the UI and,
+on Linux, can disrupt the global menu.

--- a/.claude/skills/wxmaxima-packaging/SKILL.md
+++ b/.claude/skills/wxmaxima-packaging/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: wxmaxima-packaging
+description: How wxMaxima is packaged, signed and released - the CI matrix and what each job can and cannot catch, Windows/macOS/snap specifics, code signing via SignPath, and release automation. Use when touching .github/workflows, CPack configuration, the snap, installers, or anything about shipping a release.
+---
+
+# Packaging, CI and releases
+
+## What the CI matrix can and cannot see
+
+This is the part that costs the most time when forgotten: **a green CI is not
+one signal, it is several partial ones.**
+
+- The Ubuntu jobs build with **gcc**. Clang-only diagnostics are therefore
+  invisible to them - `-Wunused-lambda-capture` has already stopped `main` from
+  compiling with clang while every Linux job stayed green. If you develop with
+  clang and `-Werror`, you will hit things CI cannot.
+- Windows builds wxWidgets **from source** at a pinned `WXVERSION`, so bumping
+  the wx version there is a one-line change. Ubuntu uses distro packages and
+  will lag for years - never gate a feature on Ubuntu's wx version; guard with
+  `wxCHECK_VERSION` and let it compile out.
+- The wxWidgets **cache key must include the version**. The path is
+  version-specific, and cache keys are immutable: after a bump, the old key
+  still exists but no longer matches the path, so nothing can ever be saved
+  under it - a permanent miss and a ~30-minute rebuild every run.
+- Tests that need a display, and tests that must not have one, are separated by
+  ctest labels (`unittest`, `needs_posix`). Keep new tests labelled correctly or
+  they run in the wrong job.
+
+## Windows
+
+- The installer is built with NSIS via CPack (`ZIP;NSIS`).
+- **Bundle the MinGW runtime DLLs** (`libstdc++-6`, `libgcc_s_seh-1`,
+  `libwinpthread-1`) explicitly. `InstallRequiredSystemLibraries` is unreliable
+  for MinGW and silently omits them, and without them the exe will not start on
+  a clean machine. A CI step asserts they are inside the produced ZIP.
+- The DPI-aware manifest is **embedded** via `wx.rc` (Common Controls v6,
+  per-monitor v2, supportedOS up to Win11). Windows ignores an external
+  `<exe>.manifest` when an embedded one exists, so do not add one.
+- Unit-test executables need that manifest too, or wx 3.3's
+  `wxApp::Initialize()` pops a modal "no correct manifest" message box and the
+  test hangs headlessly until the ctest timeout.
+
+## Code signing (SignPath)
+
+SignPath Foundation provides free certificates for open source. The mechanics
+that are not obvious:
+
+- SignPath **does not accept an uploaded file**. Its connector downloads the
+  GitHub Actions artifact itself and verifies the origin metadata (repo,
+  workflow, commit, runner). Hence the official action rather than the
+  PowerShell cmdlet, and hence the upload-artifact step.
+- `upload-artifact` always wraps files in a ZIP, so the artifact configuration's
+  root element must be `zip-file`.
+- The API token lives in an **environment** secret with a required reviewer.
+  GitHub pauses such a job *before its first step*, so signing must be its own
+  job - inside the build job it would block the entire test suite behind an
+  approval click. And `secrets.X` resolves to an empty string in any job that
+  does not declare the environment.
+- Sign only on release tags and manual runs; every push would burn quota.
+
+## macOS
+
+Runners move: pinning an installer package to a specific macOS release (e.g. a
+MacPorts `.pkg` naming a version) breaks when GitHub moves `macos-latest`.
+Resolve the package by querying the release assets for the detected major
+version, and put that major version in the cache key.
+
+## Snap
+
+Bundles Maxima via `stage-snaps`. The dependency is **unpinned**, so the snap
+can ship a Maxima version nobody chose - version-syncing that is an open
+follow-up. Bundled components bring their own licence obligations (gnuplot's is
+attributed in-tree).
+
+## Release automation
+
+On a `Version*` tag, the Windows/macOS/Ubuntu jobs attach their installer / dmg
+/ deb plus a source tarball and the NEWS.md body to the GitHub release. The
+release notes are extracted as the "Current development version" section of
+NEWS.md - which is why that section must be kept current as you go, not written
+at release time.
+
+## Third-party notices
+
+Shipping a component means reproducing its licence: `THIRD-PARTY-NOTICES.txt`
+plus a tab in the licence dialog. The WebView2 loader and the vendored nanoSVG
+are the current cases. On nanoSVG specifically: the symbol-renamed private copy
+stays deliberately - `wxBitmapBundle::FromSVG` caches every resize resolution
+with no eviction. Do not "modernise" it away.

--- a/.claude/skills/wxmaxima-translations/SKILL.md
+++ b/.claude/skills/wxmaxima-translations/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: wxmaxima-translations
+description: How wxMaxima's translations work and the many ways they have silently been lost - the xgettext source glob, msgmerge flags, the combined UI+manual .po files, po4a's data-destruction habits, and the Crowdin sync races. Use before touching anything under locales/, info/*.md, po4a.cfg, or any CI job that regenerates the POT or the translated manuals.
+---
+
+# Translations: what breaks, and how it breaks silently
+
+Translations in this project have been lost repeatedly, always quietly, and
+usually only noticed months later. Every rule here exists because something
+disappeared. Treat "the build changed a file under `locales/` or `info/`" as a
+thing to look at, never as noise.
+
+## The layout
+
+- **One combined `.po` per language**, `locales/wxMaxima/<lang>.po` - the file a
+  translator actually edits. It holds **both** wxMaxima's UI strings
+  (xgettext-extracted from the sources) **and** the manual's prose
+  (po4a-extracted from `info/wxmaxima.md`).
+- `locales/wxMaxima/wxMaxima.pot` is the template both `msgmerge` and Crowdin
+  work against. It is regenerated as the union of a fresh source scan and
+  `locales/manual/wxmaxima.md.pot`, by the `update-locale` target - and by
+  nothing else.
+- `locales/manual/<lang>.po` is po4a's own file, merged into the combined one by
+  `merge_manual_po.cmake`.
+
+## The failures, in order of how much they cost
+
+**1. The xgettext source list is an explicit glob, not a recursive one.**
+`POT_SOURCE_FILES` / `POT_SOURCE_FILES_REL` in `locales/wxMaxima/CMakeLists.txt`
+list `src/*.cpp;src/*.h;src/*/*.cpp;src/*/*.h` - exactly two levels. It was flat
+`src/*` until 2026-07, so every string under `src/cells`, `src/wizards` (since
+2020-08) and `src/sidebars`, `src/dialogs` (since 2024-01) was missing from the
+POT. Cost: **~7000 translations across 21 languages**, recovered from git
+history only in 2026-08.
+
+Nothing warned about it. xgettext is happy with a short file list, and the CI
+POT-drift check regenerates the POT and diffs it - a broken glob truncates both
+sides identically, so the check passes. That hole is now covered by the
+`check-pot-coverage` ctest, which fails if a source file sits deeper than the
+glob reaches or if a file containing `_("...")` is unreferenced by the POT.
+**Adding a `src/<a>/<b>/` level breaks the glob again**; the test will tell you.
+
+**2. `po4a` must never be pointed at `locales/wxMaxima/<lang>.po`.** It does not
+add entries to a `.po` - it treats it as *its own* and rewrites it to contain
+only what it extracted from the manual, discarding everything else. Confirmed
+live: a language with 1000 translated UI strings dropped to 69. This shipped to
+`main` once already.
+
+**3. po4a still deletes content, and a plain build triggers it.** An ordinary
+`ninja` rewrites the eight tracked `info/wxmaxima.*.md` manuals, and at the time
+of writing *removes* previously-present English paragraphs from them. So:
+**never `git add -A` after a build** in this repo, and any CI job that
+regenerates translations must commit an explicit path list and fail loudly if
+anything else changed. Also: po4a < 0.70 can silently corrupt translated text
+and the build is supposed to reject it.
+
+**4. Crowdin syncs can wipe translations.** Not theoretical - a sync race wiped
+464 translations across 16 catalogues one day after a restore, and an earlier
+"initial project sync" wiped UI translations wholesale. When you restore or bulk-
+edit catalogues, the change has to reach Crowdin too, or the next sync undoes
+it. Actively-synced catalogues also have their obsolete (`#~`) entries pruned,
+which is what turned failure 1 from recoverable into archaeology.
+
+**5. Don't drop `msgmerge --previous`.** It is what preserves the `#| msgid`
+comment recording what a fuzzy entry used to say - the only way a translator can
+see *why* something went fuzzy. A plain `msgmerge` discards those silently
+(212 entries' worth in `zh_CN.po` alone).
+
+## Recovering lost translations
+
+They are usually still in git history. The verified recipe, per language:
+
+```sh
+# keep only genuinely translated entries from each historic snapshot
+msgattrib --translated --no-fuzzy -o snap.tr.po <historic>.po
+# newest translation wins
+msgcat --use-first newer.tr.po older.tr.po -o compendium.po
+# fill only what is currently untranslated, exact msgid matches only
+msgmerge --quiet --no-wrap --previous --compendium=compendium.po \
+         --no-fuzzy-matching <lang>.po wxMaxima.pot -o <lang>.po
+```
+
+`msgattrib` first is load-bearing: `msgcat --use-first` will otherwise happily
+pick an *empty* msgstr from the newer file. `--no-fuzzy-matching` keeps it to
+exact matches, so a restored string is exactly what a translator once wrote -
+restore them unfuzzied, since fuzzy entries are not used at runtime.
+
+Two shapes of catalogue need different treatment: one that already has the
+entries but empty can be filled **in place** (one changed line per string, no
+reordering); one that is missing the entries entirely needs a real `msgmerge`
+first, because no in-place fill can reach an entry that does not exist.
+
+## Checks that exist
+
+- `check-translations` - `msgfmt` on every catalogue, chiefly `--check-format`
+  (a msgstr whose format specifiers do not match its msgid makes wxWidgets
+  format against the wrong arguments, in a language we may not read).
+- `check-pot-coverage` - the glob guard described above. Note it runs via
+  `cmake -P`, so it must set its own policies (`CMP0057` for `IN_LIST`);
+  a script run that way inherits nothing from the top-level `CMakeLists.txt`.
+- The CI POT-drift check - fails when the committed POT is stale.

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,17 @@
 CMakeDoxyfile.in
 GEMINI.md
-.claude
+# Claude Code's per-project directory is local by default: settings, hooks,
+# scheduled tasks and launch config are personal to one developer's machine.
+# The subsystem skills are the deliberate exception -- they are project
+# knowledge (how the layout engine works, how translations get lost, what the
+# CI matrix cannot see), so they have to travel with the repository for an
+# agent on a fresh checkout to start with them rather than rediscover them.
+.claude/*
+!.claude/skills/
+# ...except this one, which documents a single developer's machine -- build
+# times, which processes to kill, local display quirks -- rather than the
+# project, and would be wrong for everybody else.
+.claude/skills/run-wxmaxima/
 .bash_profiles
 .bash_profile
 .bashrc

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -654,7 +654,8 @@ tried without rebuilding.
   much smaller, semantically-justified cost: only headings, list items and
   fenced code blocks need re-confirming as fuzzy (e.g. 293 clean -> 183
   clean + 156 fuzzy for German - about 89 of those are headings whose old
-  msgstr still has the now-redundant leading `## ` baked in, since `po4a`
+  msgstr still has the now-redundant leading `##` and its space baked in,
+  since `po4a`
   auto-prepends it from the `Title ##` type instead of storing it in the
   translated text; the rest are fenced-code-block delimiters `po4a` now
   reconstructs itself instead of storing literally, plus a handful of
@@ -668,7 +669,7 @@ tried without rebuilding.
   this fix as lossless to a translator without that caveat: a previously
   fully-translated heading really does render in English again in
   `info/wxmaxima.<lang>.md` until someone reviews the (mostly mechanical:
-  strip the leading `#+ `) fuzzy diff. Fixing the wrapping bug and keeping
+  strip the leading `#+` and the space after it) fuzzy diff. Fixing the wrapping bug and keeping
   every translation rendering are in tension - there's no `po4a` option that
   gets both, since the whole point of `-o markdown` is to change what a
   heading's msgid *is*.
@@ -769,7 +770,8 @@ tried without rebuilding.
   early branch always returns first. Fixed by adding an explicit `d` case
   returning `\mathrm{d}` (no `\ensuremath{}` needed: it's only ever emitted
   already inside `IntCell::ToTeX()`'s math-mode string, which also already
-  supplies the separating `\, ` ahead of it, so don't duplicate that here).
+  supplies the separating `\,` and the space ahead of it, so don't duplicate
+  that here).
   Adding a new special case to this list resurfaced a second, easy-to-miss
   coupling: `TextCell::ToTeX()`'s own multiplication-dot logic (for e.g. the
   denominator of `d/dt` or a `dx*dy`-style differential product) identifies

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1100,6 +1100,30 @@ tried without rebuilding.
 
 ## Layout & Compatibility
 
+The rules below are the ones worth carrying around at all times. The reasoning
+behind them, the pipeline they belong to, and the recurring shapes layout bugs
+take are in the **`wxmaxima-layout` skill** (`.claude/skills/wxmaxima-layout/`),
+which loads on demand -- keep the detail there rather than growing this file.
+
+- **`RequestRecalculation()` only SCHEDULES; `RecalculateIfNeeded()` executes.**
+  Never read geometry (positions, sizes) on the line after asking for a
+  recalculation -- at that point nothing has been recalculated yet, and you get
+  the previous layout. `AdjustSize()` deliberately defers while positions are
+  stale. The name is the trap: it was called `Recalculate()` until 2026-07-08,
+  and code written against the old name reads as if it were synchronous.
+- **A composite cell's `Recalculate()` override MUST recurse unconditionally.**
+  Roughly twenty composite cells (`FracCell`, `SqrtCell`, `ParenCell`, ...) used
+  to skip recursing into their children when they judged themselves unchanged.
+  That is wrong: a child can be dirty for a reason the parent cannot see (a font
+  size change on partial breakup), and the parent's guard then strands it at a
+  stale width -- which is how parens ended up too narrow for their contents.
+  Recurse every time and let each child's own changed-flag decide.
+- **List caches must be invalidated when the configuration counter changes.**
+  Cached per-list geometry (`m_listCacheCfgCnt` and friends) survives a
+  configuration change unless it is stamped with the counter and compared on
+  use. Forgetting this produces the "stale spacing" family of bugs, where cells
+  keep a width computed under the previous font/zoom settings.
+
 - **Mathematical Cell Padding:** Use `MC_TEXT_PADDING` (in `Configuration.h`) for text-based cells. **Exception:** `DigitCell` does not include padding to ensure visual consistency in broken-up numbers.
 - **Three-Step Layout Process:**
   1. `UnBreakUpCells()`: Reset to 2D.
@@ -1113,6 +1137,26 @@ tried without rebuilding.
 - **Bidi (`src/Bidi.h`/`.cpp`):** Reorders a line of text per the Unicode Bidirectional Algorithm (UAX #9), using `libfribidi` when it's available at build time (`USE_FRIBIDI` in `BuildConfig.h`, optional, `WXM_USE_FRIBIDI` CMake option, on by default when `pkg-config fribidi` is found) and falling back to a single-run approximation otherwise. No wxWidgets backend exposes this reordering itself -- Pango/CoreText/DirectWrite compute it internally to shape glyphs but never hand it back to the app. `EditorCell::GetLineBidiRuns()` wraps it as absolute `m_text` positions; `MixedDirectionOffset()` (used by `PositionToPoint()`, hence also `MarkSelection()` and `SelectPointText()`'s click search) and `HandleSpecialKey()`'s arrow-key handling are the consumers. wxmTestApp is an OBJECT library (`test/unit_tests/CMakeLists.txt`): it compiles `Bidi.cpp` itself and needs `PkgConfig::FRIBIDI` linked directly to *it* (not just to `wxmaxima`) to get fribidi's include path at that compile step; separately, its own `target_link_libraries()` don't propagate through `$<TARGET_OBJECTS:wxmTestApp>`, so anything it needs must *also* be linked into each consuming test executable directly (`WXM_TESTAPP_EXTRA_LIBS`) for the final link. The imported target has to be declared `GLOBAL` since `test/` is a sibling directory of `src/`, not a descendant. `#include <fribidi.h>`, not `<fribidi/fribidi.h>`: pkg-config's own `-I` already points *at* fribidi's header directory (confirmed on both Debian's and Homebrew's `.pc` files), so the extra `fribidi/` prefix only "worked" on Linux by accident, via `/usr/include` being an implicit compiler search path Homebrew's non-default prefix doesn't share -- caught by a real macOS CI failure, not by this sandbox.
 - **ConfigDialogue Tabs Must Scroll:** Every tab panel in `src/dialogs/ConfigDialogue.cpp` is a `wxScrolled<wxPanel>` with `SetScrollRate(5 * GetContentScaleFactor(), 5 * GetContentScaleFactor())` and `SetMinSize(wxSize(GetContentScaleFactor() * mMinPanelWidth, GetContentScaleFactor() * mMinPanelHeight))`. Without this, a tab's natural size (which grows with font size/DPI/translation length) can make the whole dialog taller than a hi-DPI screen with no way to reach what's cut off. When adding a new tab, copy this pattern (see `CreateWorksheetPanel()`) rather than a plain `wxPanel`.
 - **Constructor Initialization:** Order initialization lists to match header declaration order to prevent `-Wreorder` warnings.
+- **AUI: `RestorePane()` does NOT undo `MinimizePane()`.** Despite the name it is
+  the counterpart to `MaximizePane()`, and its implementation rewrites *every*
+  pane's hidden state from `savedHiddenState` -- using it to un-minimize one
+  sidebar silently reshuffles all the others. There is no separate "minimized"
+  state to undo: `MinimizePane()` just calls `paneInfo.Hide()` and adds an entry
+  to a min-dock strip, and wx's own restore is nothing more than
+  `pane->Show(); m_mgr.Update();` -- exactly what `ShowPane()` and
+  `ShowWizardPane()` already do. So showing a pane the normal way restores it
+  from minimized for free. Note also that centre panes cannot be minimized and
+  `MinimizePane()` asserts on panes without a minimize button -- so wherever
+  `MinimizeButton(true)` is handed out, the worksheet and the toolbar must be
+  excluded.
+- **A wxWidgets-version fallback `#define` must come AFTER the wx header that
+  may define it.** `Compat.h` includes `<wx/defs.h>` *above* its
+  `#ifndef wxWARN_UNUSED` fallback for this reason. Reached in the other order,
+  our header defines the macro empty first, wxWidgets' own
+  `#ifndef wxWARN_UNUSED` then declines to redefine it, and the feature is
+  silently disabled on exactly the compilers that support it -- a change that
+  compiles everywhere and does nothing. The same trap applies to any future
+  `wxSOMETHING` shim added there.
 
 ## Performance & Documentation Mandates
 
@@ -1131,6 +1175,22 @@ tried without rebuilding.
 - **Consistency:** New cell types should have `*Geometry.svg` and `*LinearGeometry.svg` (if applicable) diagrams.
 
 ## Key Subsystems Map
+
+Deeper, per-subsystem background lives in `.claude/skills/`, which load only
+when they are relevant -- so that hard-won detail is available without every
+line of it sitting in context permanently. Read the matching one *before*
+starting work in that area; each is mostly a list of the ways that subsystem
+has already been broken.
+
+| Skill | Covers |
+|---|---|
+| `wxmaxima-layout` | the schedule/recalculate/resize pipeline and the layout invariants |
+| `wxmaxima-architecture` | where code lives, the friend-class decomposition, the extraction recipe |
+| `wxmaxima-translations` | the POT glob, po4a, Crowdin, and how translations get lost |
+| `wxmaxima-export` | HTML/LaTeX/image export, accessible labels, round-trip guarantees |
+| `wxmaxima-maxima-protocol` | the socket, `wxMathML.lisp`, batch mode, process lifetime |
+| `wxmaxima-packaging` | the CI matrix's blind spots, installers, signing, releases |
+| `run-wxmaxima` | building, launching and screenshotting the app |
 
 - **Layout Engine:** `src/cells/` and `src/worksheet/` (`Worksheet.cpp` and its siblings moved into that subdirectory).
 - **MathML Formatting:** `src/wxMathML.lisp` and `src/MathParser.cpp`.

--- a/NEWS.md
+++ b/NEWS.md
@@ -430,7 +430,7 @@
   neither cell was previously annotated for, so `openMacFiles` and
   `testbench_simple.wxmx` complete instead of hitting the new --batch halt
   above. Confirmed along the way: the "Enter space-separated numbers,
-  `all' or `none':" prompt reads a raw line, not a Maxima expression, so an
+  ``all' or `none':`" prompt reads a raw line, not a Maxima expression, so an
   answer ending in `;` is invalid input Maxima will wait on indefinitely --
   the new cell's recorded answer uses plain `none` instead.
 

--- a/test/check-markdown.sh.in
+++ b/test/check-markdown.sh.in
@@ -60,9 +60,17 @@ fi
 # .po catalogs hold msgids like "``` cogito => sum.  ```"). Re-formatting it
 # therefore marks some translations fuzzy -- accepted deliberately, so that the
 # manual is held to the same standard as the rest of the docs.
+#
+# .claude/skills/*/SKILL.md are excluded because their file format REQUIRES a
+# YAML frontmatter block (--- name: ... description: ... ---) before any
+# heading: that block is what makes the skill loadable at all. MD041 ("first
+# line in file should be a top level header") therefore fires on every one of
+# them, for something that cannot be changed without breaking the file. The
+# prose below the frontmatter is ordinary Markdown and would pass.
 FILES="$(printf '%s\n' "$ALL_MD" \
          | grep -Ev '(^|/)info/wxmaxima\.[A-Za-z_]+\.md$' \
          | grep -Ev '^cmake-bin2h/' \
+         | grep -Ev '^\.claude/skills/[^/]+/SKILL\.md$' \
          | sort)"
 
 if [ -z "$FILES" ]; then


### PR DESCRIPTION
Working knowledge about this codebase had accumulated where nobody else could reach it: in one assistant's local memory directory, **outside the repository**. An agent on a fresh checkout — or in a cloud environment, which is how this came up — started without any of it and rediscovered the same traps.

This moves the durable, project-level part into the repository, and only that part.

> Contains #2253 as its first commit (that one makes `check-markdown` green again on `main`, and is worth merging on its own). Once #2253 lands, this diff collapses to the distillation commit.

### Six rules into AGENTS.md

Each one cost real debugging time:

- `RequestRecalculation()` only **schedules** — and the name is the trap, since it was `Recalculate()` until 2026-07-08.
- A composite cell's `Recalculate()` must recurse **unconditionally** — a child can be dirty for a reason the parent cannot see, which is how parentheses ended up too narrow for their contents.
- Cached list geometry must be stamped with the configuration counter, or it survives a font/zoom change and hands back stale widths.
- `wxAuiManager::RestorePane()` does **not** undo `MinimizePane()` — it is the counterpart to `MaximizePane()` and rewrites *every* pane's hidden state.
- A wxWidgets-version fallback `#define` must come **after** the wx header that may define it, or it silently disables the feature on exactly the compilers that support it.
- Centre panes cannot be minimized, and `MinimizePane()` asserts without a minimize button.

### Six on-demand skills, not more AGENTS.md

AGENTS.md is already ~1200 lines and entirely in context at all times, so the longer material became `.claude/skills/`: **layout, architecture, translations, export, maxima-protocol, packaging**. Each is mostly a list of the ways that subsystem has already been broken.

The layering is deliberate — the *rule* lives in AGENTS.md, the *reasoning* in the skill — and AGENTS.md points at them so they stay discoverable and don't drift.

### Why `.gitignore` changes

`.claude` was excluded entirely, so none of this could travel with the repository — which is **precisely why a cloud checkout began cold**. It now tracks `.claude/skills/` while keeping settings, hooks and scheduled tasks local.

`run-wxmaxima` stays ignored deliberately: it documents one developer's machine (build times, which processes to kill, display quirks) rather than the project, and would be wrong for everybody else.

### What deliberately did *not* move

Machine-specific and personal material: build timings, local display and toolchain quirks, git configuration, working preferences. Publishing it would push one machine's setup onto every contributor.

### Verification

Every factual claim was checked against the code rather than trusted from the notes. That caught one: the AUI rule originally cited our own `MinimizeButton()` call site, which only exists on the unmerged #2250 branch, so it now states the wxWidgets-level constraint instead.

`check-markdown` excludes `.claude/skills/*/SKILL.md`, because that file format *requires* a YAML frontmatter block before any heading — MD041 fires on something that cannot be changed without breaking the file. The prose below the frontmatter is ordinary Markdown and would pass. The test is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q65eoSF1N7jzjdTHpBsq4Z