### PR TITLE
Fix blank set rendering, dark mode, PDF manual, batch exit codes; SignPath signing

### DIFF
--- a/.claude/skills/wxmaxima-packaging/SKILL.md
+++ b/.claude/skills/wxmaxima-packaging/SKILL.md
@@ -51,15 +51,41 @@ that are not obvious:
   PowerShell cmdlet, and hence the upload-artifact step.
 - `upload-artifact` always wraps files in a ZIP, so the artifact configuration's
   root element must be `zip-file`, wrapping the actual payload's element inside
-  it (e.g. `<zip-file><pe-file><authenticode-sign/></pe-file></zip-file>`) --
-  a bare `<pe-file>`/`<msi-file>` at the XML root, with no `zip-file` wrapper,
-  fails every submission with "The file does not correspond to the specified
-  file type," confirmed live against a real SignPath project (2026-08).
+  it -- a bare `<pe-file>`/`<msi-file>` at the XML root, with no `zip-file`
+  wrapper, fails every submission with "The file does not correspond to the
+  specified file type," confirmed live against a real SignPath project
+  (2026-08).
 - The Windows installer is an **NSIS-built `.exe`** (`CPACK_GENERATOR
   "ZIP;NSIS"`), not an MSI -- SignPath's element for a generic signable
   Windows executable is `<pe-file>` (not `<msi-file>`, and not
   `<executable-file>`, a plausible-sounding name that SignPath does not
   actually use).
+- `<pe-file>` (like any element nested inside `<zip-file>`) needs an explicit
+  `path` glob attribute -- a zip *can* hold more than one entry, so SignPath
+  needs to be told which one to sign even when, as here, there's only ever
+  one. Omitting it fails with "The required attribute 'path' is missing."
+  The working configuration, named `exeinzip` on the wxmaxima SignPath
+  project and set as its default:
+  ```xml
+  <?xml version="1.0" encoding="utf-8" ?>
+  <artifact-configuration xmlns="http://signpath.io/artifact-configuration/v1">
+    <zip-file>
+      <pe-file path="*.exe">
+        <authenticode-sign />
+      </pe-file>
+    </zip-file>
+  </artifact-configuration>
+  ```
+  `path="*.exe"` matches because `actions/upload-artifact@v7` is given a
+  single glob (`wxMaxima/build/*.exe`) with one match, so the file lands at
+  the zip's root with no subdirectory -- confirmed by three failed
+  submissions before this shape (see NEWS/commit history around 2026-08),
+  each error naming the next missing piece.  **`SIGNPATH_ARTIFACT_CONFIGURATION`
+  in `compile_windows.yml` must name the slug exactly** (`exeinzip`, not
+  `exe`/`installer`, the two earlier now-abandoned configurations) --
+  SignPath's own "default configuration" marking on its dashboard does not
+  matter here, since the workflow always passes an explicit
+  `artifact-configuration-slug`.
 - The API token lives in an **environment** secret with a required reviewer.
   GitHub pauses such a job *before its first step*, so signing must be its own
   job - inside the build job it would block the entire test suite behind an

--- a/.claude/skills/wxmaxima-packaging/SKILL.md
+++ b/.claude/skills/wxmaxima-packaging/SKILL.md
@@ -50,7 +50,16 @@ that are not obvious:
   workflow, commit, runner). Hence the official action rather than the
   PowerShell cmdlet, and hence the upload-artifact step.
 - `upload-artifact` always wraps files in a ZIP, so the artifact configuration's
-  root element must be `zip-file`.
+  root element must be `zip-file`, wrapping the actual payload's element inside
+  it (e.g. `<zip-file><pe-file><authenticode-sign/></pe-file></zip-file>`) --
+  a bare `<pe-file>`/`<msi-file>` at the XML root, with no `zip-file` wrapper,
+  fails every submission with "The file does not correspond to the specified
+  file type," confirmed live against a real SignPath project (2026-08).
+- The Windows installer is an **NSIS-built `.exe`** (`CPACK_GENERATOR
+  "ZIP;NSIS"`), not an MSI -- SignPath's element for a generic signable
+  Windows executable is `<pe-file>` (not `<msi-file>`, and not
+  `<executable-file>`, a plausible-sounding name that SignPath does not
+  actually use).
 - The API token lives in an **environment** secret with a required reviewer.
   GitHub pauses such a job *before its first step*, so signing must be its own
   job - inside the build job it would block the entire test suite behind an

--- a/.claude/skills/wxmaxima-translations/SKILL.md
+++ b/.claude/skills/wxmaxima-translations/SKILL.md
@@ -90,6 +90,49 @@ entries but empty can be filled **in place** (one changed line per string, no
 reordering); one that is missing the entries entirely needs a real `msgmerge`
 first, because no in-place fill can reach an entry that does not exist.
 
+## Manual PDF composition can fail for reasons unrelated to translation (GH #2271)
+
+`info/CMakeLists.txt`'s `generate_wxmaxima_documentation_pdf()` used to pass
+`-V 'CJKmainfont:NotoSerifCJK-Regular.ttc'` to pandoc **unconditionally, for
+every language**, not only the CJK ones (`zh_CN`/`zh_TW`). That makes pandoc
+emit `\usepackage{xeCJK}` into every language's generated LaTeX regardless of
+content, so composing *any* manual PDF -- Hungarian included, despite having
+no CJK text at all, since it has no real translation yet and silently falls
+back to the English `wxmaxima.md` (see `info/CMakeLists.txt`'s `else()`
+branch a few lines above `generate_wxmaxima_documentation_pdf` for that
+fallback) -- hard-depended on `texlive-lang-cjk`, a large package genuinely
+easy not to have on a "normal" (not `texlive-full`) install. Confirmed live:
+reproduced `! LaTeX Error: File 'xeCJK.sty' not found.` for `hu` with the CJK
+package removed, and confirmed the same command with the `-V CJKmainfont`
+argument dropped composes cleanly with the identical package set. Fixed by
+only adding that argument when `PDFLANG MATCHES "^zh"`.
+**A CI reproduction of this class of bug is not realistic**: CI has no
+`texlive-xetex`/`texlive-lang-cjk` installed at all for the unit-test job (the
+whole PDF target is silently skipped via `if(WXMAXIMA_LATEX_COMMAND)` when
+neither `xelatex` nor `lualatex` is found), so a *partial* TeX install -
+exactly what exposed this - can only be caught by someone with a real,
+non-`texlive-full` TeX toolchain building the manual locally, same as the
+original reporter. If a similar "PDF for language X won't compose" report
+comes in again, check first whether it reproduces for *every* language (a
+generic, non-language-specific missing-package problem, the actual shape this
+one turned out to have) before assuming the bug is specific to language X.
+Installing a missing texlive package inside an agent sandbox one at a time as
+each new `! LaTeX Error: File 'X' not found` appears (`lmodern` -> Noto fonts
+-> `texlive-lang-cjk`, in that order, here) is a reasonable way to find every
+missing piece **for reproduction purposes** - but doing so also leaves the
+sandbox's LaTeX toolchain in a different state than before, which can make an
+*unrelated*, previously-untested code path (e.g. `test_WorksheetExport`'s
+`RequireTexCompiles`, gated on `pdflatex`/`lualatex` being on `PATH` at all)
+start running for the first time and fail for reasons that have nothing to do
+with the change under investigation (here: `lualatex`'s `luaotfload` font
+cache failing to initialize under `ctest`'s per-test isolated, empty
+`TMPDIR`/`XDG_CONFIG_HOME` - reproduced with a trivial `\usepackage{fontspec}`
+"Hello world" document, so it is a toolchain/cache-initialization issue, not
+anything in wxMaxima's own LaTeX export). Don't mistake a newly-appearing
+failure in a previously-dormant (engine-not-installed-so-skipped) test for a
+regression in unrelated code just because it started failing in the same
+session a TeX toolchain got installed piecemeal.
+
 ## Checks that exist
 
 - `check-translations` - `msgfmt` on every catalogue, chiefly `--check-format`

--- a/.github/workflows/compile_windows.yml
+++ b/.github/workflows/compile_windows.yml
@@ -17,13 +17,17 @@ env:
   SIGNPATH_ORGANIZATION_ID: 4eaae15d-2d3a-4c8d-acf3-6e71e5837a5d
   SIGNPATH_PROJECT_SLUG: wxmaxima
   SIGNPATH_SIGNING_POLICY: test-signing
-  # "exe" wraps the artifact-configuration correctly for what we actually
-  # ship: upload-artifact always zips whatever it's given, and the Windows
-  # installer itself is an NSIS-built .exe (CPACK_GENERATOR "ZIP;NSIS"), not
-  # an .msi -- the earlier "installer" configuration used <msi-file/> at the
-  # XML root with no <zip-file/> wrapper, which SignPath rejected outright
-  # ("The file does not correspond to the specified file type").
-  SIGNPATH_ARTIFACT_CONFIGURATION: exe
+  # "exeinzip" wraps the artifact-configuration correctly for what we
+  # actually ship: upload-artifact always zips whatever it's given, and the
+  # Windows installer itself is an NSIS-built .exe (CPACK_GENERATOR
+  # "ZIP;NSIS"), not an .msi. Two earlier configurations were rejected before
+  # this one: "installer" used <msi-file/> at the XML root with no
+  # <zip-file/> wrapper ("The file does not correspond to the specified file
+  # type"), and an intermediate <zip-file><pe-file/></zip-file> attempt was
+  # rejected for missing the required path="*.exe" glob on <pe-file/> (a
+  # zip-file container can hold more than one entry, so SignPath needs to be
+  # told which one to sign even when, as here, there's only ever one).
+  SIGNPATH_ARTIFACT_CONFIGURATION: exeinzip
 
 permissions:
   contents: read

--- a/.github/workflows/compile_windows.yml
+++ b/.github/workflows/compile_windows.yml
@@ -17,7 +17,13 @@ env:
   SIGNPATH_ORGANIZATION_ID: 4eaae15d-2d3a-4c8d-acf3-6e71e5837a5d
   SIGNPATH_PROJECT_SLUG: wxmaxima
   SIGNPATH_SIGNING_POLICY: test-signing
-  SIGNPATH_ARTIFACT_CONFIGURATION: installer
+  # "exe" wraps the artifact-configuration correctly for what we actually
+  # ship: upload-artifact always zips whatever it's given, and the Windows
+  # installer itself is an NSIS-built .exe (CPACK_GENERATOR "ZIP;NSIS"), not
+  # an .msi -- the earlier "installer" configuration used <msi-file/> at the
+  # XML root with no <zip-file/> wrapper, which SignPath rejected outright
+  # ("The file does not correspond to the specified file type").
+  SIGNPATH_ARTIFACT_CONFIGURATION: exe
 
 permissions:
   contents: read

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -692,6 +692,61 @@ a local TCP socket.
   order, so it is a running-counter walk, not a search) rather than touching
   any of the already-stabilized cursor/click bidi logic itself.
 
+- **GH #2274 -- Windows Dark Mode only affecting the worksheet, not the rest
+  of the interface. Root cause found by reading wxWidgets 3.3's own MSW
+  source (`src/msw/darkmode.cpp` -- fetched directly, this sandbox only has
+  wxWidgets 3.2 installed and cannot compile or run the `wxCHECK_VERSION(3,
+  3, 0)` code path at all, so this could not be tested live and needs a
+  Windows report to confirm) -- fixed on a "the mechanism is exact, but
+  unverified on the actual platform" basis, the same caution a blind fix
+  deserves.** `main.cpp`'s `MyApp::OnInit()` already had a comment
+  explaining that `ApplyAppearanceToApp()` (which calls
+  `wxTheApp->SetAppearance()`) has to run "before the first top-level window
+  is created further down" for Windows to pick it up -- but the very first
+  thing `OnInit()` actually did, several hundred lines *earlier*, was
+  `m_logWindow = new wxLogWindow(...)`. `wxLogWindow`'s constructor
+  unconditionally does `m_pLogFrame = new wxLogFrame(...)` -- a real
+  `wxFrame` -- regardless of its `show` argument; only `Show()` afterwards is
+  conditional (confirmed by reading `src/generic/logg.cpp` directly, not
+  assumed from the class name). A `wxFrame` registers itself in the global
+  `wxTopLevelWindows` list at construction, not at `Show()` time. wx 3.3's
+  MSW `wxApp::SetAppearance()` opens with `if (!wxTopLevelWindows.empty() ||
+  gs_appMode != AppMode_Default) return AppearanceResult::CannotChange;` --
+  so by the time `ApplyAppearanceToApp()` ran, `wxTopLevelWindows` already
+  held the (still-hidden) log window's frame, and `SetAppearance()` silently
+  gave up every single time, on every startup, regardless of what the
+  in-code comment intended. This is MSW-specific: GTK's implementation has no
+  such "only before any window exists" restriction, which is exactly why the
+  maintainer's own diagnostic logging (added just before this fix, still
+  worth keeping) showed `AppearanceResult::Ok` on their Linux dev machine --
+  the bug was never visible there, only on the platform it was actually
+  reported on. Since the worksheet's own colors come from `Configuration`,
+  entirely independent of `wxApp::SetAppearance()`, it always reflected the
+  chosen appearance correctly regardless of this bug -- exactly matching the
+  reported symptom ("only the worksheet is in dark mode"). Fixed by moving
+  `m_logWindow`'s construction to *after* the `ApplyAppearanceToApp()` block,
+  the smallest change that gets a genuinely empty `wxTopLevelWindows` at the
+  point `SetAppearance()` runs, rather than trying to move the (config-file-
+  dependent, command-line-parsing-dependent) appearance-reading code earlier
+  instead. Checked for anything else constructing a top-level window before
+  that point (nothing does; `RepairFileAssociations()`, the only other
+  Windows-specific startup step ahead of it, only touches the registry) and
+  for any code between the old and new construction points that dereferences
+  `m_logWindow` before it exists (one `wxLogMessage()` call, which safely
+  falls through to whatever the default wx log target is when no custom one
+  is installed yet, no different from any `wxLogMessage()` that already ran
+  even earlier in `OnInit()`). Verified on Linux: builds clean, a live Xvfb
+  session starts up normally end to end (Maxima connects, worksheet is
+  usable), and View -> Toggle log window still successfully creates and
+  toggles the (real, `xdotool`-visible) log window frame after being moved --
+  confirming the reordering itself doesn't break anything, though the actual
+  dark-mode effect this targets can only be confirmed by someone running a
+  build on real Windows. A prior "speculative go" at this same issue
+  (changing `wxTheApp->SetAppearance()` to a hypothetical
+  `wxApp::SetAppearance()` static call) was reverted for a compile error --
+  don't repeat that: `SetAppearance()` is an ordinary (non-static) `wxApp`
+  member function.
+
 ### Communication with Maxima
 
 wxMaxima sends Lisp and Maxima commands over the socket; Maxima answers with XML

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -630,6 +630,68 @@ a local TCP socket.
   code, selected the group cell via hCaret + Shift+Up, confirmed the
   rendered text changed consistently and a single Ctrl+Z restored it).
 
+- **GH #2278 -- selection-rectangle width can slightly differ from the
+  rendered text's actual width, investigated but NOT YET FIXED (2026-08).**
+  Root cause confirmed by reading the measurement/draw code side by side, not
+  guessed: `EditorCell` computes horizontal position two structurally
+  different ways that both amount to "measure pieces separately and sum
+  them," and the pieces don't line up the same way in both places.
+  `EditorCell::Draw()` (`EditorCell.cpp` ~line 1042) paints text **per
+  `StyledText` token** -- each token gets its own `dc->GetTextExtent()` /
+  `dc->DrawText()` call, and `TextCurrentPoint.x += width` accumulates the
+  *pen* position as the sum of those independently-shaped token widths, so
+  any kerning or (for a contextual script) glyph-shape change that would
+  normally happen *across* a token boundary is never applied -- the two
+  neighboring glyphs are shaped in total isolation from each other.
+  `EditorCell::GetLineWidth()` (used by `PositionToPoint()` for an
+  ordinary, single-direction line) reimplements that same per-token
+  accumulation independently (`lineWidth += GetTextSize(snippet).GetWidth()`,
+  with the final partial token measured via `snippet.Left(pos)`) -- so for a
+  single-direction line the two at least agree with each other, both being
+  equally kerning-blind at token boundaries. The bidi work
+  (`MixedDirectionOffset()`, added for mixed-direction line support) does
+  something different: it measures each `BidiRun` **as one whole
+  substring** via `MeasureTextWidth()` (`m_text.SubString(...)`), which
+  *does* let the font shape it correctly -- kerning pairs and (critically,
+  for Arabic-like scripts) contextual join forms all resolve the way they
+  would if the run were drawn as a single unit. That's a strictly *more*
+  accurate measurement of what the font would produce for that span, but
+  it's answering a different question than what `Draw()` actually paints
+  (per-token, unshaped-across-boundaries) -- so on a mixed-direction line,
+  `MarkSelection()`'s selection rectangle (built from two
+  `MixedDirectionOffset()`-derived `PositionToPoint()` calls, `EditorCell.cpp`
+  ~line 852-877) can come out a few pixels narrower or wider than the glyphs
+  `Draw()` actually painted for that same span, especially where a token
+  boundary falls in the middle of a script that reshapes heavily by context.
+  **This is not a simple "measures per character instead of per whole
+  string" bug** (that specific hypothesis, which is how the issue itself is
+  worded, doesn't survive reading `MeasureTextWidth()` -- it already
+  measures its input as one `GetTextExtent()` call, not character by
+  character); it is a *disagreement between two independently-correct-looking
+  but differently-grained measurement strategies*, one of which (`Draw()`'s
+  per-token painting) is the one that actually determines what's on screen
+  and should be the one every other measurement is judged against.
+  A real fix needs one of: (a) make `MixedDirectionOffset()` sum cached
+  per-`StyledText`-token widths the same way `GetLineWidth()`/`Draw()` do
+  (loses the bidi work's kerning-accuracy improvement, but makes the
+  selection rectangle match pixel-for-pixel what's actually drawn -- the
+  correct alignment target), or (b) make `Draw()` paint each maximal
+  same-direction run as a single `DrawText()` call instead of per token
+  (recovers the accuracy `MixedDirectionOffset()` already computes, but
+  touches the same per-token color-styling/tab/indent-char logic that
+  `EditorCell::Draw()`'s text loop handles all at once, and duplicated across
+  `MarkSelection()`'s own line-splitting loop). Deliberately **not**
+  attempted in this pass: both routes touch code that the 2026-08 bidi work
+  (cursor placement, click-to-position, arrow-key navigation -- see
+  "Extend bidi fix to caret placement..." in git log) already spent real
+  effort getting right, and a "few pixels off" selection-rectangle glitch
+  does not obviously justify the regression risk of changing it blind. Route
+  (a) is probably the lower-risk one to attempt first: `StyledText` doesn't
+  currently track its own `m_text` character offset, so the main work is
+  adding/deriving that mapping (tokens are already emitted in `m_text`
+  order, so it is a running-counter walk, not a search) rather than touching
+  any of the already-stabilized cursor/click bidi logic itself.
+
 ### Communication with Maxima
 
 wxMaxima sends Lisp and Maxima commands over the socket; Maxima answers with XML

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1108,6 +1108,48 @@ tried without rebuilding.
   the unrelated, already-existing `%sum` `rbp` registration, not extra
   parens around the summand).
 
+- **A Maxima `{...}`/`setify(...)` set rendering as completely blank output
+  (GH #2270), despite the value being computed correctly:** `SetCell`
+  (`src/cells/SetCell.cpp`) extends `ListCell` and overrides
+  `SetCurrentPoint()` -- but the override was
+  `void SetCell::SetCurrentPoint(wxPoint point) const { Cell::SetCurrentPoint(point); }`,
+  which positions only the `SetCell` object itself and completely skips the
+  inherited `ListCell::SetCurrentPoint()`'s logic that positions
+  `m_open`/`m_innerCell`/`m_close` (the "{" glyph, the actual list content,
+  the "}" glyph). `GroupCell::UpdateOutputPositions()` calls
+  `tmp.SetCurrentPoint(in)` on each top-level entry of the output's draw
+  list (`OnDrawList()`) -- for an unbroken (fits-on-one-line) `SetCell` that
+  entry *is* the whole `SetCell`, so this override, not `ListCell`'s, is
+  what fires. Since it never touches the children, they keep whatever stale
+  or default position they last had and get drawn there instead of inside
+  the set's own bounding box -- invisible within the visible viewport, while
+  the underlying value is completely correct (confirmed live: copying the
+  blank output cell's clipboard content, or `listify(%)`, reveals the right
+  answer). The override did strictly *less* than the version it shadowed and
+  had no reason to exist at all -- deleting it outright (from both
+  `SetCell.h` and `SetCell.cpp`) is the fix, letting `SetCell` inherit
+  `ListCell::SetCurrentPoint()` normally, which already handles `m_open`/
+  `m_close` correctly regardless of what glyphs they hold. Confirmed live in
+  Xvfb: `{1,2,3};` rendered as a totally blank `(%o1)` line on an unmodified
+  build, both at default window width and narrower (forcing the set to wrap
+  across lines) -- `[1,2,3];` (a plain `ListCell`, no divergent override)
+  rendered correctly in every case tested, which is what pointed at
+  `SetCell`'s own code rather than the shared `ListCell`/layout-pipeline
+  machinery. Root-caused with gdb (`gdb -p <pid> -batch -x script.py`,
+  breaking on `SetCell::Draw`/`ListCell::Recalculate`/`Cell::BreakUpAndMark`
+  from a live, real Xvfb session -- the sandbox's earlier-documented
+  hardware-breakpoint/`rr` limitations don't affect plain software
+  breakpoints, which is all this needed) -- an initial hypothesis blaming
+  `Cell::BreakUpCells()`'s line-wrap width heuristic (a `CachedInteger`
+  reading back its `INT_MAX` "invalid" sentinel as a width) turned out to be
+  a red herring from noisy manual multi-window testing, not reproducible in
+  a clean single-cell session; always reproduce a rendering bug in a fresh,
+  isolated worksheet before trusting a gdb trace's numbers. Also fixed a
+  smaller, related inconsistency found while auditing this: `SetCell`'s
+  constructor replaces `m_open`/`m_close` with fresh "{"/"}" `TextCell`s but
+  never called `SetStyle(TS_FUNCTION)` on them the way `ListCell`'s own
+  constructor does for "["/"]", leaving the braces in the wrong style.
+
 - **"Don't unfold cells just because their folded tree is being evaluated"
   (GH #1952):** `Worksheet::ScrollToError()` -- called automatically by
   `MaximaEvaluator::CheckForErrors()` whenever `AbortOnError()` is on (the

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,18 @@
 # Current development version
 
+- Fixed a Maxima "set" (`{...}`, `setify(...)`, ...) rendering as completely
+  blank output (GH #2270), even though the value was computed correctly (a
+  right-click "Copy" of the invisible cell, or `listify(%)`, revealed the
+  right content). `SetCell::SetCurrentPoint()` shadowed the inherited
+  `ListCell::SetCurrentPoint()` with an override that positioned only the
+  cell itself, never its opening/closing brace or its contents -- so those
+  child cells kept whatever stale position they last had (or none at all)
+  and were drawn off in the wrong place instead of inside the set's visible
+  bounding box. The override did strictly less than the version it shadowed
+  and served no purpose, so it was removed outright, letting `SetCell`
+  inherit `ListCell`'s (correct) positioning logic. Also fixed the "{"/"}"
+  brace cells not getting the `TS_FUNCTION` style `ListCell`'s "["/"]"
+  cells get, a related inconsistency found while fixing this.
 - Fixed the "ASCII maths" style defaulting to a non-monospace font, which
   misaligned Maxima's own ASCII-art 2D output (fractions, matrices, sums,
   ...) since it pads with literal spaces assuming every character is the

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,16 @@
 # Current development version
 
+- Fixed Windows Dark Mode only affecting the worksheet, not the rest of the
+  interface (GH #2274). `wxLogWindow`'s constructor always creates a real
+  `wxFrame` under the hood regardless of its "show" argument, and wxMaxima
+  built its (normally hidden) log window near the very start of `OnInit()` --
+  before `wxApp::SetAppearance()` got a chance to run. On Windows,
+  `SetAppearance()` silently gives up (`AppearanceResult::CannotChange`) the
+  moment *any* top-level window already exists, shown or not, so the
+  app-wide appearance was never actually being applied to the native chrome
+  (menus, toolbars, dialogs) -- only the worksheet, which wxMaxima colors
+  itself independently of `SetAppearance()`, ever reflected the setting.
+  Moved the log window's construction to after the appearance is applied.
 - Fixed composing the manual PDF for a non-CJK language failing outright if
   `texlive`'s CJK support wasn't installed (GH #2271, e.g. `wxmaxima.hu.pdf`
   on a Debian/Sid box without it) -- the build passed `-V CJKmainfont:...` to

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,18 @@
 # Current development version
 
+- Fixed composing the manual PDF for a non-CJK language failing outright if
+  `texlive`'s CJK support wasn't installed (GH #2271, e.g. `wxmaxima.hu.pdf`
+  on a Debian/Sid box without it) -- the build passed `-V CJKmainfont:...` to
+  pandoc unconditionally for every language, not just Chinese, making every
+  manual's PDF hard-depend on a large, easy-to-not-have package it never
+  actually needed. Only the CJK languages' PDFs request a CJK font now.
+- `--batch`/`--exit-on-error` runs that halt before finishing now exit with a
+  dedicated status code (90-95) instead of a generic `1` for every reason
+  (GH #2276) -- a caller's script can now tell a Maxima error, an unanswered
+  interactive question ("Halting, as documented for --batch"), a file that
+  failed to open or save, or an image that failed to load/decode apart
+  without parsing the log. See the new "EXIT STATUS" section of the
+  `wxmaxima(1)` man page for the full list.
 - Fixed a Maxima "set" (`{...}`, `setify(...)`, ...) rendering as completely
   blank output (GH #2270), even though the value was computed correctly (a
   right-click "Copy" of the invisible cell, or `listify(%)`, revealed the

--- a/data/wxmaxima.1.in
+++ b/data/wxmaxima.1.in
@@ -93,6 +93,36 @@ Allows to specify the location of the Maxima binary.
 .I \-\-enableipc
 Lets Maxima control wxMaxima via interprocess communications. Use this option with care.
 
+.SH "EXIT STATUS"
+.PP
+A successful run, batch or interactive, exits with status 0. A
+.B \-\-batch
+run that halted before finishing (see
+.B \-\-exit-on-error
+above) exits with one of the following statuses instead, so a caller's script
+can tell why the run stopped without having to parse its log:
+.TP
+.B 90
+Maxima reported an error and
+.B \-\-exit-on-error
+was given.
+.TP
+.B 91
+Maxima asked an interactive question with no scripted answer available.
+.TP
+.B 92
+The input file named on the command line could not be opened.
+.TP
+.B 93
+Saving the worksheet failed.
+.TP
+.B 94
+An embedded image's data could not be loaded at all.
+.TP
+.B 95
+An embedded image failed to decode or render (only checked with
+.BR \-\-debug ).
+
 .SH FILES
 .TP
 .I @WXMAXIMA_CONFIGFILE_PATH@

--- a/info/CMakeLists.txt
+++ b/info/CMakeLists.txt
@@ -49,9 +49,24 @@ if(PANDOC)
 			set(PDFLANG "zh_Hans")
 		endif()
 
+		# GH #2271: -V CJKmainfont used to be passed unconditionally, for every
+		# language's PDF, not just the CJK ones. That makes pandoc emit
+		# \usepackage{xeCJK} into every manual's LaTeX regardless of whether it
+		# is actually CJK content, so composing ANY language's PDF -- Hungarian
+		# included, despite it having no CJK text at all -- hard-depends on
+		# texlive's (large, easy to not have installed) CJK support, and fails
+		# outright with "File `xeCJK.sty' not found" if that one specific
+		# package is missing, even though the rest of the LaTeX toolchain is
+		# perfectly capable of composing the document. Only the languages that
+		# actually need a CJK font should pay for requiring one.
+		set(CJK_ARGS "")
+		if(PDFLANG MATCHES "^zh")
+			set(CJK_ARGS -V 'CJKmainfont:NotoSerifCJK-Regular.ttc')
+		endif()
+
 		add_custom_command(
 			OUTPUT ${FILEBASENAME}.pdf
-			COMMAND ${PANDOC} ${FILEBASENAME}.md -t latex -o ${FILEBASENAME}.pdf -M lang=${PDFLANG} -V 'mainfont:NotoSerif-Regular.ttf' -V 'sansfont:NotoSans-Regular.ttf' -V 'monofont:NotoSansMono-Regular.ttf' -V 'mathfont:NotoSansMath-Regular.ttf' -V 'CJKmainfont:NotoSerifCJK-Regular.ttc' --number-sections --table-of-contents --standalone --metadata title="wxMaxima" --pdf-engine=${WXMAXIMA_LATEX_COMMAND}
+			COMMAND ${PANDOC} ${FILEBASENAME}.md -t latex -o ${FILEBASENAME}.pdf -M lang=${PDFLANG} -V 'mainfont:NotoSerif-Regular.ttf' -V 'sansfont:NotoSans-Regular.ttf' -V 'monofont:NotoSansMono-Regular.ttf' -V 'mathfont:NotoSansMath-Regular.ttf' ${CJK_ARGS} --number-sections --table-of-contents --standalone --metadata title="wxMaxima" --pdf-engine=${WXMAXIMA_LATEX_COMMAND}
 			COMMENT "Generating ${FILEBASENAME}.pdf")
 		add_custom_target(build_${FILEBASENAME}.pdf DEPENDS ${FILEBASENAME}.pdf)
 		add_dependencies(pdf build_${FILEBASENAME}.pdf)

--- a/src/MaximaEvaluator.cpp
+++ b/src/MaximaEvaluator.cpp
@@ -211,9 +211,9 @@ bool MaximaEvaluator::AbortOnError() {
       if (errorGroup->GetLabel())
         errorText += wxS(" -> ") + errorGroup->GetLabel()->ToString();
     }
-    wxLogMessage(_("Aborting due to --exit-on-error (exit code 1). Cell: %s"),
-                errorText);
-    wxMaxima::m_exitCode = 1;
+    wxLogMessage(_("Aborting due to --exit-on-error (exit code %d). Cell: %s"),
+                static_cast<int>(wxMaxima::EXIT_MAXIMA_ERROR), errorText);
+    wxMaxima::m_exitCode = wxMaxima::EXIT_MAXIMA_ERROR;
     m_wxMaxima.Close();
   }
   if (m_wxMaxima.m_configuration.GetAbortOnError()) {

--- a/src/MaximaFileIO.cpp
+++ b/src/MaximaFileIO.cpp
@@ -824,7 +824,7 @@ bool MaximaFileIO::SaveFile(bool forceSave) {
         ReportSaveFailed();
         m_wxMaxima.StartAutoSaveTimer();
         if (m_wxMaxima.ExitOnErrorArmed()) {
-          wxMaxima::m_exitCode = 1;
+          wxMaxima::m_exitCode = wxMaxima::EXIT_FILE_SAVE_FAILED;
           m_wxMaxima.Close();
         }
         return false;
@@ -841,7 +841,7 @@ bool MaximaFileIO::SaveFile(bool forceSave) {
         ReportSaveFailed();
         m_wxMaxima.StartAutoSaveTimer();
         if (m_wxMaxima.ExitOnErrorArmed()) {
-          wxMaxima::m_exitCode = 1;
+          wxMaxima::m_exitCode = wxMaxima::EXIT_FILE_SAVE_FAILED;
           m_wxMaxima.Close();
         }
         return false;

--- a/src/MaximaResponseReader.cpp
+++ b/src/MaximaResponseReader.cpp
@@ -522,9 +522,9 @@ void MaximaResponseReader::ReadPrompt(const wxString &data) {
     if (m_wxMaxima.m_exitAfterEval && !autoAnswer) {
       wxLogMessage(_("Batch mode: Maxima asked a question with no scripted "
                      "answer available (\"%s\"). Halting, as documented for "
-                     "--batch."),
-                   label);
-      wxMaxima::m_exitCode = 1;
+                     "--batch (exit code %d)."),
+                   label, static_cast<int>(wxMaxima::EXIT_UNANSWERED_QUESTION));
+      wxMaxima::m_exitCode = wxMaxima::EXIT_UNANSWERED_QUESTION;
       // Maxima repeats an unanswered question's prompt on its own timer (see
       // #2183) -- kill it now, rather than waiting for Close()'s eventual
       // Destroy(), so those repeats can't re-enter this branch and spam the

--- a/src/cells/SetCell.cpp
+++ b/src/cells/SetCell.cpp
@@ -35,6 +35,8 @@ SetCell::SetCell(GroupCell *group, Configuration *config,
   : ListCell(group, config, std::move(inner)) {
   m_open = std::make_unique<TextCell>(group, config, wxS("{"));
   m_close = std::make_unique<TextCell>(group, config, wxS("}"));
+  m_open->SetStyle(TS_FUNCTION);
+  m_close->SetStyle(TS_FUNCTION);
 }
 
 SetCell::SetCell(GroupCell *group, const SetCell &cell)
@@ -44,10 +46,6 @@ SetCell::SetCell(GroupCell *group, const SetCell &cell)
 }
 
 DEFINE_CELL(SetCell)
-
-void SetCell::SetCurrentPoint(wxPoint point) const {
-  Cell::SetCurrentPoint(point);
-}
 
 void SetCell::Draw(wxDC *dc, wxDC *antialiassingDC) {
   Cell::Draw(dc, antialiassingDC);

--- a/src/cells/SetCell.h
+++ b/src/cells/SetCell.h
@@ -53,8 +53,6 @@ public:
   std::unique_ptr<Cell> Copy(GroupCell *group) const override;
   const CellTypeInfo &GetInfo() override;
 
-  using Cell::SetCurrentPoint;
-  void SetCurrentPoint(wxPoint point) const override;
   void Draw(wxDC *dc, wxDC *antialiassingDC) override;
 
   wxString ToMatlab() const override;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -375,13 +375,6 @@ bool MyApp::OnInit() {
   // is sensitive around menu setup is left exactly as it was.
   wxMessageOutput::Set(new wxMessageOutputStderr(stdout));
 #endif
-  // if DEBUG=1 show the logwindow at start, else hide it.
-  // in wxMaxima.cpp we later read a configuration variable (LogWindow) and show/hide it, according to the previous state (issue #2033).
-#if (DEBUG==1)
-  m_logWindow = new wxLogWindow(NULL, wxS("wxMaxima log window"), true, false);
-#else
-  m_logWindow = new wxLogWindow(NULL, wxS("wxMaxima log window"), false, false);
-#endif
   // Needed for making wxSocket work for multiple threads. We currently don't
   // use this feature. But it doesn't harm to be prepared
   wxSocketBase::Initialize();
@@ -597,11 +590,19 @@ bool MyApp::OnInit() {
 
   // Pull the light/dark appearance lever now -- before the first top-level
   // window is created further down -- so the native chrome (menus, toolbars,
-  // sidebars, dialogs) follows it on Windows, where wxApp::SetAppearance() only
-  // affects the chrome when called during startup. The runtime call in
-  // wxMaxima::ConfigChanged() stays for macOS/GTK, which can switch live. Read
-  // the saved setting straight from the just-installed config (mirrors
-  // Configuration's own read: default followSystem, clamp to the valid range).
+  // sidebars, dialogs) follows it on Windows, where wxApp::SetAppearance()
+  // only affects the chrome when called during startup: on MSW it bails out
+  // with AppearanceResult::CannotChange (see src/msw/darkmode.cpp) the moment
+  // wxTopLevelWindows is non-empty, i.e. as soon as ANY top-level window --
+  // shown or not -- has been constructed (GH #2274). This block has to run
+  // before that happens, which is why m_logWindow -- itself a real wxFrame
+  // under the hood via wxLogFrame, constructed unconditionally by
+  // wxLogWindow's own constructor regardless of its "show" argument -- is
+  // created further down, AFTER this block, rather than right at the top of
+  // OnInit() as it used to be. The runtime call in wxMaxima::ConfigChanged()
+  // stays for macOS/GTK, which can switch live. Read the saved setting
+  // straight from the just-installed config (mirrors Configuration's own
+  // read: default followSystem, clamp to the valid range).
   {
     long appearance = static_cast<long>(Configuration::Appearance::followSystem);
     wxConfig::Get()->Read(wxS("appearance"), &appearance);
@@ -610,6 +611,14 @@ bool MyApp::OnInit() {
       appearance = static_cast<long>(Configuration::Appearance::followSystem);
     ApplyAppearanceToApp(static_cast<Configuration::Appearance>(appearance));
   }
+
+  // if DEBUG=1 show the logwindow at start, else hide it.
+  // in wxMaxima.cpp we later read a configuration variable (LogWindow) and show/hide it, according to the previous state (issue #2033).
+#if (DEBUG==1)
+  m_logWindow = new wxLogWindow(NULL, wxS("wxMaxima log window"), true, false);
+#else
+  m_logWindow = new wxLogWindow(NULL, wxS("wxMaxima log window"), false, false);
+#endif
 
   if (cmdLineParser.Found(wxS("logtostderr"))) {
 #ifdef __WXMSW__

--- a/src/wxMaxima.cpp
+++ b/src/wxMaxima.cpp
@@ -1863,7 +1863,7 @@ void wxMaxima::OnIdle(wxIdleEvent &event) {
         // report failure. (m_openInitialFileError is cleared again a few idle
         // cycles later, so the exit code has to be latched here.)
         if (m_openInitialFileError && m_exitAfterEval)
-          m_exitCode = 1;
+          m_exitCode = EXIT_FILE_OPEN_FAILED;
         event.RequestMore();
         return;
       }
@@ -2089,14 +2089,16 @@ void wxMaxima::OnIdle(wxIdleEvent &event) {
       // missing a codec for one format is never counted here at all (see
       // Image::RecordDecodeFailure()), regardless of --debug.
       if (imagesDataUnavailable > 0) {
-        wxLogMessage(_("Batch mode: %d image(s) could not be loaded at all."),
-                     imagesDataUnavailable);
-        m_exitCode = 1;
+        wxLogMessage(_("Batch mode: %d image(s) could not be loaded at all "
+                       "(exit code %d)."),
+                     imagesDataUnavailable, static_cast<int>(EXIT_IMAGE_LOAD_FAILED));
+        m_exitCode = EXIT_IMAGE_LOAD_FAILED;
       }
       if (m_configuration.GetDebugmode() && (imagesDecodeFailed > 0)) {
-        wxLogMessage(_("Batch mode: %d image(s) failed to decode/render (--debug)."),
-                     imagesDecodeFailed);
-        m_exitCode = 1;
+        wxLogMessage(_("Batch mode: %d image(s) failed to decode/render "
+                       "(--debug, exit code %d)."),
+                     imagesDecodeFailed, static_cast<int>(EXIT_IMAGE_DECODE_FAILED));
+        m_exitCode = EXIT_IMAGE_DECODE_FAILED;
       }
 
       // SaveFile is now a no-op when the session has no file name and we are

--- a/src/wxMaxima.h
+++ b/src/wxMaxima.h
@@ -212,6 +212,33 @@ public:
   //! The maxima command, if we use the --maxima=<str> command. If empty we use the configured path, not a command line option --maxima=<str>.
   static const wxString Get_Maxima_Commandline_Filename() {return maxima_command_line_filename;}
 
+  /*! Dedicated exit codes for a --batch/--exit-on-error run that aborted
+    (GH #2276): every reason used to share the same generic 1, which left an
+    end user with no way to tell *why* a batch run failed without re-reading
+    its log. Picked from the 90-99 range the issue itself suggested, clear of
+    both the shell's own reserved 126-165 range and Maxima's own process exit
+    codes (which this process's exit code is otherwise independent of, since
+    wxMaxima -- not Maxima -- is what a caller's shell actually waits on).
+    A successful run, batch or interactive, always exits 0 -- these values
+    are only ever assigned on a failure path.
+  */
+  enum ExitCode : int {
+    //! A cell reported a Maxima error and --exit-on-error is active.
+    EXIT_MAXIMA_ERROR = 90,
+    //! Maxima asked an interactive question with no scripted answer available
+    //! ("Halts on questions", as --batch's own --help text documents).
+    EXIT_UNANSWERED_QUESTION = 91,
+    //! The file named on the command line could not be opened.
+    EXIT_FILE_OPEN_FAILED = 92,
+    //! Saving the worksheet (on exit, or a --batch run's own final save)
+    //! failed.
+    EXIT_FILE_SAVE_FAILED = 93,
+    //! An embedded image's data could not be loaded at all (GH #2178).
+    EXIT_IMAGE_LOAD_FAILED = 94,
+    //! An embedded image failed to decode/render (GH #2178, --debug only).
+    EXIT_IMAGE_DECODE_FAILED = 95,
+  };
+
   static int GetExitCode(){return m_exitCode;}
 
 private:

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -628,6 +628,22 @@ add_test(
             -P ${CMAKE_CURRENT_SOURCE_DIR}/check_no_stray_procs.cmake)
 set_tests_properties(wxmaxima_no_stray_children PROPERTIES RUN_SERIAL TRUE)
 
+# GH #2276: a --batch run whose input file doesn't exist has nothing to do and
+# must report failure with the dedicated EXIT_FILE_OPEN_FAILED code (92), not
+# the generic 1 every --exit-on-error reason used to share. Chosen as the one
+# exit-code regression test worth having: unlike the other dedicated codes
+# (a Maxima error, an unanswered question, a failed save, an image load/decode
+# failure) this one needs no live Maxima evaluation to reach deterministically
+# -- the file-open check runs before any cell is ever sent to Maxima.
+add_test(
+    NAME wxmaxima_exit_code_file_not_found
+    COMMAND ${CMAKE_COMMAND}
+            -DWXMAXIMA=$<TARGET_FILE:wxmaxima>
+            "-DARGS=--batch;--exit-on-error;this-file-does-not-exist-2276.wxm"
+            -DWORKDIR=${CMAKE_CURRENT_BINARY_DIR}/automatic_test_files
+            -DEXPECTED_EXIT_CODE=92
+            -P ${CMAKE_CURRENT_SOURCE_DIR}/check_exit_code.cmake)
+
 add_test(
     NAME wxmaxima_makelist
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/automatic_test_files

--- a/test/check_exit_code.cmake
+++ b/test/check_exit_code.cmake
@@ -1,0 +1,43 @@
+# -*- mode: cmake -*-
+#
+# Regression guard for GH #2276: a --batch/--exit-on-error run that halts
+# before finishing must exit with the dedicated status code documented for
+# the reason it halted (see wxMaxima::ExitCode in wxMaxima.h and the
+# "EXIT STATUS" section of data/wxmaxima.1.in), not the generic 1 every such
+# reason used to share.
+#
+# This is a `cmake -P` script (not a shell script) so it runs identically on
+# the Linux and Windows CI, the same reasoning check_no_stray_procs.cmake
+# gives for its own use of this pattern.
+#
+# Parameters (all passed as -D on the cmake -P command line):
+#   WXMAXIMA           - path to the wxmaxima executable
+#   ARGS                - semicolon-separated argument list to pass it
+#   WORKDIR             - working directory for the run
+#   EXPECTED_EXIT_CODE  - the exit code the run must produce
+
+cmake_minimum_required(VERSION 3.16)
+
+if(NOT DEFINED WXMAXIMA)
+  message(FATAL_ERROR "check_exit_code: WXMAXIMA must be set")
+endif()
+if(NOT DEFINED EXPECTED_EXIT_CODE)
+  message(FATAL_ERROR "check_exit_code: EXPECTED_EXIT_CODE must be set")
+endif()
+
+execute_process(
+  COMMAND "${WXMAXIMA}" ${ARGS}
+  WORKING_DIRECTORY "${WORKDIR}"
+  OUTPUT_FILE "${WORKDIR}/check_exit_code_run.out"
+  ERROR_FILE  "${WORKDIR}/check_exit_code_run.err"
+  RESULT_VARIABLE run_rc)
+
+if(NOT "${run_rc}" STREQUAL "${EXPECTED_EXIT_CODE}")
+  file(READ "${WORKDIR}/check_exit_code_run.err" run_stderr)
+  message(FATAL_ERROR
+    "wxMaxima exited with code ${run_rc}, expected ${EXPECTED_EXIT_CODE}. "
+    "Command: ${WXMAXIMA} ${ARGS}\n"
+    "stderr:\n${run_stderr}")
+endif()
+
+message(STATUS "OK: wxMaxima exited with the expected code ${EXPECTED_EXIT_CODE}.")

--- a/test/unit_tests/test_LayoutInvariants.cpp
+++ b/test/unit_tests/test_LayoutInvariants.cpp
@@ -49,6 +49,7 @@
 #include "cells/Cell.h"
 #include "cells/GroupCell.h"
 #include "cells/MatrCell.h"
+#include "cells/SetCell.h"
 
 #include <cstdlib>
 #include <vector>
@@ -394,6 +395,71 @@ SCENARIO("Editing operations on one cell do not visit the cells above it") {
     }
 
     g_ws->DestroyTree();
+  }
+}
+
+// Maxima output (via wxMathML.lisp's wxxml-matchfix handler for $set) for
+//   {1,2,3};
+// -- a SetCell wrapping three plain numbers, small enough to never need to be
+// broken into lines.
+static const char *const setMathXml =
+  R"(<mth><lbl altCopy="%o1">(%o1) </lbl><mrow set="true"><t listdelim="true">{</t><mrow><n>1</n></mrow><mo>,</mo><mrow><n>2</n></mrow><mo>,</mo><mrow><n>3</n></mrow><t listdelim="true">}</t></mrow></mth>)";
+
+SCENARIO("A SetCell positions its brace and content cells (GH #2270)") {
+  // SetCell::SetCurrentPoint() used to shadow the inherited
+  // ListCell::SetCurrentPoint() with an override that positioned only the
+  // SetCell itself, never m_open/m_innerCell/m_close -- leaving those
+  // children at their default, never-positioned {-1,-1} sentinel and
+  // drawing them nowhere near the set's own bounding box (GH #2270: a set
+  // rendering as completely blank output, despite computing the right
+  // value). GetCurrentPoint() defaults to {-1,-1} (see Cell::m_currentPoint),
+  // so a child cell left at that sentinel after layout is the direct,
+  // reproducible symptom of the bug.
+  g_cfg->SetCanvasSize(wxSize(900, 600));
+  g_cfg->SetZoomFactor(1.0);
+
+  GIVEN("a group whose output is a small set") {
+    auto group = std::make_unique<GroupCell>(g_cfg, GC_TYPE_CODE, wxS("{1,2,3};"));
+    MathParser parser(g_cfg);
+    auto output = parser.ParseLine(wxString::FromUTF8(setMathXml));
+    REQUIRE(output != nullptr);
+    group->AppendOutput(std::move(output));
+    group->Recalculate();
+    group->SetCurrentPoint(wxPoint(50, 50));
+
+    Cell *setCell = group->GetOutput();
+    REQUIRE(setCell != nullptr);
+    REQUIRE(dynamic_cast<SetCell *>(setCell) != nullptr);
+
+    THEN("the set is not broken into lines and has a real, positive size") {
+      CHECK_FALSE(setCell->IsBrokenIntoLines());
+      CHECK(setCell->GetWidth() > 0);
+      CHECK(setCell->GetHeight() > 0);
+    }
+
+    THEN("its opening brace, content and closing brace are all positioned") {
+      std::vector<Cell *> pieces;
+      for (Cell &piece : OnInner(setCell))
+        pieces.push_back(&piece);
+      REQUIRE(pieces.size() == 3);
+      Cell *open = pieces[0];
+      Cell *inner = pieces[1];
+      Cell *close = pieces[2];
+
+      // None of the three may be left at the "never positioned" sentinel.
+      CHECK(open->GetCurrentPoint() != wxPoint(-1, -1));
+      CHECK(inner->GetCurrentPoint() != wxPoint(-1, -1));
+      CHECK(close->GetCurrentPoint() != wxPoint(-1, -1));
+
+      // The three pieces must be laid out left to right, inside the set's
+      // own bounding box, in that order -- not off in some stale location.
+      const int left = setCell->GetCurrentPoint().x;
+      const int right = left + setCell->GetWidth();
+      CHECK(open->GetCurrentPoint().x >= left);
+      CHECK(open->GetCurrentPoint().x < inner->GetCurrentPoint().x);
+      CHECK(inner->GetCurrentPoint().x < close->GetCurrentPoint().x);
+      CHECK(close->GetCurrentPoint().x < right);
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

- Fix a Maxima `{...}`/`setify(...)` set rendering as completely blank output despite the value being computed correctly (GH #2270) — `SetCell` had a `SetCurrentPoint()` override that shadowed `ListCell`'s and never positioned its children.
- Fix Windows Dark Mode only affecting the worksheet, not the rest of the interface (GH #2274) — `wxLogWindow` was constructed before `wxApp::SetAppearance()` ran, and on MSW that call silently no-ops once any top-level window already exists.
- Fix the manual PDF failing to build for any non-CJK language because it unconditionally required a CJK font (GH #2271) — `CJKmainfont` is now only passed to pandoc when the target language actually needs it.
- Add dedicated `--batch` exit codes (90-95) instead of a single generic exit code, documented in the new man page "EXIT STATUS" section and covered by a new ctest (GH #2276).
- Get SignPath.io Windows installer code-signing working end-to-end (correct artifact-configuration XML: `zip-file` wrapping a `pe-file`, not `executable-file`/`msi-file`).

Each of these is written up in more detail in `AGENTS.md` and the relevant `.claude/skills/*/SKILL.md`, including root-cause analysis and what was/wasn't possible to verify in this sandbox (e.g. the dark-mode fix's actual visual effect can only be confirmed on real Windows hardware).

## Test plan

- [x] Full `ctest` suite run under Xvfb: 226/227 passing (the one failure, `WorksheetExport`, was traced to this sandbox's own LaTeX toolchain state from the #2271 investigation, not a code regression — see `AGENTS.md`).
- [x] New `wxmaxima_exit_code_file_not_found` ctest passing.
- [x] Live Xvfb verification of the `SetCell` fix (`{1,2,3};` renders correctly) and of the `main.cpp` reordering not breaking startup/log-window toggling.
- [x] SignPath signing verified working end-to-end in CI (workflow run `32002673665`, green).
- [ ] Actual Windows Dark Mode visual effect — cannot be verified without real Windows hardware; mechanism confirmed by direct wxWidgets 3.3 MSW source reading.


---
_Generated by [Claude Code](https://claude.ai/code/session_011iszcZR49S3QXrTKUQjiu6)_