### PR TITLE
Add CI guard against Crowdin PRs silently wiping translations

### DIFF
--- a/.github/workflows/compile_ubuntu.yml
+++ b/.github/workflows/compile_ubuntu.yml
@@ -9,6 +9,28 @@ permissions:
   contents: read
 
 jobs:
+  check_translations_not_wiped:
+    # Guards against a failure mode that has hit this repo's translations
+    # twice now (see AGENTS.md's translations section): a Crowdin export
+    # branch forked before a translation-restoring commit landed, which then
+    # silently blanks those strings back to empty the next time it's merged
+    # -- 464 translations wiped each time, caught by hand both times. A
+    # standalone job (not a step inside the build jobs) so it runs once, in
+    # seconds, without needing any of the build dependencies those jobs
+    # install -- it's pure git + Python.
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout_git
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+      - name: check-translations-not-wiped
+        run: |
+             git fetch --depth=1 origin main
+             pip install --quiet polib
+             python3 locales/wxMaxima/check_translations_not_wiped.py origin/main
+
   compile_latest_and_test:
     runs-on: ubuntu-latest
     timeout-minutes: 120

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -646,6 +646,36 @@ tried without rebuilding.
   the languages it already had), not on wxMaxima's own git handling -- ask
   Crowdin support directly, since this session cannot access Crowdin's
   own dashboard/API to confirm the exact trigger without credentials.
+  **It did happen a third time (2026-08-12, PR #2257 from `l10n_main2`):**
+  same shape exactly, `merge-base` landing before the 464-translation
+  restoration commit (`3cf4f9c97`) this time instead of before #2241 --
+  same 464 entries, same 16 languages, zero gained, caught before merging
+  by diffing the PR branch against `origin/main` with the same
+  msgid+msgctxt-keyed `polib` technique, this time *before* merging rather
+  than after. Crowdin claimed to sync hourly regardless. The maintainer
+  switched Crowdin to a fresh `l10n_main2` -> `l10n_main3` branch as a
+  workaround, which "immediately started syncing" -- consistent with
+  Crowdin's export being tied to when *that specific branch* was created/
+  configured, not to actual polling frequency against upstream's current
+  state; still unconfirmed without Crowdin dashboard access, so don't
+  treat that as the root cause, just an observation. Added a permanent
+  safety net for this: `locales/wxMaxima/check_translations_not_wiped.py`
+  (wired into `compile_ubuntu.yml` as its own fast, standalone
+  `check_translations_not_wiped` job, no build dependencies needed) does
+  this exact msgid+msgctxt-keyed comparison against `origin/main` on every
+  push and fails loudly if any translation would go from non-empty to
+  empty -- catching this class of regression in CI before a human has to
+  notice and diff it by hand a fourth time. It only catches "translated
+  text disappeared entirely," not e.g. "translation is now provably
+  worse," and can in principle false-positive if a legitimate, unrelated
+  PR both changes a translatable string's English source text *and*
+  commits a regenerated `.po` under the old convention in the same push
+  (the old msgid's entry vanishing under a genuine rename looks identical
+  to it being wiped) -- rare in practice, since this repo's convention is
+  to not casually commit `update-locale` drift alongside unrelated changes
+  (see the "committing a `make update-locale` run's output" entry below),
+  but worth knowing if this check ever fires on something that turns out
+  to be legitimate.
 - **`test/check-pot-coverage.cmake` needs `cmake_policy(SET CMP0057 NEW)`
   explicitly.** It runs in script mode (`cmake -P`), which does not inherit
   the top-level `CMakeLists.txt`'s policy settings -- without this line,

--- a/locales/wxMaxima/check_translations_not_wiped.py
+++ b/locales/wxMaxima/check_translations_not_wiped.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""Fail if any .po file in the current tree has fewer translated strings than
+the same file on a base ref (default: origin/main).
+
+Guards against a failure mode that has hit this repo's translations twice
+now (see AGENTS.md's translations section): a Crowdin export branch that
+forked before a translation-restoring commit landed silently blanks those
+strings back to empty the next time its export gets merged, since Crowdin
+has no concept of "this string used to be translated, don't overwrite it
+with nothing." Re-syncing the Crowdin-side branch from main before it
+generates its next export is the actual fix; this script is the safety net
+that catches a bad merge before it happens, not a substitute for that fix.
+
+Usage: check_translations_not_wiped.py [base-ref]
+"""
+import subprocess
+import sys
+from pathlib import Path
+
+import polib
+
+
+def translated_map(po):
+    return {(e.msgid, e.msgctxt): e.msgstr for e in po if not e.obsolete}
+
+
+def load_from_ref(ref, path):
+    exists = subprocess.run(
+        ["git", "cat-file", "-e", f"{ref}:{path}"], capture_output=True
+    )
+    if exists.returncode != 0:
+        return None
+    content = subprocess.run(
+        ["git", "show", f"{ref}:{path}"], capture_output=True, check=True
+    ).stdout
+    tmp = Path("/tmp") / (Path(path).name + ".base-ref.po")
+    tmp.write_bytes(content)
+    return polib.pofile(str(tmp))
+
+
+def main():
+    base_ref = sys.argv[1] if len(sys.argv) > 1 else "origin/main"
+    po_dir = Path("locales/wxMaxima")
+    total_wiped = 0
+    any_wiped = False
+
+    for path in sorted(po_dir.glob("*.po")):
+        rel = str(path)
+        base_po = load_from_ref(base_ref, rel)
+        if base_po is None:
+            continue  # new file on this branch, nothing to regress against
+
+        head_po = polib.pofile(str(path))
+        base_map = translated_map(base_po)
+        head_map = translated_map(head_po)
+
+        wiped = [
+            key
+            for key, base_str in base_map.items()
+            if base_str and not head_map.get(key)
+        ]
+        if wiped:
+            any_wiped = True
+            total_wiped += len(wiped)
+            print(
+                f"::error::{path}: {len(wiped)} translation(s) would be wiped "
+                f"to empty (translated on {base_ref}, empty or missing here)"
+            )
+
+    if any_wiped:
+        print(
+            f"::error::Total: {total_wiped} translation(s) would be wiped "
+            f"compared to {base_ref}. This is the Crowdin-stale-branch "
+            f"regression documented in AGENTS.md's translations section -- "
+            f"do not merge as-is. Re-sync the source branch from {base_ref} "
+            f"before generating its export again."
+        )
+        return 1
+
+    print(f"No translations would be wiped compared to {base_ref}.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

This is the third time a Crowdin export branch has forked before a translation-restoring commit landed and then silently blanked those strings back to empty on merge (see PR #2241/#2244 for the first two -- 464 translations wiped, restored in PR #2246; and now PR #2257, the *same* 464 entries across the *same* 16 languages, caught by hand again before merging this time).

Instead of catching this by hand every time, this adds a permanent safety net:

- `locales/wxMaxima/check_translations_not_wiped.py`: compares every `.po` file's translated entries (keyed by `msgid`+`msgctxt`, the same technique used to diagnose and fix the earlier incidents) against a base ref (default `origin/main`) and fails if any would go from non-empty to empty.
- Wired into `compile_ubuntu.yml` as its own standalone `check_translations_not_wiped` job -- no build dependencies needed (pure `git` + Python), so it fails fast in seconds rather than after a full build.
- Documented the third incident and this guard in `AGENTS.md`'s translations section, including the one known false-positive edge case (a legitimate source-string rename landing alongside a regenerated `.po` in the same push -- rare in practice per this repo's own stated convention of not casually committing `update-locale` drift).

## Test plan

- [x] Ran the script against the real `l10n_main2` branch (via a worktree) that motivated this: fails with exactly 464 wiped translations across the same 16 languages as the manual investigation.
- [x] Ran the script against `origin/main` itself: passes cleanly (0 wiped).
- [x] Validated the modified workflow YAML parses correctly.


---
_Generated by [Claude Code](https://claude.ai/code/session_011iszcZR49S3QXrTKUQjiu6)_