### PR TITLE
Add a config option to show Find and Replace as a dockable sidebar

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -262,6 +262,44 @@ a local TCP socket.
   - **Linux/GTK Timing:** On Linux (especially KDE Plasma with Global Menus), calling `m_manager.Update()` can disrupt the menu bar if it's already attached. This is a known environmental issue in the interaction between wxWidgets, GTK3, and the KDE Global Menu proxy.
     - **Automated Fix:** On systems with wxWidgets <= 3.2 running on KDE, Unity, or with `appmenu-gtk-module` enabled, wxMaxima automatically sets `UBUNTU_MENUPROXY=0` at startup in `main.cpp` to force menus to remain within the window and prevent disappearance.
     - If the menu still disappears, clearing `GTK_MODULES` (e.g., `GTK_MODULES=""`) can also restore local menus.
+- **Dockable "Find and Replace" (GH #2249, `Configuration::FindDialogDockable()`):**
+  `FindReplaceDialog`/`FindReplacePane` were already split apart (a `wxDialog`
+  wrapper around a `wxPanel` holding the actual controls) specifically
+  anticipating this feature -- `FindReplacePane` climbs to the top-level
+  window and queues its search/replace events there
+  (`while(topLevelWindow->GetParent()) ...`), so it already works correctly
+  regardless of whether it's embedded in the floating dialog or registered
+  directly as an AUI sidebar pane; no changes were needed to
+  `FindReplacePane.cpp`'s event-firing logic. `Worksheet::GetActiveFindPane()`
+  is the single place that decides which presentation is live right now (the
+  dockable pane if `Configuration::FindDialogDockable()` is set, otherwise the
+  floating dialog's own pane if one is open) -- every call site that used to
+  reach into `m_findDialog` directly (the incremental-search idle task,
+  `OnFind`/`OnReplace`/`OnReplaceAll`, the wrapped-search warning dialog's
+  parent) goes through it instead. The dockable pane is registered once,
+  eagerly, in `wxMaximaFrame`'s constructor (like every other sidebar, so its
+  docked position/size persists via the AUI perspective) and is backed by its
+  own `wxMaximaFrame::m_findPaneData` member -- it can't reuse
+  `wxMaxima::m_findData` because `wxMaximaFrame`'s constructor body (where
+  `AddPane()` runs) executes *before* `wxMaxima`'s own members are
+  constructed, a plain base-before-derived C++ ordering issue. The two data
+  objects don't need to be the same instance: `FindReplacePane` already
+  persists its own live flags straight to `wxConfig` on every change, so each
+  just seeds itself independently via the new
+  `FindReplacePane::FindReplaceData::LoadFromConfig()`. Un-hiding the pane
+  from the Ctrl+F handler (`MaximaCommandMenus.cpp`) needs the base class's
+  `wxMaximaFrame::ShowPane(int, bool)` explicitly qualified as
+  `m_wxMaxima.wxMaximaFrame::ShowPane(...)` -- `wxMaxima` declares its own,
+  unrelated `ShowPane(wxCommandEvent&)` (a menu-event handler) which hides
+  the *entire* base-class overload set from lookup on `m_wxMaxima.ShowPane(...)`
+  per ordinary C++ derived-class member-hiding rules; this exact qualification
+  is already the established idiom elsewhere in the same file and in
+  `MaximaResponseReader.cpp` for the same reason. Going through the generic
+  `ShowPane()`/`IsPaneDisplayed()` (shared by every `EventIDs::menu_pane_*`
+  sidebar) is what makes Ctrl+F correctly un-minimize the pane and focus it
+  even when it starts out closed/hidden -- confirmed live in Xvfb, this was
+  the specific risk the issue itself called out ("does that still work if
+  the sidebar is minimized?").
 - **Cursors:** The worksheet has 2 types of Cursor: A standard cursor in an EditorCell or a hCaret between two worksheet cells (`m_hCaretPosition`, the horizontal bar that marks a position *between* group cells, used for inserting and for selecting whole cells). Only one cursor is active at a time.
 - **Key Classes:**
   - `wxMaxima` (`src/wxMaxima.cpp`): The main application class (subclass of `wxMaximaFrame`). Holds most of the program logic -- Maxima process management, parsing incoming XML, menu and toolbar actions, file I/O.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,12 +30,26 @@ locally before merging changes to cell lifetime, layout or parsing:
 ```sh
 cmake -S . -B build-asan -G Ninja -DWXM_SANITIZE=address,undefined
 ninja -C build-asan
-ASAN_OPTIONS=detect_leaks=0 UBSAN_OPTIONS=print_stacktrace=1 \
+ASAN_OPTIONS=detect_leaks=0:check_initialization_order=1:strict_string_checks=1:suppressions=test/asan_suppressions.txt \
+    UBSAN_OPTIONS=print_stacktrace=1 \
     xvfb-run ctest --test-dir build-asan
 ```
 
 Leak detection stays off (`detect_leaks=0`) because GTK/Pango leak noise drowns
-out real findings.
+out real findings. **The `suppressions=test/asan_suppressions.txt` is not
+optional -- omitting it makes `imageFormat` fail every single time**, with an
+`AddressSanitizer: strncpy-param-overlap` inside `wxXPMDecoder::ReadFile`
+(confirmed via `md5sum` that the test's XPM fixture is byte-identical to what
+CI uses, and confirmed deterministic here across 6 repeated runs -- it is not
+the tutorial_10Minutes-style rare race it might look like at first). This is a
+real, pre-existing bug inside wxWidgets' own XPM decoder (not wxMaxima's code,
+confirmed by the stack trace bottoming out in `libwx_gtk3u_core`), already
+known and already suppressed -- see `test/asan_suppressions.txt`'s own
+comment and `compile_ubuntu.yml`'s `run_tests` step, which sets exactly this
+`ASAN_OPTIONS` string. Running the shorter, suppressions-less command from
+memory (as opposed to copying it from here or from the workflow file) will
+reliably misreport this pre-existing, already-triaged third-party issue as a
+regression in whatever change you're actually testing.
 
 Other useful targets: `ninja -C build Doxygen` builds the source documentation
 (note the capital D, and the target only exists when Doxygen is installed), and

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,12 @@
   Needs wxWidgets 3.3.2 or newer; with an older wxWidgets the sidebars are
   unchanged.
 
+- "Find and Replace" (Ctrl+F) can now be shown as a dockable sidebar instead
+  of a floating window, for people who'd rather keep it docked alongside the
+  other sidebars (GH #2249). Off by default -- enable it via Edit ->
+  Configure -> Options -> "Show 'Find and Replace' as a dockable sidebar".
+  Ctrl+F un-hides and focuses the sidebar the same way it does for every
+  other sidebar, including when it starts out minimized/closed.
 - Restored 464 UI/manual translations across 16 languages (Catalan, Czech,
   Danish, German, Greek, Spanish, Finnish, French, Galician, Hungarian,
   Italian, Kabyle, Polish, Russian, Turkish, Ukrainian) that a Crowdin sync

--- a/locales/wxMaxima/wxMaxima.pot
+++ b/locales/wxMaxima/wxMaxima.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-10 11:07+0000\n"
+"POT-Creation-Date: 2026-08-11 17:44+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -51,117 +51,117 @@ msgid ""
 "Now reads: "
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:1982
+#: ../../src/wxMaxima.cpp:1986
 msgid ""
 "\n"
 "Use the menu \"View->Toggle log window\" to show/hide a log window with all debug messages."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1569
+#: ../../src/dialogs/ConfigDialogue.cpp:1580
 msgid "      -X \"--control-stack-size <int>\""
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1568
+#: ../../src/dialogs/ConfigDialogue.cpp:1579
 msgid "      -X \"--dynamic-space-size <int>\""
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1572
+#: ../../src/dialogs/ConfigDialogue.cpp:1583
 msgid "      -X '--control-stack-size <int>'"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1571
+#: ../../src/dialogs/ConfigDialogue.cpp:1582
 msgid "      -X '--dynamic-space-size <int>'"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1551
+#: ../../src/dialogs/ConfigDialogue.cpp:1562
 msgid "      -l <name>"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1557
+#: ../../src/dialogs/ConfigDialogue.cpp:1568
 msgid "      -u <versionnumber>"
-msgstr ""
-
-#: ../../src/Configuration.cpp:1397
-#, c-format
-msgid "  Cells converted to 2D: %ld"
-msgstr ""
-
-#: ../../src/Configuration.cpp:1396
-#, c-format
-msgid "  Cells converted to linear: %ld"
-msgstr ""
-
-#: ../../src/Configuration.cpp:1398
-#, c-format
-msgid "  Cells drawn at the wrong font size: %ld"
-msgstr ""
-
-#: ../../src/Configuration.cpp:1388
-#, c-format
-msgid "  Font cache hits: %ld"
-msgstr ""
-
-#: ../../src/Configuration.cpp:1389
-#, c-format
-msgid "  Font cache misses: %ld"
 msgstr ""
 
 #: ../../src/Configuration.cpp:1400
 #, c-format
-msgid "  Full-window worksheet repaints: %ld"
+msgid "  Cells converted to 2D: %ld"
 msgstr ""
 
-#: ../../src/Configuration.cpp:1384
+#: ../../src/Configuration.cpp:1399
 #, c-format
-msgid "  Manual anchors from built-in: %ld"
+msgid "  Cells converted to linear: %ld"
 msgstr ""
 
-#: ../../src/Configuration.cpp:1385
+#: ../../src/Configuration.cpp:1401
 #, c-format
-msgid "  Manual anchors from cache: %ld"
-msgstr ""
-
-#: ../../src/Configuration.cpp:1386
-#, c-format
-msgid "  Manual anchors self-compiled: %ld"
-msgstr ""
-
-#: ../../src/Configuration.cpp:1387
-#, c-format
-msgid "  Maxima processes spawned: %ld"
-msgstr ""
-
-#: ../../src/Configuration.cpp:1394
-#, c-format
-msgid "  Recalculation needed - Cells appended: %ld"
-msgstr ""
-
-#: ../../src/Configuration.cpp:1393
-#, c-format
-msgid "  Recalculation needed - Config changed: %ld"
-msgstr ""
-
-#: ../../src/Configuration.cpp:1395
-#, c-format
-msgid "  Recalculation needed - Editor dirty: %ld"
-msgstr ""
-
-#: ../../src/Configuration.cpp:1390
-#, c-format
-msgid "  Recalculation needed - Font invalid: %ld"
-msgstr ""
-
-#: ../../src/Configuration.cpp:1392
-#, c-format
-msgid "  Recalculation needed - Font mismatch: %ld"
+msgid "  Cells drawn at the wrong font size: %ld"
 msgstr ""
 
 #: ../../src/Configuration.cpp:1391
 #, c-format
+msgid "  Font cache hits: %ld"
+msgstr ""
+
+#: ../../src/Configuration.cpp:1392
+#, c-format
+msgid "  Font cache misses: %ld"
+msgstr ""
+
+#: ../../src/Configuration.cpp:1403
+#, c-format
+msgid "  Full-window worksheet repaints: %ld"
+msgstr ""
+
+#: ../../src/Configuration.cpp:1387
+#, c-format
+msgid "  Manual anchors from built-in: %ld"
+msgstr ""
+
+#: ../../src/Configuration.cpp:1388
+#, c-format
+msgid "  Manual anchors from cache: %ld"
+msgstr ""
+
+#: ../../src/Configuration.cpp:1389
+#, c-format
+msgid "  Manual anchors self-compiled: %ld"
+msgstr ""
+
+#: ../../src/Configuration.cpp:1390
+#, c-format
+msgid "  Maxima processes spawned: %ld"
+msgstr ""
+
+#: ../../src/Configuration.cpp:1397
+#, c-format
+msgid "  Recalculation needed - Cells appended: %ld"
+msgstr ""
+
+#: ../../src/Configuration.cpp:1396
+#, c-format
+msgid "  Recalculation needed - Config changed: %ld"
+msgstr ""
+
+#: ../../src/Configuration.cpp:1398
+#, c-format
+msgid "  Recalculation needed - Editor dirty: %ld"
+msgstr ""
+
+#: ../../src/Configuration.cpp:1393
+#, c-format
+msgid "  Recalculation needed - Font invalid: %ld"
+msgstr ""
+
+#: ../../src/Configuration.cpp:1395
+#, c-format
+msgid "  Recalculation needed - Font mismatch: %ld"
+msgstr ""
+
+#: ../../src/Configuration.cpp:1394
+#, c-format
 msgid "  Recalculation needed - Size invalid: %ld"
 msgstr ""
 
-#: ../../src/Configuration.cpp:1399
+#: ../../src/Configuration.cpp:1402
 #, c-format
 msgid "  Worksheet repaints: %ld"
 msgstr ""
@@ -193,7 +193,7 @@ msgstr ""
 msgid " Returns the unique elements of the list"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1600
+#: ../../src/wxMaximaFrame.cpp:1645
 msgid " Wrong, if a is complex"
 msgstr ""
 
@@ -209,18 +209,18 @@ msgstr ""
 msgid " times"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4473
+#: ../../src/MaximaCommandMenus.cpp:4499
 msgid ""
 "\".\" = \"The current directory\"\n"
 "\"..\" = \"One directory up\""
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4429 ../../src/MaximaCommandMenus.cpp:4435
-#: ../../src/MaximaCommandMenus.cpp:4440
+#: ../../src/MaximaCommandMenus.cpp:4455 ../../src/MaximaCommandMenus.cpp:4461
+#: ../../src/MaximaCommandMenus.cpp:4466
 msgid "\"..\" means \"one directory up\"."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1208
+#: ../../src/dialogs/ConfigDialogue.cpp:1209
 msgid "\"Copy LaTeX\" adds equation markers"
 msgstr ""
 
@@ -231,7 +231,7 @@ msgid ""
 "Bitmaps tend to need more band width than the other options. They lack support for advanced features like drag-and-drop or accessibility. Also they have problems aligning and scaling with the rest of the text and might use fonts that don't match the rest of the document."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:930
+#: ../../src/dialogs/ConfigDialogue.cpp:931
 msgid "\"Numpad Enter\" always evaluates cells"
 msgstr ""
 
@@ -244,7 +244,7 @@ msgstr ""
 msgid "%d differences"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:1832
+#: ../../src/wxMaxima.cpp:1837
 #, c-format
 msgid "%i cells in evaluation queue"
 msgstr ""
@@ -264,62 +264,62 @@ msgstr ""
 msgid "%s: Can't interpret line: %s"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2920
+#: ../../src/wxMaxima.cpp:2924
 #, c-format
 msgid ""
 "%sCould not write the setting for:%s\n"
 "(Is the client installed?)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1696
+#: ../../src/wxMaximaFrame.cpp:1741
 msgid "&Algebraic Mode"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1925
+#: ../../src/wxMaximaFrame.cpp:1970
 msgid "&Apropos..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:650
+#: ../../src/wxMaximaFrame.cpp:693
 msgid "&Batch File...\tCtrl+B"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1316
+#: ../../src/wxMaximaFrame.cpp:1361
 msgid "&Boundary Value Problem..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1991
+#: ../../src/wxMaximaFrame.cpp:2036
 msgid "&Bug Report"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1546
+#: ../../src/wxMaximaFrame.cpp:1591
 msgid "&Calculus"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1642
+#: ../../src/wxMaximaFrame.cpp:1687
 msgid "&Canonical Form"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1396
+#: ../../src/wxMaximaFrame.cpp:1441
 msgid "&Characteristic Polynomial..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1028
+#: ../../src/wxMaximaFrame.cpp:1073
 msgid "&Clear Memory"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1624
+#: ../../src/wxMaximaFrame.cpp:1669
 msgid "&Combine Factorials"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1669
+#: ../../src/wxMaximaFrame.cpp:1714
 msgid "&Complex Simplification"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1543
+#: ../../src/wxMaximaFrame.cpp:1588
 msgid "&Continued Fraction"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:679
+#: ../../src/wxMaximaFrame.cpp:722
 msgid "&Copy\tCtrl+C"
 msgstr ""
 
@@ -327,103 +327,103 @@ msgstr ""
 msgid "&Definite integration"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1662
+#: ../../src/wxMaximaFrame.cpp:1707
 msgid "&Demoivre"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1400
+#: ../../src/wxMaximaFrame.cpp:1445
 msgid "&Determinant"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1507
+#: ../../src/wxMaximaFrame.cpp:1552
 msgid "&Differentiate..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:730
+#: ../../src/wxMaximaFrame.cpp:773
 msgid "&Edit"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1284
+#: ../../src/wxMaximaFrame.cpp:1329
 msgid "&Eliminate Variable..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1356
+#: ../../src/wxMaximaFrame.cpp:1401
 msgid "&Enter Matrix..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1924
+#: ../../src/wxMaximaFrame.cpp:1969
 msgid "&Example..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1565
+#: ../../src/wxMaximaFrame.cpp:1610
 msgid "&Expand Expression"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1638
+#: ../../src/wxMaximaFrame.cpp:1683
 msgid "&Expand Trigonometric"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1667
+#: ../../src/wxMaximaFrame.cpp:1712
 msgid "&Exponentialize"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:655
+#: ../../src/wxMaximaFrame.cpp:698
 msgid "&Export..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1557
+#: ../../src/wxMaximaFrame.cpp:1602
 msgid "&Factor Expression"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:667
+#: ../../src/wxMaximaFrame.cpp:710
 msgid "&File"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1057
+#: ../../src/wxMaximaFrame.cpp:1102
 msgid "&Functions"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1531
+#: ../../src/wxMaximaFrame.cpp:1576
 msgid "&Greatest Common Divisor..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:2025
+#: ../../src/wxMaximaFrame.cpp:2070
 msgid "&Help"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1494
+#: ../../src/wxMaximaFrame.cpp:1539
 msgid "&Integrate..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1002
+#: ../../src/wxMaximaFrame.cpp:1047
 msgid "&Interrupt\tCtrl+G"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1393
+#: ../../src/wxMaximaFrame.cpp:1438
 msgid "&Invert Matrix"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1999
+#: ../../src/wxMaximaFrame.cpp:2044
 msgid "&License"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1804
+#: ../../src/wxMaximaFrame.cpp:1849
 msgid "&List"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:645
+#: ../../src/wxMaximaFrame.cpp:688
 msgid "&Load Package...\tCtrl+L"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1270
+#: ../../src/wxMaximaFrame.cpp:1315
 msgid "&Maxima"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1923
+#: ../../src/wxMaximaFrame.cpp:1968
 msgid "&Maxima help"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1701
+#: ../../src/wxMaximaFrame.cpp:1746
 msgid "&Modulus Computation..."
 msgstr ""
 
@@ -431,11 +431,11 @@ msgstr ""
 msgid "&New\tCtrl+N"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1911
+#: ../../src/wxMaximaFrame.cpp:1956
 msgid "&Numeric"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1826
+#: ../../src/wxMaximaFrame.cpp:1871
 msgid "&Numeric Output"
 msgstr ""
 
@@ -451,11 +451,11 @@ msgstr ""
 msgid "&Open\tCtrl+O"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:633
+#: ../../src/wxMaximaFrame.cpp:676
 msgid "&Open...\tCtrl+O"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1821
+#: ../../src/wxMaximaFrame.cpp:1866
 msgid "&Plot"
 msgstr ""
 
@@ -463,7 +463,7 @@ msgstr ""
 msgid "&Power series"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:659
+#: ../../src/wxMaximaFrame.cpp:702
 msgid "&Print...\tCtrl+P"
 msgstr ""
 
@@ -471,31 +471,31 @@ msgstr ""
 msgid "&Rational"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1635
+#: ../../src/wxMaximaFrame.cpp:1680
 msgid "&Reduce Trigonometric"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1012
+#: ../../src/wxMaximaFrame.cpp:1057
 msgid "&Restart Maxima\tCtrl+Alt+R"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:643
+#: ../../src/wxMaximaFrame.cpp:686
 msgid "&Save\tCtrl+S"
 msgstr ""
 
-#: ../../src/wizards/SumWiz.cpp:43 ../../src/wxMaximaFrame.cpp:1703
+#: ../../src/wizards/SumWiz.cpp:43 ../../src/wxMaximaFrame.cpp:1748
 msgid "&Simplify"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1622
+#: ../../src/wxMaximaFrame.cpp:1667
 msgid "&Simplify Factorials"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1632
+#: ../../src/wxMaximaFrame.cpp:1677
 msgid "&Simplify Trigonometric"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1276
+#: ../../src/wxMaximaFrame.cpp:1321
 msgid "&Solve..."
 msgstr ""
 
@@ -507,19 +507,19 @@ msgstr ""
 msgid "&Taylor series"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1073
+#: ../../src/wxMaximaFrame.cpp:1118
 msgid "&Time Display"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1413
+#: ../../src/wxMaximaFrame.cpp:1458
 msgid "&Transpose Matrix"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1646
+#: ../../src/wxMaximaFrame.cpp:1691
 msgid "&Trigonometric Simplification"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1059
+#: ../../src/wxMaximaFrame.cpp:1104
 msgid "&Variables"
 msgstr ""
 
@@ -575,19 +575,19 @@ msgstr ""
 msgid "(f(x),x,a,b), (semi-) infinite interval"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1882
+#: ../../src/wxMaximaFrame.cpp:1927
 msgid "(f(x),x,a,b), Epsilon algorithm"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1884
+#: ../../src/wxMaximaFrame.cpp:1929
 msgid "(f(x),x,a,b), infinite interval"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1880
+#: ../../src/wxMaximaFrame.cpp:1925
 msgid "(f(x),x,a,b), strategy of Aind"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:596 ../../src/wxMaximaFrame.cpp:1908
+#: ../../src/MaximaCommandMenus.cpp:596 ../../src/wxMaximaFrame.cpp:1953
 msgid "(f(x),x,y) with singularities+discontinuities"
 msgstr ""
 
@@ -625,23 +625,23 @@ msgstr ""
 msgid "2D"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1350
+#: ../../src/wxMaximaFrame.cpp:1395
 msgid "2D Array to Matrix..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:784
+#: ../../src/wxMaximaFrame.cpp:829
 msgid "2D equations using ASCII Art"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:787
+#: ../../src/wxMaximaFrame.cpp:832
 msgid "2D equations using ASCII Art with unicode characters, if available"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:786
+#: ../../src/dialogs/ConfigDialogue.cpp:787
 msgid "2D if it fits on the page width"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:785
+#: ../../src/dialogs/ConfigDialogue.cpp:786
 msgid "2D, whenever possible"
 msgstr ""
 
@@ -649,7 +649,7 @@ msgstr ""
 msgid "3D"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:1836
+#: ../../src/wxMaxima.cpp:1841
 #, c-format
 msgid "; %i commands left in the current cell"
 msgstr ""
@@ -666,7 +666,7 @@ msgstr ""
 msgid "A Ctrl-F event"
 msgstr ""
 
-#: ../../src/cells/GroupCell.cpp:2178
+#: ../../src/cells/GroupCell.cpp:2186
 msgid "A Maxima input cell with its output"
 msgstr ""
 
@@ -680,7 +680,7 @@ msgid ""
 "Most probable cause: A missing comma between two list items."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2703
+#: ../../src/wxMaxima.cpp:2707
 #, c-format
 msgid "A find event, %s"
 msgstr ""
@@ -701,7 +701,7 @@ msgstr ""
 msgid "A good example equation would be x^2+y^2=1"
 msgstr ""
 
-#: ../../src/cells/GroupCell.cpp:2193 ../../src/cells/GroupCell.cpp:2196
+#: ../../src/cells/GroupCell.cpp:2201 ../../src/cells/GroupCell.cpp:2204
 msgid "A heading"
 msgstr ""
 
@@ -725,7 +725,7 @@ msgstr ""
 msgid "A new document format has been introduced in wxMaxima 0.8.2 that saves not only your input and text commentaries, but also the outputs of your calculations. When saving your document, select 'Whole document (*.wxmx)' format."
 msgstr ""
 
-#: ../../src/cells/GroupCell.cpp:2175
+#: ../../src/cells/GroupCell.cpp:2183
 msgid "A page break"
 msgstr ""
 
@@ -745,11 +745,11 @@ msgstr ""
 msgid "A scale factor for the printout. Helpful for printing big equations on small pdf pages."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1675
+#: ../../src/wxMaximaFrame.cpp:1720
 msgid "A search-and-replace for equations"
 msgstr ""
 
-#: ../../src/cells/EditorCell.cpp:4522 ../../src/cells/GroupCell.cpp:2184
+#: ../../src/cells/EditorCell.cpp:4522 ../../src/cells/GroupCell.cpp:2192
 msgid "A section heading"
 msgstr ""
 
@@ -765,15 +765,15 @@ msgstr ""
 msgid "A sub-sub-subsection heading"
 msgstr ""
 
-#: ../../src/cells/EditorCell.cpp:4528 ../../src/cells/GroupCell.cpp:2190
+#: ../../src/cells/EditorCell.cpp:4528 ../../src/cells/GroupCell.cpp:2198
 msgid "A sub-subsection heading"
 msgstr ""
 
-#: ../../src/cells/EditorCell.cpp:4525 ../../src/cells/GroupCell.cpp:2187
+#: ../../src/cells/EditorCell.cpp:4525 ../../src/cells/GroupCell.cpp:2195
 msgid "A subsection heading"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1677
+#: ../../src/wxMaximaFrame.cpp:1722
 msgid "A subst with basic maths knowledge"
 msgstr ""
 
@@ -781,7 +781,7 @@ msgstr ""
 msgid "A symbol from the configuration dialogue"
 msgstr ""
 
-#: ../../src/cells/GroupCell.cpp:2181
+#: ../../src/cells/GroupCell.cpp:2189
 msgid "A text cell"
 msgstr ""
 
@@ -789,7 +789,7 @@ msgstr ""
 msgid "A text control got the mouse focus"
 msgstr ""
 
-#: ../../src/cells/GroupCell.cpp:2199
+#: ../../src/cells/GroupCell.cpp:2207
 msgid "A title"
 msgstr ""
 
@@ -799,15 +799,15 @@ msgid ""
 "Often used by solve() and algsys(), if there is an infinite number of results."
 msgstr ""
 
-#: ../../src/cells/GroupCell.cpp:2205
+#: ../../src/cells/GroupCell.cpp:2213
 msgid "A worksheet cell"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1483
+#: ../../src/wxMaximaFrame.cpp:1528
 msgid "A&pply function to each Matrix element..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1329
+#: ../../src/wxMaximaFrame.cpp:1374
 msgid "A&t Value..."
 msgstr ""
 
@@ -815,7 +815,7 @@ msgstr ""
 msgid "ASCII maths"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1618
+#: ../../src/dialogs/ConfigDialogue.cpp:1629
 msgid "Abort evaluation on error"
 msgstr ""
 
@@ -824,11 +824,11 @@ msgstr ""
 msgid "Aborting due to --exit-on-error (exit code 1). Cell: %s"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:2020
+#: ../../src/wxMaximaFrame.cpp:2065
 msgid "About"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:2020 ../../src/wxMaximaFrame.cpp:2022
+#: ../../src/wxMaximaFrame.cpp:2065 ../../src/wxMaximaFrame.cpp:2067
 msgid "About wxMaxima"
 msgstr ""
 
@@ -852,19 +852,19 @@ msgstr ""
 msgid "Accuracy"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1409
+#: ../../src/wxMaximaFrame.cpp:1454
 msgid "Ad&joint Matrix"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1698
+#: ../../src/wxMaximaFrame.cpp:1743
 msgid "Add Algebraic E&quality..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1053
+#: ../../src/wxMaximaFrame.cpp:1098
 msgid "Add a directory to search path"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1793
+#: ../../src/wxMaximaFrame.cpp:1838
 msgid "Add a new item to the beginning of the list. Useful for creating stacks."
 msgstr ""
 
@@ -880,11 +880,11 @@ msgstr ""
 msgid "Add an element to the start of a list"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4497
+#: ../../src/MaximaCommandMenus.cpp:4523
 msgid "Add dir to path:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1699
+#: ../../src/wxMaximaFrame.cpp:1744
 msgid "Add equality to the rational simplifier"
 msgstr ""
 
@@ -892,11 +892,11 @@ msgstr ""
 msgid "Add more symbols"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1262
+#: ../../src/dialogs/ConfigDialogue.cpp:1263
 msgid "Add the .wxmx file to the HTML export"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1053
+#: ../../src/wxMaximaFrame.cpp:1098
 msgid "Add to &Path..."
 msgstr ""
 
@@ -915,7 +915,7 @@ msgstr ""
 msgid "Added much text (%li chars) to the XML inspector."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1896
+#: ../../src/dialogs/ConfigDialogue.cpp:1907
 msgid "Additional clipboard formats to put on the clipboard on ordinary copy"
 msgstr ""
 
@@ -923,7 +923,7 @@ msgstr ""
 msgid "Additional commands to be added to the preamble of LaTeX output for pdftex."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1187
+#: ../../src/dialogs/ConfigDialogue.cpp:1188
 msgid "Additional lines for the TeX preamble:"
 msgstr ""
 
@@ -931,19 +931,19 @@ msgstr ""
 msgid "Additional parameters for Maxima (e.g. -l clisp)."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1543
+#: ../../src/dialogs/ConfigDialogue.cpp:1554
 msgid "Additional parameters for Maxima (restart Maxima after changes)"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1318
+#: ../../src/dialogs/ConfigDialogue.cpp:1319
 msgid "Additional symbols for the \"symbols\" sidebar:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1603
+#: ../../src/wxMaximaFrame.cpp:1648
 msgid "Additionally: log(a*b)=log(a)+log(b)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1607
+#: ../../src/wxMaximaFrame.cpp:1652
 msgid "Additionally: log(a/b)=log(a)-log(b), a and b positive integers"
 msgstr ""
 
@@ -951,15 +951,15 @@ msgstr ""
 msgid "Additive function: f(a+b)=f(a)+f(b)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1952
+#: ../../src/wxMaximaFrame.cpp:1997
 msgid "Advanced 2d plotting"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1850
+#: ../../src/wxMaximaFrame.cpp:1895
 msgid "Advanced guess (PSLQ algorithm)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1961
+#: ../../src/wxMaximaFrame.cpp:2006
 msgid "Advanced variable names"
 msgstr ""
 
@@ -975,7 +975,7 @@ msgstr ""
 msgid "Albanian"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1066
+#: ../../src/wxMaximaFrame.cpp:1111
 msgid "Aliases"
 msgstr ""
 
@@ -983,11 +983,11 @@ msgstr ""
 msgid "All Levels"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1755
+#: ../../src/wxMaximaFrame.cpp:1800
 msgid "All but the 1st n elements"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1757
+#: ../../src/wxMaximaFrame.cpp:1802
 msgid "All but the last n elements"
 msgstr ""
 
@@ -995,11 +995,11 @@ msgstr ""
 msgid "All openable types (*.wxm, *.wxmx, *.mac, *.out, *.xml)|*.wxm;*.wxmx;*.mac;*.out;*.xml|wxMaxima document (*.wxm, *.wxmx)|*.wxm;*.wxmx|Maxima session (*.mac)|*.mac|Xmaxima session (*.out)|*.out|xml from broken .wxmx (*.xml)|*.xml"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:750
+#: ../../src/dialogs/ConfigDialogue.cpp:751
 msgid "All variable names"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:774
+#: ../../src/wxMaximaFrame.cpp:819
 msgid "All visible sidebars"
 msgstr ""
 
@@ -1007,7 +1007,7 @@ msgstr ""
 msgid "Allow access to an online manual?"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1691
+#: ../../src/wxMaximaFrame.cpp:1736
 msgid "Allow substituting operators"
 msgstr ""
 
@@ -1027,15 +1027,15 @@ msgstr ""
 msgid "All|*"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:804
+#: ../../src/wxMaximaFrame.cpp:849
 msgid "Always after underscores"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:805
+#: ../../src/wxMaximaFrame.cpp:850
 msgid "Always autosubscript after an underscore"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:815
+#: ../../src/wxMaximaFrame.cpp:860
 msgid "Always display this variable with subscript"
 msgstr ""
 
@@ -1047,7 +1047,7 @@ msgstr ""
 msgid "An animation with multiple frames"
 msgstr ""
 
-#: ../../src/cells/GroupCell.cpp:2202
+#: ../../src/cells/GroupCell.cpp:2210
 msgid "An image cell"
 msgstr ""
 
@@ -1063,28 +1063,28 @@ msgstr ""
 msgid "Anchors file has no top node."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:832
+#: ../../src/wxMaximaFrame.cpp:877
 msgid "Angles"
 msgstr ""
 
-#: ../../src/worksheet/WorksheetExport.cpp:1122
-#: ../../src/worksheet/WorksheetExport.cpp:1387
+#: ../../src/worksheet/WorksheetExport.cpp:1112
+#: ../../src/worksheet/WorksheetExport.cpp:1377
 msgid "Animated Diagram"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1816
+#: ../../src/wxMaximaFrame.cpp:1861
 msgid "Animation autoplay"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1819
+#: ../../src/wxMaximaFrame.cpp:1864
 msgid "Animation framerate..."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1871
+#: ../../src/dialogs/ConfigDialogue.cpp:1882
 msgid "Announce Maxima's output as MathML"
 msgstr ""
 
-#: ../../src/worksheet/Worksheet.cpp:5467 ../../src/wxMaximaFrame.cpp:1993
+#: ../../src/worksheet/Worksheet.cpp:5473 ../../src/wxMaximaFrame.cpp:2038
 msgid "Anonymize Code for Bug Report"
 msgstr ""
 
@@ -1092,19 +1092,19 @@ msgstr ""
 msgid "Antisymmetric function: f(x)=-f(-x)"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2064
+#: ../../src/dialogs/ConfigDialogue.cpp:2075
 msgid "Appearance:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1780
+#: ../../src/wxMaximaFrame.cpp:1825
 msgid "Append"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1776
+#: ../../src/wxMaximaFrame.cpp:1821
 msgid "Append a list"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1777
+#: ../../src/wxMaximaFrame.cpp:1822
 msgid "Append a list to an existing list"
 msgstr ""
 
@@ -1112,15 +1112,15 @@ msgstr ""
 msgid "Append a list to another list"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1770
+#: ../../src/wxMaximaFrame.cpp:1815
 msgid "Append an element"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1775
+#: ../../src/wxMaximaFrame.cpp:1820
 msgid "Append an element to the beginning an existing list"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1771
+#: ../../src/wxMaximaFrame.cpp:1816
 msgid "Append an element to the end of an existing list"
 msgstr ""
 
@@ -1128,12 +1128,12 @@ msgstr ""
 msgid "Apply a function to each list element"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1851
+#: ../../src/wxMaximaFrame.cpp:1896
 #, c-format
 msgid "Approximate by a fraction using log(), sqrt() and %pi, when needed. Only available in maxima > 5.46.0"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1847
+#: ../../src/wxMaximaFrame.cpp:1892
 msgid "Approximate by nice fraction"
 msgstr ""
 
@@ -1155,23 +1155,23 @@ msgstr ""
 msgid "Arabic"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4189
+#: ../../src/MaximaCommandMenus.cpp:4215
 msgid "Are the chars equal, if case is ignored?"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4184
+#: ../../src/MaximaCommandMenus.cpp:4210
 msgid "Are the chars equal?"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4221
+#: ../../src/MaximaCommandMenus.cpp:4247
 msgid "Are these strings equal if case is ignored?"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4216
+#: ../../src/MaximaCommandMenus.cpp:4242
 msgid "Are these strings equal?"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4131
+#: ../../src/MaximaCommandMenus.cpp:4157
 msgid "Arguments:"
 msgstr ""
 
@@ -1179,7 +1179,7 @@ msgstr ""
 msgid "Array"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1061
+#: ../../src/wxMaximaFrame.cpp:1106
 msgid "Arrays"
 msgstr ""
 
@@ -1194,15 +1194,15 @@ msgstr ""
 msgid "Ascending by magnitude (numeric only)"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4180 ../../src/MaximaCommandMenus.cpp:4226
+#: ../../src/MaximaCommandMenus.cpp:4206 ../../src/MaximaCommandMenus.cpp:4252
 msgid "Ascii code to char"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1176
+#: ../../src/wxMaximaFrame.cpp:1221
 msgid "Ascii code to char..."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1397
+#: ../../src/dialogs/ConfigDialogue.cpp:1398
 msgid "Ask to save untitled documents"
 msgstr ""
 
@@ -1210,11 +1210,11 @@ msgstr ""
 msgid "Asking the user for the location of a working maxima binary"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:3552
+#: ../../src/MaximaCommandMenus.cpp:3578
 msgid "Assignment(s):"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:3553
+#: ../../src/MaximaCommandMenus.cpp:3579
 msgid "Assignments of the format a=10,b=20"
 msgstr ""
 
@@ -1226,21 +1226,21 @@ msgstr ""
 msgid "Attention: Extracting a random list element isn't efficient for long lists.Iterating over lists using makelist() or for loops is way faster."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:897
+#: ../../src/dialogs/ConfigDialogue.cpp:898
 msgid "Auto-indent new lines"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:893
+#: ../../src/dialogs/ConfigDialogue.cpp:894
 msgid "Auto-insert closing parenthesis"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1441
-#: ../../src/dialogs/ConfigDialogue.cpp:1472
+#: ../../src/dialogs/ConfigDialogue.cpp:1452
+#: ../../src/dialogs/ConfigDialogue.cpp:1483
 #: ../../src/dialogs/MaximaNotStartingDialog.cpp:43
 msgid "Autodetect"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1236
+#: ../../src/dialogs/ConfigDialogue.cpp:1237
 msgid "Automatic"
 msgstr ""
 
@@ -1248,16 +1248,16 @@ msgstr ""
 msgid "Automatic labels"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:769
+#: ../../src/dialogs/ConfigDialogue.cpp:770
 #, c-format
 msgid "Automatic labels (%i1, %o1,...)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:990
+#: ../../src/wxMaximaFrame.cpp:1035
 msgid "Automatically answer questions"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:991
+#: ../../src/wxMaximaFrame.cpp:1036
 msgid "Automatically fill in answers known from the last run"
 msgstr ""
 
@@ -1280,15 +1280,15 @@ msgstr ""
 msgid "Autosaving the .wxmx file as %s"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:822
+#: ../../src/wxMaximaFrame.cpp:867
 msgid "Autosubscript"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:823
+#: ../../src/wxMaximaFrame.cpp:868
 msgid "Autosubscript chars after an underscore"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:808
+#: ../../src/wxMaximaFrame.cpp:853
 msgid "Autosubscript numbers and text following single letters"
 msgstr ""
 
@@ -1296,7 +1296,7 @@ msgstr ""
 msgid "Autosubscript this variable"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:734
+#: ../../src/dialogs/ConfigDialogue.cpp:735
 msgid "Autowrap long lines:"
 msgstr ""
 
@@ -1316,7 +1316,7 @@ msgstr ""
 msgid "Barsplot..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1388
+#: ../../src/wxMaximaFrame.cpp:1433
 msgid "Basic matrix operations"
 msgstr ""
 
@@ -1332,12 +1332,12 @@ msgstr ""
 msgid "Batch File"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2080
+#: ../../src/wxMaxima.cpp:2084
 #, c-format
 msgid "Batch mode: %d image(s) could not be loaded at all."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2085
+#: ../../src/wxMaxima.cpp:2089
 #, c-format
 msgid "Batch mode: %d image(s) failed to decode/render (--debug)."
 msgstr ""
@@ -1359,27 +1359,27 @@ msgstr ""
 msgid "Beta"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1898
+#: ../../src/dialogs/ConfigDialogue.cpp:1909
 msgid "Bitmap"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1273
+#: ../../src/dialogs/ConfigDialogue.cpp:1274
 msgid "Bitmap scale for export:"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1223
+#: ../../src/dialogs/ConfigDialogue.cpp:1224
 msgid "Bitmaps"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2109
+#: ../../src/dialogs/ConfigDialogue.cpp:2120
 msgid "Bold"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2262
+#: ../../src/wxMaxima.cpp:2266
 msgid "Both horizontal and vertical cursor active at the same time"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1999
+#: ../../src/dialogs/ConfigDialogue.cpp:2010
 msgid "Bottom"
 msgstr ""
 
@@ -1426,11 +1426,11 @@ msgstr ""
 msgid "Bug: Cell with negative y position!"
 msgstr ""
 
-#: ../../src/worksheet/Worksheet.cpp:5905
+#: ../../src/worksheet/Worksheet.cpp:5911
 msgid "Bug: Encountered a heading I don't know how to move in one sectioning unit"
 msgstr ""
 
-#: ../../src/worksheet/Worksheet.cpp:5952
+#: ../../src/worksheet/Worksheet.cpp:5958
 msgid "Bug: Encountered a heading I don't know how to move out one sectioning unit"
 msgstr ""
 
@@ -1446,7 +1446,7 @@ msgstr ""
 msgid "Bug: Got a request to first change the contents of a cell and to then undelete it."
 msgstr ""
 
-#: ../../src/worksheet/WorksheetExport.cpp:1576
+#: ../../src/worksheet/WorksheetExport.cpp:1566
 msgid "Bug: HTML output is no valid XML"
 msgstr ""
 
@@ -1454,7 +1454,7 @@ msgstr ""
 msgid "Bug: Math Cell that claims to have no group Cell it belongs to"
 msgstr ""
 
-#: ../../src/Configuration.h:741
+#: ../../src/Configuration.h:747
 msgid "Bug: Maximum number of digits that is to be displayed is too low!"
 msgstr ""
 
@@ -1462,13 +1462,13 @@ msgstr ""
 msgid "Bug: Missing contents"
 msgstr ""
 
-#: ../../src/cells/GroupCell.cpp:1498
+#: ../../src/cells/GroupCell.cpp:1506
 msgid "Bug: No image counter to write to!"
 msgstr ""
 
 #: ../../src/cells/AnimationCell.cpp:543 ../../src/cells/EditorCell.cpp:2968
-#: ../../src/cells/ImgCell.cpp:353 ../../src/graphical_io/BitmapOut.cpp:161
-#: ../../src/graphical_io/OutCommon.cpp:264
+#: ../../src/cells/ImgCell.cpp:353 ../../src/graphical_io/BitmapOut.cpp:175
+#: ../../src/graphical_io/OutCommon.cpp:285
 #: ../../src/worksheet/Worksheet.cpp:1764
 #: ../../src/worksheet/Worksheet.cpp:1901
 #: ../../src/worksheet/Worksheet.cpp:1943
@@ -1485,11 +1485,11 @@ msgstr ""
 msgid "Bug: The clipboard isn't open on pasting into an editor cell"
 msgstr ""
 
-#: ../../src/cells/GroupCell.cpp:2288
+#: ../../src/cells/GroupCell.cpp:2296
 msgid "Bug: The predecessor to a GroupCell is not a GroupCell."
 msgstr ""
 
-#: ../../src/cells/GroupCell.cpp:2286
+#: ../../src/cells/GroupCell.cpp:2294
 msgid "Bug: The successor to a GroupCell is not a GroupCell."
 msgstr ""
 
@@ -1497,7 +1497,7 @@ msgstr ""
 msgid "Bug: Trying to append NULL to a group cell."
 msgstr ""
 
-#: ../../src/worksheet/Worksheet.cpp:5949
+#: ../../src/worksheet/Worksheet.cpp:5955
 msgid "Bug: Trying to move a title out by one sectioning unit"
 msgstr ""
 
@@ -1533,7 +1533,7 @@ msgstr ""
 msgid "Bug: y position of cell is unknown!"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1989
+#: ../../src/wxMaximaFrame.cpp:2034
 msgid "Build &Info"
 msgstr ""
 
@@ -1542,19 +1542,23 @@ msgstr ""
 msgid "Build from Git version: %s\n"
 msgstr ""
 
+#: ../../src/dialogs/ConfigDialogue.cpp:1419
+msgid "By default \"Find and Replace\" (Ctrl+F) opens as a floating window. Enable this to make it a sidebar you can dock, like the other sidebars, instead."
+msgstr ""
+
 #: ../../src/dialogs/TipOfTheDay.cpp:54
 msgid "By default, Shift-Enter is used to evaluate commands, while Enter is used for multiline input. This behaviour can be changed in 'Edit->Configure' dialog by checking 'Enter evaluates cells'. This switches the roles of these two key commands."
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4147
+#: ../../src/MaximaCommandMenus.cpp:4173
 msgid "Byte:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1499
+#: ../../src/wxMaximaFrame.cpp:1544
 msgid "C&hange Variable in Integrate..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:728
+#: ../../src/wxMaximaFrame.cpp:771
 msgid "C&onfigure"
 msgstr ""
 
@@ -1571,7 +1575,7 @@ msgstr ""
 msgid "Caching font variant: %s"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1523
+#: ../../src/wxMaximaFrame.cpp:1568
 msgid "Calculate &Product..."
 msgstr ""
 
@@ -1583,15 +1587,15 @@ msgstr ""
 msgid "Calculate Singular Value Decomposition, left and right singular vectors numerically"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1521
+#: ../../src/wxMaximaFrame.cpp:1566
 msgid "Calculate Su&m..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1836
+#: ../../src/wxMaximaFrame.cpp:1881
 msgid "Calculate bigfloat value of the last result"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1833
+#: ../../src/wxMaximaFrame.cpp:1878
 msgid "Calculate float value of the last result"
 msgstr ""
 
@@ -1607,11 +1611,11 @@ msgstr ""
 msgid "Calculate modulus:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1839
+#: ../../src/wxMaximaFrame.cpp:1884
 msgid "Calculate numeric value of the last result"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1524
+#: ../../src/wxMaximaFrame.cpp:1569
 msgid "Calculate products"
 msgstr ""
 
@@ -1619,7 +1623,7 @@ msgstr ""
 msgid "Calculate standard deviation"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1521
+#: ../../src/wxMaximaFrame.cpp:1566
 msgid "Calculate sums"
 msgstr ""
 
@@ -1651,16 +1655,16 @@ msgstr ""
 msgid "Can be specified as flag in ev(exp, flag)"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3499
+#: ../../src/wxMaxima.cpp:3503
 msgid "Can not connect to the web server."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3445 ../../src/wxMaxima.cpp:3481
-#: ../../src/wxMaxima.cpp:3533
+#: ../../src/wxMaxima.cpp:3449 ../../src/wxMaxima.cpp:3485
+#: ../../src/wxMaxima.cpp:3537
 msgid "Can not download version info."
 msgstr ""
 
-#: ../../src/MaximaProcessManager.cpp:582 ../../src/wxMaxima.cpp:1582
+#: ../../src/MaximaProcessManager.cpp:582 ../../src/wxMaxima.cpp:1587
 msgid "Can not start Maxima. The most probable cause is that Maxima isn't installed (it can be downloaded from https://maxima.sourceforge.io) or in wxMaxima's config dialogue the setting for Maxima's location is wrong."
 msgstr ""
 
@@ -1698,7 +1702,7 @@ msgstr ""
 #: ../../src/wizards/SeriesWiz.cpp:52 ../../src/wizards/SubstituteWiz.cpp:42
 #: ../../src/wizards/SubstituteWiz.cpp:44 ../../src/wizards/SumWiz.cpp:48
 #: ../../src/wizards/SumWiz.cpp:50 ../../src/wizards/SystemWiz.cpp:39
-#: ../../src/wizards/SystemWiz.cpp:41 ../../src/wxMaxima.cpp:3570
+#: ../../src/wizards/SystemWiz.cpp:41 ../../src/wxMaxima.cpp:3574
 msgid "Cancel"
 msgstr ""
 
@@ -1706,7 +1710,7 @@ msgstr ""
 msgid "Cannot authenticate Maxima!"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:1284
+#: ../../src/wxMaxima.cpp:1275
 #, c-format
 msgid "Cannot cache the list of known symbols to %s"
 msgstr ""
@@ -1730,8 +1734,8 @@ msgstr ""
 msgid "Cannot interpret the numeric value of pid %s"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3408 ../../src/wxMaxima.cpp:3415
-#: ../../src/wxMaxima.cpp:3422
+#: ../../src/wxMaxima.cpp:3412 ../../src/wxMaxima.cpp:3419
+#: ../../src/wxMaxima.cpp:3426
 #, c-format
 msgid "Cannot interpret version number component %s"
 msgstr ""
@@ -1748,7 +1752,7 @@ msgstr ""
 msgid "Cannot put the copied text on the clipboard (2nd try)"
 msgstr ""
 
-#: ../../src/graphical_io/OutCommon.cpp:98
+#: ../../src/graphical_io/OutCommon.cpp:119
 #, c-format
 msgid "Cannot remove the file %s"
 msgstr ""
@@ -1796,11 +1800,11 @@ msgstr ""
 msgid "Cauchy principal value of f(x)/(x-c), finite interval"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1886
+#: ../../src/wxMaximaFrame.cpp:1931
 msgid "Cauchy principal value, finite interval"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:993
+#: ../../src/wxMaximaFrame.cpp:1038
 msgid "Ce&ll"
 msgstr ""
 
@@ -1812,7 +1816,7 @@ msgstr ""
 msgid "Cell bracket fill, Inactive"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3143
+#: ../../src/wxMaxima.cpp:3147
 msgid "Cell ends in a backslash"
 msgstr ""
 
@@ -1821,11 +1825,11 @@ msgstr ""
 msgid "Cell with UUID %s not found!"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1076
+#: ../../src/wxMaximaFrame.cpp:1121
 msgid "Change &2d Display"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:3641
+#: ../../src/MaximaCommandMenus.cpp:3667
 msgid "Change Image"
 msgstr ""
 
@@ -1833,23 +1837,23 @@ msgstr ""
 msgid "Change Image..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:2001
+#: ../../src/wxMaximaFrame.cpp:2046
 msgid "Change Log"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4427
+#: ../../src/MaximaCommandMenus.cpp:4453
 msgid "Change directory"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1240
+#: ../../src/wxMaximaFrame.cpp:1285
 msgid "Change directory..."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:859
+#: ../../src/dialogs/ConfigDialogue.cpp:860
 msgid "Change names of greek letters to greek letters"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1077
+#: ../../src/wxMaximaFrame.cpp:1122
 msgid "Change the 2d display algorithm used to display math output"
 msgstr ""
 
@@ -1865,11 +1869,11 @@ msgstr ""
 msgid "Change variable and evaluate"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1500
+#: ../../src/wxMaximaFrame.cpp:1545
 msgid "Change variable in integral or sum"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1504
+#: ../../src/wxMaximaFrame.cpp:1549
 msgid "Change variable in integral or sum and evaluate the result"
 msgstr ""
 
@@ -1877,44 +1881,44 @@ msgstr ""
 msgid "ChangeLog"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1064
+#: ../../src/wxMaximaFrame.cpp:1109
 msgid "Changed option variables"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:3699
+#: ../../src/MaximaCommandMenus.cpp:3725
 #, c-format
 msgid "Changing image originally loaded from file %s to %s."
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4185 ../../src/MaximaCommandMenus.cpp:4190
-#: ../../src/MaximaCommandMenus.cpp:4195 ../../src/MaximaCommandMenus.cpp:4201
-#: ../../src/MaximaCommandMenus.cpp:4206 ../../src/MaximaCommandMenus.cpp:4212
+#: ../../src/MaximaCommandMenus.cpp:4211 ../../src/MaximaCommandMenus.cpp:4216
+#: ../../src/MaximaCommandMenus.cpp:4221 ../../src/MaximaCommandMenus.cpp:4227
+#: ../../src/MaximaCommandMenus.cpp:4232 ../../src/MaximaCommandMenus.cpp:4238
 msgid "Char #1:"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4186 ../../src/MaximaCommandMenus.cpp:4191
-#: ../../src/MaximaCommandMenus.cpp:4196 ../../src/MaximaCommandMenus.cpp:4201
-#: ../../src/MaximaCommandMenus.cpp:4207 ../../src/MaximaCommandMenus.cpp:4212
+#: ../../src/MaximaCommandMenus.cpp:4212 ../../src/MaximaCommandMenus.cpp:4217
+#: ../../src/MaximaCommandMenus.cpp:4222 ../../src/MaximaCommandMenus.cpp:4227
+#: ../../src/MaximaCommandMenus.cpp:4233 ../../src/MaximaCommandMenus.cpp:4238
 msgid "Char #2:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1178
+#: ../../src/wxMaximaFrame.cpp:1223
 msgid "Char to Unicode code point..."
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4230 ../../src/MaximaCommandMenus.cpp:4234
+#: ../../src/MaximaCommandMenus.cpp:4256 ../../src/MaximaCommandMenus.cpp:4260
 msgid "Char to unicode code point"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4157 ../../src/MaximaCommandMenus.cpp:4161
-#: ../../src/MaximaCommandMenus.cpp:4165 ../../src/MaximaCommandMenus.cpp:4169
-#: ../../src/MaximaCommandMenus.cpp:4173 ../../src/MaximaCommandMenus.cpp:4177
-#: ../../src/MaximaCommandMenus.cpp:4231 ../../src/MaximaCommandMenus.cpp:4235
-#: ../../src/MaximaCommandMenus.cpp:4307
+#: ../../src/MaximaCommandMenus.cpp:4183 ../../src/MaximaCommandMenus.cpp:4187
+#: ../../src/MaximaCommandMenus.cpp:4191 ../../src/MaximaCommandMenus.cpp:4195
+#: ../../src/MaximaCommandMenus.cpp:4199 ../../src/MaximaCommandMenus.cpp:4203
+#: ../../src/MaximaCommandMenus.cpp:4257 ../../src/MaximaCommandMenus.cpp:4261
+#: ../../src/MaximaCommandMenus.cpp:4333
 msgid "Char:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1169
+#: ../../src/wxMaximaFrame.cpp:1214
 msgid "Character Tests"
 msgstr ""
 
@@ -1922,15 +1926,15 @@ msgstr ""
 msgid "Characteristic polynom"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4152
+#: ../../src/MaximaCommandMenus.cpp:4178
 msgid "Chars are strings that are one character long"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:2004
+#: ../../src/wxMaximaFrame.cpp:2049
 msgid "Check for Updates"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:2005
+#: ../../src/wxMaximaFrame.cpp:2050
 msgid "Check if a newer version of wxMaxima is available."
 msgstr ""
 
@@ -1946,11 +1950,11 @@ msgstr ""
 msgid "Chinese (traditional)"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1554
+#: ../../src/dialogs/ConfigDialogue.cpp:1565
 msgid "Choose a Lisp Maxima was compiled with"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1560
+#: ../../src/dialogs/ConfigDialogue.cpp:1571
 msgid "Choose between installed Maxima versions"
 msgstr ""
 
@@ -1958,11 +1962,11 @@ msgstr ""
 msgid "Choose between the following help topics:"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2100
+#: ../../src/dialogs/ConfigDialogue.cpp:2111
 msgid "Choose font"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:793
+#: ../../src/dialogs/ConfigDialogue.cpp:794
 msgid ""
 "Choose how mathematical output is formatted:\n"
 "\"2D, whenever possible\" keeps all expressions in two-dimensional form (fractions stacked, matrices drawn as boxes), even if they overflow the page width.\n"
@@ -1974,12 +1978,12 @@ msgstr ""
 msgid "Choose new plot format:"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2432
+#: ../../src/dialogs/ConfigDialogue.cpp:2444
 #, c-format
 msgid "Choose the %s Font"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:841
+#: ../../src/wxMaximaFrame.cpp:886
 msgid "Choose the parenthesis type for Matrices"
 msgstr ""
 
@@ -1987,27 +1991,27 @@ msgstr ""
 msgid "Classes:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1416
+#: ../../src/wxMaximaFrame.cpp:1461
 msgid "Classic matrix operations"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1036
+#: ../../src/wxMaximaFrame.cpp:1081
 msgid "Clear all aliases"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1033
+#: ../../src/wxMaximaFrame.cpp:1078
 msgid "Clear all arrays"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1030
+#: ../../src/wxMaximaFrame.cpp:1075
 msgid "Clear all dependencies"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1032
+#: ../../src/wxMaximaFrame.cpp:1077
 msgid "Clear all functions"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1039
+#: ../../src/wxMaximaFrame.cpp:1084
 msgid "Clear all gradefs"
 msgstr ""
 
@@ -2015,31 +2019,31 @@ msgstr ""
 msgid "Clear all history"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1038
+#: ../../src/wxMaximaFrame.cpp:1083
 msgid "Clear all labels"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1042
+#: ../../src/wxMaximaFrame.cpp:1087
 msgid "Clear all let rule packages"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1041
+#: ../../src/wxMaximaFrame.cpp:1086
 msgid "Clear all macros"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1040
+#: ../../src/wxMaximaFrame.cpp:1085
 msgid "Clear all props"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1035
+#: ../../src/wxMaximaFrame.cpp:1080
 msgid "Clear all rules"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1037
+#: ../../src/wxMaximaFrame.cpp:1082
 msgid "Clear all structures"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1031
+#: ../../src/wxMaximaFrame.cpp:1076
 msgid "Clear all variables"
 msgstr ""
 
@@ -2052,23 +2056,23 @@ msgstr ""
 msgid "Cleared font cache for font %s"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1926
+#: ../../src/dialogs/ConfigDialogue.cpp:1937
 msgid "Clipboard format parameters"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:641
+#: ../../src/wxMaximaFrame.cpp:684
 msgid "Close\tCtrl+W"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4107
+#: ../../src/MaximaCommandMenus.cpp:4133
 msgid "Close Stream"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:641
+#: ../../src/wxMaximaFrame.cpp:684
 msgid "Close window"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1143
+#: ../../src/wxMaximaFrame.cpp:1188
 msgid "Close..."
 msgstr ""
 
@@ -2112,11 +2116,11 @@ msgstr ""
 msgid "Code highlighting: Variables"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4181 ../../src/MaximaCommandMenus.cpp:4227
+#: ../../src/MaximaCommandMenus.cpp:4207 ../../src/MaximaCommandMenus.cpp:4253
 msgid "Code number:"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4239 ../../src/MaximaCommandMenus.cpp:4245
+#: ../../src/MaximaCommandMenus.cpp:4265 ../../src/MaximaCommandMenus.cpp:4271
 msgid "Codepoint number:"
 msgstr ""
 
@@ -2148,7 +2152,7 @@ msgstr ""
 msgid "Columns:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1625
+#: ../../src/wxMaximaFrame.cpp:1670
 msgid "Combine factorials in an expression"
 msgstr ""
 
@@ -2156,7 +2160,7 @@ msgstr ""
 msgid "Comma"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3202
+#: ../../src/wxMaxima.cpp:3206
 msgid "Comma directly followed by a closing parenthesis"
 msgstr ""
 
@@ -2168,11 +2172,11 @@ msgstr ""
 msgid "Comma separated y coordinates"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4131
+#: ../../src/MaximaCommandMenus.cpp:4157
 msgid "Comma-separated arguments"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:3929 ../../src/MaximaCommandMenus.cpp:3938
+#: ../../src/MaximaCommandMenus.cpp:3955 ../../src/MaximaCommandMenus.cpp:3964
 msgid "Comma-separated commands"
 msgstr ""
 
@@ -2181,7 +2185,7 @@ msgid "Comma-separated elements"
 msgstr ""
 
 #: ../../src/MaximaCommandMenus.cpp:933 ../../src/MaximaCommandMenus.cpp:947
-#: ../../src/MaximaCommandMenus.cpp:3520
+#: ../../src/MaximaCommandMenus.cpp:3546
 msgid "Comma-separated equations"
 msgstr ""
 
@@ -2191,19 +2195,19 @@ msgstr ""
 msgid "Comma-separated expressions"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4087
+#: ../../src/MaximaCommandMenus.cpp:4113
 msgid "Comma-separated expressions that shall be converted to a string"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:3972 ../../src/MaximaCommandMenus.cpp:3986
+#: ../../src/MaximaCommandMenus.cpp:3998 ../../src/MaximaCommandMenus.cpp:4012
 msgid "Comma-separated expressions."
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:3945 ../../src/MaximaCommandMenus.cpp:4040
+#: ../../src/MaximaCommandMenus.cpp:3971 ../../src/MaximaCommandMenus.cpp:4066
 msgid "Comma-separated function names"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:3958
+#: ../../src/MaximaCommandMenus.cpp:3984
 msgid "Comma-separated function names."
 msgstr ""
 
@@ -2212,19 +2216,19 @@ msgstr ""
 msgid "Comma-separated list entry in the format val1=1,val2=2"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4077
+#: ../../src/MaximaCommandMenus.cpp:4103
 msgid "Comma-separated names of the elements that shall be written"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:3971
+#: ../../src/MaximaCommandMenus.cpp:3997
 msgid "Comma-separated names the parameters will be referenced by later."
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4360 ../../src/MaximaCommandMenus.cpp:4365
+#: ../../src/MaximaCommandMenus.cpp:4386 ../../src/MaximaCommandMenus.cpp:4391
 msgid "Comma-separated numbers from 0 to 255"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4009 ../../src/MaximaCommandMenus.cpp:4022
+#: ../../src/MaximaCommandMenus.cpp:4035 ../../src/MaximaCommandMenus.cpp:4048
 msgid "Comma-separated parameter names. A parameter in square brackets [] will be filled with the list of any additional arguments the function gets."
 msgstr ""
 
@@ -2232,13 +2236,13 @@ msgstr ""
 msgid "Comma-separated part numbers selecting the subexpression to replace (as in part())"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:3926
+#: ../../src/MaximaCommandMenus.cpp:3952
 msgid "Comma-separated variable names, can be initialized by the \":\" operator."
 msgstr ""
 
 #: ../../src/MaximaCommandMenus.cpp:711 ../../src/MaximaCommandMenus.cpp:792
 #: ../../src/MaximaCommandMenus.cpp:934 ../../src/MaximaCommandMenus.cpp:948
-#: ../../src/MaximaCommandMenus.cpp:3521
+#: ../../src/MaximaCommandMenus.cpp:3547
 msgid "Comma-separated variables"
 msgstr ""
 
@@ -2250,7 +2254,7 @@ msgstr ""
 msgid "Command:"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1145
+#: ../../src/dialogs/ConfigDialogue.cpp:1146
 msgid "Commands that are executed at every start of maxima."
 msgstr ""
 
@@ -2262,11 +2266,11 @@ msgstr ""
 msgid "Comment Selection"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:722
+#: ../../src/wxMaximaFrame.cpp:765
 msgid "Comment out the currently selected text"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:721
+#: ../../src/wxMaximaFrame.cpp:764
 msgid "Comment selection\tCtrl+/"
 msgstr ""
 
@@ -2274,7 +2278,7 @@ msgstr ""
 msgid "Commutative function"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:653
+#: ../../src/wxMaximaFrame.cpp:696
 msgid "Compare files..."
 msgstr ""
 
@@ -2282,39 +2286,39 @@ msgstr ""
 msgid "Comparing worksheets (the --diff option or the wxmxdiff command) needs 2 or 3 files to compare."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1434
+#: ../../src/wxMaximaFrame.cpp:1479
 msgid "Compile a QR decomposition using dgeqrf"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4034
+#: ../../src/MaximaCommandMenus.cpp:4060
 msgid "Compile a function"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1226
+#: ../../src/wxMaximaFrame.cpp:1271
 msgid "Compile a regular expression"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1423
+#: ../../src/wxMaximaFrame.cpp:1468
 msgid "Compile eigenvalues using dgeev"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1426
+#: ../../src/wxMaximaFrame.cpp:1471
 msgid "Compile eigenvalues using zgeev"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1429
+#: ../../src/wxMaximaFrame.cpp:1474
 msgid "Compile eigenvalues+eigenvectors using dgeev"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1432
+#: ../../src/wxMaximaFrame.cpp:1477
 msgid "Compile eigenvalues+eigenvectors using zgeev"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1114
+#: ../../src/wxMaximaFrame.cpp:1159
 msgid "Compile function..."
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4383
+#: ../../src/MaximaCommandMenus.cpp:4409
 msgid "Compile regex"
 msgstr ""
 
@@ -2327,15 +2331,15 @@ msgstr ""
 msgid "Compiling %s"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4035
+#: ../../src/MaximaCommandMenus.cpp:4061
 msgid "Compiling a function can generate a considerable speed boost if the types of the function parameters are made known to the function before it is compiled. Else the generated code has to be hideously generic."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:930
+#: ../../src/wxMaximaFrame.cpp:975
 msgid "Complete Word\tCtrl+Space"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:931
+#: ../../src/wxMaximaFrame.cpp:976
 msgid "Complete word"
 msgstr ""
 
@@ -2351,35 +2355,35 @@ msgstr ""
 msgid "Composing a list of the line starts we can use as page starts"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1544
+#: ../../src/wxMaximaFrame.cpp:1589
 msgid "Compute continued fraction of a value"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1410
+#: ../../src/wxMaximaFrame.cpp:1455
 msgid "Compute the adjoint matrix"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1397
+#: ../../src/wxMaximaFrame.cpp:1442
 msgid "Compute the characteristic polynomial of a matrix"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1401
+#: ../../src/wxMaximaFrame.cpp:1446
 msgid "Compute the determinant of a matrix"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1532
+#: ../../src/wxMaximaFrame.cpp:1577
 msgid "Compute the greatest common divisor"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1394
+#: ../../src/wxMaximaFrame.cpp:1439
 msgid "Compute the inverse of a matrix"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1535
+#: ../../src/wxMaximaFrame.cpp:1580
 msgid "Compute the least common multiple (do load(functs) before using)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1412
+#: ../../src/wxMaximaFrame.cpp:1457
 msgid "Compute the rank of a matrix"
 msgstr ""
 
@@ -2387,24 +2391,24 @@ msgstr ""
 msgid "Condition:"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2479
-#: ../../src/dialogs/ConfigDialogue.cpp:2489
-#: ../../src/dialogs/ConfigDialogue.cpp:2641
-#: ../../src/dialogs/ConfigDialogue.cpp:2647
+#: ../../src/dialogs/ConfigDialogue.cpp:2491
+#: ../../src/dialogs/ConfigDialogue.cpp:2501
+#: ../../src/dialogs/ConfigDialogue.cpp:2653
+#: ../../src/dialogs/ConfigDialogue.cpp:2659
 msgid "Config file (*.ini)|*.ini"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2539
+#: ../../src/dialogs/ConfigDialogue.cpp:2551
 #, c-format
 msgid "Config item \"%s\" was of an unknown type"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2607
+#: ../../src/dialogs/ConfigDialogue.cpp:2619
 msgid "Configuration warning"
 msgstr ""
 
 #: ../../src/ToolBar.cpp:367 ../../src/ToolBar.cpp:369
-#: ../../src/wxMaximaFrame.cpp:726 ../../src/wxMaximaFrame.cpp:728
+#: ../../src/wxMaximaFrame.cpp:769 ../../src/wxMaximaFrame.cpp:771
 msgid "Configure wxMaxima"
 msgstr ""
 
@@ -2430,7 +2434,7 @@ msgstr ""
 msgid "Construct a fraction"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1343
+#: ../../src/wxMaximaFrame.cpp:1388
 msgid "Construct fraction..."
 msgstr ""
 
@@ -2438,15 +2442,15 @@ msgstr ""
 msgid "Contents"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4030
+#: ../../src/MaximaCommandMenus.cpp:4056
 msgid "Contents:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1918
+#: ../../src/wxMaximaFrame.cpp:1963
 msgid "Context-sensitive &Help\tCtrl+?"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1920
+#: ../../src/wxMaximaFrame.cpp:1965
 msgid "Context-sensitive &Help\tF1"
 msgstr ""
 
@@ -2474,83 +2478,83 @@ msgstr ""
 msgid "Contour lines settings for the following 3d plots"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1583
+#: ../../src/wxMaximaFrame.cpp:1628
 msgid "Contract Logarithms"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1199
+#: ../../src/wxMaximaFrame.cpp:1244
 msgid "Conversions"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1267
+#: ../../src/wxMaximaFrame.cpp:1312
 msgid "Convert"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1268
+#: ../../src/wxMaximaFrame.cpp:1313
 msgid "Convert + Write to file"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1475
+#: ../../src/wxMaximaFrame.cpp:1520
 msgid "Convert Column to list..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1471
+#: ../../src/wxMaximaFrame.cpp:1516
 msgid "Convert Row to list..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1082
+#: ../../src/wxMaximaFrame.cpp:1127
 msgid "Convert a command to maxima code"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1359
+#: ../../src/wxMaximaFrame.cpp:1404
 msgid "Convert a list of lists to a matrix"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1615
+#: ../../src/wxMaximaFrame.cpp:1660
 msgid "Convert binomials, beta and gamma function to factorials"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1619
+#: ../../src/wxMaximaFrame.cpp:1664
 msgid "Convert binomials, factorials and beta function to gamma function"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1654
+#: ../../src/wxMaximaFrame.cpp:1699
 msgid "Convert complex expression to polar form"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1651
+#: ../../src/wxMaximaFrame.cpp:1696
 msgid "Convert complex expression to rect form"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1663
+#: ../../src/wxMaximaFrame.cpp:1708
 msgid "Convert exponential function of imaginary argument to trigonometric form"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4283
+#: ../../src/MaximaCommandMenus.cpp:4309
 msgid "Convert string to lowercase"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4415
+#: ../../src/MaximaCommandMenus.cpp:4441
 msgid "Convert string to matching regex"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1584
+#: ../../src/wxMaximaFrame.cpp:1629
 msgid "Convert sum of logarithms to logarithm of product"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1614
+#: ../../src/wxMaximaFrame.cpp:1659
 msgid "Convert to &Factorials"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1618
+#: ../../src/wxMaximaFrame.cpp:1663
 msgid "Convert to &Gamma"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1653
+#: ../../src/wxMaximaFrame.cpp:1698
 msgid "Convert to &Polarform"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1650
+#: ../../src/wxMaximaFrame.cpp:1695
 msgid "Convert to &Rectform"
 msgstr ""
 
@@ -2582,23 +2586,23 @@ msgstr ""
 msgid "Convert to Title"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1204
+#: ../../src/wxMaximaFrame.cpp:1249
 msgid "Convert to downcase..."
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:3888
+#: ../../src/MaximaCommandMenus.cpp:3914
 msgid "Convert to programming language"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:3894
+#: ../../src/MaximaCommandMenus.cpp:3920
 msgid "Convert to programming language file"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1643
+#: ../../src/wxMaximaFrame.cpp:1688
 msgid "Convert trigonometric expression to canonical quasilinear form"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1668
+#: ../../src/wxMaximaFrame.cpp:1713
 msgid "Convert trigonometric functions to exponential form"
 msgstr ""
 
@@ -2610,11 +2614,11 @@ msgstr ""
 msgid "Converted to linear:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1803
+#: ../../src/wxMaximaFrame.cpp:1848
 msgid "Converts a matrix to a list of lists"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1801
+#: ../../src/wxMaximaFrame.cpp:1846
 msgid "Converts a nested list like [[1,2],[3,4]] to a matrix"
 msgstr ""
 
@@ -2633,11 +2637,11 @@ msgstr ""
 msgid "Copy Animation"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:925
+#: ../../src/wxMaximaFrame.cpp:970
 msgid "Copy Previous Input\tCtrl+I"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:928
+#: ../../src/wxMaximaFrame.cpp:973
 msgid "Copy Previous Output\tCtrl+U"
 msgstr ""
 
@@ -2647,23 +2651,23 @@ msgstr ""
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:145
 #: ../../src/worksheet/WorksheetContextMenu.cpp:292
-#: ../../src/wxMaximaFrame.cpp:704
+#: ../../src/wxMaximaFrame.cpp:747
 msgid "Copy as EMF"
 msgstr ""
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:135
 #: ../../src/worksheet/WorksheetContextMenu.cpp:282
-#: ../../src/wxMaximaFrame.cpp:693
+#: ../../src/wxMaximaFrame.cpp:736
 msgid "Copy as Image"
 msgstr ""
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:126
 #: ../../src/worksheet/WorksheetContextMenu.cpp:273
-#: ../../src/wxMaximaFrame.cpp:686
+#: ../../src/wxMaximaFrame.cpp:729
 msgid "Copy as LaTeX"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:689
+#: ../../src/wxMaximaFrame.cpp:732
 msgid "Copy as MathML"
 msgstr ""
 
@@ -2674,17 +2678,17 @@ msgstr ""
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:148
 #: ../../src/worksheet/WorksheetContextMenu.cpp:295
-#: ../../src/wxMaximaFrame.cpp:699
+#: ../../src/wxMaximaFrame.cpp:742
 msgid "Copy as RTF"
 msgstr ""
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:142
 #: ../../src/worksheet/WorksheetContextMenu.cpp:289
-#: ../../src/wxMaximaFrame.cpp:696
+#: ../../src/wxMaximaFrame.cpp:739
 msgid "Copy as SVG"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:681
+#: ../../src/wxMaximaFrame.cpp:724
 msgid "Copy as Text\tCtrl+Shift+C"
 msgstr ""
 
@@ -2693,17 +2697,17 @@ msgstr ""
 msgid "Copy as plain text"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4448
+#: ../../src/MaximaCommandMenus.cpp:4474
 msgid "Copy file"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1252
+#: ../../src/wxMaximaFrame.cpp:1297
 msgid "Copy file..."
 msgstr ""
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:124
 #: ../../src/worksheet/WorksheetContextMenu.cpp:271
-#: ../../src/wxMaximaFrame.cpp:684
+#: ../../src/wxMaximaFrame.cpp:727
 msgid "Copy for Octave/Matlab"
 msgstr ""
 
@@ -2715,47 +2719,47 @@ msgid "Copy position (UUID)"
 msgstr ""
 
 #: ../../src/ToolBar.cpp:380 ../../src/ToolBar.cpp:384
-#: ../../src/wxMaximaFrame.cpp:679
+#: ../../src/wxMaximaFrame.cpp:722
 msgid "Copy selection"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:705
+#: ../../src/wxMaximaFrame.cpp:748
 msgid "Copy selection from document as an Enhanced Metafile"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:697
+#: ../../src/wxMaximaFrame.cpp:740
 msgid "Copy selection from document as an SVG image"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:694
+#: ../../src/wxMaximaFrame.cpp:737
 msgid "Copy selection from document as an image"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:700
+#: ../../src/wxMaximaFrame.cpp:743
 msgid "Copy selection from document as rtf that a word processor might understand"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:682
+#: ../../src/wxMaximaFrame.cpp:725
 msgid "Copy selection from document as text"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:687
+#: ../../src/wxMaximaFrame.cpp:730
 msgid "Copy selection from document in LaTeX format"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:685
+#: ../../src/wxMaximaFrame.cpp:728
 msgid "Copy selection from document in Matlab format"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:690
+#: ../../src/wxMaximaFrame.cpp:733
 msgid "Copy selection from document in a MathML format many word processors can display as 2d equation"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4275
+#: ../../src/MaximaCommandMenus.cpp:4301
 msgid "Copy string"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1203
+#: ../../src/wxMaximaFrame.cpp:1248
 msgid "Copy string..."
 msgstr ""
 
@@ -2763,22 +2767,22 @@ msgstr ""
 msgid "Copy, Cut and Paste button"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2523
+#: ../../src/dialogs/ConfigDialogue.cpp:2535
 #, c-format
 msgid "Copying config bool \"%s\""
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2533
+#: ../../src/dialogs/ConfigDialogue.cpp:2545
 #, c-format
 msgid "Copying config float \"%s\""
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2528
+#: ../../src/dialogs/ConfigDialogue.cpp:2540
 #, c-format
 msgid "Copying config int \"%s\""
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2518
+#: ../../src/dialogs/ConfigDialogue.cpp:2530
 #, c-format
 msgid "Copying config string \"%s\""
 msgstr ""
@@ -2812,11 +2816,11 @@ msgstr ""
 msgid "Could not write the file's contents during saving => aborting."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1363
+#: ../../src/wxMaximaFrame.cpp:1408
 msgid "Create Matrix"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1729
+#: ../../src/wxMaximaFrame.cpp:1774
 msgid "Create a list"
 msgstr ""
 
@@ -2832,39 +2836,39 @@ msgstr ""
 msgid "Create a list from a rule"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1711
+#: ../../src/wxMaximaFrame.cpp:1756
 msgid "Create a list from comma-separated elements"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:926
+#: ../../src/wxMaximaFrame.cpp:971
 msgid "Create a new cell with previous input"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:929
+#: ../../src/wxMaximaFrame.cpp:974
 msgid "Create a new cell with previous output"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1386
+#: ../../src/wxMaximaFrame.cpp:1431
 msgid "Create copy, not clone..."
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4433
+#: ../../src/MaximaCommandMenus.cpp:4459
 msgid "Create directory"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1241
+#: ../../src/wxMaximaFrame.cpp:1286
 msgid "Create directory..."
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4291
+#: ../../src/MaximaCommandMenus.cpp:4317
 msgid "Create empty string"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1206
+#: ../../src/wxMaximaFrame.cpp:1251
 msgid "Create empty string..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1728
+#: ../../src/wxMaximaFrame.cpp:1773
 msgid "Create list"
 msgstr ""
 
@@ -2872,11 +2876,11 @@ msgstr ""
 msgid "Create list from comma-separated elements"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1389
+#: ../../src/dialogs/ConfigDialogue.cpp:1390
 msgid "Create scalable plots."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1120
+#: ../../src/wxMaximaFrame.cpp:1165
 msgid "Create struct..."
 msgstr ""
 
@@ -2884,7 +2888,7 @@ msgstr ""
 msgid "Created a .zip archive (the .wxmx file technically is a .zip file)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1387
+#: ../../src/wxMaximaFrame.cpp:1432
 msgid "Creates an independent matrix with the same contents"
 msgstr ""
 
@@ -2896,7 +2900,7 @@ msgstr ""
 msgid "Csv files (*.csv)|*.csv|Text files (*.txt)|*.txt|All|*"
 msgstr ""
 
-#: ../../src/worksheet/Worksheet.cpp:6125
+#: ../../src/worksheet/Worksheet.cpp:6131
 msgid "Cursor"
 msgstr ""
 
@@ -2909,12 +2913,12 @@ msgstr ""
 msgid "Cut"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:677
+#: ../../src/wxMaximaFrame.cpp:720
 msgid "Cut\tCtrl+X"
 msgstr ""
 
 #: ../../src/ToolBar.cpp:379 ../../src/ToolBar.cpp:383
-#: ../../src/wxMaximaFrame.cpp:677
+#: ../../src/wxMaximaFrame.cpp:720
 msgid "Cut selection"
 msgstr ""
 
@@ -2926,7 +2930,7 @@ msgstr ""
 msgid "Danish"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2069
+#: ../../src/dialogs/ConfigDialogue.cpp:2080
 msgid "Dark"
 msgstr ""
 
@@ -2947,19 +2951,19 @@ msgstr ""
 #: ../../src/MaximaCommandMenus.cpp:1785 ../../src/MaximaCommandMenus.cpp:1789
 #: ../../src/MaximaCommandMenus.cpp:1793 ../../src/MaximaCommandMenus.cpp:1797
 #: ../../src/MaximaCommandMenus.cpp:1801 ../../src/MaximaCommandMenus.cpp:1815
-#: ../../src/MaximaCommandMenus.cpp:1822 ../../src/MaximaCommandMenus.cpp:3519
+#: ../../src/MaximaCommandMenus.cpp:1822 ../../src/MaximaCommandMenus.cpp:3545
 msgid "Data:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1095
+#: ../../src/wxMaximaFrame.cpp:1140
 msgid "Debugger trigger"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:820
+#: ../../src/wxMaximaFrame.cpp:865
 msgid "Declare Text to always be displayed as subscript"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:3941
+#: ../../src/MaximaCommandMenus.cpp:3967
 msgid "Declare a function local to a Program"
 msgstr ""
 
@@ -2976,7 +2980,7 @@ msgstr ""
 msgid "Declare main variable:"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4043
+#: ../../src/MaximaCommandMenus.cpp:4069
 msgid "Declare the type of a function parameter"
 msgstr ""
 
@@ -2984,7 +2988,7 @@ msgstr ""
 msgid "Declare these chars as ordinary letters"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1541 ../../src/wxMaximaFrame.cpp:1577
+#: ../../src/wxMaximaFrame.cpp:1586 ../../src/wxMaximaFrame.cpp:1622
 msgid "Decompose rational function to partial fractions"
 msgstr ""
 
@@ -2992,51 +2996,51 @@ msgstr ""
 msgid "Decreasing function f(x)<x"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1336
+#: ../../src/dialogs/ConfigDialogue.cpp:1337
 msgid "Default animation framerate:"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:717
+#: ../../src/dialogs/ConfigDialogue.cpp:718
 msgid "Default plot size for new maxima sessions:"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1534
+#: ../../src/dialogs/ConfigDialogue.cpp:1545
 msgid "Default port for communication with wxMaxima:"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4006
+#: ../../src/MaximaCommandMenus.cpp:4032
 msgid "Define a function"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4019
+#: ../../src/MaximaCommandMenus.cpp:4045
 msgid "Define a macro"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4061
+#: ../../src/MaximaCommandMenus.cpp:4087
 msgid "Define a structure"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4055
+#: ../../src/MaximaCommandMenus.cpp:4081
 msgid "Define a structure type"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4028
+#: ../../src/MaximaCommandMenus.cpp:4054
 msgid "Define a variable"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1110
+#: ../../src/wxMaximaFrame.cpp:1155
 msgid "Define function..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1117
+#: ../../src/wxMaximaFrame.cpp:1162
 msgid "Define macro..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1115
+#: ../../src/wxMaximaFrame.cpp:1160
 msgid "Define parameter type..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1119
+#: ../../src/wxMaximaFrame.cpp:1164
 msgid "Define struct..."
 msgstr ""
 
@@ -3044,11 +3048,11 @@ msgstr ""
 msgid "Define the default speed (in frames per second) animations are played back with."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1118
+#: ../../src/wxMaximaFrame.cpp:1163
 msgid "Define variable..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1817
+#: ../../src/wxMaximaFrame.cpp:1862
 msgid "Defines if an animation is automatically started or only by clicking on it."
 msgstr ""
 
@@ -3056,7 +3060,7 @@ msgstr ""
 msgid "Degree:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1023
+#: ../../src/wxMaximaFrame.cpp:1068
 msgid "Delete F&unction..."
 msgstr ""
 
@@ -3065,51 +3069,51 @@ msgstr ""
 msgid "Delete Selection"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1025
+#: ../../src/wxMaximaFrame.cpp:1070
 msgid "Delete V&ariable..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1024
+#: ../../src/wxMaximaFrame.cpp:1069
 msgid "Delete a function"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1026
+#: ../../src/wxMaximaFrame.cpp:1071
 msgid "Delete a variable"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1020
+#: ../../src/wxMaximaFrame.cpp:1065
 msgid "Delete all objects with a given name"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1029
+#: ../../src/wxMaximaFrame.cpp:1074
 msgid "Delete all values from memory"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4460
+#: ../../src/MaximaCommandMenus.cpp:4486
 msgid "Delete file"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1254
+#: ../../src/wxMaximaFrame.cpp:1299
 msgid "Delete file..."
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4555
+#: ../../src/MaximaCommandMenus.cpp:4581
 msgid "Delete function(s)"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4551
+#: ../../src/MaximaCommandMenus.cpp:4577
 msgid "Delete named object(s)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1019
+#: ../../src/wxMaximaFrame.cpp:1064
 msgid "Delete named object..."
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4546
+#: ../../src/MaximaCommandMenus.cpp:4572
 msgid "Delete variable(s)"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4302
+#: ../../src/MaximaCommandMenus.cpp:4328
 msgid "Delimiter:"
 msgstr ""
 
@@ -3123,7 +3127,7 @@ msgstr ""
 msgid "Demo for \"%s\""
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1971
+#: ../../src/wxMaximaFrame.cpp:2016
 msgid "Demos"
 msgstr ""
 
@@ -3135,7 +3139,7 @@ msgstr ""
 msgid "Denominator:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1068
+#: ../../src/wxMaximaFrame.cpp:1113
 msgid "Dependencies"
 msgstr ""
 
@@ -3178,11 +3182,11 @@ msgstr ""
 msgid "Deviation..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1538
+#: ../../src/wxMaximaFrame.cpp:1583
 msgid "Di&vide Polynomials..."
 msgstr ""
 
-#: ../../src/worksheet/WorksheetExport.cpp:1400
+#: ../../src/worksheet/WorksheetExport.cpp:1390
 msgid "Diagram"
 msgstr ""
 
@@ -3198,7 +3202,7 @@ msgstr ""
 msgid "Didn't find the maxima HTML manual."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:1686
+#: ../../src/wxMaxima.cpp:1691
 msgid "Didn't get a help browser launch program command line, but can request the system's default help browser."
 msgstr ""
 
@@ -3215,11 +3219,11 @@ msgstr ""
 msgid "Difference %d / %d"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:264 ../../src/MaximaCommandMenus.cpp:3544
+#: ../../src/MaximaCommandMenus.cpp:264 ../../src/MaximaCommandMenus.cpp:3570
 msgid "Differentiate"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1508
+#: ../../src/wxMaximaFrame.cpp:1553
 msgid "Differentiate expression"
 msgstr ""
 
@@ -3231,7 +3235,7 @@ msgstr ""
 msgid "Differentiates an expression n times"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:3544
+#: ../../src/MaximaCommandMenus.cpp:3570
 msgid "Differentiates the expression n times"
 msgstr ""
 
@@ -3239,7 +3243,7 @@ msgstr ""
 msgid "Direction:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1250
+#: ../../src/wxMaximaFrame.cpp:1295
 msgid "Directory operations"
 msgstr ""
 
@@ -3251,35 +3255,35 @@ msgstr ""
 msgid "Discrete plot"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:699
+#: ../../src/dialogs/ConfigDialogue.cpp:700
 msgid "Display"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1079
+#: ../../src/wxMaximaFrame.cpp:1124
 msgid "Display Te&X Form"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:3844
+#: ../../src/MaximaCommandMenus.cpp:3870
 msgid "Display algorithm"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:827
+#: ../../src/dialogs/ConfigDialogue.cpp:828
 msgid "Display all and allow linebreaks in long numbers"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:820
+#: ../../src/dialogs/ConfigDialogue.cpp:821
 msgid "Display all digits"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:792
+#: ../../src/wxMaximaFrame.cpp:837
 msgid "Display an expression as maxima's internal lisp representation"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:795
+#: ../../src/wxMaximaFrame.cpp:840
 msgid "Display an expression as wxMaxima's internal XML representation"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:799
+#: ../../src/wxMaximaFrame.cpp:844
 msgid "Display equations"
 msgstr ""
 
@@ -3291,11 +3295,11 @@ msgstr ""
 msgid "Display expression in wxMaxima's internal representation"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1080
+#: ../../src/wxMaximaFrame.cpp:1125
 msgid "Display last result in TeX form"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:804
+#: ../../src/dialogs/ConfigDialogue.cpp:805
 msgid "Display of long numbers"
 msgstr ""
 
@@ -3304,11 +3308,11 @@ msgstr ""
 msgid "Display resolution according to wxWidgets: %li x %li ppi"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:843
+#: ../../src/wxMaximaFrame.cpp:888
 msgid "Display string quotation marks"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1074
+#: ../../src/wxMaximaFrame.cpp:1119
 msgid "Display time used for evaluation"
 msgstr ""
 
@@ -3316,32 +3320,32 @@ msgstr ""
 msgid "Displayed Precision"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1954
+#: ../../src/wxMaximaFrame.cpp:1999
 msgid "Displaying 3d curves"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1503
+#: ../../src/wxMaximaFrame.cpp:1548
 msgid "Dito, and evaluate the result..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1486
+#: ../../src/wxMaximaFrame.cpp:1531
 msgid "Dito, but affect all clones of the Matrix..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1293
+#: ../../src/wxMaximaFrame.cpp:1338
 msgid "Dito, but as fraction (real only)..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1573
+#: ../../src/wxMaximaFrame.cpp:1618
 msgid "Dito, including denominator"
 msgstr ""
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:488
-#: ../../src/wxMaximaFrame.cpp:982
+#: ../../src/wxMaximaFrame.cpp:1027
 msgid "Divide Cell"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1539
+#: ../../src/wxMaximaFrame.cpp:1584
 msgid "Divide numbers or polynomials"
 msgstr ""
 
@@ -3353,12 +3357,12 @@ msgstr ""
 msgid "Do for each list element"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3564
+#: ../../src/wxMaxima.cpp:3568
 #, c-format
 msgid "Do you want to save the changes you made in the document \"%s\"?"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:765
+#: ../../src/wxMaximaFrame.cpp:810
 msgid "Dock all Sidebars"
 msgstr ""
 
@@ -3374,27 +3378,27 @@ msgstr ""
 msgid "Document was saved using a newer version of wxMaxima. Please update your wxMaxima."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1170
+#: ../../src/dialogs/ConfigDialogue.cpp:1171
 msgid "Documentclass for TeX export:"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1178
+#: ../../src/dialogs/ConfigDialogue.cpp:1179
 msgid "Documentclass options:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:811
+#: ../../src/wxMaximaFrame.cpp:856
 msgid "Don't autosubscript after an underscore"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1124
+#: ../../src/wxMaximaFrame.cpp:1169
 msgid "Don't evaluate Expression..."
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:3989
+#: ../../src/MaximaCommandMenus.cpp:4015
 msgid "Don't evaluate one command"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4001
+#: ../../src/MaximaCommandMenus.cpp:4027
 msgid "Don't evaluate one whole expression"
 msgstr ""
 
@@ -3408,7 +3412,7 @@ msgstr ""
 msgid "Don't mark this message text in yellow"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3570
+#: ../../src/wxMaxima.cpp:3574
 msgid "Don't save"
 msgstr ""
 
@@ -3420,7 +3424,7 @@ msgstr ""
 msgid "Don't use if unassigned"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:838
+#: ../../src/wxMaximaFrame.cpp:883
 msgid "Don't use parenthesis for matrices"
 msgstr ""
 
@@ -3452,35 +3456,35 @@ msgstr ""
 msgid "Dutch"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1344
+#: ../../src/wxMaximaFrame.cpp:1389
 msgid "E&quations"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:662
+#: ../../src/wxMaximaFrame.cpp:705
 msgid "E&xit\tCtrl+Q"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1406
+#: ../../src/wxMaximaFrame.cpp:1451
 msgid "Eige&nvectors"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1403
+#: ../../src/wxMaximaFrame.cpp:1448
 msgid "Eigen&values"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1425
+#: ../../src/wxMaximaFrame.cpp:1470
 msgid "Eigenvalues (complex)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1422
+#: ../../src/wxMaximaFrame.cpp:1467
 msgid "Eigenvalues (real)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1431
+#: ../../src/wxMaximaFrame.cpp:1476
 msgid "Eigenvalues, left+right eigenvectors (complex)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1428
+#: ../../src/wxMaximaFrame.cpp:1473
 msgid "Eigenvalues, left+right eigenvectors (real)"
 msgstr ""
 
@@ -3522,7 +3526,7 @@ msgstr ""
 msgid "Element-by-element exponentiation of two matrices"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1380
+#: ../../src/wxMaximaFrame.cpp:1425
 msgid "Element-by-element multiplication"
 msgstr ""
 
@@ -3530,7 +3534,7 @@ msgstr ""
 msgid "Element:"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4076
+#: ../../src/MaximaCommandMenus.cpp:4102
 msgid "Elements:"
 msgstr ""
 
@@ -3538,7 +3542,7 @@ msgstr ""
 msgid "Eliminate a variable"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1285
+#: ../../src/wxMaximaFrame.cpp:1330
 msgid "Eliminate a variable from a system of equations"
 msgstr ""
 
@@ -3588,7 +3592,7 @@ msgstr ""
 msgid "Ended lisp mode after receiving a maxima prompt!"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1869
+#: ../../src/wxMaximaFrame.cpp:1914
 msgid "Engineering format (12.1e6 etc.)"
 msgstr ""
 
@@ -3600,7 +3604,7 @@ msgstr ""
 msgid "Enhanced 3D settings:"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1919
+#: ../../src/dialogs/ConfigDialogue.cpp:1930
 msgid "Enhanced meta file (emf)"
 msgstr ""
 
@@ -3612,11 +3616,11 @@ msgstr ""
 msgid "Enter UUID to jump to:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1357
+#: ../../src/wxMaximaFrame.cpp:1402
 msgid "Enter a matrix"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:925
+#: ../../src/dialogs/ConfigDialogue.cpp:926
 msgid "Enter adds newlines, Ctrl+Enter evaluates cells"
 msgstr ""
 
@@ -3628,7 +3632,7 @@ msgstr ""
 msgid "Enter comma separated list of variables."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:921
+#: ../../src/dialogs/ConfigDialogue.cpp:922
 msgid "Enter evaluates cells, Ctrl+Enter adds newlines"
 msgstr ""
 
@@ -3652,11 +3656,11 @@ msgstr ""
 msgid "Enumerator:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1258
+#: ../../src/wxMaximaFrame.cpp:1303
 msgid "Environment variables"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1605
+#: ../../src/dialogs/ConfigDialogue.cpp:1616
 msgid "Environment variables for maxima"
 msgstr ""
 
@@ -3668,11 +3672,11 @@ msgstr ""
 msgid "Epsilon:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1162 ../../src/wxMaximaFrame.cpp:1173
+#: ../../src/wxMaximaFrame.cpp:1207 ../../src/wxMaximaFrame.cpp:1218
 msgid "Equal, ignoring case?..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1171
+#: ../../src/wxMaximaFrame.cpp:1216
 msgid "Equal?..."
 msgstr ""
 
@@ -3695,7 +3699,7 @@ msgstr ""
 
 #: ../../src/MaximaCommandMenus.cpp:150 ../../src/MaximaCommandMenus.cpp:170
 #: ../../src/MaximaCommandMenus.cpp:957 ../../src/MaximaCommandMenus.cpp:969
-#: ../../src/MaximaCommandMenus.cpp:1832 ../../src/MaximaCommandMenus.cpp:3528
+#: ../../src/MaximaCommandMenus.cpp:1832 ../../src/MaximaCommandMenus.cpp:3554
 msgid "Equation:"
 msgstr ""
 
@@ -3711,9 +3715,9 @@ msgstr ""
 #: ../../src/WXMXformat.cpp:290 ../../src/WXMXformat.cpp:298
 #: ../../src/WXMXformat.cpp:313 ../../src/WXMXformat.cpp:334
 #: ../../src/WXMXformat.cpp:364 ../../src/dialogs/BinaryNameCtrl.cpp:78
-#: ../../src/main.cpp:750 ../../src/wxMaxima.cpp:3445
-#: ../../src/wxMaxima.cpp:3481 ../../src/wxMaxima.cpp:3499
-#: ../../src/wxMaxima.cpp:3533
+#: ../../src/main.cpp:750 ../../src/wxMaxima.cpp:3449
+#: ../../src/wxMaxima.cpp:3485 ../../src/wxMaxima.cpp:3503
+#: ../../src/wxMaxima.cpp:3537
 msgid "Error"
 msgstr ""
 
@@ -3751,7 +3755,7 @@ msgid ""
 "%s"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4416
+#: ../../src/MaximaCommandMenus.cpp:4442
 msgid "Escapes all special characters in a string. The result is a regex that matches this string exactly."
 msgstr ""
 
@@ -3763,15 +3767,15 @@ msgstr ""
 msgid "Evaluate"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1693
+#: ../../src/wxMaximaFrame.cpp:1738
 msgid "Evaluate &Noun Forms..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:894
+#: ../../src/wxMaximaFrame.cpp:939
 msgid "Evaluate All Cells\tCtrl+Shift+R"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:889
+#: ../../src/wxMaximaFrame.cpp:934
 msgid "Evaluate All Visible Cells\tCtrl+R"
 msgstr ""
 
@@ -3780,7 +3784,7 @@ msgid "Evaluate Cell"
 msgstr ""
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:169
-#: ../../src/wxMaximaFrame.cpp:882
+#: ../../src/wxMaximaFrame.cpp:927
 msgid "Evaluate Cell(s)"
 msgstr ""
 
@@ -3789,13 +3793,13 @@ msgstr ""
 msgid "Evaluate Cells Above"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:904
+#: ../../src/wxMaximaFrame.cpp:949
 msgid "Evaluate Cells Above\tCtrl+Shift+P"
 msgstr ""
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:173
 #: ../../src/worksheet/WorksheetContextMenu.cpp:449
-#: ../../src/wxMaximaFrame.cpp:914
+#: ../../src/wxMaximaFrame.cpp:959
 msgid "Evaluate Cells Below"
 msgstr ""
 
@@ -3837,7 +3841,7 @@ msgstr ""
 msgid "Evaluate Subsection\tShift+Ctrl+Enter"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:883
+#: ../../src/wxMaximaFrame.cpp:928
 msgid "Evaluate active or selected cell(s)"
 msgstr ""
 
@@ -3845,15 +3849,15 @@ msgstr ""
 msgid "Evaluate all"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:895
+#: ../../src/wxMaximaFrame.cpp:940
 msgid "Evaluate all cells in the document"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1694
+#: ../../src/wxMaximaFrame.cpp:1739
 msgid "Evaluate all noun forms in expression"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:890
+#: ../../src/wxMaximaFrame.cpp:935
 msgid "Evaluate all visible cells in the document"
 msgstr ""
 
@@ -3861,11 +3865,11 @@ msgstr ""
 msgid "Evaluate current cell"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4267
+#: ../../src/MaximaCommandMenus.cpp:4293
 msgid "Evaluate string"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1189
+#: ../../src/wxMaximaFrame.cpp:1234
 msgid "Evaluate string..."
 msgstr ""
 
@@ -3893,15 +3897,15 @@ msgstr ""
 msgid "Even number"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2659
+#: ../../src/dialogs/ConfigDialogue.cpp:2671
 msgid "Example text"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1547
+#: ../../src/dialogs/ConfigDialogue.cpp:1558
 msgid "Examples:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1744
+#: ../../src/wxMaximaFrame.cpp:1789
 msgid "Execute a command for each element of the list"
 msgstr ""
 
@@ -3921,11 +3925,11 @@ msgstr ""
 msgid "Expand Expression"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1566
+#: ../../src/wxMaximaFrame.cpp:1611
 msgid "Expand an expression"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1572
+#: ../../src/wxMaximaFrame.cpp:1617
 msgid "Expand for given variables"
 msgstr ""
 
@@ -3937,19 +3941,19 @@ msgstr ""
 msgid "Expand for variable(s):"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1586
+#: ../../src/wxMaximaFrame.cpp:1631
 msgid "Expand log in previous expression"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1639
+#: ../../src/wxMaximaFrame.cpp:1684
 msgid "Expand trigonometric expression"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1829
+#: ../../src/wxMaximaFrame.cpp:1874
 msgid "Expect numbers harder to be complex"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1830
+#: ../../src/wxMaximaFrame.cpp:1875
 msgid "Expect variables to contain complex numbers"
 msgstr ""
 
@@ -3962,15 +3966,15 @@ msgstr ""
 msgid "Export As"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1746
+#: ../../src/wxMaximaFrame.cpp:1791
 msgid "Export List to csv file..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1747
+#: ../../src/wxMaximaFrame.cpp:1792
 msgid "Export a list to a csv file"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1370
+#: ../../src/wxMaximaFrame.cpp:1415
 msgid "Export a matrix to a csv file"
 msgstr ""
 
@@ -3978,7 +3982,7 @@ msgstr ""
 msgid "Export all history to a .mac file"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1016
+#: ../../src/dialogs/ConfigDialogue.cpp:1017
 msgid "Export all settings"
 msgstr ""
 
@@ -3986,15 +3990,15 @@ msgstr ""
 msgid "Export commands from the current maxima session to a .mac file"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:656
+#: ../../src/wxMaximaFrame.cpp:699
 msgid "Export document to a HTML or LaTeX file"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1218
+#: ../../src/dialogs/ConfigDialogue.cpp:1219
 msgid "Export equations to HTML as:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:604
+#: ../../src/wxMaximaFrame.cpp:636
 msgid "Export failed."
 msgstr ""
 
@@ -4010,15 +4014,15 @@ msgstr ""
 msgid "Export selected commands to a .mac file"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:592
+#: ../../src/wxMaximaFrame.cpp:624
 msgid "Export successful."
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:3468
+#: ../../src/MaximaCommandMenus.cpp:3494
 msgid "Export the selected output(s) to this folder"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1022
+#: ../../src/dialogs/ConfigDialogue.cpp:1023
 msgid "Export the style settings"
 msgstr ""
 
@@ -4026,12 +4030,12 @@ msgstr ""
 msgid "Export visible commands to a .mac file"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:3477
+#: ../../src/MaximaCommandMenus.cpp:3503
 #, c-format
 msgid "Exported %d output image(s) to %s"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2201 ../../src/wxMaxima.cpp:2243
+#: ../../src/wxMaxima.cpp:2205 ../../src/wxMaxima.cpp:2247
 #, c-format
 msgid "Exported the worksheet to %s"
 msgstr ""
@@ -4052,7 +4056,7 @@ msgstr ""
 msgid "Exporting to maxima batch file failed!"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:586
+#: ../../src/wxMaximaFrame.cpp:618
 msgid "Exporting..."
 msgstr ""
 
@@ -4063,12 +4067,12 @@ msgstr ""
 #: ../../src/MaximaCommandMenus.cpp:625 ../../src/MaximaCommandMenus.cpp:630
 #: ../../src/MaximaCommandMenus.cpp:650 ../../src/MaximaCommandMenus.cpp:1408
 #: ../../src/MaximaCommandMenus.cpp:3030 ../../src/MaximaCommandMenus.cpp:3036
-#: ../../src/MaximaCommandMenus.cpp:3554 ../../src/sidebars/DrawSidebar.cpp:54
+#: ../../src/MaximaCommandMenus.cpp:3580 ../../src/sidebars/DrawSidebar.cpp:54
 #: ../../src/wizards/Plot3dWiz.cpp:32
 msgid "Expression"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:3891 ../../src/MaximaCommandMenus.cpp:3897
+#: ../../src/MaximaCommandMenus.cpp:3917 ../../src/MaximaCommandMenus.cpp:3923
 msgid "Expression or a list of comma-separated expressions"
 msgstr ""
 
@@ -4088,15 +4092,15 @@ msgstr ""
 msgid "Expression to plot"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1126
+#: ../../src/wxMaximaFrame.cpp:1171
 msgid "Expression to string..."
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:3985
+#: ../../src/MaximaCommandMenus.cpp:4011
 msgid "Expression whose output is to be used as maxima's input."
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4086 ../../src/wizards/Plot2dWiz.cpp:39
+#: ../../src/MaximaCommandMenus.cpp:4112 ../../src/wizards/Plot2dWiz.cpp:39
 msgid "Expression(s):"
 msgstr ""
 
@@ -4105,29 +4109,29 @@ msgstr ""
 #: ../../src/MaximaCommandMenus.cpp:235 ../../src/MaximaCommandMenus.cpp:252
 #: ../../src/MaximaCommandMenus.cpp:258 ../../src/MaximaCommandMenus.cpp:265
 #: ../../src/MaximaCommandMenus.cpp:297 ../../src/MaximaCommandMenus.cpp:316
-#: ../../src/MaximaCommandMenus.cpp:3545 ../../src/wizards/IntegrateWiz.cpp:33
+#: ../../src/MaximaCommandMenus.cpp:3571 ../../src/wizards/IntegrateWiz.cpp:33
 #: ../../src/wizards/LimitWiz.cpp:29 ../../src/wizards/SeriesWiz.cpp:30
 #: ../../src/wizards/SubstituteWiz.cpp:29 ../../src/wizards/SumWiz.cpp:31
 msgid "Expression:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1461
+#: ../../src/wxMaximaFrame.cpp:1506
 msgid "Extract Column..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1767
+#: ../../src/wxMaximaFrame.cpp:1812
 msgid "Extract Elements"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1459
+#: ../../src/wxMaximaFrame.cpp:1504
 msgid "Extract Row..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1462
+#: ../../src/wxMaximaFrame.cpp:1507
 msgid "Extract a column from the matrix"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1476
+#: ../../src/wxMaximaFrame.cpp:1521
 msgid "Extract a column from the matrix and convert it to a list"
 msgstr ""
 
@@ -4139,7 +4143,7 @@ msgstr ""
 msgid "Extract a matrix column as a list"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1351
+#: ../../src/wxMaximaFrame.cpp:1396
 msgid "Extract a matrix from a 2-dimensional array"
 msgstr ""
 
@@ -4151,11 +4155,11 @@ msgstr ""
 msgid "Extract a matrix row as a list"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1460
+#: ../../src/wxMaximaFrame.cpp:1505
 msgid "Extract a row from the matrix"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1472
+#: ../../src/wxMaximaFrame.cpp:1517
 msgid "Extract a row from the matrix and convert it to a list"
 msgstr ""
 
@@ -4163,35 +4167,35 @@ msgstr ""
 msgid "Extract a variable's value from a list of variable values"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1764
+#: ../../src/wxMaximaFrame.cpp:1809
 msgid "Extract an actual value for a variable"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1201
+#: ../../src/wxMaximaFrame.cpp:1246
 msgid "Extract char..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1245
+#: ../../src/wxMaximaFrame.cpp:1290
 msgid "Extract dir from path..."
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4477
+#: ../../src/MaximaCommandMenus.cpp:4503
 msgid "Extract directory part"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4489
+#: ../../src/MaximaCommandMenus.cpp:4515
 msgid "Extract file type extension"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1247
+#: ../../src/wxMaximaFrame.cpp:1292
 msgid "Extract filename from path..."
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4483
+#: ../../src/MaximaCommandMenus.cpp:4509
 msgid "Extract filename part"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1249
+#: ../../src/wxMaximaFrame.cpp:1294
 msgid "Extract filetype from path..."
 msgstr ""
 
@@ -4199,7 +4203,7 @@ msgstr ""
 msgid "Extract function arguments"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1768
+#: ../../src/wxMaximaFrame.cpp:1813
 msgid "Extract list Elements"
 msgstr ""
 
@@ -4207,7 +4211,7 @@ msgstr ""
 msgid "Extract matrix from 2D array"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1727
+#: ../../src/wxMaximaFrame.cpp:1772
 msgid "Extract the argument list from a function call"
 msgstr ""
 
@@ -4219,7 +4223,7 @@ msgstr ""
 msgid "Extract the last n list elements"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4248
+#: ../../src/MaximaCommandMenus.cpp:4274
 msgid "Extract the nth char of a string"
 msgstr ""
 
@@ -4227,11 +4231,11 @@ msgstr ""
 msgid "Extract the nth list elements"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1765
+#: ../../src/wxMaximaFrame.cpp:1810
 msgid "Extract the value for one variable assigned in a list"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1480
+#: ../../src/wxMaximaFrame.cpp:1525
 msgid "Extract, append or delete rows or columns"
 msgstr ""
 
@@ -4243,7 +4247,7 @@ msgstr ""
 msgid "Factor"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1562
+#: ../../src/wxMaximaFrame.cpp:1607
 msgid "Factor Complex"
 msgstr ""
 
@@ -4251,19 +4255,19 @@ msgstr ""
 msgid "Factor Expression"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1560
+#: ../../src/wxMaximaFrame.cpp:1605
 msgid "Factor Expression including subexpressions"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1558 ../../src/wxMaximaFrame.cpp:1561
+#: ../../src/wxMaximaFrame.cpp:1603 ../../src/wxMaximaFrame.cpp:1606
 msgid "Factor an expression"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1563
+#: ../../src/wxMaximaFrame.cpp:1608
 msgid "Factor an expression in Gaussian numbers"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1628
+#: ../../src/wxMaximaFrame.cpp:1673
 msgid "Factorials and &Gamma"
 msgstr ""
 
@@ -4285,11 +4289,11 @@ msgstr ""
 msgid "Failed to write to Maxima's stdin (LDB)."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1456
+#: ../../src/wxMaximaFrame.cpp:1501
 msgid "Fast fortran routines that perform numerical tasks"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1963
+#: ../../src/wxMaximaFrame.cpp:2008
 msgid "Fast list access"
 msgstr ""
 
@@ -4301,19 +4305,19 @@ msgstr ""
 msgid "Field Separator"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4063
+#: ../../src/MaximaCommandMenus.cpp:4089
 msgid "Field contents:"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4070
+#: ../../src/MaximaCommandMenus.cpp:4096
 msgid "Field name:"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4057
+#: ../../src/MaximaCommandMenus.cpp:4083
 msgid "Fields:"
 msgstr ""
 
-#: ../../src/cells/GroupCell.cpp:2115
+#: ../../src/cells/GroupCell.cpp:2123
 #, c-format
 msgid "Figure %d:"
 msgstr ""
@@ -4322,7 +4326,7 @@ msgstr ""
 msgid "File"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1371
+#: ../../src/wxMaximaFrame.cpp:1416
 msgid "File I/O"
 msgstr ""
 
@@ -4333,12 +4337,12 @@ msgstr ""
 msgid "File could not be opened"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4113 ../../src/MaximaCommandMenus.cpp:4118
-#: ../../src/MaximaCommandMenus.cpp:4123
+#: ../../src/MaximaCommandMenus.cpp:4139 ../../src/MaximaCommandMenus.cpp:4144
+#: ../../src/MaximaCommandMenus.cpp:4149
 msgid "File name:"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3056 ../../src/wxMaxima.cpp:3099
+#: ../../src/wxMaxima.cpp:3060 ../../src/wxMaxima.cpp:3103
 msgid "File not found"
 msgstr ""
 
@@ -4346,15 +4350,15 @@ msgstr ""
 msgid "File opened"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1255
+#: ../../src/wxMaximaFrame.cpp:1300
 msgid "File operations"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3055 ../../src/wxMaxima.cpp:3098
+#: ../../src/wxMaxima.cpp:3059 ../../src/wxMaxima.cpp:3102
 msgid "File you tried to open does not exist."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1259
+#: ../../src/wxMaximaFrame.cpp:1304
 msgid "File/directory functions"
 msgstr ""
 
@@ -4362,7 +4366,7 @@ msgstr ""
 msgid "Filename"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:3899
+#: ../../src/MaximaCommandMenus.cpp:3925
 msgid "Filename or a list of comma-separated file names"
 msgstr ""
 
@@ -4374,15 +4378,15 @@ msgstr ""
 msgid "Find"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:711
+#: ../../src/wxMaximaFrame.cpp:754
 msgid "Find\tCtrl+F"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1509
+#: ../../src/wxMaximaFrame.cpp:1554
 msgid "Find &Limit..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1511
+#: ../../src/wxMaximaFrame.cpp:1556
 msgid "Find Minimum..."
 msgstr ""
 
@@ -4390,76 +4394,80 @@ msgstr ""
 msgid "Find Root..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1512
+#: ../../src/wxMaximaFrame.cpp:1557
 msgid "Find a (unconstrained) minimum of an expression"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1845
+#: ../../src/wxMaximaFrame.cpp:1890
 msgid "Find a fraction that represents this float exactly"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1510
+#: ../../src/wxMaximaFrame.cpp:1555
 msgid "Find a limit of an expression"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1848
+#: ../../src/wxMaximaFrame.cpp:1893
 msgid "Find a nice fraction that is similar to this float"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1321
+#: ../../src/wxMaximaFrame.cpp:1366
 msgid "Find a numerical solution for a first degree ODE"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1290
+#: ../../src/wxMaximaFrame.cpp:1335
 msgid "Find a root of an equation on an interval"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1297
+#: ../../src/wxMaximaFrame.cpp:1342
 msgid "Find all roots of a polynomial"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1300
+#: ../../src/wxMaximaFrame.cpp:1345
 msgid "Find all roots of a polynomial (bfloat)"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:3103
+#: ../../src/MaximaCommandMenus.cpp:3129 ../../src/wxMaximaFrame.cpp:361
 msgid "Find and Replace"
 msgstr ""
 
+#: ../../src/wxMaximaFrame.cpp:798
+msgid "Find and Replace (if set to dockable)"
+msgstr ""
+
 #: ../../src/ToolBar.cpp:401 ../../src/ToolBar.cpp:403
-#: ../../src/wxMaximaFrame.cpp:711
+#: ../../src/wxMaximaFrame.cpp:754
 msgid "Find and replace"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4306
+#: ../../src/MaximaCommandMenus.cpp:4332
 msgid "Find char in string"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1210
+#: ../../src/wxMaximaFrame.cpp:1255
 msgid "Find char in string..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1575
+#: ../../src/wxMaximaFrame.cpp:1620
 msgid "Find common denominator"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1404
+#: ../../src/wxMaximaFrame.cpp:1449
 msgid "Find eigenvalues of a matrix"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1407
+#: ../../src/wxMaximaFrame.cpp:1452
 msgid "Find eigenvectors of a matrix"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4296
+#: ../../src/MaximaCommandMenus.cpp:4322
 msgid "Find first difference"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1208
+#: ../../src/wxMaximaFrame.cpp:1253
 msgid "Find first difference..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1294
+#: ../../src/wxMaximaFrame.cpp:1339
 msgid "Find fractions that real roots of a polynomial and "
 msgstr ""
 
@@ -4467,11 +4475,11 @@ msgstr ""
 msgid "Find minimum"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1289
+#: ../../src/wxMaximaFrame.cpp:1334
 msgid "Find numerical solution..."
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:3524
+#: ../../src/MaximaCommandMenus.cpp:3550
 msgid "Find root (solve numerically)"
 msgstr ""
 
@@ -4491,7 +4499,7 @@ msgstr ""
 msgid "Find:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1873
+#: ../../src/wxMaximaFrame.cpp:1918
 msgid "Fine-tune the display of engineering-format numbers"
 msgstr ""
 
@@ -4499,36 +4507,36 @@ msgstr ""
 msgid "Finnish"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1753
+#: ../../src/wxMaximaFrame.cpp:1798
 msgid "First"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1959
+#: ../../src/wxMaximaFrame.cpp:2004
 msgid "Fitting curves to measurement data"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1404
+#: ../../src/dialogs/ConfigDialogue.cpp:1405
 #, c-format
 msgid "Fix reordered reference indices (of %i, %o) before saving"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:873
+#: ../../src/dialogs/ConfigDialogue.cpp:874
 msgid "Fixed font in text controls"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4099
+#: ../../src/MaximaCommandMenus.cpp:4125
 msgid "Flush stream"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1141
+#: ../../src/wxMaximaFrame.cpp:1186
 msgid "Flush..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:960
+#: ../../src/wxMaximaFrame.cpp:1005
 msgid "Fold All\tCtrl+Alt+["
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:961
+#: ../../src/wxMaximaFrame.cpp:1006
 msgid "Fold all sections"
 msgstr ""
 
@@ -4536,7 +4544,7 @@ msgstr ""
 msgid "Follow"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2070
+#: ../../src/dialogs/ConfigDialogue.cpp:2081
 msgid "Follow system"
 msgstr ""
 
@@ -4556,7 +4564,7 @@ msgstr ""
 msgid "Font cache misses:"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2047
+#: ../../src/dialogs/ConfigDialogue.cpp:2058
 msgid "Fonts"
 msgstr ""
 
@@ -4578,11 +4586,11 @@ msgid ""
 "   Ctrl+7: Heading6 cell\n"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:3910
+#: ../../src/MaximaCommandMenus.cpp:3936
 msgid "For loop"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1100
+#: ../../src/wxMaximaFrame.cpp:1145
 msgid "For loop..."
 msgstr ""
 
@@ -4590,11 +4598,11 @@ msgstr ""
 msgid "Format:"
 msgstr ""
 
-#: ../../src/worksheet/Worksheet.cpp:301 ../../src/wxMaxima.cpp:3584
+#: ../../src/worksheet/Worksheet.cpp:301 ../../src/wxMaxima.cpp:3588
 msgid "Forwarding the keyboard focus to a text control"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3587
+#: ../../src/wxMaxima.cpp:3591
 msgid "Forwarding the keyboard focus to the worksheet"
 msgstr ""
 
@@ -4622,7 +4630,7 @@ msgstr ""
 msgid "Fourier coefficients"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1517
+#: ../../src/wxMaximaFrame.cpp:1562
 msgid "Fourier coefficients..."
 msgstr ""
 
@@ -4647,7 +4655,7 @@ msgstr ""
 msgid "Frame rate"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1043 ../../src/wxMaximaFrame.cpp:1047
+#: ../../src/wxMaximaFrame.cpp:1088 ../../src/wxMaximaFrame.cpp:1092
 msgid "Free all unused items now"
 msgstr ""
 
@@ -4655,11 +4663,11 @@ msgstr ""
 msgid "French"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1451
+#: ../../src/wxMaximaFrame.cpp:1496
 msgid "Frobenius Norm sqrt(sum((A(i,j))^2)) (complex)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1449
+#: ../../src/wxMaximaFrame.cpp:1494
 msgid "Frobenius Norm sqrt(sum((A(i,j))^2)) (real)"
 msgstr ""
 
@@ -4670,11 +4678,11 @@ msgstr ""
 msgid "From:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:868
+#: ../../src/wxMaximaFrame.cpp:913
 msgid "Full Screen\tAlt+Enter"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:865
+#: ../../src/wxMaximaFrame.cpp:910
 msgid "Full Screen\tF11"
 msgstr ""
 
@@ -4682,7 +4690,7 @@ msgstr ""
 msgid "Full-window repaints:"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4012
+#: ../../src/MaximaCommandMenus.cpp:4038
 msgid "Function contents:"
 msgstr ""
 
@@ -4694,11 +4702,11 @@ msgstr ""
 msgid "Function name"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4039
+#: ../../src/MaximaCommandMenus.cpp:4065
 msgid "Function name(s):"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4007 ../../src/MaximaCommandMenus.cpp:4556
+#: ../../src/MaximaCommandMenus.cpp:4033 ../../src/MaximaCommandMenus.cpp:4582
 msgid "Function name:"
 msgstr ""
 
@@ -4706,15 +4714,15 @@ msgstr ""
 msgid "Function:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1671
+#: ../../src/wxMaximaFrame.cpp:1716
 msgid "Functions for complex simplification"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1629
+#: ../../src/wxMaximaFrame.cpp:1674
 msgid "Functions for simplifying factorials and gamma function"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1647
+#: ../../src/wxMaximaFrame.cpp:1692
 msgid "Functions for simplifying trigonometric expressions"
 msgstr ""
 
@@ -4722,11 +4730,11 @@ msgstr ""
 msgid "GCD"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:3715
+#: ../../src/MaximaCommandMenus.cpp:3741
 msgid "GIF image (*.gif)|*.gif"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:3615
+#: ../../src/MaximaCommandMenus.cpp:3641
 msgid "GIF image (*.gif)|*.gif|Portable anymap (*.pnm)|*.pnm|Tagged image file format (*.tif)|*.tif|X pixmap (*.xpm)|*.xpm"
 msgstr ""
 
@@ -4746,27 +4754,27 @@ msgstr ""
 msgid "General Math"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:738
+#: ../../src/wxMaximaFrame.cpp:781
 msgid "General Math\tAlt+Shift+M"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1354
+#: ../../src/wxMaximaFrame.cpp:1399
 msgid "Generate Matrix from Expression..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1355
+#: ../../src/wxMaximaFrame.cpp:1400
 msgid "Generate a matrix from a lambda expression"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1716
+#: ../../src/wxMaximaFrame.cpp:1761
 msgid "Generate a new list using a lists' elements"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1722
+#: ../../src/wxMaximaFrame.cpp:1767
 msgid "Generate a storage for variable values that can be introduced into equations at any time"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1713
+#: ../../src/wxMaximaFrame.cpp:1758
 msgid "Generate list elements using a rule"
 msgstr ""
 
@@ -4774,7 +4782,7 @@ msgstr ""
 msgid "Generate matrix from a rule"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1132
+#: ../../src/wxMaximaFrame.cpp:1177
 msgid "Generate unused symbol name"
 msgstr ""
 
@@ -4794,39 +4802,39 @@ msgstr ""
 msgid "German"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1660
+#: ../../src/wxMaximaFrame.cpp:1705
 msgid "Get &Imaginary Part"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1526
+#: ../../src/wxMaximaFrame.cpp:1571
 msgid "Get Laplace transformation of an expression"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1656
+#: ../../src/wxMaximaFrame.cpp:1701
 msgid "Get Real P&art"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1239
+#: ../../src/wxMaximaFrame.cpp:1284
 msgid "Get current directory"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1530
+#: ../../src/wxMaximaFrame.cpp:1575
 msgid "Get inverse Laplace transformation of an expression"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4095
+#: ../../src/MaximaCommandMenus.cpp:4121
 msgid "Get position in stream"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1140
+#: ../../src/wxMaximaFrame.cpp:1185
 msgid "Get position..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1661
+#: ../../src/wxMaximaFrame.cpp:1706
 msgid "Get the imaginary part of complex expression"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1657
+#: ../../src/wxMaximaFrame.cpp:1702
 msgid "Get the real part of complex expression"
 msgstr ""
 
@@ -4835,7 +4843,7 @@ msgstr ""
 msgid "Gnuplot (command line) found at: %s"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1629
+#: ../../src/dialogs/ConfigDialogue.cpp:1640
 msgid "Gnuplot flavour"
 msgstr ""
 
@@ -4861,7 +4869,7 @@ msgid ""
 "%s"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:2071 ../../src/wxMaximaFrame.cpp:1928
+#: ../../src/MaximaCommandMenus.cpp:2071 ../../src/wxMaximaFrame.cpp:1973
 msgid "Go to URL"
 msgstr ""
 
@@ -4873,7 +4881,7 @@ msgstr ""
 msgid "Got a request to undo an action that involves a delete which isn't possible at this moment."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1069
+#: ../../src/wxMaximaFrame.cpp:1114
 msgid "Gradefs"
 msgstr ""
 
@@ -4881,7 +4889,7 @@ msgstr ""
 msgid "Greater or less than a value"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1168
+#: ../../src/wxMaximaFrame.cpp:1213
 msgid "Greater, ignoring case?..."
 msgstr ""
 
@@ -4893,7 +4901,7 @@ msgstr ""
 msgid "Greek Letters"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:742
+#: ../../src/wxMaximaFrame.cpp:785
 msgid "Greek Letters\tAlt+Shift+G"
 msgstr ""
 
@@ -4905,11 +4913,11 @@ msgstr ""
 msgid "Grid:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1856
+#: ../../src/wxMaximaFrame.cpp:1901
 msgid "Guess an exact number that could be meant by this float"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1215
+#: ../../src/dialogs/ConfigDialogue.cpp:1216
 msgid "HTML"
 msgstr ""
 
@@ -4917,7 +4925,7 @@ msgstr ""
 msgid "HTML file (*.html)|*.html|maxima batch file (*.mac)|*.mac|LaTeX file (*.tex)|*.tex"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1379
+#: ../../src/wxMaximaFrame.cpp:1424
 msgid "Hadamard (element-by-element) product..."
 msgstr ""
 
@@ -4929,7 +4937,7 @@ msgstr ""
 msgid "Hadamard exponent"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1383
+#: ../../src/wxMaximaFrame.cpp:1428
 msgid "Hadamard exponent..."
 msgstr ""
 
@@ -4953,11 +4961,11 @@ msgid "Hebrew"
 msgstr ""
 
 #: ../../src/ToolBar.cpp:544 ../../src/ToolBar.cpp:546
-#: ../../src/wxMaximaFrame.cpp:355
+#: ../../src/wxMaximaFrame.cpp:374
 msgid "Help"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1461
+#: ../../src/dialogs/ConfigDialogue.cpp:1472
 msgid "Help browser:"
 msgstr ""
 
@@ -4984,7 +4992,7 @@ msgstr ""
 msgid "Hide Code"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:768
+#: ../../src/wxMaximaFrame.cpp:813
 msgid "Hide Code Cells\tAlt+Ctrl+H"
 msgstr ""
 
@@ -5012,7 +5020,7 @@ msgstr ""
 msgid "Hide Subsubsection"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:770
+#: ../../src/wxMaximaFrame.cpp:815
 msgid "Hide all Sidebars\tAlt+Shift+-"
 msgstr ""
 
@@ -5020,7 +5028,7 @@ msgstr ""
 msgid "Hide all multiplication signs that aren't really necessary for understanding the equation"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:771
+#: ../../src/wxMaximaFrame.cpp:816
 msgid "Hide all panes"
 msgstr ""
 
@@ -5036,7 +5044,7 @@ msgstr ""
 msgid "Hide multiplication dots"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:854
+#: ../../src/dialogs/ConfigDialogue.cpp:855
 msgid "Hide multiplication signs, if possible"
 msgstr ""
 
@@ -5062,7 +5070,7 @@ msgstr ""
 msgid "Highlight (box)"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:869
+#: ../../src/dialogs/ConfigDialogue.cpp:870
 msgid "Highlight the matching parenthesis"
 msgstr ""
 
@@ -5086,7 +5094,7 @@ msgstr ""
 msgid "History"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:748
+#: ../../src/wxMaximaFrame.cpp:791
 msgid "History\tAlt+Shift+I"
 msgstr ""
 
@@ -5094,11 +5102,11 @@ msgstr ""
 msgid "Horizontal cursor works like a normal cursor, but it operates on cells: press up or down arrow to move it, holding down Shift while moving will select cells, pressing backspace or delete twice will delete a cell next to it."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1567
+#: ../../src/wxMaximaFrame.cpp:1612
 msgid "Horner's rule"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:918
+#: ../../src/dialogs/ConfigDialogue.cpp:919
 msgid "Hotkeys for sending commands to maxima"
 msgstr ""
 
@@ -5106,7 +5114,7 @@ msgstr ""
 msgid "How many digits to show:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:800
+#: ../../src/wxMaximaFrame.cpp:845
 msgid "How to display new equations"
 msgstr ""
 
@@ -5114,7 +5122,7 @@ msgstr ""
 msgid "Hungarian"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1151
+#: ../../src/wxMaximaFrame.cpp:1196
 msgid "I/O"
 msgstr ""
 
@@ -5122,7 +5130,7 @@ msgstr ""
 msgid "Identical to"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:3934
+#: ../../src/MaximaCommandMenus.cpp:3960
 msgid "If a program doesn't need local variables, Maxima allows putting the commands between parentheses. The result of the last operation is the return value of the program."
 msgstr ""
 
@@ -5154,11 +5162,11 @@ msgstr ""
 msgid "If multiple cells are evaluated in one go: Abort evaluation if wxMaxima detects that maxima has encountered any error."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:727
+#: ../../src/dialogs/ConfigDialogue.cpp:728
 msgid "If not extremely long"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:726
+#: ../../src/dialogs/ConfigDialogue.cpp:727
 msgid "If not very long"
 msgstr ""
 
@@ -5178,7 +5186,7 @@ msgstr ""
 msgid "If the thing maxima complains about actually looks like a polynomial you can try running it through ratdisrep() in order to fix that problem."
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4044
+#: ../../src/MaximaCommandMenus.cpp:4070
 msgid ""
 "If the type of a function parameter is known when compiling a function the code can vastly be optimized.\n"
 "Known types:\n"
@@ -5202,7 +5210,7 @@ msgstr ""
 msgid "If this isn't a function returning a lambda() expression a multiplication sign (*) between closing and opening parenthesis is missing here."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:942
+#: ../../src/dialogs/ConfigDialogue.cpp:943
 msgid ""
 "If this option is enabled, the filename and path of images inserted with \"Cell\" -> \"Insert Image...\" is stored in the worksheet file on save. This enables reloading of the image file via the context menu after re-opening the worksheet, but storing the filenames and paths may be an undesired data leak. If this option is disabled, reloading still works as long as the worksheet is not closed.\n"
 "\n"
@@ -5213,7 +5221,7 @@ msgstr ""
 msgid "If this option is set the .wxmx source of the current file is copied to a place a link to is put into the result of an export."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1873
+#: ../../src/dialogs/ConfigDialogue.cpp:1884
 msgid "If unset, Maxima's output is announced to the screen reader as maths in a linear text form. Set this option if your screen reader can speak MathML properly."
 msgstr ""
 
@@ -5242,7 +5250,7 @@ msgid "Image data had zero length!"
 msgstr ""
 
 #: ../../src/MaximaCommandMenus.cpp:2564 ../../src/MaximaCommandMenus.cpp:2933
-#: ../../src/MaximaCommandMenus.cpp:3642
+#: ../../src/MaximaCommandMenus.cpp:3668
 msgid "Image files ("
 msgstr ""
 
@@ -5251,7 +5259,7 @@ msgstr ""
 msgid "Image of type %s found."
 msgstr ""
 
-#: ../../src/worksheet/WorksheetExport.cpp:1407
+#: ../../src/worksheet/WorksheetExport.cpp:1397
 msgid "ImageCell without image."
 msgstr ""
 
@@ -5259,11 +5267,11 @@ msgstr ""
 msgid "Implicit Plot"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1028
+#: ../../src/dialogs/ConfigDialogue.cpp:1029
 msgid "Import settings"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1013
+#: ../../src/dialogs/ConfigDialogue.cpp:1014
 msgid "Import+Export"
 msgstr ""
 
@@ -5281,7 +5289,7 @@ msgid ""
 "If you change an element of one matrix the same element will change in all of its clones. copymatrix() instead generates a copy of a matrix: A new matrix that, if changed in any way, won't change the original."
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4276
+#: ../../src/MaximaCommandMenus.cpp:4302
 msgid "In order to save memory the : operator doesn't create an individual copy of the string, but a clone that changes when the original string changes."
 msgstr ""
 
@@ -5316,11 +5324,11 @@ msgstr ""
 msgid "Increasing function f(x)>x"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:884
+#: ../../src/dialogs/ConfigDialogue.cpp:885
 msgid "Incremental Search"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:844
+#: ../../src/dialogs/ConfigDialogue.cpp:845
 msgid "Indent equations by the label width"
 msgstr ""
 
@@ -5369,7 +5377,7 @@ msgstr ""
 msgid "Infinity"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1990
+#: ../../src/wxMaximaFrame.cpp:2035
 msgid "Info about Maxima build"
 msgstr ""
 
@@ -5385,11 +5393,11 @@ msgstr ""
 msgid "Initial Condition"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1308
+#: ../../src/wxMaximaFrame.cpp:1353
 msgid "Initial Value Problem (&1)..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1312
+#: ../../src/wxMaximaFrame.cpp:1357
 msgid "Initial Value Problem (&2)..."
 msgstr ""
 
@@ -5425,19 +5433,19 @@ msgstr ""
 msgid "Insert"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:889
+#: ../../src/dialogs/ConfigDialogue.cpp:890
 msgid "Insert % before an operator at the beginning of a cell"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:943
+#: ../../src/wxMaximaFrame.cpp:988
 msgid "Insert &Section Cell\tCtrl+3"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:939
+#: ../../src/wxMaximaFrame.cpp:984
 msgid "Insert &Text Cell\tCtrl+1"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:752
+#: ../../src/wxMaximaFrame.cpp:795
 msgid "Insert Cell\tAlt+Shift+C"
 msgstr ""
 
@@ -5453,23 +5461,23 @@ msgstr ""
 msgid "Insert Image"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:955
+#: ../../src/wxMaximaFrame.cpp:1000
 msgid "Insert Image..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:937
+#: ../../src/wxMaximaFrame.cpp:982
 msgid "Insert Input &Cell\tCtrl+0"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:957
+#: ../../src/wxMaximaFrame.cpp:1002
 msgid "Insert Page Break"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:945
+#: ../../src/wxMaximaFrame.cpp:990
 msgid "Insert S&ubsection Cell\tCtrl+4"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:948
+#: ../../src/wxMaximaFrame.cpp:993
 msgid "Insert S&ubsubsection Cell\tCtrl+5"
 msgstr ""
 
@@ -5485,7 +5493,7 @@ msgstr ""
 msgid "Insert Subsubsection Cell"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:941
+#: ../../src/wxMaximaFrame.cpp:986
 msgid "Insert T&itle Cell\tCtrl+2"
 msgstr ""
 
@@ -5497,67 +5505,67 @@ msgstr ""
 msgid "Insert Title Cell"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:951
+#: ../../src/wxMaximaFrame.cpp:996
 msgid "Insert a new heading5 cell"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:953
+#: ../../src/wxMaximaFrame.cpp:998
 msgid "Insert a new heading6 cell"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:938
+#: ../../src/wxMaximaFrame.cpp:983
 msgid "Insert a new input cell"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:944
+#: ../../src/wxMaximaFrame.cpp:989
 msgid "Insert a new section cell"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:946
+#: ../../src/wxMaximaFrame.cpp:991
 msgid "Insert a new subsection cell"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:949
+#: ../../src/wxMaximaFrame.cpp:994
 msgid "Insert a new subsubsection cell"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:940
+#: ../../src/wxMaximaFrame.cpp:985
 msgid "Insert a new text cell"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:942
+#: ../../src/wxMaximaFrame.cpp:987
 msgid "Insert a new title cell"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:958
+#: ../../src/wxMaximaFrame.cpp:1003
 msgid "Insert a page break"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4261
+#: ../../src/MaximaCommandMenus.cpp:4287
 msgid "Insert a string into another"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1202
+#: ../../src/wxMaximaFrame.cpp:1247
 msgid "Insert char..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:950
+#: ../../src/wxMaximaFrame.cpp:995
 msgid "Insert heading5 Cell\tCtrl+6"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:952
+#: ../../src/wxMaximaFrame.cpp:997
 msgid "Insert heading6 Cell\tCtrl+7"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:955
+#: ../../src/wxMaximaFrame.cpp:1000
 msgid "Insert image"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:954
+#: ../../src/wxMaximaFrame.cpp:999
 msgid "Insert textbased cell"
 msgstr ""
 
-#: ../../src/worksheet/Worksheet.cpp:6131
+#: ../../src/worksheet/Worksheet.cpp:6137
 msgid "Insertion point between cells"
 msgstr ""
 
@@ -5573,7 +5581,7 @@ msgstr ""
 msgid "Instructed to prefer wgnuplot over gnuplot"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:749
+#: ../../src/dialogs/ConfigDialogue.cpp:750
 msgid "Integers and single letters"
 msgstr ""
 
@@ -5585,7 +5593,7 @@ msgstr ""
 msgid "Integral/Sum:"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:240 ../../src/MaximaCommandMenus.cpp:3533
+#: ../../src/MaximaCommandMenus.cpp:240 ../../src/MaximaCommandMenus.cpp:3559
 #: ../../src/wizards/IntegrateWiz.cpp:73
 msgid "Integrate"
 msgstr ""
@@ -5594,15 +5602,15 @@ msgstr ""
 msgid "Integrate (risch)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1495
+#: ../../src/wxMaximaFrame.cpp:1540
 msgid "Integrate expression"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1497
+#: ../../src/wxMaximaFrame.cpp:1542
 msgid "Integrate expression with Risch algorithm"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1910
+#: ../../src/wxMaximaFrame.cpp:1955
 msgid "Integrate numerically (QUADPACK)"
 msgstr ""
 
@@ -5611,23 +5619,23 @@ msgstr ""
 msgid "Integrate..."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:834
+#: ../../src/dialogs/ConfigDialogue.cpp:835
 msgid "Intelligently hide cell brackets"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:881
+#: ../../src/dialogs/ConfigDialogue.cpp:882
 msgid "Interaction"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1349
+#: ../../src/dialogs/ConfigDialogue.cpp:1350
 msgid "Interactive popup memory limit [MB/plot]:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1778
+#: ../../src/wxMaximaFrame.cpp:1823
 msgid "Interleave"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1779
+#: ../../src/wxMaximaFrame.cpp:1824
 msgid "Interleave the values of two lists"
 msgstr ""
 
@@ -5635,23 +5643,23 @@ msgstr ""
 msgid "Interleave two lists"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1465
+#: ../../src/dialogs/ConfigDialogue.cpp:1476
 msgid "Internal"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1125
+#: ../../src/wxMaximaFrame.cpp:1170
 msgid "Interpret like input..."
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:3976
+#: ../../src/MaximaCommandMenus.cpp:4002
 msgid "Interpret maxima's output as input"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4374
+#: ../../src/MaximaCommandMenus.cpp:4400
 msgid "Interpret string as maxima code"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1127
+#: ../../src/wxMaximaFrame.cpp:1172
 msgid "Interpret string..."
 msgstr ""
 
@@ -5659,7 +5667,7 @@ msgstr ""
 msgid "Interrupt"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1003
+#: ../../src/wxMaximaFrame.cpp:1048
 msgid "Interrupt current computation"
 msgstr ""
 
@@ -5676,11 +5684,11 @@ msgstr ""
 msgid "Introduce a list of actual values into an equation"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1738
+#: ../../src/wxMaximaFrame.cpp:1783
 msgid "Introduce the actual values for variables stored in the list"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:3551
+#: ../../src/MaximaCommandMenus.cpp:3577
 msgid "Introduces one or more assignments into an expression"
 msgstr ""
 
@@ -5697,7 +5705,7 @@ msgstr ""
 msgid "Inverse Laplace"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1529
+#: ../../src/wxMaximaFrame.cpp:1574
 msgid "Inverse Laplace T&ransform..."
 msgstr ""
 
@@ -5705,27 +5713,27 @@ msgstr ""
 msgid "Iota"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4210
+#: ../../src/MaximaCommandMenus.cpp:4236
 msgid "Is Char 1 greater than Char2, if case is ignored?"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4205
+#: ../../src/MaximaCommandMenus.cpp:4231
 msgid "Is Char 1 greater than Char2?"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4199
+#: ../../src/MaximaCommandMenus.cpp:4225
 msgid "Is Char 1 less than Char2, if case is ignored?"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4194
+#: ../../src/MaximaCommandMenus.cpp:4220
 msgid "Is Char 1 less than Char2?"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4152
+#: ../../src/MaximaCommandMenus.cpp:4178
 msgid "Is a char?"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1153
+#: ../../src/wxMaximaFrame.cpp:1198
 msgid "Is a char?..."
 msgstr ""
 
@@ -5733,19 +5741,19 @@ msgstr ""
 msgid "Is a complex variable"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4164
+#: ../../src/MaximaCommandMenus.cpp:4190
 msgid "Is a digit?"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1156
+#: ../../src/wxMaximaFrame.cpp:1201
 msgid "Is a digit?..."
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4176
+#: ../../src/MaximaCommandMenus.cpp:4202
 msgid "Is a lowercase char?"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4168
+#: ../../src/MaximaCommandMenus.cpp:4194
 msgid "Is a printable char?"
 msgstr ""
 
@@ -5753,23 +5761,23 @@ msgstr ""
 msgid "Is a real variable"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4172
+#: ../../src/MaximaCommandMenus.cpp:4198
 msgid "Is a uppercase char?"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1154
+#: ../../src/wxMaximaFrame.cpp:1199
 msgid "Is alphabetic?..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1155
+#: ../../src/wxMaximaFrame.cpp:1200
 msgid "Is alphanumeric?..."
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4156
+#: ../../src/MaximaCommandMenus.cpp:4182
 msgid "Is an alphabetic char?"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4160
+#: ../../src/MaximaCommandMenus.cpp:4186
 msgid "Is an alphanumeric char?"
 msgstr ""
 
@@ -5789,19 +5797,19 @@ msgstr ""
 msgid "Is an odd function"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1160
+#: ../../src/wxMaximaFrame.cpp:1205
 msgid "Is equal?..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1166
+#: ../../src/wxMaximaFrame.cpp:1211
 msgid "Is greater?..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1163
+#: ../../src/wxMaximaFrame.cpp:1208
 msgid "Is lower?..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1159
+#: ../../src/wxMaximaFrame.cpp:1204
 msgid "Is lowercase?..."
 msgstr ""
 
@@ -5809,11 +5817,11 @@ msgstr ""
 msgid "Is no integer variable"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1157
+#: ../../src/wxMaximaFrame.cpp:1202
 msgid "Is printable?..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1158
+#: ../../src/wxMaximaFrame.cpp:1203
 msgid "Is uppercase?..."
 msgstr ""
 
@@ -5849,7 +5857,7 @@ msgstr ""
 msgid "Italian"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2111
+#: ../../src/dialogs/ConfigDialogue.cpp:2122
 msgid "Italic"
 msgstr ""
 
@@ -5869,11 +5877,11 @@ msgstr ""
 msgid "Jump to UUID"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:665
+#: ../../src/wxMaximaFrame.cpp:708
 msgid "Jump to UUID..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1086
+#: ../../src/wxMaximaFrame.cpp:1131
 msgid "Jump to last error"
 msgstr ""
 
@@ -5885,7 +5893,7 @@ msgstr ""
 msgid "Jump to previous difference"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1087
+#: ../../src/wxMaximaFrame.cpp:1132
 msgid "Jump to the last cell Maxima has reported an error in."
 msgstr ""
 
@@ -5897,7 +5905,7 @@ msgstr ""
 msgid "Kappa"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:864
+#: ../../src/dialogs/ConfigDialogue.cpp:865
 #, c-format
 msgid "Keep percent sign with special symbols: %e, %i, etc."
 msgstr ""
@@ -5910,48 +5918,48 @@ msgstr ""
 msgid "LCM"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1445
+#: ../../src/wxMaximaFrame.cpp:1490
 msgid "L[1] Norm (complex)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1444
+#: ../../src/wxMaximaFrame.cpp:1489
 msgid "L[1] Norm (real)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1447
+#: ../../src/wxMaximaFrame.cpp:1492
 msgid "L[inf] Norm (complex)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1446
+#: ../../src/wxMaximaFrame.cpp:1491
 msgid "L[inf] Norm (real)"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1166
+#: ../../src/dialogs/ConfigDialogue.cpp:1167
 msgid "LaTeX"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1199
+#: ../../src/dialogs/ConfigDialogue.cpp:1200
 msgid "LaTeX: Place exponents after, instead above subscripts"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1204
+#: ../../src/dialogs/ConfigDialogue.cpp:1205
 msgid "LaTeX: Use the \"partial derivative\" symbol to represent diff()"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:758
+#: ../../src/dialogs/ConfigDialogue.cpp:759
 msgid "Label width:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1063
+#: ../../src/wxMaximaFrame.cpp:1108
 msgid "Labels"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:3962
+#: ../../src/MaximaCommandMenus.cpp:3988
 #: ../../src/sidebars/GreekSidebar.cpp:188
 msgid "Lambda"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:3963
+#: ../../src/MaximaCommandMenus.cpp:3989
 msgid ""
 "Lambda generates a function, but doesn't give it a name.\n"
 "This is useful if you want to use a function only once, perhaps as a parameter to another function and don't need it to be named.\n"
@@ -5962,7 +5970,7 @@ msgstr ""
 msgid "Language used for wxMaxima GUI."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1311
+#: ../../src/dialogs/ConfigDialogue.cpp:1312
 msgid "Language:"
 msgstr ""
 
@@ -5970,11 +5978,11 @@ msgstr ""
 msgid "Laplace"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1525
+#: ../../src/wxMaximaFrame.cpp:1570
 msgid "Laplace &Transform..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1759
+#: ../../src/wxMaximaFrame.cpp:1804
 msgid "Last"
 msgstr ""
 
@@ -5988,11 +5996,11 @@ msgstr ""
 msgid "Last message from maxima's stdout: %s"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1761
+#: ../../src/wxMaximaFrame.cpp:1806
 msgid "Last n"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3148
+#: ../../src/wxMaxima.cpp:3152
 msgid "Last non-whitespace is a question mark"
 msgstr ""
 
@@ -6000,12 +6008,12 @@ msgstr ""
 msgid "Latvian"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:1676
+#: ../../src/wxMaxima.cpp:1681
 #, c-format
 msgid "Launching the system's default help browser as %s."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:1667 ../../src/wxMaxima.cpp:1688
+#: ../../src/wxMaxima.cpp:1672 ../../src/wxMaxima.cpp:1693
 msgid "Launching the system's default help browser failed."
 msgstr ""
 
@@ -6013,7 +6021,7 @@ msgstr ""
 msgid "Leads to"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1534
+#: ../../src/wxMaximaFrame.cpp:1579
 msgid "Least Common Multiple..."
 msgstr ""
 
@@ -6025,7 +6033,7 @@ msgstr ""
 msgid "Least Squares Fit..."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2007
+#: ../../src/dialogs/ConfigDialogue.cpp:2018
 msgid "Left"
 msgstr ""
 
@@ -6038,23 +6046,23 @@ msgstr ""
 msgid "Left end"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1335
+#: ../../src/wxMaximaFrame.cpp:1380
 msgid "Left side to the \"=\""
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1782
+#: ../../src/wxMaximaFrame.cpp:1827
 msgid "Length"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1142 ../../src/wxMaximaFrame.cpp:1205
+#: ../../src/wxMaximaFrame.cpp:1187 ../../src/wxMaximaFrame.cpp:1250
 msgid "Length..."
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4293
+#: ../../src/MaximaCommandMenus.cpp:4319
 msgid "Length:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1070
+#: ../../src/wxMaximaFrame.cpp:1115
 msgid "Letrules"
 msgstr ""
 
@@ -6067,7 +6075,7 @@ msgstr ""
 msgid "License"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2068
+#: ../../src/dialogs/ConfigDialogue.cpp:2079
 msgid "Light"
 msgstr ""
 
@@ -6091,19 +6099,19 @@ msgstr ""
 msgid "Linear Regression..."
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4128
+#: ../../src/MaximaCommandMenus.cpp:4154
 msgid "Lisp format string:"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4130
+#: ../../src/MaximaCommandMenus.cpp:4156
 msgid "Lisp format strings are more powerful than c++ format strings"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:1875
+#: ../../src/wxMaxima.cpp:1880
 msgid "Lisp mode."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1048 ../../src/wxMaximaFrame.cpp:1050
+#: ../../src/wxMaximaFrame.cpp:1093 ../../src/wxMaximaFrame.cpp:1095
 msgid "Lisp normally frees memory only when it has time or runs out of space"
 msgstr ""
 
@@ -6127,11 +6135,11 @@ msgstr ""
 msgid "List #2"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1238
+#: ../../src/wxMaximaFrame.cpp:1283
 msgid "List directory"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1243
+#: ../../src/wxMaximaFrame.cpp:1288
 msgid "List directory..."
 msgstr ""
 
@@ -6147,15 +6155,15 @@ msgstr ""
 msgid "List of changed options"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4257
+#: ../../src/MaximaCommandMenus.cpp:4283
 msgid "List of char to String"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1188
+#: ../../src/wxMaximaFrame.cpp:1233
 msgid "List of chars to string..."
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4258
+#: ../../src/MaximaCommandMenus.cpp:4284
 msgid "List of chars:"
 msgstr ""
 
@@ -6220,7 +6228,7 @@ msgstr ""
 msgid "Lithuanian"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2162
+#: ../../src/dialogs/ConfigDialogue.cpp:2173
 msgid "Load"
 msgstr ""
 
@@ -6228,51 +6236,51 @@ msgstr ""
 msgid "Load Package"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:648
+#: ../../src/wxMaximaFrame.cpp:691
 msgid "Load Recent Package"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:651
+#: ../../src/wxMaximaFrame.cpp:694
 msgid "Load a Maxima file using the batch command"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:646
+#: ../../src/wxMaximaFrame.cpp:689
 msgid "Load a Maxima package file"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1362 ../../src/wxMaximaFrame.cpp:1368
+#: ../../src/wxMaximaFrame.cpp:1407 ../../src/wxMaximaFrame.cpp:1413
 msgid "Load a matrix from a csv file"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1719
+#: ../../src/wxMaximaFrame.cpp:1764
 msgid "Load a nested list from a csv file"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1419 ../../src/wxMaximaFrame.cpp:1420
+#: ../../src/wxMaximaFrame.cpp:1464 ../../src/wxMaximaFrame.cpp:1465
 msgid "Load lapack"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4080
+#: ../../src/MaximaCommandMenus.cpp:4106
 msgid "Load lisp code"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1130
+#: ../../src/wxMaximaFrame.cpp:1175
 msgid "Load lisp..."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2645
+#: ../../src/dialogs/ConfigDialogue.cpp:2657
 msgid "Load style from file"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1236
+#: ../../src/wxMaximaFrame.cpp:1281
 msgid "Load the file/dir operations (operatingsystem)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1225
+#: ../../src/wxMaximaFrame.cpp:1270
 msgid "Load the regular expression package (sregex)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1262
+#: ../../src/wxMaximaFrame.cpp:1307
 msgid "Load the translation generator (gentran)"
 msgstr ""
 
@@ -6284,15 +6292,15 @@ msgstr ""
 msgid "Loop variable"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:959 ../../src/MaximaCommandMenus.cpp:3529
+#: ../../src/MaximaCommandMenus.cpp:959 ../../src/MaximaCommandMenus.cpp:3555
 msgid "Lower bound:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1165
+#: ../../src/wxMaximaFrame.cpp:1210
 msgid "Lower, ignoring case?..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1489
+#: ../../src/wxMaximaFrame.cpp:1534
 msgid "M&atrix"
 msgstr ""
 
@@ -6300,19 +6308,19 @@ msgstr ""
 msgid "MAXIMA RESPONSE:"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4025
+#: ../../src/MaximaCommandMenus.cpp:4051
 msgid "Macro contents:"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4020
+#: ../../src/MaximaCommandMenus.cpp:4046
 msgid "Macro name:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1062
+#: ../../src/wxMaximaFrame.cpp:1107
 msgid "Macros"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:873
+#: ../../src/wxMaximaFrame.cpp:918
 msgid "Main Toolbar\tShift+Alt+B"
 msgstr ""
 
@@ -6324,7 +6332,7 @@ msgstr ""
 msgid "Make an eventual ev() evaluate this"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1108
+#: ../../src/wxMaximaFrame.cpp:1153
 msgid "Make function local..."
 msgstr ""
 
@@ -6352,11 +6360,11 @@ msgstr ""
 msgid "Map an expression"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1484
+#: ../../src/wxMaximaFrame.cpp:1529
 msgid "Map function to a matrix"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1487
+#: ../../src/wxMaximaFrame.cpp:1532
 msgid "Map function to a matrix, affecting all of its clones"
 msgstr ""
 
@@ -6368,7 +6376,7 @@ msgstr ""
 msgid "Math Default"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:789
+#: ../../src/dialogs/ConfigDialogue.cpp:790
 msgid "Math layout strategy"
 msgstr ""
 
@@ -6376,19 +6384,19 @@ msgstr ""
 msgid "Math output"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1221
+#: ../../src/dialogs/ConfigDialogue.cpp:1222
 msgid "MathML (rendered by the browser)"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1222
+#: ../../src/dialogs/ConfigDialogue.cpp:1223
 msgid "MathML + MathJaX fall-back for old browsers"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1906
+#: ../../src/dialogs/ConfigDialogue.cpp:1917
 msgid "MathML as HTML"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1902
+#: ../../src/dialogs/ConfigDialogue.cpp:1913
 msgid "MathML description"
 msgstr ""
 
@@ -6416,15 +6424,15 @@ msgstr ""
 msgid "Matrix Exponent"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1377
+#: ../../src/wxMaximaFrame.cpp:1422
 msgid "Matrix exponent..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1367
+#: ../../src/wxMaximaFrame.cpp:1412
 msgid "Matrix from csv file"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1361
+#: ../../src/wxMaximaFrame.cpp:1406
 msgid "Matrix from csv file..."
 msgstr ""
 
@@ -6436,19 +6444,19 @@ msgstr ""
 msgid "Matrix name:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:839
+#: ../../src/wxMaximaFrame.cpp:884
 msgid "Matrix parenthesis"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1369
+#: ../../src/wxMaximaFrame.cpp:1414
 msgid "Matrix to csv file"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1372
+#: ../../src/wxMaximaFrame.cpp:1417
 msgid "Matrix to file or Matrix from file"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1802
+#: ../../src/wxMaximaFrame.cpp:1847
 msgid "Matrix to nested List"
 msgstr ""
 
@@ -6464,7 +6472,7 @@ msgstr ""
 msgid "Matrix:"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1370
+#: ../../src/dialogs/ConfigDialogue.cpp:1371
 msgid "Max. layout time [s] (0=no limit)"
 msgstr ""
 
@@ -6472,7 +6480,7 @@ msgstr ""
 msgid "Maxima"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1433
+#: ../../src/dialogs/ConfigDialogue.cpp:1444
 msgid "Maxima Location"
 msgstr ""
 
@@ -6502,7 +6510,7 @@ msgstr ""
 msgid "Maxima assigns each command/equation an automatic label (which looks like %i1 or %o1). If a command begins with a descriptive name followed by a : wxMaxima will call the descriptive name a \"user-defined label\" instead. This selection now allows telling wxMaxima whether to show only automatic labels, automatic labels if there aren't user-defined ones or no label at all until a user-defined label can be found by wxMaxima's heuristics. If automatic labels are suppressed extra vertical space is added between equations in order to ease discerning which line starts a new equation and which one only continues the one from the last line."
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:3990
+#: ../../src/MaximaCommandMenus.cpp:4016
 msgid ""
 "Maxima automatically simplifies expressions it gets as input and then tries to evaluate their value. The ' operator tells maxima that we want a command to be in noun form, which means: stand here as is, and unevaluated.\n"
 "The ' operator can be undone by using the '' operator."
@@ -6512,15 +6520,15 @@ msgstr ""
 msgid "Maxima code"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1110
+#: ../../src/dialogs/ConfigDialogue.cpp:1111
 msgid "Maxima commands to be executed at every start of Maxima"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1063
+#: ../../src/dialogs/ConfigDialogue.cpp:1064
 msgid "Maxima commands to be executed every time wxMaxima starts Maxima"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1507
+#: ../../src/dialogs/ConfigDialogue.cpp:1518
 msgid "Maxima configuration"
 msgstr ""
 
@@ -6553,7 +6561,7 @@ msgstr ""
 msgid "Maxima has sent a new variable value."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2669
+#: ../../src/wxMaxima.cpp:2673
 #, c-format
 msgid ""
 "Maxima has started, but hasn't connected to wxMaxima within 5 seconds.\n"
@@ -6563,7 +6571,7 @@ msgid ""
 "Command: %s"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2643
+#: ../../src/wxMaxima.cpp:2647
 #, c-format
 msgid ""
 "Maxima has started, but hasn't connected to wxMaxima yet.\n"
@@ -6596,7 +6604,7 @@ msgstr ""
 msgid "Maxima help file not found!"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1081
+#: ../../src/wxMaximaFrame.cpp:1126
 msgid "Maxima input"
 msgstr ""
 
@@ -6604,11 +6612,11 @@ msgstr ""
 msgid "Maxima is calculating"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:1877
+#: ../../src/wxMaxima.cpp:1882
 msgid "Maxima is ready for input."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2665 ../../src/wxMaxima.cpp:2680
+#: ../../src/wxMaxima.cpp:2669 ../../src/wxMaxima.cpp:2684
 msgid "Maxima isn't connecting"
 msgstr ""
 
@@ -6629,7 +6637,7 @@ msgstr ""
 msgid "Maxima process terminated unexpectedly."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1437
+#: ../../src/dialogs/ConfigDialogue.cpp:1448
 msgid "Maxima program:"
 msgstr ""
 
@@ -6657,15 +6665,15 @@ msgstr ""
 msgid "Maxima session (*.mac)|*.mac"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1518 ../../src/wxMaximaFrame.cpp:1985
+#: ../../src/dialogs/ConfigDialogue.cpp:1529 ../../src/wxMaximaFrame.cpp:2030
 msgid "Maxima shows help in a browser"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1523 ../../src/wxMaximaFrame.cpp:1981
+#: ../../src/dialogs/ConfigDialogue.cpp:1534 ../../src/wxMaximaFrame.cpp:2026
 msgid "Maxima shows help in a sidebar"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1511 ../../src/wxMaximaFrame.cpp:1976
+#: ../../src/dialogs/ConfigDialogue.cpp:1522 ../../src/wxMaximaFrame.cpp:2021
 msgid "Maxima shows help in the console"
 msgstr ""
 
@@ -6685,7 +6693,7 @@ msgstr ""
 msgid "Maxima starts:"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1143
+#: ../../src/dialogs/ConfigDialogue.cpp:1144
 msgid "Maxima startup file location: "
 msgstr ""
 
@@ -6693,11 +6701,11 @@ msgstr ""
 msgid "Maxima supports three types of numbers: exact fractions (which can be generated for example by typing 1/10), IEEE floating-point numbers (0.2) and arbitrary precision big floats (1b-1). Note that, owing to their nature as binary (not decimal) numbers, there is for example no way to generate an IEEE floating-point number that exactly equals 0.1. If floating-point numbers are used instead of fractions, Maxima will therefore sometimes have to introduce a (very small) error and use things like 3602879701896397/36028797018963968 for 0.1."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1269
+#: ../../src/wxMaximaFrame.cpp:1314
 msgid "Maxima to other language"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4085
+#: ../../src/MaximaCommandMenus.cpp:4111
 msgid "Maxima to string"
 msgstr ""
 
@@ -6705,7 +6713,7 @@ msgstr ""
 msgid "Maxima tried to find out where between two points a curve crosses the zero line. Since the curve is on the same side of the zero line in both points its algorithms fails here. Set find_root_error to false if you want it to return false instead of an error."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1615
+#: ../../src/dialogs/ConfigDialogue.cpp:1626
 msgid "Maxima usage"
 msgstr ""
 
@@ -6748,7 +6756,7 @@ msgstr ""
 msgid "Maxima version: %s, Anchors cache version"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1966
+#: ../../src/wxMaximaFrame.cpp:2011
 msgid "Maxima vs. Programming languages"
 msgstr ""
 
@@ -6809,7 +6817,7 @@ msgstr ""
 msgid "Maxima's power lies in symbolic operations."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2632
+#: ../../src/wxMaxima.cpp:2636
 msgid "Maxima's process is running, but hasn't connected back to wxMaxima within 5 seconds."
 msgstr ""
 
@@ -6859,7 +6867,7 @@ msgstr ""
 msgid "Maximum absolute value printed without exponent"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1931
+#: ../../src/dialogs/ConfigDialogue.cpp:1942
 msgid "Maximum bitmap size on clipboard [Mb]:"
 msgstr ""
 
@@ -6872,7 +6880,7 @@ msgstr ""
 msgid "Maximum number of digits to be displayed:"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:811
+#: ../../src/dialogs/ConfigDialogue.cpp:812
 msgid "Maximum number of displayed digits:"
 msgstr ""
 
@@ -6896,16 +6904,16 @@ msgstr ""
 msgid "Median..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1965
+#: ../../src/wxMaximaFrame.cpp:2010
 msgid "Memoizing"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1051
+#: ../../src/wxMaximaFrame.cpp:1096
 msgid "Memory"
 msgstr ""
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:180
-#: ../../src/wxMaximaFrame.cpp:973
+#: ../../src/wxMaximaFrame.cpp:1018
 msgid "Merge Cells"
 msgstr ""
 
@@ -6917,7 +6925,7 @@ msgstr ""
 msgid "Method:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1364
+#: ../../src/wxMaximaFrame.cpp:1409
 msgid "Methods of generating a matrix"
 msgstr ""
 
@@ -6940,15 +6948,15 @@ msgstr ""
 msgid "Minimum absolute value printed without exponent:"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1270
+#: ../../src/dialogs/ConfigDialogue.cpp:1271
 msgid "Misc"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1963
+#: ../../src/dialogs/ConfigDialogue.cpp:1974
 msgid "Misc settings"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3197 ../../src/wxMaxima.cpp:3199
+#: ../../src/wxMaxima.cpp:3201 ../../src/wxMaxima.cpp:3203
 msgid "Mismatched parenthesis"
 msgstr ""
 
@@ -6986,7 +6994,7 @@ msgstr ""
 msgid "Mu"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1390
+#: ../../src/wxMaximaFrame.cpp:1435
 msgid "Multiplication, exponent and similar"
 msgstr ""
 
@@ -6994,7 +7002,7 @@ msgstr ""
 msgid "Multiplicative function: f(a*b)=f(a)*f(b)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1376
+#: ../../src/wxMaximaFrame.cpp:1421
 msgid "Multiply matrices..."
 msgstr ""
 
@@ -7022,7 +7030,7 @@ msgstr ""
 msgid "Nepali"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1358 ../../src/wxMaximaFrame.cpp:1800
+#: ../../src/wxMaximaFrame.cpp:1403 ../../src/wxMaximaFrame.cpp:1845
 msgid "Nested list to Matrix"
 msgstr ""
 
@@ -7030,9 +7038,9 @@ msgstr ""
 msgid "Nested list to matrix"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:748
-#: ../../src/dialogs/ConfigDialogue.cpp:772 ../../src/wxMaximaFrame.cpp:810
-#: ../../src/wxMaximaFrame.cpp:1091
+#: ../../src/dialogs/ConfigDialogue.cpp:749
+#: ../../src/dialogs/ConfigDialogue.cpp:773 ../../src/wxMaximaFrame.cpp:855
+#: ../../src/wxMaximaFrame.cpp:1136
 msgid "Never"
 msgstr ""
 
@@ -7040,7 +7048,7 @@ msgstr ""
 msgid "Never autosubscript this variable"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:817
+#: ../../src/wxMaximaFrame.cpp:862
 msgid "Never display this variable with subscript"
 msgstr ""
 
@@ -7053,7 +7061,7 @@ msgstr ""
 msgid "New"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:632
+#: ../../src/wxMaximaFrame.cpp:675
 msgid "New\tCtrl+N"
 msgstr ""
 
@@ -7077,7 +7085,7 @@ msgstr ""
 msgid "New document"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:901
+#: ../../src/dialogs/ConfigDialogue.cpp:902
 msgid "New lines: Jump to text"
 msgstr ""
 
@@ -7086,7 +7094,7 @@ msgstr ""
 msgid "New maxima Operators detected: %s"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4262
+#: ../../src/MaximaCommandMenus.cpp:4288
 msgid "New part:"
 msgstr ""
 
@@ -7099,7 +7107,7 @@ msgstr ""
 msgid "New variable:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:967
+#: ../../src/wxMaximaFrame.cpp:1012
 msgid "Next Command\tAlt+Down"
 msgstr ""
 
@@ -7107,12 +7115,12 @@ msgstr ""
 msgid "Next Difference"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:789
+#: ../../src/wxMaximaFrame.cpp:834
 msgid "Nice Graphical Equations"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:725
-#: ../../src/dialogs/ConfigDialogue.cpp:737 ../../src/wxMaximaFrame.cpp:1591
+#: ../../src/dialogs/ConfigDialogue.cpp:726
+#: ../../src/dialogs/ConfigDialogue.cpp:738 ../../src/wxMaximaFrame.cpp:1636
 msgid "No"
 msgstr ""
 
@@ -7124,7 +7132,7 @@ msgstr ""
 msgid "No Scalar"
 msgstr ""
 
-#: ../../src/worksheet/Worksheet.cpp:5466
+#: ../../src/worksheet/Worksheet.cpp:5472
 msgid "No cells are selected. Anonymize the code in the whole document?"
 msgstr ""
 
@@ -7136,7 +7144,7 @@ msgstr ""
 msgid "No differences"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3230
+#: ../../src/wxMaxima.cpp:3234
 msgid "No dollar ($) or semicolon (;) at the end of command"
 msgstr ""
 
@@ -7156,12 +7164,12 @@ msgstr ""
 msgid "No gnuplot source!"
 msgstr ""
 
-#: ../../src/cells/GroupCell.cpp:1500
+#: ../../src/cells/GroupCell.cpp:1508
 msgid "No image to export"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2714 ../../src/wxMaxima.cpp:2722
-#: ../../src/wxMaxima.cpp:2743 ../../src/wxMaxima.cpp:2755
+#: ../../src/wxMaxima.cpp:2718 ../../src/wxMaxima.cpp:2726
+#: ../../src/wxMaxima.cpp:2747 ../../src/wxMaxima.cpp:2759
 msgid "No matches found!"
 msgstr ""
 
@@ -7189,7 +7197,7 @@ msgstr ""
 msgid "Non-builtin symbols"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:838
+#: ../../src/wxMaximaFrame.cpp:883
 msgid "None"
 msgstr ""
 
@@ -7262,23 +7270,23 @@ msgstr ""
 msgid "Number of equations:"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4353
+#: ../../src/MaximaCommandMenus.cpp:4379
 msgid "Number to octets"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1192
+#: ../../src/wxMaximaFrame.cpp:1237
 msgid "Number to octets..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1947
+#: ../../src/wxMaximaFrame.cpp:1992
 msgid "Number types"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4354
+#: ../../src/MaximaCommandMenus.cpp:4380
 msgid "Number:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1827
+#: ../../src/wxMaximaFrame.cpp:1872
 msgid "Numeric output"
 msgstr ""
 
@@ -7286,7 +7294,7 @@ msgstr ""
 msgid "Numerical QR decomposition of a matrix"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1455
+#: ../../src/wxMaximaFrame.cpp:1500
 msgid "Numerical operations (lapack)"
 msgstr ""
 
@@ -7294,19 +7302,19 @@ msgstr ""
 msgid "Numerical solution for 1st degree ODE"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1320
+#: ../../src/wxMaximaFrame.cpp:1365
 msgid "Numerical solution..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1299
+#: ../../src/wxMaximaFrame.cpp:1344
 msgid "Numerical solutions of polynomial (bfloat)..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1296
+#: ../../src/wxMaximaFrame.cpp:1341
 msgid "Numerical solutions of polynomial..."
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:3265 ../../src/MaximaCommandMenus.cpp:3690
+#: ../../src/MaximaCommandMenus.cpp:3291 ../../src/MaximaCommandMenus.cpp:3716
 #: ../../src/dialogs/ChangeLogDialog.cpp:131
 #: ../../src/dialogs/LicenseDialog.cpp:90
 #: ../../src/dialogs/MaxSizeChooser.cpp:44
@@ -7357,31 +7365,31 @@ msgstr ""
 msgid "Object composed of elements"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4552
+#: ../../src/MaximaCommandMenus.cpp:4578
 msgid "Object name:"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4153
+#: ../../src/MaximaCommandMenus.cpp:4179
 msgid "Object:"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4358
+#: ../../src/MaximaCommandMenus.cpp:4384
 msgid "Octets to Number"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4363
+#: ../../src/MaximaCommandMenus.cpp:4389
 msgid "Octets to String"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1194
+#: ../../src/wxMaximaFrame.cpp:1239
 msgid "Octets to number..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1196
+#: ../../src/wxMaximaFrame.cpp:1241
 msgid "Octets to string..."
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4359 ../../src/MaximaCommandMenus.cpp:4364
+#: ../../src/MaximaCommandMenus.cpp:4385 ../../src/MaximaCommandMenus.cpp:4390
 msgid "Octets:"
 msgstr ""
 
@@ -7389,7 +7397,7 @@ msgstr ""
 msgid "Odd number"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:910
+#: ../../src/dialogs/ConfigDialogue.cpp:911
 msgid "Offer answers for questions known from previous runs"
 msgstr ""
 
@@ -7414,11 +7422,11 @@ msgstr ""
 msgid "Omicron"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1093
+#: ../../src/wxMaximaFrame.cpp:1138
 msgid "On all errors"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1092
+#: ../../src/wxMaximaFrame.cpp:1137
 msgid "On lisp errors"
 msgstr ""
 
@@ -7426,15 +7434,15 @@ msgstr ""
 msgid "One sample t-test"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1968
+#: ../../src/wxMaximaFrame.cpp:2013
 msgid "Online tutorials"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:807
+#: ../../src/wxMaximaFrame.cpp:852
 msgid "Only Integers and single letters"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:771
+#: ../../src/dialogs/ConfigDialogue.cpp:772
 msgid "Only user-defined labels"
 msgstr ""
 
@@ -7443,15 +7451,15 @@ msgstr ""
 msgid "Open"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:905
+#: ../../src/dialogs/ConfigDialogue.cpp:906
 msgid "Open a cell when Maxima expects input"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:633
+#: ../../src/wxMaximaFrame.cpp:676
 msgid "Open a document"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:632
+#: ../../src/wxMaximaFrame.cpp:675
 msgid "Open a new window"
 msgstr ""
 
@@ -7463,27 +7471,27 @@ msgstr ""
 msgid "Open document"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4111
+#: ../../src/MaximaCommandMenus.cpp:4137
 msgid "Open for appending"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1137
+#: ../../src/wxMaximaFrame.cpp:1182
 msgid "Open for appending..."
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4116
+#: ../../src/MaximaCommandMenus.cpp:4142
 msgid "Open for reading"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1136
+#: ../../src/wxMaximaFrame.cpp:1181
 msgid "Open for reading..."
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4121
+#: ../../src/MaximaCommandMenus.cpp:4147
 msgid "Open for writing"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1138
+#: ../../src/wxMaximaFrame.cpp:1183
 msgid "Open for writing..."
 msgstr ""
 
@@ -7491,7 +7499,7 @@ msgstr ""
 msgid "Open matrix"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:635
+#: ../../src/wxMaximaFrame.cpp:678
 msgid "Open recent"
 msgstr ""
 
@@ -7504,16 +7512,16 @@ msgstr ""
 msgid "Opening file"
 msgstr ""
 
-#: ../../src/sidebars/HelpBrowser.cpp:175 ../../src/wxMaxima.cpp:1809
+#: ../../src/sidebars/HelpBrowser.cpp:175 ../../src/wxMaxima.cpp:1814
 #, c-format
 msgid "Opening help file %s"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1571
+#: ../../src/wxMaximaFrame.cpp:1616
 msgid "Optimize for CPU time"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1570
+#: ../../src/wxMaximaFrame.cpp:1615
 msgid "Optimize for memory"
 msgstr ""
 
@@ -7534,15 +7542,15 @@ msgstr ""
 msgid "Output"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1263
+#: ../../src/wxMaximaFrame.cpp:1308
 msgid "Output C"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1264
+#: ../../src/wxMaximaFrame.cpp:1309
 msgid "Output Fortran"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1266
+#: ../../src/wxMaximaFrame.cpp:1311
 msgid "Output Rational Fortran"
 msgstr ""
 
@@ -7579,11 +7587,11 @@ msgstr ""
 msgid "Output: Variable names"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:839
+#: ../../src/dialogs/ConfigDialogue.cpp:840
 msgid "Overlay scrollbars (slow: repaints the worksheet while they fade)"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:3609
+#: ../../src/MaximaCommandMenus.cpp:3635
 msgid "PNG image (*.png)|*.png|JPEG image (*.jpg)|*.jpg|Windows bitmap (*.bmp)|*.bmp|"
 msgstr ""
 
@@ -7595,7 +7603,7 @@ msgstr ""
 msgid "Pade approximation"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1519
+#: ../../src/wxMaximaFrame.cpp:1564
 msgid "Pade approximation of a Taylor series"
 msgstr ""
 
@@ -7603,7 +7611,7 @@ msgstr ""
 msgid "Pagebreak"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1678
+#: ../../src/wxMaximaFrame.cpp:1723
 msgid "Parallel Substitute..."
 msgstr ""
 
@@ -7615,11 +7623,11 @@ msgstr ""
 msgid "Parallel to"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4051
+#: ../../src/MaximaCommandMenus.cpp:4077
 msgid "Parameter name:"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4008 ../../src/MaximaCommandMenus.cpp:4021
+#: ../../src/MaximaCommandMenus.cpp:4034 ../../src/MaximaCommandMenus.cpp:4047
 msgid "Parameter(s):"
 msgstr ""
 
@@ -7631,11 +7639,11 @@ msgstr ""
 msgid "Parametric plot"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4271
+#: ../../src/MaximaCommandMenus.cpp:4297
 msgid "Parse string"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1190
+#: ../../src/wxMaximaFrame.cpp:1235
 msgid "Parse string only..."
 msgstr ""
 
@@ -7643,11 +7651,11 @@ msgstr ""
 msgid "Parsing output"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4336
+#: ../../src/MaximaCommandMenus.cpp:4362
 msgid "Part:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1540 ../../src/wxMaximaFrame.cpp:1576
+#: ../../src/wxMaximaFrame.cpp:1585 ../../src/wxMaximaFrame.cpp:1621
 msgid "Partial &Fractions..."
 msgstr ""
 
@@ -7661,7 +7669,7 @@ msgstr ""
 msgid "Paste"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:708
+#: ../../src/wxMaximaFrame.cpp:751
 msgid "Paste\tCtrl+V"
 msgstr ""
 
@@ -7669,15 +7677,15 @@ msgstr ""
 msgid "Paste from clipboard"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:709
+#: ../../src/wxMaximaFrame.cpp:752
 msgid "Paste text from clipboard"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:276 ../../src/wxMaximaFrame.cpp:763
+#: ../../src/wxMaximaFrame.cpp:276 ../../src/wxMaximaFrame.cpp:808
 msgid "Performance Monitor"
 msgstr ""
 
-#: ../../src/Configuration.cpp:1383
+#: ../../src/Configuration.cpp:1386
 msgid "Performance Statistics:"
 msgstr ""
 
@@ -7701,11 +7709,11 @@ msgstr ""
 msgid "Piechart..."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:1588
+#: ../../src/wxMaxima.cpp:1593
 msgid "Please configure wxMaxima with 'Edit->Configure'."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2606
+#: ../../src/dialogs/ConfigDialogue.cpp:2618
 msgid "Please restart wxMaxima for changes to take effect!"
 msgstr ""
 
@@ -7713,19 +7721,19 @@ msgstr ""
 msgid "Please select exactly 2 or 3 files."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1809
+#: ../../src/wxMaximaFrame.cpp:1854
 msgid "Plot &2d..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1811
+#: ../../src/wxMaximaFrame.cpp:1856
 msgid "Plot &3d..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1813
+#: ../../src/wxMaximaFrame.cpp:1858
 msgid "Plot &Format..."
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:107 ../../src/MaximaCommandMenus.cpp:3557
+#: ../../src/MaximaCommandMenus.cpp:107 ../../src/MaximaCommandMenus.cpp:3583
 #: ../../src/wizards/Plot2dWiz.cpp:108 ../../src/wizards/Plot2dWiz.cpp:428
 #: ../../src/wizards/Plot2dWiz.cpp:441
 msgid "Plot 2D"
@@ -7736,7 +7744,7 @@ msgstr ""
 msgid "Plot 2D..."
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:85 ../../src/MaximaCommandMenus.cpp:3568
+#: ../../src/MaximaCommandMenus.cpp:85 ../../src/MaximaCommandMenus.cpp:3594
 #: ../../src/wizards/Plot3dWiz.cpp:103
 msgid "Plot 3D"
 msgstr ""
@@ -7771,11 +7779,11 @@ msgstr ""
 msgid "Plot format"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1809
+#: ../../src/wxMaximaFrame.cpp:1854
 msgid "Plot in 2 dimensions"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1811
+#: ../../src/wxMaximaFrame.cpp:1856
 msgid "Plot in 3 dimensions"
 msgstr ""
 
@@ -7787,7 +7795,7 @@ msgstr ""
 msgid "Plot to file:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:345 ../../src/wxMaximaFrame.cpp:753
+#: ../../src/wxMaximaFrame.cpp:345 ../../src/wxMaximaFrame.cpp:796
 msgid "Plot using Draw"
 msgstr ""
 
@@ -7836,7 +7844,7 @@ msgstr ""
 msgid "Polynomial:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1795
+#: ../../src/wxMaximaFrame.cpp:1840
 msgid "Pop"
 msgstr ""
 
@@ -7845,7 +7853,7 @@ msgstr ""
 msgid "Popout interactively"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:3605
+#: ../../src/MaximaCommandMenus.cpp:3631
 msgid "Portable anymap (*.pnm)|*.pnm|Tagged image file format (*.tif)|*.tif|X pixmap (*.xpm)|*.xpm"
 msgstr ""
 
@@ -7857,11 +7865,11 @@ msgstr ""
 msgid "Portuguese (Brazilian)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1227
+#: ../../src/wxMaximaFrame.cpp:1272
 msgid "Position of a match"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4092 ../../src/MaximaCommandMenus.cpp:4263
+#: ../../src/MaximaCommandMenus.cpp:4118 ../../src/MaximaCommandMenus.cpp:4289
 msgid "Position:"
 msgstr ""
 
@@ -7877,7 +7885,7 @@ msgstr ""
 msgid "Power series"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1516
+#: ../../src/wxMaximaFrame.cpp:1561
 msgid "Power series..."
 msgstr ""
 
@@ -7885,11 +7893,11 @@ msgstr ""
 msgid "Precision"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:787
+#: ../../src/dialogs/ConfigDialogue.cpp:788
 msgid "Prefer 1D"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1492
+#: ../../src/dialogs/ConfigDialogue.cpp:1503
 msgid "Prefer the all-in-one-file >1000 page manual"
 msgstr ""
 
@@ -7905,11 +7913,11 @@ msgstr ""
 msgid "Preferences button"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:726
+#: ../../src/wxMaximaFrame.cpp:769
 msgid "Preferences...\tCtrl+,"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1774
+#: ../../src/wxMaximaFrame.cpp:1819
 msgid "Prepend an element"
 msgstr ""
 
@@ -7921,7 +7929,7 @@ msgstr ""
 msgid "Pressing Ctrl+Space or Ctrl+Tab starts an autocomplete function that can not only complete all functions that are integrated into the Maxima core and their parameters: It also knows about parameters from currently loaded packages and from functions that are defined in the current file."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:965
+#: ../../src/wxMaximaFrame.cpp:1010
 msgid "Previous Command\tAlt+Up"
 msgstr ""
 
@@ -7933,7 +7941,7 @@ msgstr ""
 msgid "Print"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1988
+#: ../../src/dialogs/ConfigDialogue.cpp:1999
 msgid "Print Margins"
 msgstr ""
 
@@ -7946,19 +7954,19 @@ msgid "Print cell brackets"
 msgstr ""
 
 #: ../../src/ToolBar.cpp:343 ../../src/ToolBar.cpp:345
-#: ../../src/wxMaximaFrame.cpp:659
+#: ../../src/wxMaximaFrame.cpp:702
 msgid "Print document"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1870
+#: ../../src/wxMaximaFrame.cpp:1915
 msgid "Print floating-point numbers with exponents dividable by 3"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1968
+#: ../../src/dialogs/ConfigDialogue.cpp:1979
 msgid "Print scale:"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1981
+#: ../../src/dialogs/ConfigDialogue.cpp:1992
 msgid "Print the cell brackets [drawn to their left]"
 msgstr ""
 
@@ -8008,7 +8016,7 @@ msgstr ""
 msgid "Printout: Setting the device origin to %lix%li"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:936
+#: ../../src/dialogs/ConfigDialogue.cpp:937
 msgid "Privacy settings"
 msgstr ""
 
@@ -8026,23 +8034,23 @@ msgstr ""
 msgid "Product sign"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1133
+#: ../../src/wxMaximaFrame.cpp:1178
 msgid "Program"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:3933
+#: ../../src/MaximaCommandMenus.cpp:3959
 msgid "Program (no local variables)"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:3924
+#: ../../src/MaximaCommandMenus.cpp:3950
 msgid "Program block"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1104
+#: ../../src/wxMaximaFrame.cpp:1149
 msgid "Program block with local variables..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1106
+#: ../../src/wxMaximaFrame.cpp:1151
 msgid "Program block, no local variables..."
 msgstr ""
 
@@ -8050,7 +8058,7 @@ msgstr ""
 msgid "Psi"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1792
+#: ../../src/wxMaximaFrame.cpp:1837
 msgid "Push"
 msgstr ""
 
@@ -8058,7 +8066,7 @@ msgstr ""
 msgid "Push an element to a list"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1433
+#: ../../src/wxMaximaFrame.cpp:1478
 msgid "QR decomposition"
 msgstr ""
 
@@ -8066,11 +8074,11 @@ msgstr ""
 msgid "Querying gnuplot which graphics drivers it supports."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:662
+#: ../../src/wxMaximaFrame.cpp:705
 msgid "Quit wxMaxima"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1910
+#: ../../src/dialogs/ConfigDialogue.cpp:1921
 msgid "RTF with OMML maths"
 msgstr ""
 
@@ -8078,28 +8086,28 @@ msgstr ""
 msgid "Range radius:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1412
+#: ../../src/wxMaximaFrame.cpp:1457
 msgid "Rank"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:264 ../../src/wxMaximaFrame.cpp:761
+#: ../../src/wxMaximaFrame.cpp:264 ../../src/wxMaximaFrame.cpp:806
 msgid "Raw XML monitor"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:2195
+#: ../../src/wxMaximaFrame.cpp:2240
 #, c-format
 msgid "Re-Reading the config from %s."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:2192
+#: ../../src/wxMaximaFrame.cpp:2237
 msgid "Re-Reading the config from the default location."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:905
+#: ../../src/wxMaximaFrame.cpp:950
 msgid "Re-evaluate all cells above the one the cursor is in"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:915
+#: ../../src/wxMaximaFrame.cpp:960
 msgid "Re-evaluate all cells below the one the cursor is in"
 msgstr ""
 
@@ -8115,12 +8123,12 @@ msgstr ""
 msgid "Re-opening STDOUT failed."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2950
+#: ../../src/wxMaxima.cpp:2954
 #, c-format
 msgid "Re-pointed the .wxmx file association at %s"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4384
+#: ../../src/MaximaCommandMenus.cpp:4410
 msgid "Re-using a compiled regex is faster that using the same regex string multiple times."
 msgstr ""
 
@@ -8128,7 +8136,7 @@ msgstr ""
 msgid "Read .wxm data from clipboard"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4471
+#: ../../src/MaximaCommandMenus.cpp:4497
 msgid "Read Directory"
 msgstr ""
 
@@ -8136,35 +8144,35 @@ msgstr ""
 msgid "Read Matrix..."
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4068
+#: ../../src/MaximaCommandMenus.cpp:4094
 msgid "Read a structure field"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4142 ../../src/MaximaCommandMenus.cpp:4146
+#: ../../src/MaximaCommandMenus.cpp:4168 ../../src/MaximaCommandMenus.cpp:4172
 msgid "Read byte"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4138
+#: ../../src/MaximaCommandMenus.cpp:4164
 msgid "Read char"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2488
+#: ../../src/dialogs/ConfigDialogue.cpp:2500
 msgid "Read config to file"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4465
+#: ../../src/MaximaCommandMenus.cpp:4491
 msgid "Read environment variable"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1257
+#: ../../src/wxMaximaFrame.cpp:1302
 msgid "Read environment variable..."
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4134
+#: ../../src/MaximaCommandMenus.cpp:4160
 msgid "Read line"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1718
+#: ../../src/wxMaximaFrame.cpp:1763
 msgid "Read nested list from csv file..."
 msgstr ""
 
@@ -8243,11 +8251,11 @@ msgstr ""
 msgid "Recalculation hit the end of the worksheet => Updating its size (Visited %d cells, recalculated %d, in %ld ms)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:968
+#: ../../src/wxMaximaFrame.cpp:1013
 msgid "Recall next command from history"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:966
+#: ../../src/wxMaximaFrame.cpp:1011
 msgid "Recall previous command from history"
 msgstr ""
 
@@ -8261,11 +8269,11 @@ msgstr ""
 msgid "Received maxima's first prompt: %s"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1327
+#: ../../src/dialogs/ConfigDialogue.cpp:1328
 msgid "Recent files list length:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:638
+#: ../../src/wxMaximaFrame.cpp:681
 msgid "Recover unsaved"
 msgstr ""
 
@@ -8273,7 +8281,7 @@ msgstr ""
 msgid "Rectform"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1681
+#: ../../src/wxMaximaFrame.cpp:1726
 msgid "Recursive Substitute..."
 msgstr ""
 
@@ -8285,11 +8293,11 @@ msgstr ""
 msgid "Redo"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:674
+#: ../../src/wxMaximaFrame.cpp:717
 msgid "Redo\tCtrl+Y"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:674
+#: ../../src/wxMaximaFrame.cpp:717
 msgid "Redo last change"
 msgstr ""
 
@@ -8297,7 +8305,7 @@ msgstr ""
 msgid "Reduce (tr)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1636
+#: ../../src/wxMaximaFrame.cpp:1681
 msgid "Reduce trigonometric expression"
 msgstr ""
 
@@ -8315,23 +8323,23 @@ msgstr ""
 msgid "Regex"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4395
+#: ../../src/MaximaCommandMenus.cpp:4421
 msgid "Regex match"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4390
+#: ../../src/MaximaCommandMenus.cpp:4416
 msgid "Regex match position"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:2013
+#: ../../src/wxMaximaFrame.cpp:2058
 msgid "Register wxMaxima as the tool that compares .wxmx files in TortoiseSVN and TortoiseGit"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1233
+#: ../../src/wxMaximaFrame.cpp:1278
 msgid "Regular expression that matches a string"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1234
+#: ../../src/wxMaximaFrame.cpp:1279
 msgid "Regular expressions"
 msgstr ""
 
@@ -8344,24 +8352,24 @@ msgstr ""
 msgid "Reload Image \"%s\""
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:997
+#: ../../src/dialogs/ConfigDialogue.cpp:998
 msgid "Reload all GUI settings from disc"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1004
+#: ../../src/dialogs/ConfigDialogue.cpp:1005
 msgid "Reload the style settings from disc"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:3272
+#: ../../src/MaximaCommandMenus.cpp:3298
 #, c-format
 msgid "Reloading image file %s."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2573
+#: ../../src/dialogs/ConfigDialogue.cpp:2585
 msgid "Reloading the configuration from disc"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2581
+#: ../../src/dialogs/ConfigDialogue.cpp:2593
 msgid "Reloading the styles from disc"
 msgstr ""
 
@@ -8369,15 +8377,15 @@ msgstr ""
 msgid "Remove"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:921
+#: ../../src/wxMaximaFrame.cpp:966
 msgid "Remove All Output"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1467
+#: ../../src/wxMaximaFrame.cpp:1512
 msgid "Remove Columns..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1464
+#: ../../src/wxMaximaFrame.cpp:1509
 msgid "Remove Rows..."
 msgstr ""
 
@@ -8385,15 +8393,15 @@ msgstr ""
 msgid "Remove all"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1789
+#: ../../src/wxMaximaFrame.cpp:1834
 msgid "Remove all list elements that appear twice in a row. Normally used in conjunction with sort."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1212
+#: ../../src/wxMaximaFrame.cpp:1257
 msgid "Remove all occurrences of a word..."
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4311
+#: ../../src/MaximaCommandMenus.cpp:4337
 msgid "Remove all occurrences of part"
 msgstr ""
 
@@ -8405,27 +8413,27 @@ msgstr ""
 msgid "Remove and return the first element of a list"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1468
+#: ../../src/wxMaximaFrame.cpp:1513
 msgid "Remove columns from a matrix"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4438
+#: ../../src/MaximaCommandMenus.cpp:4464
 msgid "Remove directory"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1242
+#: ../../src/wxMaximaFrame.cpp:1287
 msgid "Remove directory..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1788
+#: ../../src/wxMaximaFrame.cpp:1833
 msgid "Remove duplicates"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1214
+#: ../../src/wxMaximaFrame.cpp:1259
 msgid "Remove first occurrence of a word..."
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4316
+#: ../../src/MaximaCommandMenus.cpp:4342
 msgid "Remove first occurrence of part"
 msgstr ""
 
@@ -8437,27 +8445,27 @@ msgstr ""
 msgid "Remove matrix rows"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:922
+#: ../../src/wxMaximaFrame.cpp:967
 msgid "Remove output from input cells"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1465
+#: ../../src/wxMaximaFrame.cpp:1510
 msgid "Remove rows from the a matrix"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4454
+#: ../../src/MaximaCommandMenus.cpp:4480
 msgid "Rename file"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1253
+#: ../../src/wxMaximaFrame.cpp:1298
 msgid "Rename file..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1568
+#: ../../src/wxMaximaFrame.cpp:1613
 msgid "Reorganize an expression using horner's rule"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1384
+#: ../../src/wxMaximaFrame.cpp:1429
 msgid "Repetitive element-by-element multiplication"
 msgstr ""
 
@@ -8465,27 +8473,27 @@ msgstr ""
 msgid "Replace All"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4410
+#: ../../src/MaximaCommandMenus.cpp:4436
 msgid "Replace all regex matches"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4405
+#: ../../src/MaximaCommandMenus.cpp:4431
 msgid "Replace first regex match"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1994
+#: ../../src/wxMaximaFrame.cpp:2039
 msgid "Replace non-builtin variable and function names in the selected code cells (or the whole document) with random names, so a worksheet can be shared without revealing its original names"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4335
+#: ../../src/MaximaCommandMenus.cpp:4361
 msgid "Replace the first occurrence of Part"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1218
+#: ../../src/wxMaximaFrame.cpp:1263
 msgid "Replace..."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2781
+#: ../../src/wxMaxima.cpp:2785
 #, c-format
 msgid "Replaced %li occurrences."
 msgstr ""
@@ -8498,29 +8506,29 @@ msgstr ""
 msgid "Replaces the subexpression that part(expr, n_1, n_2, ...) would select by a new value. The part numbers form a path: n_1 selects a part of the expression, n_2 a part of that, and so on."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1991
+#: ../../src/wxMaximaFrame.cpp:2036
 msgid "Report bug"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:983
+#: ../../src/dialogs/ConfigDialogue.cpp:984
 msgid "Reset all GUI settings"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1034
+#: ../../src/wxMaximaFrame.cpp:1079
 msgid "Reset option variables"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:990
+#: ../../src/dialogs/ConfigDialogue.cpp:991
 msgid "Reset the Style settings"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2557
-#: ../../src/dialogs/ConfigDialogue.cpp:2565
+#: ../../src/dialogs/ConfigDialogue.cpp:2569
+#: ../../src/dialogs/ConfigDialogue.cpp:2577
 msgid "Resetting all configuration settings"
 msgstr ""
 
 #: ../../src/ToolBar.cpp:411 ../../src/ToolBar.cpp:417
-#: ../../src/wxMaximaFrame.cpp:1012
+#: ../../src/wxMaximaFrame.cpp:1057
 msgid "Restart Maxima"
 msgstr ""
 
@@ -8529,7 +8537,7 @@ msgstr ""
 msgid "Restrict Maximum size"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:3520
+#: ../../src/MaximaCommandMenus.cpp:3546
 msgid "Result variables:"
 msgstr ""
 
@@ -8537,19 +8545,19 @@ msgstr ""
 msgid "Resulting Matrix name (may be empty):"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1228
+#: ../../src/wxMaximaFrame.cpp:1273
 msgid "Return a match"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:3949
+#: ../../src/MaximaCommandMenus.cpp:3975
 msgid "Return from a block or loop"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1107
+#: ../../src/wxMaximaFrame.cpp:1152
 msgid "Return from current block/loop..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1796
+#: ../../src/wxMaximaFrame.cpp:1841
 msgid "Return the first item of the list and remove it from the list. Useful for creating stacks."
 msgstr ""
 
@@ -8565,7 +8573,7 @@ msgstr ""
 msgid "Return to the cell that is currently being evaluated"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1752
+#: ../../src/wxMaximaFrame.cpp:1797
 msgid "Returns an arbitrary list item"
 msgstr ""
 
@@ -8573,7 +8581,7 @@ msgstr ""
 msgid "Returns the first element of a list"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1754
+#: ../../src/wxMaximaFrame.cpp:1799
 msgid "Returns the first item of the list"
 msgstr ""
 
@@ -8581,23 +8589,23 @@ msgstr ""
 msgid "Returns the last element of a list"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1760
+#: ../../src/wxMaximaFrame.cpp:1805
 msgid "Returns the last item of the list"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1762
+#: ../../src/wxMaximaFrame.cpp:1807
 msgid "Returns the last n items of the list"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1783
+#: ../../src/wxMaximaFrame.cpp:1828
 msgid "Returns the length of the list"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1756
+#: ../../src/wxMaximaFrame.cpp:1801
 msgid "Returns the list without its first n elements"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1758
+#: ../../src/wxMaximaFrame.cpp:1803
 msgid "Returns the list without its last n elements"
 msgstr ""
 
@@ -8609,11 +8617,11 @@ msgstr ""
 msgid "Reuse last"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1784
+#: ../../src/wxMaximaFrame.cpp:1829
 msgid "Reverse"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1785
+#: ../../src/wxMaximaFrame.cpp:1830
 msgid "Reverse the order of the list items"
 msgstr ""
 
@@ -8625,7 +8633,7 @@ msgstr ""
 msgid "Revert all to defaults"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:980
+#: ../../src/dialogs/ConfigDialogue.cpp:981
 msgid "Revert changes"
 msgstr ""
 
@@ -8633,7 +8641,7 @@ msgstr ""
 msgid "Rho"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2015
+#: ../../src/dialogs/ConfigDialogue.cpp:2026
 msgid "Right"
 msgstr ""
 
@@ -8650,11 +8658,11 @@ msgstr ""
 msgid "Right end"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1339
+#: ../../src/wxMaximaFrame.cpp:1384
 msgid "Right side to the \"=\""
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1496
+#: ../../src/wxMaximaFrame.cpp:1541
 msgid "Risch Integration..."
 msgstr ""
 
@@ -8662,11 +8670,11 @@ msgstr ""
 msgid "Romanian"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:826
+#: ../../src/wxMaximaFrame.cpp:871
 msgid "Rounded"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1478
+#: ../../src/wxMaximaFrame.cpp:1523
 msgid "Row and column operations"
 msgstr ""
 
@@ -8694,11 +8702,11 @@ msgstr ""
 msgid "Rule:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1065
+#: ../../src/wxMaximaFrame.cpp:1110
 msgid "Rules"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1734
+#: ../../src/wxMaximaFrame.cpp:1779
 msgid "Run each element through an expression"
 msgstr ""
 
@@ -8744,11 +8752,11 @@ msgstr ""
 msgid "Runs each element of an object (list, matrix, equation,...) through an expression individually"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1732
+#: ../../src/wxMaximaFrame.cpp:1777
 msgid "Runs each element through a function"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1735
+#: ../../src/wxMaximaFrame.cpp:1780
 msgid "Runs each element through an expression"
 msgstr ""
 
@@ -8756,11 +8764,11 @@ msgstr ""
 msgid "Russian"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1578
+#: ../../src/dialogs/ConfigDialogue.cpp:1589
 msgid "SBCL: use <int>Mbytes of heap"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1585
+#: ../../src/dialogs/ConfigDialogue.cpp:1596
 msgid "SBCL: use <int>Mbytes of stack for function calls"
 msgstr ""
 
@@ -8768,7 +8776,7 @@ msgstr ""
 msgid "SENT TO MAXIMA:"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1224
+#: ../../src/dialogs/ConfigDialogue.cpp:1225
 msgid "SVG graphics"
 msgstr ""
 
@@ -8801,7 +8809,7 @@ msgid "Samples on a line:"
 msgstr ""
 
 #: ../../src/ToolBar.cpp:331 ../../src/ToolBar.cpp:334
-#: ../../src/dialogs/ConfigDialogue.cpp:2163 ../../src/wxMaxima.cpp:3570
+#: ../../src/dialogs/ConfigDialogue.cpp:2174 ../../src/wxMaxima.cpp:3574
 msgid "Save"
 msgstr ""
 
@@ -8813,7 +8821,7 @@ msgstr ""
 msgid "Save As"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:644
+#: ../../src/wxMaximaFrame.cpp:687
 msgid "Save As...\tShift+Ctrl+S"
 msgstr ""
 
@@ -8825,32 +8833,32 @@ msgstr ""
 msgid "Save Selection to Image"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:716
+#: ../../src/wxMaximaFrame.cpp:759
 msgid "Save Selection to Image..."
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:3713
+#: ../../src/MaximaCommandMenus.cpp:3739
 msgid "Save animation to file"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4075
+#: ../../src/MaximaCommandMenus.cpp:4101
 msgid "Save as lisp code"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1129
+#: ../../src/wxMaximaFrame.cpp:1174
 msgid "Save as lisp..."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2478
+#: ../../src/dialogs/ConfigDialogue.cpp:2490
 msgid "Save config to file"
 msgstr ""
 
 #: ../../src/ToolBar.cpp:331 ../../src/ToolBar.cpp:334
-#: ../../src/wxMaximaFrame.cpp:643
+#: ../../src/wxMaximaFrame.cpp:686
 msgid "Save document"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:644
+#: ../../src/wxMaximaFrame.cpp:687
 msgid "Save document as"
 msgstr ""
 
@@ -8858,19 +8866,19 @@ msgstr ""
 msgid "Save plot to file"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:717
+#: ../../src/wxMaximaFrame.cpp:760
 msgid "Save selection from document to an image file"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:3620
+#: ../../src/MaximaCommandMenus.cpp:3646
 msgid "Save selection to file"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2640
+#: ../../src/dialogs/ConfigDialogue.cpp:2652
 msgid "Save style to file"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1384
+#: ../../src/dialogs/ConfigDialogue.cpp:1385
 msgid "Save the worksheet automatically"
 msgstr ""
 
@@ -8878,7 +8886,7 @@ msgstr ""
 msgid "Saving failed!"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:598
+#: ../../src/wxMaximaFrame.cpp:630
 msgid "Saving failed."
 msgstr ""
 
@@ -8886,11 +8894,11 @@ msgstr ""
 msgid "Saving succeeded, but the resulting files has disappeared ?!?."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1914
+#: ../../src/dialogs/ConfigDialogue.cpp:1925
 msgid "Scalable Vector Graphics (svg)"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:3596
+#: ../../src/MaximaCommandMenus.cpp:3622
 msgid "Scalable Vector image (*.svg)|*.svg|Compressed Scalable Vector Image (*.svgz)|*.svgz|PNG image (*.png)|*.png|JPEG image (*.jpg)|*.jpg|GIF image (*.gif)|*.gif|Windows bitmap (*.bmp)|*.bmp|"
 msgstr ""
 
@@ -8910,11 +8918,11 @@ msgstr ""
 msgid "Scheduling a background task that scans for autocompletable file names."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1867
+#: ../../src/dialogs/ConfigDialogue.cpp:1878
 msgid "Screen reader"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:666
+#: ../../src/wxMaximaFrame.cpp:709
 msgid "Scroll to a cell with a certain UUID"
 msgstr ""
 
@@ -8922,7 +8930,7 @@ msgstr ""
 msgid "Search button"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4326
+#: ../../src/MaximaCommandMenus.cpp:4352
 msgid "Search first occurrence of part"
 msgstr ""
 
@@ -8930,7 +8938,7 @@ msgstr ""
 msgid "Search input / UUID"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1216
+#: ../../src/wxMaximaFrame.cpp:1261
 msgid "Search..."
 msgstr ""
 
@@ -8950,7 +8958,7 @@ msgstr ""
 msgid "See also the speed <-> accuracy button."
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4090
+#: ../../src/MaximaCommandMenus.cpp:4116
 msgid "Seek to position"
 msgstr ""
 
@@ -8975,7 +8983,7 @@ msgstr ""
 msgid "Select All"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:714
+#: ../../src/wxMaximaFrame.cpp:757
 msgid "Select All\tCtrl+A"
 msgstr ""
 
@@ -8994,7 +9002,7 @@ msgid "Select a constant"
 msgstr ""
 
 #: ../../src/ToolBar.cpp:390 ../../src/ToolBar.cpp:392
-#: ../../src/wxMaximaFrame.cpp:714
+#: ../../src/wxMaximaFrame.cpp:757
 msgid "Select all"
 msgstr ""
 
@@ -9006,7 +9014,7 @@ msgstr ""
 msgid "Select csv file to read"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:3843
+#: ../../src/MaximaCommandMenus.cpp:3869
 msgid "Select math display algorithm"
 msgstr ""
 
@@ -9054,7 +9062,7 @@ msgstr ""
 msgid "Sending maxima the info how to express 2d maths as XML"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1574
+#: ../../src/wxMaximaFrame.cpp:1619
 msgid "Sequential Comparative Simplification"
 msgstr ""
 
@@ -9066,7 +9074,7 @@ msgstr ""
 msgid "Series"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1520
+#: ../../src/wxMaximaFrame.cpp:1565
 msgid "Series approximation"
 msgstr ""
 
@@ -9074,27 +9082,27 @@ msgstr ""
 msgid "Server started"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1865
+#: ../../src/wxMaximaFrame.cpp:1910
 msgid "Set &displayed Precision..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1604
+#: ../../src/wxMaximaFrame.cpp:1649
 msgid "Set Maxima option variable logexpand:all"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1608
+#: ../../src/wxMaximaFrame.cpp:1653
 msgid "Set Maxima option variable logexpand:super"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1601
+#: ../../src/wxMaximaFrame.cpp:1646
 msgid "Set Maxima option variable logexpand:true"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:863
+#: ../../src/wxMaximaFrame.cpp:908
 msgid "Set Zoom"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1860
+#: ../../src/wxMaximaFrame.cpp:1905
 msgid "Set bigfloat &Precision..."
 msgstr ""
 
@@ -9111,7 +9119,7 @@ msgstr ""
 msgid "Set image resolution [in ppi]"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1551
+#: ../../src/wxMaximaFrame.cpp:1596
 msgid "Set main variable..."
 msgstr ""
 
@@ -9119,15 +9127,15 @@ msgstr ""
 msgid "Set maximum image size [in mm]"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1814
+#: ../../src/wxMaximaFrame.cpp:1859
 msgid "Set plot format"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1139
+#: ../../src/wxMaximaFrame.cpp:1184
 msgid "Set position..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1697
+#: ../../src/wxMaximaFrame.cpp:1742
 msgid "Set the \"algebraic\" flag"
 msgstr ""
 
@@ -9135,7 +9143,7 @@ msgstr ""
 msgid "Set the diagram title"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1820
+#: ../../src/wxMaximaFrame.cpp:1865
 msgid "Set the frame rate for animations."
 msgstr ""
 
@@ -9147,31 +9155,31 @@ msgstr ""
 msgid "Set the next plot's title. Empty = no title."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1861
+#: ../../src/wxMaximaFrame.cpp:1906
 msgid "Set the precision for numbers that are defined as bigfloat. Such numbers can be generated by entering 1.5b12 or as bfloat(1.234)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:852
+#: ../../src/wxMaximaFrame.cpp:897
 msgid "Set zoom to 100%"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:854
+#: ../../src/wxMaximaFrame.cpp:899
 msgid "Set zoom to 120%"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:856
+#: ../../src/wxMaximaFrame.cpp:901
 msgid "Set zoom to 150%"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:858
+#: ../../src/wxMaximaFrame.cpp:903
 msgid "Set zoom to 200%"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:860
+#: ../../src/wxMaximaFrame.cpp:905
 msgid "Set zoom to 300%"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:850
+#: ../../src/wxMaximaFrame.cpp:895
 msgid "Set zoom to 80%"
 msgstr ""
 
@@ -9209,11 +9217,11 @@ msgstr ""
 msgid "Setup a 3D plot"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1330
+#: ../../src/wxMaximaFrame.cpp:1375
 msgid "Setup atvalues for solving ODE with Laplace transformation"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1702
+#: ../../src/wxMaximaFrame.cpp:1747
 msgid "Setup modulus computation"
 msgstr ""
 
@@ -9229,7 +9237,7 @@ msgstr ""
 msgid "Setup the engineering format"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1872
+#: ../../src/wxMaximaFrame.cpp:1917
 msgid "Setup the engineering format..."
 msgstr ""
 
@@ -9241,7 +9249,11 @@ msgstr ""
 msgid "Show \"%\" in special constants"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1930
+#: ../../src/dialogs/ConfigDialogue.cpp:1417
+msgid "Show \"Find and Replace\" as a dockable sidebar"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1975
 msgid "Show &Tips..."
 msgstr ""
 
@@ -9249,15 +9261,15 @@ msgstr ""
 msgid "Show * as multiplication dot"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:933
+#: ../../src/wxMaximaFrame.cpp:978
 msgid "Show Template\tCtrl+Shift+Space"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:794
+#: ../../src/wxMaximaFrame.cpp:839
 msgid "Show XML representation"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1930
+#: ../../src/wxMaximaFrame.cpp:1975
 msgid "Show a tip"
 msgstr ""
 
@@ -9277,7 +9289,7 @@ msgstr ""
 msgid "Show an example for the command:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1924
+#: ../../src/wxMaximaFrame.cpp:1969
 msgid "Show an example of usage"
 msgstr ""
 
@@ -9285,31 +9297,31 @@ msgstr ""
 msgid "Show commands from current session only"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1925
+#: ../../src/wxMaximaFrame.cpp:1970
 msgid "Show commands similar to"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1058
+#: ../../src/wxMaximaFrame.cpp:1103
 msgid "Show defined functions"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1060
+#: ../../src/wxMaximaFrame.cpp:1105
 msgid "Show defined variables"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1112
+#: ../../src/wxMaximaFrame.cpp:1157
 msgid "Show definition of a function"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:781
+#: ../../src/wxMaximaFrame.cpp:826
 msgid "Show equations in their linear form"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1111
+#: ../../src/wxMaximaFrame.cpp:1156
 msgid "Show function &Definition..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:934
+#: ../../src/wxMaximaFrame.cpp:979
 msgid "Show function template"
 msgstr ""
 
@@ -9317,11 +9329,11 @@ msgstr ""
 msgid "Show input labels"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:766
+#: ../../src/dialogs/ConfigDialogue.cpp:767
 msgid "Show labels:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:791
+#: ../../src/wxMaximaFrame.cpp:836
 msgid "Show lisp representation"
 msgstr ""
 
@@ -9329,7 +9341,7 @@ msgstr ""
 msgid "Show long expressions in wxMaxima document."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:722
+#: ../../src/dialogs/ConfigDialogue.cpp:723
 msgid "Show long expressions:"
 msgstr ""
 
@@ -9345,7 +9357,7 @@ msgstr ""
 msgid "Show max. 50 digits"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:872
+#: ../../src/wxMaximaFrame.cpp:917
 msgid "Show or hide the wxMaxima logging window"
 msgstr ""
 
@@ -9369,11 +9381,11 @@ msgstr ""
 msgid "Show the Copy, Cut and the Paste button?"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:654
+#: ../../src/wxMaximaFrame.cpp:697
 msgid "Show the differences between 2 or 3 files"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:3905
+#: ../../src/MaximaCommandMenus.cpp:3931
 msgid "Show the function's definition"
 msgstr ""
 
@@ -9397,24 +9409,24 @@ msgstr ""
 msgid "Show tips at Startup"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1044 ../../src/wxMaximaFrame.cpp:1049
+#: ../../src/wxMaximaFrame.cpp:1089 ../../src/wxMaximaFrame.cpp:1094
 msgid "Show used + to-be-freed memory"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1071
+#: ../../src/wxMaximaFrame.cpp:1116
 msgid "Show user definitions"
 msgstr ""
 
 #: ../../src/ToolBar.cpp:544 ../../src/ToolBar.cpp:546
-#: ../../src/wxMaximaFrame.cpp:1918 ../../src/wxMaximaFrame.cpp:1920
+#: ../../src/wxMaximaFrame.cpp:1963 ../../src/wxMaximaFrame.cpp:1965
 msgid "Show wxMaxima help"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1866
+#: ../../src/wxMaximaFrame.cpp:1911
 msgid "Shows how many digits of a numbers are displayed"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:773
+#: ../../src/wxMaximaFrame.cpp:818
 msgid "Sidebars"
 msgstr ""
 
@@ -9434,7 +9446,7 @@ msgstr ""
 msgid "Simplify"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1554
+#: ../../src/wxMaximaFrame.cpp:1599
 msgid "Simplify &Radicals..."
 msgstr ""
 
@@ -9450,19 +9462,19 @@ msgstr ""
 msgid "Simplify Expression"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1609
+#: ../../src/wxMaximaFrame.cpp:1654
 msgid "Simplify Logarithms"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1623
+#: ../../src/wxMaximaFrame.cpp:1668
 msgid "Simplify an expression containing factorials"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1580
+#: ../../src/wxMaximaFrame.cpp:1625
 msgid "Simplify equations"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1555
+#: ../../src/wxMaximaFrame.cpp:1600
 msgid "Simplify expression containing radicals"
 msgstr ""
 
@@ -9470,11 +9482,11 @@ msgstr ""
 msgid "Simplify radicals"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1553
+#: ../../src/wxMaximaFrame.cpp:1598
 msgid "Simplify rational expression"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1579
+#: ../../src/wxMaximaFrame.cpp:1624
 msgid "Simplify sum() commands..."
 msgstr ""
 
@@ -9486,7 +9498,7 @@ msgstr ""
 msgid "Simplify the sum"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1633
+#: ../../src/wxMaximaFrame.cpp:1678
 msgid "Simplify trigonometric expression"
 msgstr ""
 
@@ -9494,15 +9506,15 @@ msgstr ""
 msgid "Since wxMaxima 0.8.2 you can also insert images into your documents. Use 'Cell->Insert Image...' menu command."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1437
+#: ../../src/wxMaximaFrame.cpp:1482
 msgid "Singular Values"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1438 ../../src/wxMaximaFrame.cpp:1441
+#: ../../src/wxMaximaFrame.cpp:1483 ../../src/wxMaximaFrame.cpp:1486
 msgid "Singular values using dgesvd"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1440
+#: ../../src/wxMaximaFrame.cpp:1485
 msgid "Singular values, left + right vectors"
 msgstr ""
 
@@ -9522,7 +9534,7 @@ msgstr ""
 msgid "Size of internal work array. limit/2 is the maximum number of subintervals to use."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2113
+#: ../../src/dialogs/ConfigDialogue.cpp:2124
 msgid "Slanted"
 msgstr ""
 
@@ -9534,7 +9546,7 @@ msgstr ""
 msgid "Slovenian"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1676
+#: ../../src/wxMaximaFrame.cpp:1721
 msgid "Smart Substitute..."
 msgstr ""
 
@@ -9551,23 +9563,23 @@ msgstr ""
 msgid "Solution:"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:3506
+#: ../../src/MaximaCommandMenus.cpp:3532
 msgid "Solve"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1282
+#: ../../src/wxMaximaFrame.cpp:1327
 msgid "Solve &Algebraic System..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1280
+#: ../../src/wxMaximaFrame.cpp:1325
 msgid "Solve &Linear System..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1304
+#: ../../src/wxMaximaFrame.cpp:1349
 msgid "Solve &ODE..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1278
+#: ../../src/wxMaximaFrame.cpp:1323
 msgid "Solve (to_poly)..."
 msgstr ""
 
@@ -9575,7 +9587,7 @@ msgstr ""
 msgid "Solve A*x=b numerically"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1435
+#: ../../src/wxMaximaFrame.cpp:1480
 msgid "Solve Ax=b"
 msgstr ""
 
@@ -9583,7 +9595,7 @@ msgstr ""
 msgid "Solve ODE"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1325
+#: ../../src/wxMaximaFrame.cpp:1370
 msgid "Solve ODE with Lapla&ce..."
 msgstr ""
 
@@ -9591,7 +9603,7 @@ msgstr ""
 msgid "Solve ODE..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1436
+#: ../../src/wxMaximaFrame.cpp:1481
 msgid "Solve a linear equation system using dgesv"
 msgstr ""
 
@@ -9599,11 +9611,11 @@ msgstr ""
 msgid "Solve algebraic system"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1283
+#: ../../src/wxMaximaFrame.cpp:1328
 msgid "Solve algebraic system of equations"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1317
+#: ../../src/wxMaximaFrame.cpp:1362
 msgid "Solve boundary value problem for second degree ODE"
 msgstr ""
 
@@ -9611,11 +9623,11 @@ msgstr ""
 msgid "Solve differential equations using laplace()"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:925 ../../src/wxMaximaFrame.cpp:1276
+#: ../../src/MaximaCommandMenus.cpp:925 ../../src/wxMaximaFrame.cpp:1321
 msgid "Solve equation(s)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1279
+#: ../../src/wxMaximaFrame.cpp:1324
 msgid "Solve equation(s) with to_poly_solve"
 msgstr ""
 
@@ -9627,11 +9639,11 @@ msgstr ""
 msgid "Solve equations to polynom"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1309
+#: ../../src/wxMaximaFrame.cpp:1354
 msgid "Solve initial value problem for first degree ODE"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1313
+#: ../../src/wxMaximaFrame.cpp:1358
 msgid "Solve initial value problem for second degree ODE"
 msgstr ""
 
@@ -9639,19 +9651,19 @@ msgstr ""
 msgid "Solve linear system"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1281
+#: ../../src/wxMaximaFrame.cpp:1326
 msgid "Solve linear system of equations"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1301
+#: ../../src/wxMaximaFrame.cpp:1346
 msgid "Solve numerical, 1 Variable"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1305
+#: ../../src/wxMaximaFrame.cpp:1350
 msgid "Solve ordinary differential equation of maximum degree 2"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1326
+#: ../../src/wxMaximaFrame.cpp:1371
 msgid "Solve ordinary differential equations with Laplace transformation"
 msgstr ""
 
@@ -9667,7 +9679,7 @@ msgstr ""
 msgid "Solve polynomials numerically (real roots)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1287
+#: ../../src/wxMaximaFrame.cpp:1332
 msgid "Solve symbolically"
 msgstr ""
 
@@ -9676,22 +9688,22 @@ msgstr ""
 msgid "Solve..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1957
+#: ../../src/wxMaximaFrame.cpp:2002
 msgid "Solving differential equations"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1945
+#: ../../src/wxMaximaFrame.cpp:1990
 msgid "Solving equations with Maxima"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:3977
+#: ../../src/MaximaCommandMenus.cpp:4003
 #, c-format
 msgid ""
 "Sometimes one wants maxima to loose the information that a function name was used with the ' operator in order to make maxima not evaluate it. In other places one wants % to mean \"the last expression at the time this function was created\", not \"the last expression now\".\n"
 "In both cases the '' operator will do what is requested."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1787
+#: ../../src/wxMaximaFrame.cpp:1832
 msgid "Sort"
 msgstr ""
 
@@ -9703,11 +9715,11 @@ msgstr ""
 msgid "Sort a list"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4331
+#: ../../src/MaximaCommandMenus.cpp:4357
 msgid "Sort all characters in string"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1217
+#: ../../src/wxMaximaFrame.cpp:1262
 msgid "Sort the characters..."
 msgstr ""
 
@@ -9728,31 +9740,31 @@ msgstr ""
 msgid "Speed versus accuracy"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4301
+#: ../../src/MaximaCommandMenus.cpp:4327
 msgid "Split"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1229
+#: ../../src/wxMaximaFrame.cpp:1274
 msgid "Split on match"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4400
+#: ../../src/MaximaCommandMenus.cpp:4426
 msgid "Split on regex match"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4321
+#: ../../src/MaximaCommandMenus.cpp:4347
 msgid "Split string into tokens"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1209
+#: ../../src/wxMaximaFrame.cpp:1254
 msgid "Split..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:829
+#: ../../src/wxMaximaFrame.cpp:874
 msgid "Square"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1300
+#: ../../src/dialogs/ConfigDialogue.cpp:1301
 msgid "Standard Options"
 msgstr ""
 
@@ -9764,7 +9776,7 @@ msgstr ""
 msgid "Start Animation"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1622
+#: ../../src/dialogs/ConfigDialogue.cpp:1633
 msgid "Start a new maxima for each re-evaluation"
 msgstr ""
 
@@ -9800,7 +9812,7 @@ msgstr ""
 msgid "Start value of the parameter"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:404
+#: ../../src/wxMaxima.cpp:395
 msgid "Starting Maxima process failed"
 msgstr ""
 
@@ -9808,7 +9820,7 @@ msgstr ""
 msgid "Starting a new wxMaxima process for a new window"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:1859 ../../src/wxMaxima.cpp:1885
+#: ../../src/wxMaxima.cpp:1864 ../../src/wxMaxima.cpp:1890
 msgid "Starting evaluation of the document"
 msgstr ""
 
@@ -9829,7 +9841,7 @@ msgstr ""
 msgid "Statistics"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:740
+#: ../../src/wxMaximaFrame.cpp:783
 msgid "Statistics\tAlt+Shift+S"
 msgstr ""
 
@@ -9837,97 +9849,97 @@ msgstr ""
 msgid "Step width:"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:939
+#: ../../src/dialogs/ConfigDialogue.cpp:940
 msgid "Store filenames in image cells to enable image reloading after re-opening the worksheet"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:835
+#: ../../src/wxMaximaFrame.cpp:880
 msgid "Straight lines"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1144
+#: ../../src/wxMaximaFrame.cpp:1189
 msgid "Stream"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4103
+#: ../../src/MaximaCommandMenus.cpp:4129
 msgid "Stream length"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4091 ../../src/MaximaCommandMenus.cpp:4096
-#: ../../src/MaximaCommandMenus.cpp:4100 ../../src/MaximaCommandMenus.cpp:4104
-#: ../../src/MaximaCommandMenus.cpp:4108 ../../src/MaximaCommandMenus.cpp:4112
 #: ../../src/MaximaCommandMenus.cpp:4117 ../../src/MaximaCommandMenus.cpp:4122
-#: ../../src/MaximaCommandMenus.cpp:4128 ../../src/MaximaCommandMenus.cpp:4135
-#: ../../src/MaximaCommandMenus.cpp:4139 ../../src/MaximaCommandMenus.cpp:4143
-#: ../../src/MaximaCommandMenus.cpp:4148
+#: ../../src/MaximaCommandMenus.cpp:4126 ../../src/MaximaCommandMenus.cpp:4130
+#: ../../src/MaximaCommandMenus.cpp:4134 ../../src/MaximaCommandMenus.cpp:4138
+#: ../../src/MaximaCommandMenus.cpp:4143 ../../src/MaximaCommandMenus.cpp:4148
+#: ../../src/MaximaCommandMenus.cpp:4154 ../../src/MaximaCommandMenus.cpp:4161
+#: ../../src/MaximaCommandMenus.cpp:4165 ../../src/MaximaCommandMenus.cpp:4169
+#: ../../src/MaximaCommandMenus.cpp:4174
 msgid "Stream:"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2117
+#: ../../src/dialogs/ConfigDialogue.cpp:2128
 msgid "Strike Through"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1223
+#: ../../src/wxMaximaFrame.cpp:1268
 msgid "String"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4217 ../../src/MaximaCommandMenus.cpp:4222
-#: ../../src/MaximaCommandMenus.cpp:4297
+#: ../../src/MaximaCommandMenus.cpp:4243 ../../src/MaximaCommandMenus.cpp:4248
+#: ../../src/MaximaCommandMenus.cpp:4323
 msgid "String #1:"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4218 ../../src/MaximaCommandMenus.cpp:4223
-#: ../../src/MaximaCommandMenus.cpp:4298
+#: ../../src/MaximaCommandMenus.cpp:4244 ../../src/MaximaCommandMenus.cpp:4249
+#: ../../src/MaximaCommandMenus.cpp:4324
 msgid "String #2:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1174
+#: ../../src/wxMaximaFrame.cpp:1219
 msgid "String Tests"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4287
+#: ../../src/MaximaCommandMenus.cpp:4313
 msgid "String length"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4253
+#: ../../src/MaximaCommandMenus.cpp:4279
 msgid "String to list of char"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1186
+#: ../../src/wxMaximaFrame.cpp:1231
 msgid "String to list of chars..."
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4368
+#: ../../src/MaximaCommandMenus.cpp:4394
 msgid "String to octets"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1198
+#: ../../src/wxMaximaFrame.cpp:1243
 msgid "String to octets..."
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4249 ../../src/MaximaCommandMenus.cpp:4254
-#: ../../src/MaximaCommandMenus.cpp:4263 ../../src/MaximaCommandMenus.cpp:4268
-#: ../../src/MaximaCommandMenus.cpp:4272 ../../src/MaximaCommandMenus.cpp:4279
-#: ../../src/MaximaCommandMenus.cpp:4284 ../../src/MaximaCommandMenus.cpp:4288
-#: ../../src/MaximaCommandMenus.cpp:4292 ../../src/MaximaCommandMenus.cpp:4302
-#: ../../src/MaximaCommandMenus.cpp:4308 ../../src/MaximaCommandMenus.cpp:4313
-#: ../../src/MaximaCommandMenus.cpp:4318 ../../src/MaximaCommandMenus.cpp:4322
-#: ../../src/MaximaCommandMenus.cpp:4328 ../../src/MaximaCommandMenus.cpp:4332
-#: ../../src/MaximaCommandMenus.cpp:4337 ../../src/MaximaCommandMenus.cpp:4342
-#: ../../src/MaximaCommandMenus.cpp:4346 ../../src/MaximaCommandMenus.cpp:4350
-#: ../../src/MaximaCommandMenus.cpp:4369
+#: ../../src/MaximaCommandMenus.cpp:4275 ../../src/MaximaCommandMenus.cpp:4280
+#: ../../src/MaximaCommandMenus.cpp:4289 ../../src/MaximaCommandMenus.cpp:4294
+#: ../../src/MaximaCommandMenus.cpp:4298 ../../src/MaximaCommandMenus.cpp:4305
+#: ../../src/MaximaCommandMenus.cpp:4310 ../../src/MaximaCommandMenus.cpp:4314
+#: ../../src/MaximaCommandMenus.cpp:4318 ../../src/MaximaCommandMenus.cpp:4328
+#: ../../src/MaximaCommandMenus.cpp:4334 ../../src/MaximaCommandMenus.cpp:4339
+#: ../../src/MaximaCommandMenus.cpp:4344 ../../src/MaximaCommandMenus.cpp:4348
+#: ../../src/MaximaCommandMenus.cpp:4354 ../../src/MaximaCommandMenus.cpp:4358
+#: ../../src/MaximaCommandMenus.cpp:4363 ../../src/MaximaCommandMenus.cpp:4368
+#: ../../src/MaximaCommandMenus.cpp:4372 ../../src/MaximaCommandMenus.cpp:4376
+#: ../../src/MaximaCommandMenus.cpp:4395
 msgid "String:"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4069
+#: ../../src/MaximaCommandMenus.cpp:4095
 msgid "Struct :"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4056 ../../src/MaximaCommandMenus.cpp:4062
+#: ../../src/MaximaCommandMenus.cpp:4082 ../../src/MaximaCommandMenus.cpp:4088
 msgid "Struct type name:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1067
+#: ../../src/wxMaximaFrame.cpp:1112
 msgid "Structs"
 msgstr ""
 
@@ -9935,7 +9947,7 @@ msgstr ""
 msgid "Style"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2082
+#: ../../src/dialogs/ConfigDialogue.cpp:2093
 msgid "Styles"
 msgstr ""
 
@@ -9951,7 +9963,7 @@ msgstr ""
 msgid "Subsection cell (Heading 3)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1684
+#: ../../src/wxMaximaFrame.cpp:1729
 msgid "Subst constant t into eq with diff(x,t)..."
 msgstr ""
 
@@ -9963,17 +9975,17 @@ msgstr ""
 msgid "Subst..."
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:715 ../../src/MaximaCommandMenus.cpp:3550
-#: ../../src/MaximaCommandMenus.cpp:4560 ../../src/wizards/SubstituteWiz.cpp:53
-#: ../../src/wxMaximaFrame.cpp:1692
+#: ../../src/MaximaCommandMenus.cpp:715 ../../src/MaximaCommandMenus.cpp:3576
+#: ../../src/MaximaCommandMenus.cpp:4586 ../../src/wizards/SubstituteWiz.cpp:53
+#: ../../src/wxMaximaFrame.cpp:1737
 msgid "Substitute"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1231
+#: ../../src/wxMaximaFrame.cpp:1276
 msgid "Substitute all matches"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1230
+#: ../../src/wxMaximaFrame.cpp:1275
 msgid "Substitute first match"
 msgstr ""
 
@@ -9981,20 +9993,20 @@ msgstr ""
 msgid "Substitute only in a specific part"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1687
+#: ../../src/wxMaximaFrame.cpp:1732
 msgid "Substitute only in parts..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1688
+#: ../../src/wxMaximaFrame.cpp:1733
 msgid "Substitute only in the elements n_1, n_2,..."
 msgstr ""
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:358
-#: ../../src/wxMaximaFrame.cpp:1674
+#: ../../src/wxMaximaFrame.cpp:1719
 msgid "Substitute..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1682 ../../src/wxMaximaFrame.cpp:1685
+#: ../../src/wxMaximaFrame.cpp:1727 ../../src/wxMaximaFrame.cpp:1730
 msgid "Substitutes until the equation no more changes"
 msgstr ""
 
@@ -10011,7 +10023,7 @@ msgstr ""
 msgid "Substitutes, but makes sure that nothing is substituted into the other substituents."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1679
+#: ../../src/wxMaximaFrame.cpp:1724
 msgid "Substitutes, but not in the other substituents"
 msgstr ""
 
@@ -10043,7 +10055,7 @@ msgstr ""
 msgid "Swedish"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1592
+#: ../../src/wxMaximaFrame.cpp:1637
 msgid "Switch off simplifications of log(). Set Maxima option variable logexpand:false"
 msgstr ""
 
@@ -10060,7 +10072,7 @@ msgstr ""
 msgid "Symbolic Constant"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:744
+#: ../../src/wxMaximaFrame.cpp:787
 msgid "Symbols\tAlt+Shift+Y"
 msgstr ""
 
@@ -10088,7 +10100,7 @@ msgstr ""
 msgid "Table of Contents"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:750
+#: ../../src/wxMaximaFrame.cpp:793
 msgid "Table of Contents\tAlt+Shift+T"
 msgstr ""
 
@@ -10108,7 +10120,7 @@ msgstr ""
 msgid "Taylor series"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1515
+#: ../../src/wxMaximaFrame.cpp:1560
 msgid "Taylor series..."
 msgstr ""
 
@@ -10116,7 +10128,7 @@ msgstr ""
 msgid "Taylor series:"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:1489
+#: ../../src/wxMaxima.cpp:1494
 msgid "Telling maxima about the new working directory."
 msgstr ""
 
@@ -10124,15 +10136,15 @@ msgstr ""
 msgid "Tells maxima for an f(x), that f(x=t)=a"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1986
+#: ../../src/wxMaximaFrame.cpp:2031
 msgid "Tells maxima to show the help for ?, ?? and describe() in a separate browser window"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1982
+#: ../../src/wxMaximaFrame.cpp:2027
 msgid "Tells maxima to show the help for ?, ?? and describe() in a wxMaxima sidebar"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1977
+#: ../../src/wxMaximaFrame.cpp:2022
 msgid "Tells maxima to show the help for ?, ?? and describe() on the console"
 msgstr ""
 
@@ -10144,11 +10156,11 @@ msgstr ""
 msgid "Text"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:739
+#: ../../src/dialogs/ConfigDialogue.cpp:740
 msgid "Text & Code"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:738
+#: ../../src/dialogs/ConfigDialogue.cpp:739
 msgid "Text Only"
 msgstr ""
 
@@ -10209,7 +10221,7 @@ msgstr ""
 msgid "The cache for the subjects the manual contains is from a different Maxima version."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1417
+#: ../../src/wxMaximaFrame.cpp:1462
 msgid "The classic operations one typically uses matrices for"
 msgstr ""
 
@@ -10217,15 +10229,15 @@ msgstr ""
 msgid "The color of the next line to draw"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4065
+#: ../../src/MaximaCommandMenus.cpp:4091
 msgid "The comma-separated contents of the struct fields"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4058
+#: ../../src/MaximaCommandMenus.cpp:4084
 msgid "The comma-separated names of the struct fields"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:3942
+#: ../../src/MaximaCommandMenus.cpp:3968
 msgid "The command local() allows telling Maxima which functions to make local to the current program when defined."
 msgstr ""
 
@@ -10249,7 +10261,7 @@ msgstr ""
 msgid "The diagram title"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2401
+#: ../../src/dialogs/ConfigDialogue.cpp:2413
 #, c-format
 msgid "The directory %s with maxima's startup file doesn't exist. Trying to create it..."
 msgstr ""
@@ -10307,11 +10319,11 @@ msgstr ""
 msgid "The grid in the background of the diagram"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1336
+#: ../../src/wxMaximaFrame.cpp:1381
 msgid "The half of the equation that is to the left of the \"=\""
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1340
+#: ../../src/wxMaximaFrame.cpp:1385
 msgid "The half of the equation that is to the right of the \"=\""
 msgstr ""
 
@@ -10325,12 +10337,12 @@ msgid ""
 "One example of the latter would be: Gnuplot refuses to plot entirely empty images"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:3262 ../../src/MaximaCommandMenus.cpp:3687
+#: ../../src/MaximaCommandMenus.cpp:3288 ../../src/MaximaCommandMenus.cpp:3713
 #, c-format
 msgid "The image file \"%s\" cannot be found."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:757
+#: ../../src/wxMaximaFrame.cpp:802
 msgid "The integrated help browser"
 msgstr ""
 
@@ -10362,11 +10374,11 @@ msgstr ""
 msgid "The main toolbar"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1923
+#: ../../src/wxMaximaFrame.cpp:1968
 msgid "The manual of Maxima"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1922
+#: ../../src/wxMaximaFrame.cpp:1967
 msgid "The manual of wxMaxima"
 msgstr ""
 
@@ -10374,27 +10386,27 @@ msgstr ""
 msgid "The maximum size for this image. Values <= 0 mean: Unspecified."
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:3997
+#: ../../src/MaximaCommandMenus.cpp:4023
 msgid "The name of a function we don't want to be evaluated here"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4003
+#: ../../src/MaximaCommandMenus.cpp:4029
 msgid "The name of an expression that we don't want to be evaluated."
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4071
+#: ../../src/MaximaCommandMenus.cpp:4097
 msgid "The name of the field to read"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4057
+#: ../../src/MaximaCommandMenus.cpp:4083
 msgid "The name of the new struct type"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4070
+#: ../../src/MaximaCommandMenus.cpp:4096
 msgid "The name of the struct"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4063
+#: ../../src/MaximaCommandMenus.cpp:4089
 msgid "The name of the struct type"
 msgstr ""
 
@@ -10418,8 +10430,8 @@ msgstr ""
 msgid "The options the document class LaTeX is instructed to use for our documents gets."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1065
-#: ../../src/dialogs/ConfigDialogue.cpp:1112
+#: ../../src/dialogs/ConfigDialogue.cpp:1066
+#: ../../src/dialogs/ConfigDialogue.cpp:1113
 msgid "The part of the output of these commands that isn't declared as \"math\" might be suppressed by wxMaxima. As always maxima commands are required to end in a \";\" or a \"$\""
 msgstr ""
 
@@ -10460,7 +10472,7 @@ msgstr ""
 msgid "The second argument of at() isn't an equation or a list of equations. Most probably it was lacking an \"=\"."
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:3481
+#: ../../src/MaximaCommandMenus.cpp:3507
 msgid "The selection contains no output that could be exported."
 msgstr ""
 
@@ -10507,7 +10519,7 @@ msgstr ""
 msgid "The worksheet"
 msgstr ""
 
-#: ../../src/worksheet/Worksheet.cpp:6371
+#: ../../src/worksheet/Worksheet.cpp:6377
 msgid "The worksheet containing maxima's input and output"
 msgstr ""
 
@@ -10597,7 +10609,7 @@ msgid ""
 "overwritten if maxima's version changes or the file cannot be read"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1097
+#: ../../src/dialogs/ConfigDialogue.cpp:1098
 msgid "This file won't be read by maxima if maxima is used without wxMaxima. In order to add startup commands that are executed in this case, too, please add them to maxima-init.mac, instead."
 msgstr ""
 
@@ -10642,11 +10654,11 @@ msgstr ""
 msgid "Ticks:"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1359
+#: ../../src/dialogs/ConfigDialogue.cpp:1360
 msgid "Time [in Minutes] between autosaves"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:267 ../../src/MaximaCommandMenus.cpp:3547
+#: ../../src/MaximaCommandMenus.cpp:267 ../../src/MaximaCommandMenus.cpp:3573
 msgid "Times:"
 msgstr ""
 
@@ -10670,11 +10682,11 @@ msgstr ""
 msgid "Title, section and subsection cells can be folded to hide their contents. To fold or unfold, click in the square next to the cell. If you shift-click, all sublevels of that cell will also fold/unfold."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1835
+#: ../../src/wxMaximaFrame.cpp:1880
 msgid "To &Bigfloat"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1832
+#: ../../src/wxMaximaFrame.cpp:1877
 msgid "To &Float"
 msgstr ""
 
@@ -10682,15 +10694,15 @@ msgstr ""
 msgid "To Float"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1838
+#: ../../src/wxMaximaFrame.cpp:1883
 msgid "To Numeri&c\tCtrl+Shift+N"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1844
+#: ../../src/wxMaximaFrame.cpp:1889
 msgid "To exact fraction"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1855
+#: ../../src/wxMaximaFrame.cpp:1900
 msgid "To exact number"
 msgstr ""
 
@@ -10721,7 +10733,7 @@ msgstr ""
 msgid "Toc levels shown here"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:866 ../../src/wxMaximaFrame.cpp:869
+#: ../../src/wxMaximaFrame.cpp:911 ../../src/wxMaximaFrame.cpp:914
 msgid "Toggle full screen editing"
 msgstr ""
 
@@ -10737,11 +10749,11 @@ msgstr ""
 msgid "Toggle vertical scroll synchronization"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1215
+#: ../../src/wxMaximaFrame.cpp:1260
 msgid "Tokenize..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1950
+#: ../../src/wxMaximaFrame.cpp:1995
 msgid "Tolerance calculations with Maxima"
 msgstr ""
 
@@ -10749,7 +10761,7 @@ msgstr ""
 msgid "Toolbar"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1991
+#: ../../src/dialogs/ConfigDialogue.cpp:2002
 msgid "Top"
 msgstr ""
 
@@ -10757,23 +10769,23 @@ msgstr ""
 msgid "Top end"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2923
+#: ../../src/wxMaxima.cpp:2927
 msgid "Tortoise diff tool"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1116
+#: ../../src/wxMaximaFrame.cpp:1161
 msgid "Trace a function..."
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:3956
+#: ../../src/MaximaCommandMenus.cpp:3982
 msgid "Trace function(s)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1222
+#: ../../src/wxMaximaFrame.cpp:1267
 msgid "Transformations"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1414
+#: ../../src/wxMaximaFrame.cpp:1459
 msgid "Transpose a matrix"
 msgstr ""
 
@@ -10781,7 +10793,7 @@ msgstr ""
 msgid "Tries to find a numerical solution for a 1st order ODE (or in other words: a equation of the format depends(x,t);diff(x,t)=(something containing x and t)"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:3525
+#: ../../src/MaximaCommandMenus.cpp:3551
 msgid "Tries to find a solution of the equation that lies between the two bounds."
 msgstr ""
 
@@ -10817,31 +10829,31 @@ msgid ""
 "See also guess_exact_value()"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1219
+#: ../../src/wxMaximaFrame.cpp:1264
 msgid "Trim both ends..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1220
+#: ../../src/wxMaximaFrame.cpp:1265
 msgid "Trim left..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1221
+#: ../../src/wxMaximaFrame.cpp:1266
 msgid "Trim right..."
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4345
+#: ../../src/MaximaCommandMenus.cpp:4371
 msgid "Trim string left"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4341
+#: ../../src/MaximaCommandMenus.cpp:4367
 msgid "Trim string on both ends"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4349
+#: ../../src/MaximaCommandMenus.cpp:4375
 msgid "Trim string right"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1552
+#: ../../src/wxMaximaFrame.cpp:1597
 msgid "Try to guess which form is &simple"
 msgstr ""
 
@@ -10897,7 +10909,7 @@ msgstr ""
 msgid "Turkish"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1969
+#: ../../src/wxMaximaFrame.cpp:2014
 msgid "Tutorials"
 msgstr ""
 
@@ -10905,7 +10917,7 @@ msgstr ""
 msgid "Two sample t-test"
 msgstr ""
 
-#: ../../src/worksheet/Worksheet.cpp:6249
+#: ../../src/worksheet/Worksheet.cpp:6255
 msgid "Type"
 msgstr ""
 
@@ -10913,7 +10925,7 @@ msgstr ""
 msgid "Type in text"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4052 ../../src/wizards/MatWiz.cpp:158
+#: ../../src/MaximaCommandMenus.cpp:4078 ../../src/wizards/MatWiz.cpp:158
 msgid "Type:"
 msgstr ""
 
@@ -10921,11 +10933,11 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1231
+#: ../../src/dialogs/ConfigDialogue.cpp:1232
 msgid "URL MathJaX.js is located at:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1184
+#: ../../src/wxMaximaFrame.cpp:1229
 msgid "UTF8 to Unicode code point..."
 msgstr ""
 
@@ -10933,25 +10945,25 @@ msgstr ""
 msgid "Ukrainian"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3227
+#: ../../src/wxMaxima.cpp:3231
 msgid "Un-closed parenthesis"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3215
+#: ../../src/wxMaxima.cpp:3219
 msgid "Un-closed parenthesis on encountering ; or $"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3529
+#: ../../src/wxMaxima.cpp:3533
 #, c-format
 msgid "Unable to interpret the version info I got from %s: %s"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3475
+#: ../../src/wxMaxima.cpp:3479
 #, c-format
 msgid "Unable to interpret the version info I got: %s"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1045
+#: ../../src/wxMaximaFrame.cpp:1090
 msgid "Undefine"
 msgstr ""
 
@@ -10960,11 +10972,11 @@ msgstr ""
 msgid "Undefined"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2115
+#: ../../src/dialogs/ConfigDialogue.cpp:2126
 msgid "Underlined"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:745
+#: ../../src/dialogs/ConfigDialogue.cpp:746
 msgid "Underscore converts to subscripts:"
 msgstr ""
 
@@ -10972,7 +10984,7 @@ msgstr ""
 msgid "Undo"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:672
+#: ../../src/wxMaximaFrame.cpp:715
 msgid "Undo\tCtrl+Z"
 msgstr ""
 
@@ -10980,7 +10992,7 @@ msgstr ""
 msgid "Undo and redo button"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:672
+#: ../../src/wxMaximaFrame.cpp:715
 msgid "Undo last change"
 msgstr ""
 
@@ -10989,11 +11001,11 @@ msgstr ""
 msgid "Unexpected text style %li for TextCell"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:962
+#: ../../src/wxMaximaFrame.cpp:1007
 msgid "Unfold All\tCtrl+Alt+]"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:963
+#: ../../src/wxMaximaFrame.cpp:1008
 msgid "Unfold all folded sections"
 msgstr ""
 
@@ -11033,23 +11045,23 @@ msgstr ""
 msgid "Unicode characters"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:746
+#: ../../src/wxMaximaFrame.cpp:789
 msgid "Unicode chars\tAlt+Shift+U"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1182
+#: ../../src/wxMaximaFrame.cpp:1227
 msgid "Unicode code point to UTF8..."
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4238
+#: ../../src/MaximaCommandMenus.cpp:4264
 msgid "Unicode code point to char"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1180
+#: ../../src/wxMaximaFrame.cpp:1225
 msgid "Unicode code point to char..."
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4243
+#: ../../src/MaximaCommandMenus.cpp:4269
 msgid "Unicode code point to utf8 numbers"
 msgstr ""
 
@@ -11057,15 +11069,15 @@ msgstr ""
 msgid "Unicode symbols:"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:3950
+#: ../../src/MaximaCommandMenus.cpp:3976
 msgid "Unlike in other programming language return() only exits from the current loop or block(), not from the whole function."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3166
+#: ../../src/wxMaxima.cpp:3170
 msgid "Unterminated comment."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3209
+#: ../../src/wxMaxima.cpp:3213
 msgid "Unterminated string."
 msgstr ""
 
@@ -11081,9 +11093,9 @@ msgstr ""
 msgid "Updating maxima's configuration"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3468 ../../src/wxMaxima.cpp:3473
-#: ../../src/wxMaxima.cpp:3475 ../../src/wxMaxima.cpp:3522
-#: ../../src/wxMaxima.cpp:3527 ../../src/wxMaxima.cpp:3530
+#: ../../src/wxMaxima.cpp:3472 ../../src/wxMaxima.cpp:3477
+#: ../../src/wxMaxima.cpp:3479 ../../src/wxMaxima.cpp:3526
+#: ../../src/wxMaxima.cpp:3531 ../../src/wxMaxima.cpp:3534
 msgid "Upgrade"
 msgstr ""
 
@@ -11092,7 +11104,7 @@ msgstr ""
 msgid "Upper bound on the number of cycles. Must be greater than or equal to 3."
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:960 ../../src/MaximaCommandMenus.cpp:3530
+#: ../../src/MaximaCommandMenus.cpp:960 ../../src/MaximaCommandMenus.cpp:3556
 msgid "Upper bound:"
 msgstr ""
 
@@ -11100,7 +11112,7 @@ msgstr ""
 msgid "Upsilon"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:833
+#: ../../src/wxMaximaFrame.cpp:878
 msgid "Use \"<\" and \">\" as parenthesis for matrices"
 msgstr ""
 
@@ -11120,7 +11132,7 @@ msgstr ""
 msgid "Use Text search filtering"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1749 ../../src/wxMaximaFrame.cpp:1780
+#: ../../src/wxMaximaFrame.cpp:1794 ../../src/wxMaximaFrame.cpp:1825
 msgid "Use a list"
 msgstr ""
 
@@ -11128,7 +11140,7 @@ msgstr ""
 msgid "Use a list as parameter list for a function"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:2012
+#: ../../src/wxMaximaFrame.cpp:2057
 msgid "Use as TortoiseSVN/Git diff tool"
 msgstr ""
 
@@ -11136,27 +11148,27 @@ msgstr ""
 msgid "Use centered dot and Minus, not Star and Hyphen"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:849
+#: ../../src/dialogs/ConfigDialogue.cpp:850
 msgid "Use centered dot character for multiplication"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1749
+#: ../../src/wxMaximaFrame.cpp:1794
 msgid "Use list"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1742
+#: ../../src/wxMaximaFrame.cpp:1787
 msgid "Use list as the arguments of a function"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:827
+#: ../../src/wxMaximaFrame.cpp:872
 msgid "Use rounded parenthesis for matrices"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:830
+#: ../../src/wxMaximaFrame.cpp:875
 msgid "Use square parenthesis for matrices"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1121
+#: ../../src/wxMaximaFrame.cpp:1166
 msgid "Use struct field..."
 msgstr ""
 
@@ -11164,11 +11176,11 @@ msgstr ""
 msgid "Use the \"partial derivative\" symbol to represent the fraction that represents a diff() when exporting LaTeX"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2052
+#: ../../src/dialogs/ConfigDialogue.cpp:2063
 msgid "Use unicode Math Symbols, if available"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:836
+#: ../../src/wxMaximaFrame.cpp:881
 msgid "Use vertical lines instead of parenthesis for matrices"
 msgstr ""
 
@@ -11176,9 +11188,9 @@ msgstr ""
 msgid "User labels only"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1248
-#: ../../src/dialogs/ConfigDialogue.cpp:1452
-#: ../../src/dialogs/ConfigDialogue.cpp:1480
+#: ../../src/dialogs/ConfigDialogue.cpp:1249
+#: ../../src/dialogs/ConfigDialogue.cpp:1463
+#: ../../src/dialogs/ConfigDialogue.cpp:1491
 #: ../../src/dialogs/MaximaNotStartingDialog.cpp:54
 msgid "User specified"
 msgstr ""
@@ -11187,7 +11199,7 @@ msgstr ""
 msgid "User-defined labels"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:770
+#: ../../src/dialogs/ConfigDialogue.cpp:771
 msgid "User-defined labels if available"
 msgstr ""
 
@@ -11195,11 +11207,11 @@ msgstr ""
 msgid "Using Maxima help file from wxMaxima configuration file (helpFile=...))"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:1567
+#: ../../src/wxMaxima.cpp:1572
 msgid "Using Maxima path from command line."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:1564
+#: ../../src/wxMaxima.cpp:1569
 msgid "Using configured Maxima path."
 msgstr ""
 
@@ -11285,11 +11297,11 @@ msgstr ""
 msgid "Variable name"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1123
+#: ../../src/wxMaximaFrame.cpp:1168
 msgid "Variable name, not contents..."
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4029 ../../src/MaximaCommandMenus.cpp:4547
+#: ../../src/MaximaCommandMenus.cpp:4055 ../../src/MaximaCommandMenus.cpp:4573
 msgid "Variable name:"
 msgstr ""
 
@@ -11298,14 +11310,14 @@ msgid "Variable(s)"
 msgstr ""
 
 #: ../../src/MaximaCommandMenus.cpp:266 ../../src/MaximaCommandMenus.cpp:1030
-#: ../../src/MaximaCommandMenus.cpp:1082 ../../src/MaximaCommandMenus.cpp:3546
+#: ../../src/MaximaCommandMenus.cpp:1082 ../../src/MaximaCommandMenus.cpp:3572
 msgid "Variable(s):"
 msgstr ""
 
 #: ../../src/MaximaCommandMenus.cpp:185 ../../src/MaximaCommandMenus.cpp:195
 #: ../../src/MaximaCommandMenus.cpp:206 ../../src/MaximaCommandMenus.cpp:231
 #: ../../src/MaximaCommandMenus.cpp:236 ../../src/MaximaCommandMenus.cpp:317
-#: ../../src/MaximaCommandMenus.cpp:958 ../../src/MaximaCommandMenus.cpp:3528
+#: ../../src/MaximaCommandMenus.cpp:958 ../../src/MaximaCommandMenus.cpp:3554
 #: ../../src/wizards/IntegrateWiz.cpp:36 ../../src/wizards/LimitWiz.cpp:32
 #: ../../src/wizards/Plot2dWiz.cpp:45 ../../src/wizards/Plot2dWiz.cpp:55
 #: ../../src/wizards/Plot2dWiz.cpp:496 ../../src/wizards/Plot3dWiz.cpp:34
@@ -11314,7 +11326,7 @@ msgstr ""
 msgid "Variable:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:302 ../../src/wxMaximaFrame.cpp:759
+#: ../../src/wxMaximaFrame.cpp:302 ../../src/wxMaximaFrame.cpp:804
 msgid "Variables"
 msgstr ""
 
@@ -11335,7 +11347,7 @@ msgstr ""
 msgid "Vietnamese"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:874
+#: ../../src/wxMaximaFrame.cpp:919
 msgid "View"
 msgstr ""
 
@@ -11351,17 +11363,17 @@ msgstr ""
 msgid "Waiting for the thread that parses the maxima manual to finish"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1410
+#: ../../src/dialogs/ConfigDialogue.cpp:1411
 msgid "Warn if an inactive window is idle"
 msgstr ""
 
 #: ../../src/MathParser.cpp:1343 ../../src/MaximaFileIO.cpp:536
 #: ../../src/MaximaProcessManager.cpp:1105
-#: ../../src/MaximaResponseReader.cpp:361 ../../src/wxMaxima.cpp:1586
+#: ../../src/MaximaResponseReader.cpp:361 ../../src/wxMaxima.cpp:1591
 msgid "Warning"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1597
+#: ../../src/wxMaximaFrame.cpp:1642
 msgid "Warning:"
 msgstr ""
 
@@ -11376,7 +11388,7 @@ msgstr ""
 msgid "Warning: Lookalike chars: "
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1587
+#: ../../src/wxMaximaFrame.cpp:1632
 msgid "Warning: No test if the argument of the log is complex, positive or negative"
 msgstr ""
 
@@ -11387,11 +11399,11 @@ msgid ""
 "Please enter the path to the program again."
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:3603 ../../src/MaximaCommandMenus.cpp:3613
+#: ../../src/MaximaCommandMenus.cpp:3629 ../../src/MaximaCommandMenus.cpp:3639
 msgid "WebP (*.webp)|*.webp|"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:1872
+#: ../../src/wxMaxima.cpp:1877
 msgid "Welcome to wxMaxima"
 msgstr ""
 
@@ -11403,15 +11415,15 @@ msgstr ""
 msgid "When applying functions with one argument from menus, the default argument is '%'. To apply the function to some other value, select it in the document before executing a menu command."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1096
+#: ../../src/wxMaximaFrame.cpp:1141
 msgid "When to invoke the lisp compiler's debugger"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:3918
+#: ../../src/MaximaCommandMenus.cpp:3944
 msgid "While loop"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1101
+#: ../../src/wxMaximaFrame.cpp:1146
 msgid "While loop..."
 msgstr ""
 
@@ -11452,7 +11464,7 @@ msgstr ""
 msgid "Wrap equations exported by the \"copy as LaTeX\" feature between \\[ and \\] as equation markers"
 msgstr ""
 
-#: ../../src/worksheet/Worksheet.cpp:5200
+#: ../../src/worksheet/Worksheet.cpp:5206
 msgid "Wrapped search"
 msgstr ""
 
@@ -11482,7 +11494,7 @@ msgstr ""
 msgid "Xi"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:728
+#: ../../src/dialogs/ConfigDialogue.cpp:729
 msgid "Yes"
 msgstr ""
 
@@ -11521,7 +11533,7 @@ msgstr ""
 msgid "You got an idea for an improvement of wxMaxima? Great! Please submit your idea at https://github.com/wxMaxima-developers/wxmaxima/issues. "
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3465 ../../src/wxMaxima.cpp:3519
+#: ../../src/wxMaxima.cpp:3469 ../../src/wxMaxima.cpp:3523
 #, c-format
 msgid ""
 "You have version %s. The newest wxMaxima release is %s.\n"
@@ -11529,11 +11541,11 @@ msgid ""
 "Select OK to visit the wxMaxima webpage."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3569
+#: ../../src/wxMaxima.cpp:3573
 msgid "Your changes will be lost if you don't save them."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3473 ../../src/wxMaxima.cpp:3527
+#: ../../src/wxMaxima.cpp:3477 ../../src/wxMaxima.cpp:3531
 msgid "Your version of wxMaxima is up to date."
 msgstr ""
 
@@ -11541,27 +11553,27 @@ msgstr ""
 msgid "Zeta"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:846
+#: ../../src/wxMaximaFrame.cpp:891
 msgid "Zoom &In\tCtrl++"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:847
+#: ../../src/wxMaximaFrame.cpp:892
 msgid "Zoom Ou&t\tCtrl+-"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:846
+#: ../../src/wxMaximaFrame.cpp:891
 msgid "Zoom in 10%"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:847
+#: ../../src/wxMaximaFrame.cpp:892
 msgid "Zoom out 10%"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3265 ../../src/wxMaximaFrame.cpp:205
+#: ../../src/wxMaxima.cpp:3269 ../../src/wxMaximaFrame.cpp:205
 msgid "[ unsaved ]"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3267
+#: ../../src/wxMaxima.cpp:3271
 msgid "[ unsaved* ]"
 msgstr ""
 
@@ -11589,23 +11601,23 @@ msgstr ""
 msgid "antisymmetric"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1731
+#: ../../src/wxMaximaFrame.cpp:1776
 msgid "apply function to each element"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:780
+#: ../../src/wxMaximaFrame.cpp:825
 msgid "as 1D ASCII"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:783
+#: ../../src/wxMaximaFrame.cpp:828
 msgid "as ASCII Art"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:786
+#: ../../src/wxMaximaFrame.cpp:831
 msgid "as ASCII+Unicode Art"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1721
+#: ../../src/wxMaximaFrame.cpp:1766
 msgid "as storage for actual values for variables"
 msgstr ""
 
@@ -11617,7 +11629,7 @@ msgstr ""
 msgid "both sides"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1177
+#: ../../src/wxMaximaFrame.cpp:1222
 msgid "char to Ascii code..."
 msgstr ""
 
@@ -11651,7 +11663,7 @@ msgstr ""
 msgid "diff(x,t)="
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1102 ../../src/wxMaximaFrame.cpp:1743
+#: ../../src/wxMaximaFrame.cpp:1147 ../../src/wxMaximaFrame.cpp:1788
 msgid "do for each element"
 msgstr ""
 
@@ -11679,7 +11691,7 @@ msgstr ""
 msgid "exists"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4002
+#: ../../src/MaximaCommandMenus.cpp:4028
 msgid "expression:"
 msgstr ""
 
@@ -11694,23 +11706,23 @@ msgid ""
 "all=_ marks subscripts."
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4076 ../../src/MaximaCommandMenus.cpp:4081
+#: ../../src/MaximaCommandMenus.cpp:4102 ../../src/MaximaCommandMenus.cpp:4107
 msgid "filename:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1715
+#: ../../src/wxMaximaFrame.cpp:1760
 msgid "from a list"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1712
+#: ../../src/wxMaximaFrame.cpp:1757
 msgid "from a rule"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1726
+#: ../../src/wxMaximaFrame.cpp:1771
 msgid "from function arguments"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1710
+#: ../../src/wxMaximaFrame.cpp:1755
 msgid "from individual elements"
 msgstr ""
 
@@ -11726,7 +11738,7 @@ msgstr ""
 msgid "general"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1630
+#: ../../src/dialogs/ConfigDialogue.cpp:1641
 msgid "gnuplot: Without command console"
 msgstr ""
 
@@ -11738,7 +11750,7 @@ msgstr ""
 msgid "in"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:788
+#: ../../src/wxMaximaFrame.cpp:833
 msgid "in 2D"
 msgstr ""
 
@@ -11785,11 +11797,11 @@ msgstr ""
 msgid "matrix([x_1,x_2,...],[y_1,y_2,...])"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1443
+#: ../../src/wxMaximaFrame.cpp:1488
 msgid "max(abs(A(i,j))) (complex)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1442
+#: ../../src/wxMaximaFrame.cpp:1487
 msgid "max(abs(A(i,j))) (real)"
 msgstr ""
 
@@ -11810,7 +11822,7 @@ msgid "m×n Matrix A:"
 msgstr ""
 
 #: ../../src/MaximaCommandMenus.cpp:1538 ../../src/MaximaCommandMenus.cpp:1544
-#: ../../src/MaximaCommandMenus.cpp:4250
+#: ../../src/MaximaCommandMenus.cpp:4276
 msgid "n:"
 msgstr ""
 
@@ -11850,7 +11862,7 @@ msgstr ""
 msgid "noun: Not evaluated by default"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1751
+#: ../../src/wxMaximaFrame.cpp:1796
 msgid "nth"
 msgstr ""
 
@@ -11882,8 +11894,8 @@ msgstr ""
 msgid "part() or the [] operator was used in order to extract the nth element of something that was less than n elements long."
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4312 ../../src/MaximaCommandMenus.cpp:4317
-#: ../../src/MaximaCommandMenus.cpp:4327
+#: ../../src/MaximaCommandMenus.cpp:4338 ../../src/MaximaCommandMenus.cpp:4343
+#: ../../src/MaximaCommandMenus.cpp:4353
 msgid "part:"
 msgstr ""
 
@@ -11916,11 +11928,11 @@ msgstr ""
 msgid "printOut: Setting the page size to (%li,%li)"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4127
+#: ../../src/MaximaCommandMenus.cpp:4153
 msgid "printf"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1146
+#: ../../src/wxMaximaFrame.cpp:1191
 msgid "printf..."
 msgstr ""
 
@@ -11940,15 +11952,15 @@ msgstr ""
 msgid "ratsubst works like subst, but it knows some basic maths, if needed."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1149
+#: ../../src/wxMaximaFrame.cpp:1194
 msgid "readbyte..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1148
+#: ../../src/wxMaximaFrame.cpp:1193
 msgid "readchar..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1147
+#: ../../src/wxMaximaFrame.cpp:1192
 msgid "readline..."
 msgstr ""
 
@@ -11984,7 +11996,7 @@ msgstr ""
 msgid "sigma"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:3507
+#: ../../src/MaximaCommandMenus.cpp:3533
 msgid ""
 "solve() will solve a list of equations only if for n independent equations there are n variables to solve to.\n"
 "If only one result variable is of interest the other result variables can be used to to tell solve() which variables to eliminate from the solution\n"
@@ -12061,11 +12073,11 @@ msgstr ""
 msgid "union"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1113
+#: ../../src/wxMaximaFrame.cpp:1158
 msgid "unnamed function (lambda)..."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3557
+#: ../../src/wxMaxima.cpp:3561
 msgid "unsaved"
 msgstr ""
 
@@ -12078,19 +12090,19 @@ msgstr ""
 msgid "upsilon"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1741
+#: ../../src/wxMaximaFrame.cpp:1786
 msgid "use as function arguments"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1737
+#: ../../src/wxMaximaFrame.cpp:1782
 msgid "use the actual values stored"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1633
+#: ../../src/dialogs/ConfigDialogue.cpp:1644
 msgid "wgnuplot: Steals the mouse focus during plotting"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1150
+#: ../../src/wxMaximaFrame.cpp:1195
 msgid "writebyte..."
 msgstr ""
 
@@ -12103,7 +12115,7 @@ msgstr ""
 msgid "wxMaxima %ld"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3254 ../../src/wxMaximaFrame.cpp:203
+#: ../../src/wxMaxima.cpp:3258 ../../src/wxMaximaFrame.cpp:203
 #, c-format
 msgid "wxMaxima %s (%s) "
 msgstr ""
@@ -12137,7 +12149,7 @@ msgstr ""
 msgid "wxMaxima dialogs set default values for inputs entries, one of which is '%'. If you have made a selection in your document, the selection will be used instead of '%'."
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4604
+#: ../../src/MaximaCommandMenus.cpp:4630
 msgid "wxMaxima document"
 msgstr ""
 
@@ -12150,7 +12162,7 @@ msgstr ""
 msgid "wxMaxima encountered an error loading "
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1922
+#: ../../src/wxMaximaFrame.cpp:1967
 msgid "wxMaxima help"
 msgstr ""
 
@@ -12158,7 +12170,7 @@ msgstr ""
 msgid "wxMaxima is a cross-platform graphical user interface for the computer algebra system Maxima based on wxWidgets.\n"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2915
+#: ../../src/wxMaxima.cpp:2919
 #, c-format
 msgid ""
 "wxMaxima is now the .wxmx diff tool for:%s\n"
@@ -12203,15 +12215,15 @@ msgstr ""
 msgid "wxMaxima remembers the answers to maxima's questions. If this checkbox is set it automatically offers to enter the last answer to this question the user has input."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1937
+#: ../../src/wxMaximaFrame.cpp:1982
 msgid "wxMaxima shows help in a browser"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1935
+#: ../../src/wxMaximaFrame.cpp:1980
 msgid "wxMaxima shows help in the sidebar"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1095
+#: ../../src/dialogs/ConfigDialogue.cpp:1096
 msgid "wxMaxima startup file location: "
 msgstr ""
 
@@ -12220,15 +12232,15 @@ msgstr ""
 msgid "wxMaxima version %s"
 msgstr ""
 
-#: ../../src/worksheet/Worksheet.cpp:6164
+#: ../../src/worksheet/Worksheet.cpp:6170
 msgid "wxMaxima worksheet"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:2001
+#: ../../src/wxMaximaFrame.cpp:2046
 msgid "wxMaxima's ChangeLog"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1999
+#: ../../src/wxMaximaFrame.cpp:2044
 msgid "wxMaxima's license"
 msgstr ""
 
@@ -12248,22 +12260,22 @@ msgstr ""
 msgid "wxworksheettohtml/totex: no target file name was given."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2205
+#: ../../src/wxMaxima.cpp:2209
 #, c-format
 msgid "wxworksheettohtml: could not write \"%s\"."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2179
+#: ../../src/wxMaxima.cpp:2183
 #, c-format
 msgid "wxworksheettohtml: unknown flavor \"%s\"; using native MathML. Known flavors: mathml, mathjax, svg, bitmap."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2247
+#: ../../src/wxMaxima.cpp:2251
 #, c-format
 msgid "wxworksheettotex: could not write \"%s\"."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:709
+#: ../../src/dialogs/ConfigDialogue.cpp:710
 msgid "x"
 msgstr ""
 

--- a/src/Configuration.cpp
+++ b/src/Configuration.cpp
@@ -118,6 +118,7 @@ Configuration::Configuration(const Configuration &o) :
   m_printBrackets(o.m_printBrackets),
   m_changeAsterisk(o.m_changeAsterisk),
   m_notifyIfIdle(o.m_notifyIfIdle),
+  m_findDialogDockable(o.m_findDialogDockable),
   m_displayedDigits(o.m_displayedDigits),
   m_autoWrap(o.m_autoWrap),
   m_autoIndent(o.m_autoIndent),
@@ -307,6 +308,7 @@ void Configuration::ResetAllToDefaults() {
   m_enterEvaluates = false;
   m_printScale = 1.0;
   m_notifyIfIdle = true;
+  m_findDialogDockable = false;
   m_fixReorderedIndices = true;
   m_rightToLeftDocument = false;
   m_showBrackets = true;
@@ -1279,6 +1281,7 @@ Configuration::ScalarConfigSettings() {
     {wxS("maximaUsesHhtmlBrowser"), &Configuration::m_maximaUsesHhtmlBrowser},
     {wxS("MaxLayoutTime"), &Configuration::m_maxLayoutTime},
     {wxS("notifyIfIdle"), &Configuration::m_notifyIfIdle},
+    {wxS("findDialogDockable"), &Configuration::m_findDialogDockable},
     {wxS("numpadEnterEvaluates"), &Configuration::m_numpadEnterEvaluates},
     {wxS("offerKnownAnswers"), &Configuration::m_offerKnownAnswers},
     {wxS("openHCaret"), &Configuration::m_openHCaret},

--- a/src/Configuration.h
+++ b/src/Configuration.h
@@ -729,6 +729,12 @@ public:
 
   void NotifyIfIdle(bool notify) {m_notifyIfIdle = notify;}
 
+  //! Show "Find and Replace" as a dockable sidebar instead of a floating dialog?
+  bool FindDialogDockable() const
+    { return m_findDialogDockable; }
+
+  void FindDialogDockable(bool dockable) {m_findDialogDockable = dockable;}
+
   /*! Returns the maximum number of displayed digits
 
     m_displayedDigits is always >= 20, so we can guarantee the number we return to be unsigned.
@@ -1403,6 +1409,8 @@ private:
   bool m_changeAsterisk;
   //! Notify the user if maxima is idle
   bool m_notifyIfIdle;
+  //! Show "Find and Replace" as a dockable sidebar instead of a floating dialog?
+  bool m_findDialogDockable;
   //! How many digits of a number we show by default?
   long m_displayedDigits;
   //! Automatically wrap long lines?

--- a/src/EventIDs.cpp
+++ b/src/EventIDs.cpp
@@ -45,6 +45,7 @@ const wxWindowIDRef EventIDs::menu_pane_symbols(wxWindow::NewControlId());
 const wxWindowIDRef EventIDs::menu_pane_stats(wxWindow::NewControlId());
 const wxWindowIDRef EventIDs::menu_pane_performance(wxWindow::NewControlId());
 const wxWindowIDRef EventIDs::menu_pane_wizard(wxWindow::NewControlId());
+const wxWindowIDRef EventIDs::menu_pane_find(wxWindow::NewControlId());
 const wxWindowIDRef EventIDs::menu_pane_toolbar(wxWindow::NewControlId());
 const wxWindowIDRef EventIDs::menu_pane_console(wxWindow::NewControlId());
 const wxWindowIDRef EventIDs::menu_pane_dockAll(wxWindow::NewControlId());

--- a/src/EventIDs.h
+++ b/src/EventIDs.h
@@ -102,6 +102,7 @@ public:
   static const wxWindowIDRef menu_pane_help;      //!< Both the "toggle the draw pane" command for the help browser
   static const wxWindowIDRef menu_pane_symbols;   //!< Both the "toggle the symbols pane" command for the "symbols" pane
   static const wxWindowIDRef menu_pane_wizard;    //!< Both the "toggle the wizard pane" command for the "wizard" pane
+  static const wxWindowIDRef menu_pane_find;      //!< Both the "toggle the find pane" command and the dockable find/replace pane (GH #2249)
   static const wxWindowIDRef menu_pane_toolbar;   //!< Both the "toggle the toolbar" command for the "toolbar" pane
   static const wxWindowIDRef menu_pane_console;   //!< The id for the worksheet
   /*! Both used as the "toggle the stats pane" command and as the ID of the stats pane

--- a/src/MaximaCommandMenus.cpp
+++ b/src/MaximaCommandMenus.cpp
@@ -3097,6 +3097,32 @@ void MaximaCommandMenus::EditMenu(wxCommandEvent &event) {
   }
   else if(event.GetId() == wxID_FIND) {
     wxLogMessage(_("A Ctrl-F event"));
+    if (m_wxMaxima.m_configuration.FindDialogDockable()) {
+      // Dockable sidebar (GH #2249): the pane already exists (created once
+      // at startup, see wxMaximaFrame's ctor) -- ShowPane() un-minimizes/
+      // un-docks-hidden it exactly the same generic way it does for every
+      // other sidebar, which is what answers the issue's own worry about
+      // whether Ctrl+F still works while the sidebar is minimized.
+      bool findPaneActiveWas = m_wxMaxima.IsPaneDisplayed(EventIDs::menu_pane_find);
+      m_wxMaxima.wxMaximaFrame::ShowPane(EventIDs::menu_pane_find, true);
+      if (m_wxMaxima.GetWorksheet()->GetActiveCell() != NULL) {
+        wxString selected = m_wxMaxima.GetWorksheet()->GetActiveCell()->GetSelectionString();
+
+        // Start incremental search and highlighting of search results again.
+        if(findPaneActiveWas)
+          m_wxMaxima.m_oldFindString.Clear();
+        else
+          m_wxMaxima.m_oldFindString = selected;
+
+        if (selected.Length() > 0)
+          m_wxMaxima.GetWorksheet()->m_findPane->SetFindString(selected);
+      }
+      m_wxMaxima.GetWorksheet()->FocusFindDialogue();
+#ifdef __WXMSW__
+      m_wxMaxima.CallAfter([this]{m_wxMaxima.GetWorksheet()->FocusFindDialogue();});
+#endif
+      return;
+    }
     bool findDialogActiveWas = ((m_wxMaxima.GetWorksheet()->m_findDialog != NULL) &&
                                 (m_wxMaxima.GetWorksheet()->m_findDialog->IsShown()));
     if (m_wxMaxima.GetWorksheet()->m_findDialog == NULL)

--- a/src/dialogs/ConfigDialogue.cpp
+++ b/src/dialogs/ConfigDialogue.cpp
@@ -603,6 +603,7 @@ void ConfigDialogue::SetCheckboxValues() {
   m_fixReorderedIndices->SetValue(configuration->FixReorderedIndices());
   m_incrementalSearch->SetValue(configuration->IncrementalSearch());
   m_notifyIfIdle->SetValue(configuration->NotifyIfIdle());
+  m_findDialogDockable->SetValue(configuration->FindDialogDockable());
   m_fixedFontInTC->SetValue(configuration->FixedFontInTextControls());
   m_offerKnownAnswers->SetValue(m_configuration->OfferKnownAnswers());
 #if wxUSE_ACCESSIBILITY
@@ -1409,6 +1410,16 @@ wxWindow *ConfigDialogue::CreateOptionsPanel() {
     new wxCheckBox(stdOpts_sizer->GetStaticBox(), wxID_ANY,
                    _("Warn if an inactive window is idle"));
   stdOpts_sizer->Add(m_notifyIfIdle,
+                     wxSizerFlags().Border(wxALL, 5 * GetContentScaleFactor()));
+
+  m_findDialogDockable =
+    new wxCheckBox(stdOpts_sizer->GetStaticBox(), wxID_ANY,
+                   _("Show \"Find and Replace\" as a dockable sidebar"));
+  m_findDialogDockable->SetToolTip(
+    _("By default \"Find and Replace\" (Ctrl+F) opens as a floating "
+      "window. Enable this to make it a sidebar you can dock, like the "
+      "other sidebars, instead."));
+  stdOpts_sizer->Add(m_findDialogDockable,
                      wxSizerFlags().Border(wxALL, 5 * GetContentScaleFactor()));
 
   vsizer->Add(stdOpts_sizer, wxSizerFlags().Expand().Border(
@@ -2308,6 +2319,7 @@ void ConfigDialogue::WriteSettings() {
   configuration->FixReorderedIndices(m_fixReorderedIndices->GetValue());
   configuration->IncrementalSearch(m_incrementalSearch->GetValue());
   configuration->NotifyIfIdle(m_notifyIfIdle->GetValue());
+  configuration->FindDialogDockable(m_findDialogDockable->GetValue());
   configuration->SetLabelChoice(
                                 (Configuration::showLabels)m_showUserDefinedLabels->GetSelection());
   configuration->DefaultPort(m_defaultPort->GetValue());

--- a/src/dialogs/ConfigDialogue.h
+++ b/src/dialogs/ConfigDialogue.h
@@ -339,6 +339,7 @@ protected:
   wxCheckBox *m_fixReorderedIndices;
   wxCheckBox *m_incrementalSearch;
   wxCheckBox *m_notifyIfIdle;
+  wxCheckBox *m_findDialogDockable;
   wxChoice *m_showUserDefinedLabels;
   wxButton *m_getStyleFont;
   //! Light / Dark / Follow-system selector (also picks which set the editor edits).

--- a/src/dialogs/FindReplaceDialog.h
+++ b/src/dialogs/FindReplaceDialog.h
@@ -60,6 +60,11 @@ public:
   void SetFindString(const wxString &strng)
     { m_contents->SetFindString(strng); }
 
+  //! The pane this dialog wraps -- shared with the dockable sidebar's
+  //! GetActiveFindPane() (GH #2249) so search logic doesn't need to know
+  //! which presentation is currently active.
+  FindReplacePane *GetPane() const { return m_contents; }
+
 protected:
   //! Is called if this element looses or gets the focus
   void OnActivateEvent(wxActivateEvent &WXUNUSED(event));

--- a/src/dialogs/FindReplacePane.cpp
+++ b/src/dialogs/FindReplacePane.cpp
@@ -145,6 +145,19 @@ FindReplacePane::FindReplaceData::FindReplaceData() :
 {
 }
 
+void FindReplacePane::FindReplaceData::LoadFromConfig() {
+  int findFlags = wxFR_DOWN | wxFR_MATCHCASE |
+    FindReplacePane::wxFR_SEARCH_IN_INPUT | FindReplacePane::wxFR_SEARCH_IN_OUTPUT;
+  if (wxConfig::Get()->Read(wxS("Find/Flags"), &findFlags)) {
+    if (!(findFlags & (FindReplacePane::wxFR_SEARCH_IN_INPUT | FindReplacePane::wxFR_SEARCH_IN_OUTPUT)))
+      findFlags |= FindReplacePane::wxFR_SEARCH_IN_INPUT | FindReplacePane::wxFR_SEARCH_IN_OUTPUT;
+  }
+  SetFlags(findFlags);
+  bool findRegex = false;
+  wxConfig::Get()->Read(wxS("Find/RegexSearch"), &findRegex);
+  SetRegexSearch(findRegex);
+}
+
 void FindReplacePane::LoadHistory(wxComboBox *combo, const wxString &key) {
   wxConfigBase *config = wxConfig::Get();
   long count = 0;

--- a/src/dialogs/FindReplacePane.h
+++ b/src/dialogs/FindReplacePane.h
@@ -52,6 +52,10 @@ public:
     FindReplaceData();
     bool GetRegexSearch() const {return m_regexSearch;}
     void SetRegexSearch(bool regexSearch) {m_regexSearch = regexSearch;}
+    //! Seed the find flags from wxConfig, with the same defaults regardless
+    //! of whether the resulting object backs the floating dialog or the
+    //! dockable sidebar (GH #2249).
+    void LoadFromConfig();
   private:
     bool m_regexSearch;
   };

--- a/src/worksheet/Worksheet.cpp
+++ b/src/worksheet/Worksheet.cpp
@@ -5180,6 +5180,12 @@ WorksheetSearch::SearchStart Worksheet::FindStart(bool down) {
   return start;
 }
 
+FindReplacePane *Worksheet::GetActiveFindPane() const {
+  if (m_configuration->FindDialogDockable())
+    return m_findPane;
+  return m_findDialog ? m_findDialog->GetPane() : nullptr;
+}
+
 bool Worksheet::ApplyFindResult(const WorksheetSearch::SearchTarget &target,
                                 bool warn) {
   if (!target.Found())
@@ -5197,7 +5203,7 @@ bool Worksheet::ApplyFindResult(const WorksheetSearch::SearchTarget &target,
   UpdateTableOfContents();
   RequestRedraw();
   if (target.m_wrapped && warn) {
-    LoggingMessageDialog dialog(m_findDialog, _("Wrapped search"),
+    LoggingMessageDialog dialog(GetActiveFindPane(), _("Wrapped search"),
                                 wxEmptyString, wxCENTER | wxOK);
     dialog.ShowModal();
   }

--- a/src/worksheet/Worksheet.h
+++ b/src/worksheet/Worksheet.h
@@ -633,9 +633,14 @@ private:
 public:
   void FocusFindDialogue()
     {
-      if(m_findDialog)
-        m_findDialog->SetFocus();
+      if(FindReplacePane *pane = GetActiveFindPane())
+        pane->SetFocus();
     }
+  //! Whichever find/replace UI is actually in use right now: the dockable
+  //! sidebar (GH #2249) if Configuration::FindDialogDockable() is set and
+  //! it exists, otherwise the floating dialog's own pane, if one is open.
+  //! Returns NULL if neither is currently available.
+  FindReplacePane *GetActiveFindPane() const;
   //! The storage for the autocompletion feature
   AutoComplete &GetAutocomplete() { return m_autocomplete; }
 private:
@@ -778,6 +783,10 @@ public:
 
   //! The find-and-replace-dialog
   FindReplaceDialog *m_findDialog = NULL;
+  //! The dockable find-and-replace sidebar (GH #2249), set once by
+  //! wxMaximaFrame at startup and never destroyed -- unlike m_findDialog,
+  //! which is created/destroyed on demand.
+  FindReplacePane *m_findPane = NULL;
 
   //! Is the vertically-drawn cursor active?
   bool HCaretActive() const { return GetHCaretCursor().IsActive(); }

--- a/src/wxMaxima.cpp
+++ b/src/wxMaxima.cpp
@@ -1307,6 +1307,20 @@ wxMaxima::~wxMaxima() {
   if (m_fileSaved)
     RemoveTempAutosavefile();
 
+  // If the floating Find and Replace dialog is still open, its destructor
+  // (via the FindReplacePane it wraps) writes m_findData's flags back to
+  // wxConfig -- and m_findData is a member of this class, about to be
+  // destroyed along with the rest of wxMaxima's members right after this
+  // destructor body finishes. Left to the wxWindow base class, the dialog
+  // (a child window) wouldn't be destroyed until far later, after m_findData
+  // is already gone (see wxMaximaFrame::~wxMaximaFrame()'s identical
+  // reasoning for the dockable find pane, GH #2249). Destroy it here,
+  // deterministically, while m_findData is still alive.
+  if (GetWorksheet() && GetWorksheet()->m_findDialog) {
+    GetWorksheet()->m_findDialog->Destroy();
+    GetWorksheet()->m_findDialog = NULL;
+  }
+
   // This window is still counted among the top-level windows while its close
   // event is being handled, so CountWindows() == 1 means it is the last
   // wxMaxima window.

--- a/src/wxMaxima.cpp
+++ b/src/wxMaxima.cpp
@@ -339,16 +339,7 @@ wxMaxima::wxMaxima(wxWindow *parent, int id,
   }
 
   m_oldFindString.Clear();
-  int findFlags = wxFR_DOWN | wxFR_MATCHCASE | FindReplacePane::wxFR_SEARCH_IN_INPUT | FindReplacePane::wxFR_SEARCH_IN_OUTPUT;
-  if (wxConfig::Get()->Read(wxS("Find/Flags"), &findFlags))
-    {
-      if (!(findFlags & (FindReplacePane::wxFR_SEARCH_IN_INPUT | FindReplacePane::wxFR_SEARCH_IN_OUTPUT)))
-        findFlags |= FindReplacePane::wxFR_SEARCH_IN_INPUT | FindReplacePane::wxFR_SEARCH_IN_OUTPUT;
-    }
-  m_findData.SetFlags(findFlags);
-  bool findRegex = false;
-  wxConfig::Get()->Read(wxS("Find/RegexSearch"), &findRegex);
-  m_findData.SetRegexSearch(findRegex);
+  m_findData.LoadFromConfig();
   if(GetWorksheet())
     GetWorksheet()->KeyboardInactiveTimer().SetOwner(this,
                                                      KEYBOARD_INACTIVITY_TIMER_ID);
@@ -1905,27 +1896,26 @@ void wxMaxima::OnIdle(wxIdleEvent &event) {
   // Incremental search is done from the idle task. This means that we don't
   // forcefully need to do a new search on every character that is entered into
   // the search box.
-  if (GetWorksheet()->m_findDialog != NULL) {
-    if ((m_oldFindString !=
-         GetWorksheet()->m_findDialog->GetData()->GetFindString()) ||
-        (m_oldFindFlags != GetWorksheet()->m_findDialog->GetData()->GetFlags())) {
+  if (FindReplacePane *findPane = GetWorksheet()->GetActiveFindPane()) {
+    wxFindReplaceData *findData = findPane->GetData();
+    if ((m_oldFindString != findData->GetFindString()) ||
+        (m_oldFindFlags != findData->GetFlags())) {
 
-      if ((m_configuration.IncrementalSearch()) &&
-          (GetWorksheet()->m_findDialog != NULL)) {
-        if(!GetWorksheet()->m_findDialog->GetRegexSearch())
-          GetWorksheet()->FindIncremental(m_findData.GetFindString(),
-                                       m_findData.GetFlags() & wxFR_DOWN,
-                                       !(m_findData.GetFlags() & wxFR_MATCHCASE),
-                                       !!(m_findData.GetFlags() & FindReplacePane::wxFR_SEARCH_IN_INPUT),
-                                       !!(m_findData.GetFlags() & FindReplacePane::wxFR_SEARCH_IN_OUTPUT));
+      if (m_configuration.IncrementalSearch()) {
+        if(!findPane->GetRegexSearch())
+          GetWorksheet()->FindIncremental(findData->GetFindString(),
+                                       findData->GetFlags() & wxFR_DOWN,
+                                       !(findData->GetFlags() & wxFR_MATCHCASE),
+                                       !!(findData->GetFlags() & FindReplacePane::wxFR_SEARCH_IN_INPUT),
+                                       !!(findData->GetFlags() & FindReplacePane::wxFR_SEARCH_IN_OUTPUT));
         else
-          GetWorksheet()->FindIncremental_RegEx(m_findData.GetFindString(),
-                                             m_findData.GetFlags() & wxFR_DOWN,
-                                             !!(m_findData.GetFlags() & FindReplacePane::wxFR_SEARCH_IN_INPUT),
-                                             !!(m_findData.GetFlags() & FindReplacePane::wxFR_SEARCH_IN_OUTPUT));
+          GetWorksheet()->FindIncremental_RegEx(findData->GetFindString(),
+                                             findData->GetFlags() & wxFR_DOWN,
+                                             !!(findData->GetFlags() & FindReplacePane::wxFR_SEARCH_IN_INPUT),
+                                             !!(findData->GetFlags() & FindReplacePane::wxFR_SEARCH_IN_OUTPUT));
         GetWorksheet()->RequestRedraw();
-        m_oldFindFlags = GetWorksheet()->m_findDialog->GetData()->GetFlags();
-        m_oldFindString = GetWorksheet()->m_findDialog->GetData()->GetFindString();
+        m_oldFindFlags = findData->GetFlags();
+        m_oldFindString = findData->GetFindString();
         event.RequestMore();
         return;
       }
@@ -2701,9 +2691,9 @@ void wxMaxima::OnFind(wxFindDialogEvent &event) {
   if(!GetWorksheet())
     return;
   wxLogMessage(_("A find event, %s"), event.GetFindString());
-  if(GetWorksheet()->m_findDialog)
+  if(FindReplacePane *findPane = GetWorksheet()->GetActiveFindPane())
     {
-      if(!GetWorksheet()->m_findDialog->GetRegexSearch())
+      if(!findPane->GetRegexSearch())
         {
           if (!GetWorksheet()->FindNext(event.GetFindString(),
                                      event.GetFlags() & wxFR_DOWN,
@@ -2730,7 +2720,7 @@ void wxMaxima::OnReplace(wxFindDialogEvent &event) {
   event.Skip();
   if(!GetWorksheet())
     return;
-  if(!GetWorksheet()->m_findDialog->GetRegexSearch())
+  if(!GetWorksheet()->GetActiveFindPane()->GetRegexSearch())
     {
       GetWorksheet()->Replace(event.GetFindString(), event.GetReplaceString(),
                            !(event.GetFlags() & wxFR_MATCHCASE));
@@ -2765,7 +2755,7 @@ void wxMaxima::OnReplaceAll(wxFindDialogEvent &event) {
     return;
   long count;
 
-  if(!GetWorksheet()->m_findDialog->GetRegexSearch())
+  if(!GetWorksheet()->GetActiveFindPane()->GetRegexSearch())
     {
       count =
         GetWorksheet()->ReplaceAll(event.GetFindString(), event.GetReplaceString(),

--- a/src/wxMaximaFrame.cpp
+++ b/src/wxMaximaFrame.cpp
@@ -653,6 +653,17 @@ wxMaximaFrame::~wxMaximaFrame() {
   // destroy the worksheet deterministically while the configuration is
   // whole. (Destroy() on a non-top-level child deletes it immediately and
   // unlinks it from the frame, so the base class won't destroy it twice.)
+  // The dockable find pane (GH #2249) has the same problem: its destructor
+  // writes m_findPaneData's flags back to wxConfig, and m_findPaneData is a
+  // member of this class -- destroyed with the rest of the members, before
+  // the base class destructor would otherwise get around to destroying this
+  // child window. Destroy it here, deterministically, while m_findPaneData
+  // is still alive.
+  if (GetWorksheet()->m_findPane) {
+    m_manager.DetachPane(GetWorksheet()->m_findPane);
+    GetWorksheet()->m_findPane->Destroy();
+    GetWorksheet()->m_findPane = nullptr;
+  }
   m_manager.DetachPane(m_worksheet);
   m_worksheet->Destroy();
 }

--- a/src/wxMaximaFrame.cpp
+++ b/src/wxMaximaFrame.cpp
@@ -348,6 +348,25 @@ wxMaximaFrame::wxMaximaFrame(wxWindow *parent, int id,
                     .Name(m_sidebarNames[EventIDs::menu_pane_draw])
                     .Left());
 
+  if(GetWorksheet())
+    {
+      // The dockable find/replace sidebar (GH #2249). Registered eagerly,
+      // like every other sidebar, so its docked position/size persists via
+      // the AUI perspective -- not created lazily on first use the way the
+      // floating FindReplaceDialog is, since that would lose the benefit of
+      // LoadPerspective() below ever having a pane to restore. Stays hidden
+      // until Configuration::FindDialogDockable() is set and Ctrl+F/Edit->
+      // Find is used; the floating dialog remains the default.
+      m_sidebarNames[EventIDs::menu_pane_find] = wxS("find");
+      m_sidebarCaption[EventIDs::menu_pane_find] = _("Find and Replace");
+      m_findPaneData.LoadFromConfig();
+      GetWorksheet()->m_findPane = new FindReplacePane(this, &m_findPaneData);
+      m_manager.AddPane(GetWorksheet()->m_findPane,
+                        wxAuiPaneInfo()
+                        .Name(m_sidebarNames[EventIDs::menu_pane_find])
+                        .Right());
+    }
+
 #ifdef USE_WEBVIEW
   if(GetWorksheet())
     {
@@ -764,6 +783,8 @@ void wxMaximaFrame::SetupViewMenu() {
   m_Maxima_Panes_Sub->AppendCheckItem(EventIDs::menu_pane_format,
                                       _("Insert Cell\tAlt+Shift+C"));
   m_Maxima_Panes_Sub->AppendCheckItem(EventIDs::menu_pane_draw, _("Plot using Draw"));
+  m_Maxima_Panes_Sub->AppendCheckItem(EventIDs::menu_pane_find,
+                                      _("Find and Replace (if set to dockable)"));
 
 #ifdef USE_WEBVIEW
   m_Maxima_Panes_Sub->AppendCheckItem(EventIDs::menu_pane_help,
@@ -2272,6 +2293,7 @@ void wxMaximaFrame::HideAllSidebars(wxCommandEvent &WXUNUSED(ev)) {
   m_manager.GetPane(m_sidebarNames[EventIDs::menu_pane_help]).Hide();
   m_manager.GetPane(m_sidebarNames[EventIDs::menu_pane_variables]).Hide();;
   m_manager.GetPane(m_sidebarNames[EventIDs::menu_pane_xmlInspector]).Hide();
+  m_manager.GetPane(m_sidebarNames[EventIDs::menu_pane_find]).Hide();
   AuiManagerUpdate();
 }
 void wxMaximaFrame::AuiManagerUpdate() {

--- a/src/wxMaximaFrame.h
+++ b/src/wxMaximaFrame.h
@@ -335,6 +335,11 @@ protected:
 #ifdef USE_WEBVIEW
   HelpBrowser *m_helpPane = NULL;
 #endif
+  //! The data backing the dockable find/replace sidebar (GH #2249) -- kept
+  //! separate from wxMaxima::m_findData (the floating dialog's own data)
+  //! since the two presentations are never both live at once, and each
+  //! only needs to be seeded from wxConfig once, at construction.
+  FindReplacePane::FindReplaceData m_findPaneData;
 
   //! Looks up which demo file belongs to a wxWindowID
   wxString GetDemoFile(wxWindowID id) const;


### PR DESCRIPTION
## Summary

- Closes #2249. wxMaxima's Find and Replace has always opened as a floating dialog. Some people find an undocked pane ugly and would rather dock it alongside the other sidebars, so this adds a "Show 'Find and Replace' as a dockable sidebar" option under Edit -> Configure -> Options (off by default; the floating dialog stays the default behavior).
- `FindReplaceDialog`/`FindReplacePane` were already split apart (a `wxDialog` wrapper around a `wxPanel` holding the actual controls) specifically anticipating this feature, so `FindReplacePane` itself needed no changes: it already climbs to the top-level window to fire its search/replace events, which works identically whether it's embedded in the floating dialog or registered directly as an AUI sidebar pane.
- `Worksheet::GetActiveFindPane()` is the single place that decides which presentation is currently live, so the incremental-search idle task, `OnFind`/`OnReplace`/`OnReplaceAll`, and the wrapped-search warning dialog no longer need to know which UI is in use.
- Un-hiding the dockable pane from Ctrl+F goes through the same generic `ShowPane()`/`IsPaneDisplayed()` every other sidebar uses, so it correctly un-minimizes and focuses the pane even if it was previously closed/hidden -- this was the specific risk the issue itself called out ("does that still work if the sidebar is minimized?").

## Test plan

- [x] `ninja` full build, clean.
- [x] `xvfb-run ctest` full suite: 226/226 (two initially-flaky tests, `openMacFiles` and `tutorial_10Minutes`, both pass cleanly in isolation -- both are pre-documented, unrelated timing/nondeterminism flakes in AGENTS.md).
- [x] Live Xvfb verification: dialog mode (default) unchanged; dockable mode shows a proper AUI sidebar; Ctrl+F un-hides and focuses the pane after it's closed/minimized; new checkbox appears correctly in Edit -> Configure -> Options.
- [x] NEWS.md and AGENTS.md updated.


---
_Generated by [Claude Code](https://claude.ai/code/session_011iszcZR49S3QXrTKUQjiu6)_