### PR TITLE
Add an in-app AI chat sidebar (Anthropic/OpenAI/Google/Qwen)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,7 +89,36 @@ working without extra checks.
   worktree, so it's pre-existing and unrelated to any particular change) --
   not yet root-caused. Don't burn time re-diagnosing either symptom from
   scratch; both are sandbox/pre-existing, not something a code change here
-  broke.
+  broke. **Neither this workaround nor `gnuplot`'s installation (below)
+  persists across sandbox instances** -- confirmed directly: a session that
+  applied both earlier came back to a broad `ctest -E
+  "tutorial|openMacFiles|_cmdline_wxmathml|wxmaxima_version"` run showing 66
+  of 194 tests failing (`boxes`, `lisp`, `threadtest`, `autosave`,
+  `printf_*`, `multiplication`, `config_dialogue_sample`, ... -- a broad,
+  cross-cutting spread with no relation to whatever code change was
+  actually being tested that session), which briefly looked like a real
+  regression until re-running a handful of the failing tests in isolation
+  showed the exact `maxima-index.lisp`/`--exit-on-error` symptom above.
+  **A second, independent gap found the same way, same session: `gnuplot`
+  itself was not installed at all** (`threadtest` failed with `/bin/sh: 1:
+  gnuplot: not found`, no relation to the maxima-index.lisp issue). Plain
+  `apt-get install gnuplot`/`gnuplot-nox` failed here with an unmet
+  `libgd3` dependency -- this sandbox's apt sources include a `ppa:ondrej/
+  php` entry offering a newer `libgd3` build than Ubuntu's own archive, and
+  that PPA's package host was blocked by this sandbox's proxy (`403` on
+  `ppa.launchpadcontent.net`), while the plain Ubuntu-archive `libgd3`
+  (also present as a candidate, just lower-priority) was fetchable fine.
+  Fixed with `apt-get install libgd3=2.3.3-9ubuntu5 gnuplot-nox` (the exact
+  archive version may drift; `apt-cache policy libgd3` shows both
+  candidates and which one is blocked) -- pinning the plain-archive version
+  explicitly sidesteps the blocked PPA instead of needing the PPA fixed.
+  **Moral for future sessions:** if a broad ctest run shows a large,
+  topically-scattered batch of failures all at once (rather than one
+  focused area related to the change being tested), suspect a fresh
+  sandbox instance missing one of these two pre-existing workarounds
+  before suspecting a real regression -- re-run 2-3 of the failing tests
+  in isolation and check their actual output for these exact symptoms
+  first, per the "don't burn time re-diagnosing from scratch" note above.
 
 - **`tutorial_10Minutes` intermittent CI failure -- the workaround below is
   verified, but the real underlying bug is CONFIRMED and still UNFIXED

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -415,6 +415,132 @@ a local TCP socket.
     process and the port genuinely closes. Also confirmed the whole
     `ctest` suite's non-batch/non-live-Maxima tests still pass and the
     full tree rebuilds with zero new warnings.
+- **AI chat sidebar (`src/ai/AiProvider.{h,cpp}`, `src/sidebars/AiChatSidebar.{h,cpp}`)
+  -- a follow-up to the MCP server above, for the case where the "AI tool"
+  is wxMaxima's own UI rather than an external one.** A docked sidebar
+  (View -> Sidebars -> AI Chat) that chats with Anthropic, OpenAI, Google
+  Gemini or Qwen (via DashScope's OpenAI-compatible endpoint) using a
+  pasted API key -- no OAuth, since none of these four offer a legitimate
+  third-party OAuth flow for a desktop app to use. v1 is deliberately
+  read-only and has no tool-calling: `AiChatSidebar::BuildContextSnapshot()`
+  sends one plain-text snapshot of the worksheet (via the *same* `McpTools`
+  the MCP server already uses, `McpTools::ReadWorksheet()`) as a system-
+  style context message, truncated to `MAX_CONTEXT_LENGTH` (8000 chars);
+  the model can discuss it but has no way to act on the worksheet, since
+  wiring up real tool-calling (there are 8 tools now, MCP's `tools/call`
+  can already run them) is real design work of its own -- a natural
+  follow-up, not attempted here.
+  - **Provider abstraction (`AiProvider.h`):** one small `AiProvider` base
+    class per provider family, each implementing four things that differ
+    per API -- `RequestUrl()`, `AuthHeaders()`, `BuildRequestBody()`,
+    `ParseReply()` -- all pure string/JSON logic with no networking of its
+    own, which is what makes `test/unit_tests/test_AiProvider.cpp` able to
+    pin all four providers' request/response shapes with zero live network
+    access (`#include "ai/AiProvider.cpp"` directly, same lightweight
+    pattern as `test_MaximaProtocol.cpp`). OpenAI and Qwen share one
+    `OpenAiCompatibleProvider` implementation (DashScope's compatible-mode
+    endpoint is byte-for-byte the same `chat/completions` shape, only the
+    URL differs) -- confirmed via `test_AiProvider.cpp`'s "Qwen, via
+    DashScope's OpenAI-compatible endpoint" scenario, not assumed from the
+    provider's marketing docs.
+  - **Lifetime safety across the async boundary:** `MakeAiProvider()`
+    returns a `std::shared_ptr<AiProvider>`, not `unique_ptr`, and the
+    static `AiProvider::SendChat(std::shared_ptr<const AiProvider> self,
+    ...)` takes that shared ownership explicitly and captures it by value
+    into the completion lambda. This is load-bearing, not defensive
+    overkill: `AiChatSidebar::m_provider` can be replaced mid-flight (the
+    user opens Options and changes provider/model while a request is still
+    in the air), and without the shared_ptr the callback's `self->Name()`/
+    `self->ParseReply()` calls would use a dangling pointer to whatever the
+    sidebar used to point at. `wxWebRequest` itself follows the exact same
+    "local value, never stored anywhere else, goes out of scope right
+    after `.Start()`" shape as the codebase's one prior use
+    (`wxMaxima::CheckForUpdates()`) -- confirmed this is fine because
+    `wxWebRequest` is a ref-counted handle wxWebSession itself keeps alive
+    while the request is in flight, not something this code has to keep
+    alive itself. The completion lambda is deliberately never `Unbind()`'d
+    for the same reason `CheckForUpdates()`'s never is: wx's functor-based
+    `Bind()` has no reliable identity to `Unbind()` a lambda by, and one
+    small permanently-bound no-op-after-firing lambda per chat turn is not
+    a real leak at realistic chat volumes. The request's id must be a real,
+    unique one from `wxWindow::NewControlId()` (stored in a
+    `wxWindowIDRef`, which releases it back to wx's finite id pool once
+    nothing references it, unlike a plain `int`) -- with the default
+    `wxID_ANY` every request would share one id and every past request's
+    stale lambda would refire on every new request's completion.
+  - **`wxWebRequest::State_Unauthorized` is not optional to handle -- an
+    invalid API key hangs the chat forever, silently, if you only handle
+    `State_Completed`/`State_Failed`/`State_Cancelled` (confirmed live,
+    not guessed).** The natural-looking implementation handles exactly
+    those three states and falls through to `default: break;` for
+    anything else. Live-testing against the real Anthropic API with a
+    deliberately wrong key (`sk-ant-fake-test-key-1234` -- this sandbox's
+    `no_proxy` list happens to include `api.anthropic.com`, so direct
+    outbound HTTPS to it works here without a real key or a full model
+    call) reproduced a genuine hang: the sidebar sat on "Waiting for
+    Anthropic..." with Send disabled for 7+ minutes and never recovered.
+    Root-caused with `/proc/<pid>/fd` + `/proc/<pid>/net/tcp` (this
+    sandbox has no `tcpdump`): a real ESTABLISHED TCP connection to
+    `api.anthropic.com`'s actual IP was sitting open and idle (0 bytes in
+    either queue), and a raw `curl` to the same endpoint with the same fake
+    key returned instantly with a normal HTTP 401 -- so the network path
+    itself was never the problem. Confirmed with temporary `wxLogMessage`
+    tracing in the event handler (removed before committing) that
+    `wxWebRequestEvent::GetState()` reports `State_Unauthorized` (value
+    `1`) for this response, not `State_Completed` with `status==401` --
+    wx's web-request backend intercepts any 401 (confirmed via a raw
+    `curl -i` that Anthropic's actual 401 response carries no
+    `WWW-Authenticate` header at all, so this isn't about a real HTTP-auth
+    challenge, just the status code alone) and diverts it to this separate
+    state, meant for the case where the app might retry with different
+    credentials via `wxWebAuthChallenge::SetCredentials()`. None of these
+    four providers use real HTTP Basic/Digest auth -- they authenticate via
+    a plain header (`x-api-key`/`Authorization: Bearer`/`x-goog-api-key`)
+    -- so there is no challenge this app could ever answer, and left
+    unhandled the request simply never produces another event on its own.
+    Fixed by adding an explicit `case wxWebRequest::State_Unauthorized`
+    that reads `evt.GetResponse()` (still valid here -- the server's full
+    401 response already arrived before wx reinterpreted it), reports it
+    through the same `callback(false, ...)` path as a non-2xx
+    `State_Completed`, and calls `.Cancel()` on a copy of
+    `evt.GetRequest()` (a ref-counted handle, so the copy cancels the same
+    underlying request) so the connection doesn't dangle. `Cancel()` itself
+    raises a *second* event (`State_Cancelled`) for the same request id,
+    so a `std::shared_ptr<bool> done` guard (captured by the lambda,
+    checked at the top and set before every `callback()` call) stops that
+    second event from invoking `callback` twice for one chat turn -- caught
+    by reasoning through the control flow before it could ship as a
+    double-`AppendToHistory()` bug, not found live. Re-verified live after
+    the fix with the identical fake-key setup: the sidebar's history now
+    shows the real `{"type":"error","error":{"type":"authentication_error",
+    "message":"API key is invalid."},...}` body from Anthropic, the status
+    line returns to "Chatting with Anthropic", and Send/Clear both
+    re-enable -- confirming the fix, not just the absence of a hang.
+  - **Layout: this sidebar docks into a narrow shared column (e.g. next to
+    Table of Contents), and any horizontal-sibling layout inside it risks
+    the same "one control crowds another down to an invisible sliver"
+    failure.** First cut put the input box beside a button column, and
+    separately tried two buttons side by side below a full-width input --
+    both silently rendered one of the two controls at a few pixels wide,
+    invisible in normal use. Confirmed live (not guessed) by temporarily
+    setting each competing control's background to a distinct debug colour
+    and screenshotting in Xvfb: the "input" area was entirely one colour
+    with zero of the other visible anywhere. Fixed by abandoning every
+    horizontal pairing and stacking status/history/input/Send/Clear as
+    five independent children of one vertical `wxBoxSizer`, each full
+    width -- no two controls ever compete for the same row's width.
+  - **Verification recap:** `test_AiProvider` (54 assertions across all
+    four providers' request/response/error shapes, no live network) plus
+    the live Xvfb round trip above through the real Anthropic API endpoint
+    (this sandbox's `no_proxy` list permits it) covering the layout fix,
+    the full send/receive/error cycle, and the `State_Unauthorized` hang
+    and its fix. Not verified here: a real, valid API key's successful
+    reply for any of the four providers (this sandbox has no real
+    credentials for any of them, and the user's own account is Anthropic's
+    -- theirs to try first), and OpenAI/Google/Qwen's actual live endpoints
+    at all (only Anthropic was reachable from this sandbox; the other
+    three were checked only against their documented request/response
+    shapes in `test_AiProvider.cpp`, not against a live server).
 - **wxAuiManager:** The application uses `wxAuiManager` for its complex layout (sidebars, toolbars, worksheet).
   - **Linux/GTK Timing:** On Linux (especially KDE Plasma with Global Menus), calling `m_manager.Update()` can disrupt the menu bar if it's already attached. This is a known environmental issue in the interaction between wxWidgets, GTK3, and the KDE Global Menu proxy.
     - **Automated Fix:** On systems with wxWidgets <= 3.2 running on KDE, Unity, or with `appmenu-gtk-module` enabled, wxMaxima automatically sets `UBUNTU_MENUPROXY=0` at startup in `main.cpp` to force menus to remain within the window and prevent disappearance.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1215,6 +1215,100 @@ a local TCP socket.
     **Do not re-attempt the struct-copy-vs-dup2 theory a third time** -- it
     has now been disconfirmed twice, once by real CI and once by a
     controlled, reproducible Wine-based test built specifically to check it.
+  - **Follow-up session (2026-09-06): three more concrete theories tested
+    and disconfirmed with targeted Wine repros, and one genuinely new,
+    unexamined fact surfaced -- still unsolved, but the search space is
+    narrower.** Prompted by the user directly asking why a "theoretically
+    deterministic" system could be flaky at all -- a fair challenge, and
+    the answer turned out to be "several plausible mechanisms exist and
+    were checked one at a time," not "there's an obvious smoking gun."
+    1. *Richer repro, closer to the real `OnInit()` sequence.* The
+       previous session's Wine repro was a bare `fprintf` -- this pass
+       built a second repro (no wxWidgets, still cross-compiled
+       `-mwindows -static` MinGW, run under the same 32-bit Wine prefix)
+       that adds back three things the minimal repro omitted: a real
+       native `HWND` via `CreateWindowExA`/`RegisterClassA` (mimicking
+       `wxLogWindow`'s always-real `wxFrame`), a real Windows registry
+       touch via `RegCreateKeyExA`/`RegCloseKey` (mimicking
+       `wxConfig::Set(new wxConfig(...))`), a `LoadLibraryA("uxtheme.dll")`
+       call (mimicking `ApplyAppearanceToApp()`'s likely internal use of
+       that DLL on wx >= 3.3, per GH #2274's own investigation), and
+       several `fprintf(stderr, ...)` calls interleaved with the above
+       (mimicking `--logtostderr`'s `wxLogChain(new wxLogStderr)` plus the
+       several real startup log lines the actual app emits before reaching
+       `-v`) -- then the real `--version`-equivalent `fprintf(stdout,
+       ...)` and `exit(0)`. Piped through `| cat` (this sandbox has no
+       Windows/real ctest to test against directly) for 150 runs: **0
+       failures.** This doesn't clear any of those four mechanisms
+       individually, but it does rule out this *specific combination* of
+       them as sufficient on its own to reproduce the bug under Wine.
+    2. *A new, specific hypothesis about `_dup2()` itself, tested and
+       disconfirmed decisively (not just "didn't reproduce in N runs" --
+       a targeted mechanism check).* Reasoned through
+       `BindStdStreamToParent()`'s exact sequence
+       (`_open_osfhandle()` -> `_dup2(fd, target)` -> `_close(fd)`) and
+       asked: does `_dup2()` actually duplicate the underlying Win32
+       `HANDLE` (POSIX-correct: the source and target fds become
+       independently closeable), or does it just copy the raw handle
+       *value* into the target fd's slot -- in which case `_close(fd)`
+       right after would close the ONE shared handle out from under the
+       target too, a genuine use-after-close bug whose symptom (silently
+       broken or misdirected writes) would exactly fit the observed
+       failure? Wrote a standalone micro-test (`dup2test.cpp`, this
+       session's scratchpad) around a real `CreatePipe()`: opens the
+       write end via `_open_osfhandle()`, `_dup2()`s it onto `stdout`,
+       closes the source fd exactly like the real code does, then probes
+       with `_get_osfhandle()` before/after and an actual
+       `fprintf(stdout, ...)` read back via `PeekNamedPipe`/`ReadFile` on
+       the pipe's read end. Result: `_dup2()` produced a genuinely
+       *independent* duplicated handle (different raw value from the
+       source), closing the source left the target's handle valid, and
+       the probe write landed correctly in the pipe. **This specific
+       failure mode is ruled out** -- at least as Wine's `msvcrt`
+       reimplementation behaves; real Windows' actual `ucrtbase.dll`/
+       `msvcrt.dll` could in principle differ from Wine's compatibility
+       shim here, which is the one caveat this test can't close without
+       real hardware.
+    3. *A newly-surfaced, previously-undocumented fact: the failing test
+       runs under real `ctest -j 2` parallelism on the actual CI job,*
+       not serially. `.github/workflows/compile_windows.yml`'s "Run
+       integration tests" step (where `wxmaxima_version_string` actually
+       runs -- it isn't part of the earlier `-L unittest` step, which is
+       serial) is `ctest -LE "unittest|needs_posix" -E "multithreadtest"
+       --repeat after-timeout:2 -j 2 --output-on-failure`. Nothing in the
+       investigation up to this point had considered concurrent test
+       execution as a factor at all. `--repeat after-timeout:2` only
+       retries a *timed-out* test, not this failure mode (exit 0, wrong/
+       missing content) -- consistent with every observed failure being a
+       first-try, non-retried one. Tested by running pairs of the richer
+       repro (#1 above) concurrently under Wine, 60 pairs (120 runs): **0
+       failures.** Real contention for CPU/scheduler time between two
+       genuinely concurrent Windows processes is very plausibly still a
+       necessary ingredient this sandbox's Wine environment (limited
+       parallelism, no real multi-core Windows scheduler, no antivirus/
+       Defender real-time scanning, none of the other background load a
+       shared GitHub Actions Windows runner carries) simply can't
+       reproduce regardless of how faithfully the *code path* is copied --
+       which would also explain why every purely-mechanism-level Wine
+       repro across two sessions has failed to reproduce this, while the
+       bug remains completely reliable-in-its-unreliability on the actual
+       CI runner. **This `-j 2` fact belongs in any future bisection
+       attempt** (e.g. a real Windows machine specifically running the
+       full integration suite with `-j 2` many times, not just the single
+       `wxmaxima_version_string` test in isolation, to preserve whatever
+       contention the parallel scheduling introduces) and should not be
+       re-discovered from scratch.
+    **Net effect of this session's pass**: three more plausible, concrete
+    mechanisms individually checked and ruled out (or at least not
+    reproduced) with real, targeted tests rather than guesses -- the
+    struct-copy/dup2 theory, the richer-repro combination, the
+    shared-handle-after-close theory, and the bare concurrent-execution
+    theory are all now either disconfirmed or failed to reproduce under
+    Wine. The bug is still open. The most defensible remaining position:
+    whatever the actual trigger is, it very likely needs *real Windows*
+    (not Wine) under *real contention* (not a quiet, idle sandbox) to
+    reproduce at all -- which matches this bug's own history of being
+    essentially unreproducible everywhere except the actual CI runner.
 
 - **System tray icon (`src/TrayIcon.{h,cpp}`, GH #2286) -- mirrors the busy
   status, gated entirely by `wxUSE_TASKBARICON`.** The maintainer's own

--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,11 @@
   in the worksheet -- every tool only reads, except adding/removing a
   variable from the watchlist, which only changes what that sidebar
   displays, the same as typing a name into it by hand.
+- Added an "AI Chat" sidebar (View -> Sidebars -> AI Chat) that lets you
+  chat about the current worksheet with Anthropic, OpenAI, Google Gemini or
+  Qwen, using your own API key (configured in Options -> AI Chat). It sends
+  a read-only snapshot of the worksheet as context; it cannot edit,
+  evaluate or otherwise change the worksheet itself.
 - Fixed a modal dialog popping up at every startup on wxWidgets >= 3.3
   reporting the (successful) dark/light appearance change as a debug
   message -- the diagnostic log call ran before wxMaxima's own log window

--- a/locales/wxMaxima/wxMaxima.pot
+++ b/locales/wxMaxima/wxMaxima.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-09-06 13:41+0000\n"
+"POT-Creation-Date: 2026-09-06 15:12+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -51,117 +51,117 @@ msgid ""
 "Now reads: "
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2010
+#: ../../src/wxMaxima.cpp:2011
 msgid ""
 "\n"
 "Use the menu \"View->Toggle log window\" to show/hide a log window with all debug messages."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1609
+#: ../../src/dialogs/ConfigDialogue.cpp:1623
 msgid "      -X \"--control-stack-size <int>\""
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1608
+#: ../../src/dialogs/ConfigDialogue.cpp:1622
 msgid "      -X \"--dynamic-space-size <int>\""
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1612
+#: ../../src/dialogs/ConfigDialogue.cpp:1626
 msgid "      -X '--control-stack-size <int>'"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1611
+#: ../../src/dialogs/ConfigDialogue.cpp:1625
 msgid "      -X '--dynamic-space-size <int>'"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1591
+#: ../../src/dialogs/ConfigDialogue.cpp:1605
 msgid "      -l <name>"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1597
+#: ../../src/dialogs/ConfigDialogue.cpp:1611
 msgid "      -u <versionnumber>"
 msgstr ""
 
-#: ../../src/Configuration.cpp:1406
+#: ../../src/Configuration.cpp:1429
 #, c-format
 msgid "  Cells converted to 2D: %ld"
 msgstr ""
 
-#: ../../src/Configuration.cpp:1405
+#: ../../src/Configuration.cpp:1428
 #, c-format
 msgid "  Cells converted to linear: %ld"
 msgstr ""
 
-#: ../../src/Configuration.cpp:1407
+#: ../../src/Configuration.cpp:1430
 #, c-format
 msgid "  Cells drawn at the wrong font size: %ld"
 msgstr ""
 
-#: ../../src/Configuration.cpp:1397
+#: ../../src/Configuration.cpp:1420
 #, c-format
 msgid "  Font cache hits: %ld"
 msgstr ""
 
-#: ../../src/Configuration.cpp:1398
+#: ../../src/Configuration.cpp:1421
 #, c-format
 msgid "  Font cache misses: %ld"
 msgstr ""
 
-#: ../../src/Configuration.cpp:1409
+#: ../../src/Configuration.cpp:1432
 #, c-format
 msgid "  Full-window worksheet repaints: %ld"
 msgstr ""
 
-#: ../../src/Configuration.cpp:1393
+#: ../../src/Configuration.cpp:1416
 #, c-format
 msgid "  Manual anchors from built-in: %ld"
 msgstr ""
 
-#: ../../src/Configuration.cpp:1394
+#: ../../src/Configuration.cpp:1417
 #, c-format
 msgid "  Manual anchors from cache: %ld"
 msgstr ""
 
-#: ../../src/Configuration.cpp:1395
+#: ../../src/Configuration.cpp:1418
 #, c-format
 msgid "  Manual anchors self-compiled: %ld"
 msgstr ""
 
-#: ../../src/Configuration.cpp:1396
+#: ../../src/Configuration.cpp:1419
 #, c-format
 msgid "  Maxima processes spawned: %ld"
 msgstr ""
 
-#: ../../src/Configuration.cpp:1403
+#: ../../src/Configuration.cpp:1426
 #, c-format
 msgid "  Recalculation needed - Cells appended: %ld"
 msgstr ""
 
-#: ../../src/Configuration.cpp:1402
+#: ../../src/Configuration.cpp:1425
 #, c-format
 msgid "  Recalculation needed - Config changed: %ld"
 msgstr ""
 
-#: ../../src/Configuration.cpp:1404
+#: ../../src/Configuration.cpp:1427
 #, c-format
 msgid "  Recalculation needed - Editor dirty: %ld"
 msgstr ""
 
-#: ../../src/Configuration.cpp:1399
+#: ../../src/Configuration.cpp:1422
 #, c-format
 msgid "  Recalculation needed - Font invalid: %ld"
 msgstr ""
 
-#: ../../src/Configuration.cpp:1401
+#: ../../src/Configuration.cpp:1424
 #, c-format
 msgid "  Recalculation needed - Font mismatch: %ld"
 msgstr ""
 
-#: ../../src/Configuration.cpp:1400
+#: ../../src/Configuration.cpp:1423
 #, c-format
 msgid "  Recalculation needed - Size invalid: %ld"
 msgstr ""
 
-#: ../../src/Configuration.cpp:1408
+#: ../../src/Configuration.cpp:1431
 #, c-format
 msgid "  Worksheet repaints: %ld"
 msgstr ""
@@ -193,7 +193,7 @@ msgstr ""
 msgid " Returns the unique elements of the list"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1655
+#: ../../src/wxMaximaFrame.cpp:1666
 msgid " Wrong, if a is complex"
 msgstr ""
 
@@ -220,18 +220,18 @@ msgstr ""
 msgid "\"..\" means \"one directory up\"."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1211
+#: ../../src/dialogs/ConfigDialogue.cpp:1225
 msgid "\"Copy LaTeX\" adds equation markers"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:446
+#: ../../src/dialogs/ConfigDialogue.cpp:449
 msgid ""
 "\"MathML (rendered by the browser)\" is the recommended choice: every current browser renders MathML natively and instantly, and the exported page needs no JavaScript and makes no requests to any external server.\n"
 "\"MathML + MathJaX fall-back for old browsers\" behaves the same on current browsers, but additionally downloads MathJaX from an external server (a CDN) as a fall-back on browsers too old to support MathML. Only choose this if you need to support such browsers and accept the external dependency.\n"
 "Bitmaps tend to need more band width than the other options. They lack support for advanced features like drag-and-drop or accessibility. Also they have problems aligning and scaling with the rest of the text and might use fonts that don't match the rest of the document."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:933
+#: ../../src/dialogs/ConfigDialogue.cpp:947
 msgid "\"Numpad Enter\" always evaluates cells"
 msgstr ""
 
@@ -244,7 +244,7 @@ msgstr ""
 msgid "%d differences"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:1861
+#: ../../src/wxMaxima.cpp:1862
 #, c-format
 msgid "%i cells in evaluation queue"
 msgstr ""
@@ -259,67 +259,77 @@ msgstr ""
 msgid "%s image, %li×%li, %li ppi"
 msgstr ""
 
+#: ../../src/ai/AiProvider.cpp:315
+#, c-format
+msgid "%s rejected the API key (HTTP 401): %s"
+msgstr ""
+
+#: ../../src/ai/AiProvider.cpp:286
+#, c-format
+msgid "%s returned HTTP %d: %s"
+msgstr ""
+
 #: ../../src/Autocomplete.cpp:405
 #, c-format
 msgid "%s: Can't interpret line: %s"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2954
+#: ../../src/wxMaxima.cpp:2955
 #, c-format
 msgid ""
 "%sCould not write the setting for:%s\n"
 "(Is the client installed?)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1751
+#: ../../src/wxMaximaFrame.cpp:1762
 msgid "&Algebraic Mode"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1980
+#: ../../src/wxMaximaFrame.cpp:1991
 msgid "&Apropos..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:703
+#: ../../src/wxMaximaFrame.cpp:713
 msgid "&Batch File...\tCtrl+B"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1371
+#: ../../src/wxMaximaFrame.cpp:1382
 msgid "&Boundary Value Problem..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:2046
+#: ../../src/wxMaximaFrame.cpp:2057
 msgid "&Bug Report"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1601
+#: ../../src/wxMaximaFrame.cpp:1612
 msgid "&Calculus"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1697
+#: ../../src/wxMaximaFrame.cpp:1708
 msgid "&Canonical Form"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1451
+#: ../../src/wxMaximaFrame.cpp:1462
 msgid "&Characteristic Polynomial..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1083
+#: ../../src/wxMaximaFrame.cpp:1094
 msgid "&Clear Memory"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1679
+#: ../../src/wxMaximaFrame.cpp:1690
 msgid "&Combine Factorials"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1724
+#: ../../src/wxMaximaFrame.cpp:1735
 msgid "&Complex Simplification"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1598
+#: ../../src/wxMaximaFrame.cpp:1609
 msgid "&Continued Fraction"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:732
+#: ../../src/wxMaximaFrame.cpp:742
 msgid "&Copy\tCtrl+C"
 msgstr ""
 
@@ -327,103 +337,103 @@ msgstr ""
 msgid "&Definite integration"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1717
+#: ../../src/wxMaximaFrame.cpp:1728
 msgid "&Demoivre"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1455
+#: ../../src/wxMaximaFrame.cpp:1466
 msgid "&Determinant"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1562
+#: ../../src/wxMaximaFrame.cpp:1573
 msgid "&Differentiate..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:783
+#: ../../src/wxMaximaFrame.cpp:793
 msgid "&Edit"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1339
+#: ../../src/wxMaximaFrame.cpp:1350
 msgid "&Eliminate Variable..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1411
+#: ../../src/wxMaximaFrame.cpp:1422
 msgid "&Enter Matrix..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1979
+#: ../../src/wxMaximaFrame.cpp:1990
 msgid "&Example..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1620
+#: ../../src/wxMaximaFrame.cpp:1631
 msgid "&Expand Expression"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1693
+#: ../../src/wxMaximaFrame.cpp:1704
 msgid "&Expand Trigonometric"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1722
+#: ../../src/wxMaximaFrame.cpp:1733
 msgid "&Exponentialize"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:708
+#: ../../src/wxMaximaFrame.cpp:718
 msgid "&Export..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1612
+#: ../../src/wxMaximaFrame.cpp:1623
 msgid "&Factor Expression"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:720
+#: ../../src/wxMaximaFrame.cpp:730
 msgid "&File"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1112
+#: ../../src/wxMaximaFrame.cpp:1123
 msgid "&Functions"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1586
+#: ../../src/wxMaximaFrame.cpp:1597
 msgid "&Greatest Common Divisor..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:2080
+#: ../../src/wxMaximaFrame.cpp:2091
 msgid "&Help"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1549
+#: ../../src/wxMaximaFrame.cpp:1560
 msgid "&Integrate..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1057
+#: ../../src/wxMaximaFrame.cpp:1068
 msgid "&Interrupt\tCtrl+G"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1448
+#: ../../src/wxMaximaFrame.cpp:1459
 msgid "&Invert Matrix"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:2054
+#: ../../src/wxMaximaFrame.cpp:2065
 msgid "&License"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1859
+#: ../../src/wxMaximaFrame.cpp:1870
 msgid "&List"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:698
+#: ../../src/wxMaximaFrame.cpp:708
 msgid "&Load Package...\tCtrl+L"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1325
+#: ../../src/wxMaximaFrame.cpp:1336
 msgid "&Maxima"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1978
+#: ../../src/wxMaximaFrame.cpp:1989
 msgid "&Maxima help"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1756
+#: ../../src/wxMaximaFrame.cpp:1767
 msgid "&Modulus Computation..."
 msgstr ""
 
@@ -431,11 +441,11 @@ msgstr ""
 msgid "&New\tCtrl+N"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1966
+#: ../../src/wxMaximaFrame.cpp:1977
 msgid "&Numeric"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1881
+#: ../../src/wxMaximaFrame.cpp:1892
 msgid "&Numeric Output"
 msgstr ""
 
@@ -451,11 +461,11 @@ msgstr ""
 msgid "&Open\tCtrl+O"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:686
+#: ../../src/wxMaximaFrame.cpp:696
 msgid "&Open...\tCtrl+O"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1876
+#: ../../src/wxMaximaFrame.cpp:1887
 msgid "&Plot"
 msgstr ""
 
@@ -463,7 +473,7 @@ msgstr ""
 msgid "&Power series"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:712
+#: ../../src/wxMaximaFrame.cpp:722
 msgid "&Print...\tCtrl+P"
 msgstr ""
 
@@ -471,31 +481,31 @@ msgstr ""
 msgid "&Rational"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1690
+#: ../../src/wxMaximaFrame.cpp:1701
 msgid "&Reduce Trigonometric"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1067
+#: ../../src/wxMaximaFrame.cpp:1078
 msgid "&Restart Maxima\tCtrl+Alt+R"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:696
+#: ../../src/wxMaximaFrame.cpp:706
 msgid "&Save\tCtrl+S"
 msgstr ""
 
-#: ../../src/wizards/SumWiz.cpp:43 ../../src/wxMaximaFrame.cpp:1758
+#: ../../src/wizards/SumWiz.cpp:43 ../../src/wxMaximaFrame.cpp:1769
 msgid "&Simplify"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1677
+#: ../../src/wxMaximaFrame.cpp:1688
 msgid "&Simplify Factorials"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1687
+#: ../../src/wxMaximaFrame.cpp:1698
 msgid "&Simplify Trigonometric"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1331
+#: ../../src/wxMaximaFrame.cpp:1342
 msgid "&Solve..."
 msgstr ""
 
@@ -507,19 +517,19 @@ msgstr ""
 msgid "&Taylor series"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1128
+#: ../../src/wxMaximaFrame.cpp:1139
 msgid "&Time Display"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1468
+#: ../../src/wxMaximaFrame.cpp:1479
 msgid "&Transpose Matrix"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1701
+#: ../../src/wxMaximaFrame.cpp:1712
 msgid "&Trigonometric Simplification"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1114
+#: ../../src/wxMaximaFrame.cpp:1125
 msgid "&Variables"
 msgstr ""
 
@@ -559,7 +569,7 @@ msgstr ""
 msgid "(Not a valid variable name)"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:183
+#: ../../src/dialogs/ConfigDialogue.cpp:184
 msgid "(Use default language)"
 msgstr ""
 
@@ -575,19 +585,19 @@ msgstr ""
 msgid "(f(x),x,a,b), (semi-) infinite interval"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1937
+#: ../../src/wxMaximaFrame.cpp:1948
 msgid "(f(x),x,a,b), Epsilon algorithm"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1939
+#: ../../src/wxMaximaFrame.cpp:1950
 msgid "(f(x),x,a,b), infinite interval"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1935
+#: ../../src/wxMaximaFrame.cpp:1946
 msgid "(f(x),x,a,b), strategy of Aind"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:596 ../../src/wxMaximaFrame.cpp:1963
+#: ../../src/MaximaCommandMenus.cpp:596 ../../src/wxMaximaFrame.cpp:1974
 msgid "(f(x),x,y) with singularities+discontinuities"
 msgstr ""
 
@@ -625,23 +635,23 @@ msgstr ""
 msgid "2D"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1405
+#: ../../src/wxMaximaFrame.cpp:1416
 msgid "2D Array to Matrix..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:839
+#: ../../src/wxMaximaFrame.cpp:850
 msgid "2D equations using ASCII Art"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:842
+#: ../../src/wxMaximaFrame.cpp:853
 msgid "2D equations using ASCII Art with unicode characters, if available"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:789
+#: ../../src/dialogs/ConfigDialogue.cpp:803
 msgid "2D if it fits on the page width"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:788
+#: ../../src/dialogs/ConfigDialogue.cpp:802
 msgid "2D, whenever possible"
 msgstr ""
 
@@ -649,7 +659,7 @@ msgstr ""
 msgid "3D"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:1865
+#: ../../src/wxMaxima.cpp:1866
 #, c-format
 msgid "; %i commands left in the current cell"
 msgstr ""
@@ -680,7 +690,7 @@ msgid ""
 "Most probable cause: A missing comma between two list items."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2737
+#: ../../src/wxMaxima.cpp:2738
 #, c-format
 msgid "A find event, %s"
 msgstr ""
@@ -741,11 +751,11 @@ msgstr ""
 msgid "A right-associative function"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:436
+#: ../../src/dialogs/ConfigDialogue.cpp:439
 msgid "A scale factor for the printout. Helpful for printing big equations on small pdf pages."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1730
+#: ../../src/wxMaximaFrame.cpp:1741
 msgid "A search-and-replace for equations"
 msgstr ""
 
@@ -773,7 +783,7 @@ msgstr ""
 msgid "A subsection heading"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1732
+#: ../../src/wxMaximaFrame.cpp:1743
 msgid "A subst with basic maths knowledge"
 msgstr ""
 
@@ -803,19 +813,28 @@ msgstr ""
 msgid "A worksheet cell"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1538
+#: ../../src/wxMaximaFrame.cpp:1549
 msgid "A&pply function to each Matrix element..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1384
+#: ../../src/wxMaximaFrame.cpp:1395
 msgid "A&t Value..."
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:290 ../../src/wxMaximaFrame.cpp:314
+#: ../../src/wxMaximaFrame.cpp:825
+msgid "AI Chat"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1983
+msgid "API key:"
 msgstr ""
 
 #: ../../src/Styles.cpp:169
 msgid "ASCII maths"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1658
+#: ../../src/dialogs/ConfigDialogue.cpp:1672
 msgid "Abort evaluation on error"
 msgstr ""
 
@@ -824,11 +843,11 @@ msgstr ""
 msgid "Aborting due to --exit-on-error (exit code %d). Cell: %s"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:2075
+#: ../../src/wxMaximaFrame.cpp:2086
 msgid "About"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:2075 ../../src/wxMaximaFrame.cpp:2077
+#: ../../src/wxMaximaFrame.cpp:2086 ../../src/wxMaximaFrame.cpp:2088
 msgid "About wxMaxima"
 msgstr ""
 
@@ -844,7 +863,7 @@ msgstr ""
 msgid "Accepts one variable or a list in the format [var1,var2,...]"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:292
+#: ../../src/dialogs/ConfigDialogue.cpp:295
 msgid "Accessibility"
 msgstr ""
 
@@ -852,19 +871,23 @@ msgstr ""
 msgid "Accuracy"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1464
+#: ../../src/dialogs/ConfigDialogue.cpp:1960
+msgid "Active provider:"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1475
 msgid "Ad&joint Matrix"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1753
+#: ../../src/wxMaximaFrame.cpp:1764
 msgid "Add Algebraic E&quality..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1108
+#: ../../src/wxMaximaFrame.cpp:1119
 msgid "Add a directory to search path"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1848
+#: ../../src/wxMaximaFrame.cpp:1859
 msgid "Add a new item to the beginning of the list. Useful for creating stacks."
 msgstr ""
 
@@ -884,7 +907,7 @@ msgstr ""
 msgid "Add dir to path:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1754
+#: ../../src/wxMaximaFrame.cpp:1765
 msgid "Add equality to the rational simplifier"
 msgstr ""
 
@@ -892,11 +915,11 @@ msgstr ""
 msgid "Add more symbols"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1265
+#: ../../src/dialogs/ConfigDialogue.cpp:1279
 msgid "Add the .wxmx file to the HTML export"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1108
+#: ../../src/wxMaximaFrame.cpp:1119
 msgid "Add to &Path..."
 msgstr ""
 
@@ -915,35 +938,35 @@ msgstr ""
 msgid "Added much text (%li chars) to the XML inspector."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1936
+#: ../../src/dialogs/ConfigDialogue.cpp:2023
 msgid "Additional clipboard formats to put on the clipboard on ordinary copy"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:393
+#: ../../src/dialogs/ConfigDialogue.cpp:396
 msgid "Additional commands to be added to the preamble of LaTeX output for pdftex."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1190
+#: ../../src/dialogs/ConfigDialogue.cpp:1204
 msgid "Additional lines for the TeX preamble:"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:389
+#: ../../src/dialogs/ConfigDialogue.cpp:392
 msgid "Additional parameters for Maxima (e.g. -l clisp)."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1583
+#: ../../src/dialogs/ConfigDialogue.cpp:1597
 msgid "Additional parameters for Maxima (restart Maxima after changes)"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1321
+#: ../../src/dialogs/ConfigDialogue.cpp:1335
 msgid "Additional symbols for the \"symbols\" sidebar:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1658
+#: ../../src/wxMaximaFrame.cpp:1669
 msgid "Additionally: log(a*b)=log(a)+log(b)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1662
+#: ../../src/wxMaximaFrame.cpp:1673
 msgid "Additionally: log(a/b)=log(a)-log(b), a and b positive integers"
 msgstr ""
 
@@ -951,19 +974,19 @@ msgstr ""
 msgid "Additive function: f(a+b)=f(a)+f(b)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:2007
+#: ../../src/wxMaximaFrame.cpp:2018
 msgid "Advanced 2d plotting"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1905
+#: ../../src/wxMaximaFrame.cpp:1916
 msgid "Advanced guess (PSLQ algorithm)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:2016
+#: ../../src/wxMaximaFrame.cpp:2027
 msgid "Advanced variable names"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:184
+#: ../../src/dialogs/ConfigDialogue.cpp:185
 msgid "Afrikaans"
 msgstr ""
 
@@ -971,11 +994,11 @@ msgstr ""
 msgid "After clicking on animations created with with_slider_draw() or similar, this slider allows changing the current frame."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:185
+#: ../../src/dialogs/ConfigDialogue.cpp:186
 msgid "Albanian"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1121
+#: ../../src/wxMaximaFrame.cpp:1132
 msgid "Aliases"
 msgstr ""
 
@@ -983,11 +1006,11 @@ msgstr ""
 msgid "All Levels"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1810
+#: ../../src/wxMaximaFrame.cpp:1821
 msgid "All but the 1st n elements"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1812
+#: ../../src/wxMaximaFrame.cpp:1823
 msgid "All but the last n elements"
 msgstr ""
 
@@ -995,11 +1018,11 @@ msgstr ""
 msgid "All openable types (*.wxm, *.wxmx, *.mac, *.out, *.xml)|*.wxm;*.wxmx;*.mac;*.out;*.xml|wxMaxima document (*.wxm, *.wxmx)|*.wxm;*.wxmx|Maxima session (*.mac)|*.mac|Xmaxima session (*.out)|*.out|xml from broken .wxmx (*.xml)|*.xml"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:753
+#: ../../src/dialogs/ConfigDialogue.cpp:767
 msgid "All variable names"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:829
+#: ../../src/wxMaximaFrame.cpp:840
 msgid "All visible sidebars"
 msgstr ""
 
@@ -1007,7 +1030,7 @@ msgstr ""
 msgid "Allow access to an online manual?"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1746
+#: ../../src/wxMaximaFrame.cpp:1757
 msgid "Allow substituting operators"
 msgstr ""
 
@@ -1027,15 +1050,15 @@ msgstr ""
 msgid "All|*"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:859
+#: ../../src/wxMaximaFrame.cpp:870
 msgid "Always after underscores"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:860
+#: ../../src/wxMaximaFrame.cpp:871
 msgid "Always autosubscript after an underscore"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:870
+#: ../../src/wxMaximaFrame.cpp:881
 msgid "Always display this variable with subscript"
 msgstr ""
 
@@ -1063,7 +1086,7 @@ msgstr ""
 msgid "Anchors file has no top node."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:887
+#: ../../src/wxMaximaFrame.cpp:898
 msgid "Angles"
 msgstr ""
 
@@ -1072,19 +1095,19 @@ msgstr ""
 msgid "Animated Diagram"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1871
+#: ../../src/wxMaximaFrame.cpp:1882
 msgid "Animation autoplay"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1874
+#: ../../src/wxMaximaFrame.cpp:1885
 msgid "Animation framerate..."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1911
+#: ../../src/dialogs/ConfigDialogue.cpp:1925
 msgid "Announce Maxima's output as MathML"
 msgstr ""
 
-#: ../../src/worksheet/Worksheet.cpp:5507 ../../src/wxMaximaFrame.cpp:2048
+#: ../../src/worksheet/Worksheet.cpp:5507 ../../src/wxMaximaFrame.cpp:2059
 msgid "Anonymize Code for Bug Report"
 msgstr ""
 
@@ -1092,19 +1115,19 @@ msgstr ""
 msgid "Antisymmetric function: f(x)=-f(-x)"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2104
+#: ../../src/dialogs/ConfigDialogue.cpp:2191
 msgid "Appearance:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1835
+#: ../../src/wxMaximaFrame.cpp:1846
 msgid "Append"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1831
+#: ../../src/wxMaximaFrame.cpp:1842
 msgid "Append a list"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1832
+#: ../../src/wxMaximaFrame.cpp:1843
 msgid "Append a list to an existing list"
 msgstr ""
 
@@ -1112,15 +1135,15 @@ msgstr ""
 msgid "Append a list to another list"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1825
+#: ../../src/wxMaximaFrame.cpp:1836
 msgid "Append an element"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1830
+#: ../../src/wxMaximaFrame.cpp:1841
 msgid "Append an element to the beginning an existing list"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1826
+#: ../../src/wxMaximaFrame.cpp:1837
 msgid "Append an element to the end of an existing list"
 msgstr ""
 
@@ -1128,12 +1151,12 @@ msgstr ""
 msgid "Apply a function to each list element"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1906
+#: ../../src/wxMaximaFrame.cpp:1917
 #, c-format
 msgid "Approximate by a fraction using log(), sqrt() and %pi, when needed. Only available in maxima > 5.46.0"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1902
+#: ../../src/wxMaximaFrame.cpp:1913
 msgid "Approximate by nice fraction"
 msgstr ""
 
@@ -1151,7 +1174,7 @@ msgstr ""
 msgid "Apropos"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:186
+#: ../../src/dialogs/ConfigDialogue.cpp:187
 msgid "Arabic"
 msgstr ""
 
@@ -1179,7 +1202,7 @@ msgstr ""
 msgid "Array"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1116
+#: ../../src/wxMaximaFrame.cpp:1127
 msgid "Arrays"
 msgstr ""
 
@@ -1198,11 +1221,11 @@ msgstr ""
 msgid "Ascii code to char"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1231
+#: ../../src/wxMaximaFrame.cpp:1242
 msgid "Ascii code to char..."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1400
+#: ../../src/dialogs/ConfigDialogue.cpp:1414
 msgid "Ask to save untitled documents"
 msgstr ""
 
@@ -1226,21 +1249,21 @@ msgstr ""
 msgid "Attention: Extracting a random list element isn't efficient for long lists.Iterating over lists using makelist() or for loops is way faster."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:900
+#: ../../src/dialogs/ConfigDialogue.cpp:914
 msgid "Auto-indent new lines"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:896
+#: ../../src/dialogs/ConfigDialogue.cpp:910
 msgid "Auto-insert closing parenthesis"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1481
-#: ../../src/dialogs/ConfigDialogue.cpp:1512
+#: ../../src/dialogs/ConfigDialogue.cpp:1495
+#: ../../src/dialogs/ConfigDialogue.cpp:1526
 #: ../../src/dialogs/MaximaNotStartingDialog.cpp:43
 msgid "Autodetect"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1239
+#: ../../src/dialogs/ConfigDialogue.cpp:1253
 msgid "Automatic"
 msgstr ""
 
@@ -1248,20 +1271,20 @@ msgstr ""
 msgid "Automatic labels"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:772
+#: ../../src/dialogs/ConfigDialogue.cpp:786
 #, c-format
 msgid "Automatic labels (%i1, %o1,...)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1045
+#: ../../src/wxMaximaFrame.cpp:1056
 msgid "Automatically answer questions"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1046
+#: ../../src/wxMaximaFrame.cpp:1057
 msgid "Automatically fill in answers known from the last run"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:460
+#: ../../src/dialogs/ConfigDialogue.cpp:463
 msgid "Automatically insert a closing parenthesis the moment the user enters an opening one."
 msgstr ""
 
@@ -1280,15 +1303,15 @@ msgstr ""
 msgid "Autosaving the .wxmx file as %s"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:877
+#: ../../src/wxMaximaFrame.cpp:888
 msgid "Autosubscript"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:878
+#: ../../src/wxMaximaFrame.cpp:889
 msgid "Autosubscript chars after an underscore"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:863
+#: ../../src/wxMaximaFrame.cpp:874
 msgid "Autosubscript numbers and text following single letters"
 msgstr ""
 
@@ -1296,7 +1319,7 @@ msgstr ""
 msgid "Autosubscript this variable"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:737
+#: ../../src/dialogs/ConfigDialogue.cpp:751
 msgid "Autowrap long lines:"
 msgstr ""
 
@@ -1316,11 +1339,11 @@ msgstr ""
 msgid "Barsplot..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1443
+#: ../../src/wxMaximaFrame.cpp:1454
 msgid "Basic matrix operations"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:187
+#: ../../src/dialogs/ConfigDialogue.cpp:188
 msgid "Basque"
 msgstr ""
 
@@ -1332,12 +1355,12 @@ msgstr ""
 msgid "Batch File"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2108
+#: ../../src/wxMaxima.cpp:2109
 #, c-format
 msgid "Batch mode: %d image(s) could not be loaded at all (exit code %d)."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2114
+#: ../../src/wxMaxima.cpp:2115
 #, c-format
 msgid "Batch mode: %d image(s) failed to decode/render (--debug, exit code %d)."
 msgstr ""
@@ -1359,27 +1382,27 @@ msgstr ""
 msgid "Beta"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1938
+#: ../../src/dialogs/ConfigDialogue.cpp:2025
 msgid "Bitmap"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1276
+#: ../../src/dialogs/ConfigDialogue.cpp:1290
 msgid "Bitmap scale for export:"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1226
+#: ../../src/dialogs/ConfigDialogue.cpp:1240
 msgid "Bitmaps"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2149
+#: ../../src/dialogs/ConfigDialogue.cpp:2236
 msgid "Bold"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2292
+#: ../../src/wxMaxima.cpp:2293
 msgid "Both horizontal and vertical cursor active at the same time"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2039
+#: ../../src/dialogs/ConfigDialogue.cpp:2126
 msgid "Bottom"
 msgstr ""
 
@@ -1454,7 +1477,7 @@ msgstr ""
 msgid "Bug: Math Cell that claims to have no group Cell it belongs to"
 msgstr ""
 
-#: ../../src/Configuration.h:760
+#: ../../src/Configuration.h:794
 msgid "Bug: Maximum number of digits that is to be displayed is too low!"
 msgstr ""
 
@@ -1534,7 +1557,7 @@ msgstr ""
 msgid "Bug: y position of cell is unknown!"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:2044
+#: ../../src/wxMaximaFrame.cpp:2055
 msgid "Build &Info"
 msgstr ""
 
@@ -1543,7 +1566,7 @@ msgstr ""
 msgid "Build from Git version: %s\n"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1421
+#: ../../src/dialogs/ConfigDialogue.cpp:1435
 msgid "By default \"Find and Replace\" (Ctrl+F) opens as a floating window. Enable this to make it a sidebar you can dock, like the other sidebars, instead."
 msgstr ""
 
@@ -1555,11 +1578,11 @@ msgstr ""
 msgid "Byte:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1554
+#: ../../src/wxMaximaFrame.cpp:1565
 msgid "C&hange Variable in Integrate..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:781
+#: ../../src/wxMaximaFrame.cpp:791
 msgid "C&onfigure"
 msgstr ""
 
@@ -1576,7 +1599,7 @@ msgstr ""
 msgid "Caching font variant: %s"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1578
+#: ../../src/wxMaximaFrame.cpp:1589
 msgid "Calculate &Product..."
 msgstr ""
 
@@ -1588,15 +1611,15 @@ msgstr ""
 msgid "Calculate Singular Value Decomposition, left and right singular vectors numerically"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1576
+#: ../../src/wxMaximaFrame.cpp:1587
 msgid "Calculate Su&m..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1891
+#: ../../src/wxMaximaFrame.cpp:1902
 msgid "Calculate bigfloat value of the last result"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1888
+#: ../../src/wxMaximaFrame.cpp:1899
 msgid "Calculate float value of the last result"
 msgstr ""
 
@@ -1612,11 +1635,11 @@ msgstr ""
 msgid "Calculate modulus:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1894
+#: ../../src/wxMaximaFrame.cpp:1905
 msgid "Calculate numeric value of the last result"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1579
+#: ../../src/wxMaximaFrame.cpp:1590
 msgid "Calculate products"
 msgstr ""
 
@@ -1624,7 +1647,7 @@ msgstr ""
 msgid "Calculate standard deviation"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1576
+#: ../../src/wxMaximaFrame.cpp:1587
 msgid "Calculate sums"
 msgstr ""
 
@@ -1656,16 +1679,16 @@ msgstr ""
 msgid "Can be specified as flag in ev(exp, flag)"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3533
+#: ../../src/wxMaxima.cpp:3534
 msgid "Can not connect to the web server."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3479 ../../src/wxMaxima.cpp:3515
-#: ../../src/wxMaxima.cpp:3567
+#: ../../src/wxMaxima.cpp:3480 ../../src/wxMaxima.cpp:3516
+#: ../../src/wxMaxima.cpp:3568
 msgid "Can not download version info."
 msgstr ""
 
-#: ../../src/MaximaProcessManager.cpp:595 ../../src/wxMaxima.cpp:1611
+#: ../../src/MaximaProcessManager.cpp:595 ../../src/wxMaxima.cpp:1612
 msgid "Can not start Maxima. The most probable cause is that Maxima isn't installed (it can be downloaded from https://maxima.sourceforge.io) or in wxMaxima's config dialogue the setting for Maxima's location is wrong."
 msgstr ""
 
@@ -1703,7 +1726,7 @@ msgstr ""
 #: ../../src/wizards/SeriesWiz.cpp:52 ../../src/wizards/SubstituteWiz.cpp:42
 #: ../../src/wizards/SubstituteWiz.cpp:44 ../../src/wizards/SumWiz.cpp:48
 #: ../../src/wizards/SumWiz.cpp:50 ../../src/wizards/SystemWiz.cpp:39
-#: ../../src/wizards/SystemWiz.cpp:41 ../../src/wxMaxima.cpp:3604
+#: ../../src/wizards/SystemWiz.cpp:41 ../../src/wxMaxima.cpp:3605
 msgid "Cancel"
 msgstr ""
 
@@ -1711,7 +1734,7 @@ msgstr ""
 msgid "Cannot authenticate Maxima!"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:1299
+#: ../../src/wxMaxima.cpp:1300
 #, c-format
 msgid "Cannot cache the list of known symbols to %s"
 msgstr ""
@@ -1735,8 +1758,8 @@ msgstr ""
 msgid "Cannot interpret the numeric value of pid %s"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3442 ../../src/wxMaxima.cpp:3449
-#: ../../src/wxMaxima.cpp:3456
+#: ../../src/wxMaxima.cpp:3443 ../../src/wxMaxima.cpp:3450
+#: ../../src/wxMaxima.cpp:3457
 #, c-format
 msgid "Cannot interpret version number component %s"
 msgstr ""
@@ -1793,7 +1816,7 @@ msgstr ""
 msgid "Canonical (tr)"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:188
+#: ../../src/dialogs/ConfigDialogue.cpp:189
 msgid "Catalan"
 msgstr ""
 
@@ -1801,11 +1824,11 @@ msgstr ""
 msgid "Cauchy principal value of f(x)/(x-c), finite interval"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1941
+#: ../../src/wxMaximaFrame.cpp:1952
 msgid "Cauchy principal value, finite interval"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1048
+#: ../../src/wxMaximaFrame.cpp:1059
 msgid "Ce&ll"
 msgstr ""
 
@@ -1817,7 +1840,7 @@ msgstr ""
 msgid "Cell bracket fill, Inactive"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3177
+#: ../../src/wxMaxima.cpp:3178
 msgid "Cell ends in a backslash"
 msgstr ""
 
@@ -1826,7 +1849,7 @@ msgstr ""
 msgid "Cell with UUID %s not found!"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1131
+#: ../../src/wxMaximaFrame.cpp:1142
 msgid "Change &2d Display"
 msgstr ""
 
@@ -1838,7 +1861,7 @@ msgstr ""
 msgid "Change Image..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:2056
+#: ../../src/wxMaximaFrame.cpp:2067
 msgid "Change Log"
 msgstr ""
 
@@ -1846,19 +1869,19 @@ msgstr ""
 msgid "Change directory"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1295
+#: ../../src/wxMaximaFrame.cpp:1306
 msgid "Change directory..."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:862
+#: ../../src/dialogs/ConfigDialogue.cpp:876
 msgid "Change names of greek letters to greek letters"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1132
+#: ../../src/wxMaximaFrame.cpp:1143
 msgid "Change the 2d display algorithm used to display math output"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:489
+#: ../../src/dialogs/ConfigDialogue.cpp:492
 msgid "Change the text \"alpha\" and \"beta\" to the corresponding greek letter?"
 msgstr ""
 
@@ -1870,11 +1893,11 @@ msgstr ""
 msgid "Change variable and evaluate"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1555
+#: ../../src/wxMaximaFrame.cpp:1566
 msgid "Change variable in integral or sum"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1559
+#: ../../src/wxMaximaFrame.cpp:1570
 msgid "Change variable in integral or sum and evaluate the result"
 msgstr ""
 
@@ -1882,7 +1905,7 @@ msgstr ""
 msgid "ChangeLog"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1119
+#: ../../src/wxMaximaFrame.cpp:1130
 msgid "Changed option variables"
 msgstr ""
 
@@ -1903,7 +1926,7 @@ msgstr ""
 msgid "Char #2:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1233
+#: ../../src/wxMaximaFrame.cpp:1244
 msgid "Char to Unicode code point..."
 msgstr ""
 
@@ -1919,7 +1942,7 @@ msgstr ""
 msgid "Char:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1224
+#: ../../src/wxMaximaFrame.cpp:1235
 msgid "Character Tests"
 msgstr ""
 
@@ -1931,11 +1954,16 @@ msgstr ""
 msgid "Chars are strings that are one character long"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:2059
+#: ../../src/sidebars/AiChatSidebar.cpp:151
+#, c-format
+msgid "Chatting with %s"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:2070
 msgid "Check for Updates"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:2060
+#: ../../src/wxMaximaFrame.cpp:2071
 msgid "Check if a newer version of wxMaxima is available."
 msgstr ""
 
@@ -1943,19 +1971,19 @@ msgstr ""
 msgid "Chi"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:189
+#: ../../src/dialogs/ConfigDialogue.cpp:190
 msgid "Chinese (Simplified)"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:190
+#: ../../src/dialogs/ConfigDialogue.cpp:191
 msgid "Chinese (traditional)"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1594
+#: ../../src/dialogs/ConfigDialogue.cpp:1608
 msgid "Choose a Lisp Maxima was compiled with"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1600
+#: ../../src/dialogs/ConfigDialogue.cpp:1614
 msgid "Choose between installed Maxima versions"
 msgstr ""
 
@@ -1963,11 +1991,11 @@ msgstr ""
 msgid "Choose between the following help topics:"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2140
+#: ../../src/dialogs/ConfigDialogue.cpp:2227
 msgid "Choose font"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:796
+#: ../../src/dialogs/ConfigDialogue.cpp:810
 msgid ""
 "Choose how mathematical output is formatted:\n"
 "\"2D, whenever possible\" keeps all expressions in two-dimensional form (fractions stacked, matrices drawn as boxes), even if they overflow the page width.\n"
@@ -1979,12 +2007,12 @@ msgstr ""
 msgid "Choose new plot format:"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2475
+#: ../../src/dialogs/ConfigDialogue.cpp:2571
 #, c-format
 msgid "Choose the %s Font"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:896
+#: ../../src/wxMaximaFrame.cpp:907
 msgid "Choose the parenthesis type for Matrices"
 msgstr ""
 
@@ -1992,27 +2020,31 @@ msgstr ""
 msgid "Classes:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1471
+#: ../../src/wxMaximaFrame.cpp:1482
 msgid "Classic matrix operations"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1091
+#: ../../src/sidebars/AiChatSidebar.cpp:66
+msgid "Clear"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1102
 msgid "Clear all aliases"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1088
+#: ../../src/wxMaximaFrame.cpp:1099
 msgid "Clear all arrays"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1085
+#: ../../src/wxMaximaFrame.cpp:1096
 msgid "Clear all dependencies"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1087
+#: ../../src/wxMaximaFrame.cpp:1098
 msgid "Clear all functions"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1094
+#: ../../src/wxMaximaFrame.cpp:1105
 msgid "Clear all gradefs"
 msgstr ""
 
@@ -2020,31 +2052,31 @@ msgstr ""
 msgid "Clear all history"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1093
+#: ../../src/wxMaximaFrame.cpp:1104
 msgid "Clear all labels"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1097
+#: ../../src/wxMaximaFrame.cpp:1108
 msgid "Clear all let rule packages"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1096
+#: ../../src/wxMaximaFrame.cpp:1107
 msgid "Clear all macros"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1095
+#: ../../src/wxMaximaFrame.cpp:1106
 msgid "Clear all props"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1090
+#: ../../src/wxMaximaFrame.cpp:1101
 msgid "Clear all rules"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1092
+#: ../../src/wxMaximaFrame.cpp:1103
 msgid "Clear all structures"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1086
+#: ../../src/wxMaximaFrame.cpp:1097
 msgid "Clear all variables"
 msgstr ""
 
@@ -2057,11 +2089,11 @@ msgstr ""
 msgid "Cleared font cache for font %s"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1966
+#: ../../src/dialogs/ConfigDialogue.cpp:2053
 msgid "Clipboard format parameters"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:694
+#: ../../src/wxMaximaFrame.cpp:704
 msgid "Close\tCtrl+W"
 msgstr ""
 
@@ -2069,11 +2101,11 @@ msgstr ""
 msgid "Close Stream"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:694
+#: ../../src/wxMaximaFrame.cpp:704
 msgid "Close window"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1198
+#: ../../src/wxMaximaFrame.cpp:1209
 msgid "Close..."
 msgstr ""
 
@@ -2153,7 +2185,7 @@ msgstr ""
 msgid "Columns:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1680
+#: ../../src/wxMaximaFrame.cpp:1691
 msgid "Combine factorials in an expression"
 msgstr ""
 
@@ -2161,7 +2193,7 @@ msgstr ""
 msgid "Comma"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3236
+#: ../../src/wxMaxima.cpp:3237
 msgid "Comma directly followed by a closing parenthesis"
 msgstr ""
 
@@ -2255,7 +2287,7 @@ msgstr ""
 msgid "Command:"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1148
+#: ../../src/dialogs/ConfigDialogue.cpp:1162
 msgid "Commands that are executed at every start of maxima."
 msgstr ""
 
@@ -2267,11 +2299,11 @@ msgstr ""
 msgid "Comment Selection"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:775
+#: ../../src/wxMaximaFrame.cpp:785
 msgid "Comment out the currently selected text"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:774
+#: ../../src/wxMaximaFrame.cpp:784
 msgid "Comment selection\tCtrl+/"
 msgstr ""
 
@@ -2279,7 +2311,7 @@ msgstr ""
 msgid "Commutative function"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:706
+#: ../../src/wxMaximaFrame.cpp:716
 msgid "Compare files..."
 msgstr ""
 
@@ -2287,7 +2319,7 @@ msgstr ""
 msgid "Comparing worksheets (the --diff option or the wxmxdiff command) needs 2 or 3 files to compare."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1489
+#: ../../src/wxMaximaFrame.cpp:1500
 msgid "Compile a QR decomposition using dgeqrf"
 msgstr ""
 
@@ -2295,27 +2327,27 @@ msgstr ""
 msgid "Compile a function"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1281
+#: ../../src/wxMaximaFrame.cpp:1292
 msgid "Compile a regular expression"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1478
+#: ../../src/wxMaximaFrame.cpp:1489
 msgid "Compile eigenvalues using dgeev"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1481
+#: ../../src/wxMaximaFrame.cpp:1492
 msgid "Compile eigenvalues using zgeev"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1484
+#: ../../src/wxMaximaFrame.cpp:1495
 msgid "Compile eigenvalues+eigenvectors using dgeev"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1487
+#: ../../src/wxMaximaFrame.cpp:1498
 msgid "Compile eigenvalues+eigenvectors using zgeev"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1169
+#: ../../src/wxMaximaFrame.cpp:1180
 msgid "Compile function..."
 msgstr ""
 
@@ -2336,11 +2368,11 @@ msgstr ""
 msgid "Compiling a function can generate a considerable speed boost if the types of the function parameters are made known to the function before it is compiled. Else the generated code has to be hideously generic."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:985
+#: ../../src/wxMaximaFrame.cpp:996
 msgid "Complete Word\tCtrl+Space"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:986
+#: ../../src/wxMaximaFrame.cpp:997
 msgid "Complete word"
 msgstr ""
 
@@ -2356,35 +2388,35 @@ msgstr ""
 msgid "Composing a list of the line starts we can use as page starts"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1599
+#: ../../src/wxMaximaFrame.cpp:1610
 msgid "Compute continued fraction of a value"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1465
+#: ../../src/wxMaximaFrame.cpp:1476
 msgid "Compute the adjoint matrix"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1452
+#: ../../src/wxMaximaFrame.cpp:1463
 msgid "Compute the characteristic polynomial of a matrix"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1456
+#: ../../src/wxMaximaFrame.cpp:1467
 msgid "Compute the determinant of a matrix"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1587
+#: ../../src/wxMaximaFrame.cpp:1598
 msgid "Compute the greatest common divisor"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1449
+#: ../../src/wxMaximaFrame.cpp:1460
 msgid "Compute the inverse of a matrix"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1590
+#: ../../src/wxMaximaFrame.cpp:1601
 msgid "Compute the least common multiple (do load(functs) before using)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1467
+#: ../../src/wxMaximaFrame.cpp:1478
 msgid "Compute the rank of a matrix"
 msgstr ""
 
@@ -2392,24 +2424,24 @@ msgstr ""
 msgid "Condition:"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2522
-#: ../../src/dialogs/ConfigDialogue.cpp:2532
-#: ../../src/dialogs/ConfigDialogue.cpp:2684
-#: ../../src/dialogs/ConfigDialogue.cpp:2690
+#: ../../src/dialogs/ConfigDialogue.cpp:2618
+#: ../../src/dialogs/ConfigDialogue.cpp:2628
+#: ../../src/dialogs/ConfigDialogue.cpp:2780
+#: ../../src/dialogs/ConfigDialogue.cpp:2786
 msgid "Config file (*.ini)|*.ini"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2582
+#: ../../src/dialogs/ConfigDialogue.cpp:2678
 #, c-format
 msgid "Config item \"%s\" was of an unknown type"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2650
+#: ../../src/dialogs/ConfigDialogue.cpp:2746
 msgid "Configuration warning"
 msgstr ""
 
 #: ../../src/ToolBar.cpp:367 ../../src/ToolBar.cpp:369
-#: ../../src/wxMaximaFrame.cpp:779 ../../src/wxMaximaFrame.cpp:781
+#: ../../src/wxMaximaFrame.cpp:789 ../../src/wxMaximaFrame.cpp:791
 msgid "Configure wxMaxima"
 msgstr ""
 
@@ -2435,7 +2467,7 @@ msgstr ""
 msgid "Construct a fraction"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1398
+#: ../../src/wxMaximaFrame.cpp:1409
 msgid "Construct fraction..."
 msgstr ""
 
@@ -2447,11 +2479,11 @@ msgstr ""
 msgid "Contents:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1973
+#: ../../src/wxMaximaFrame.cpp:1984
 msgid "Context-sensitive &Help\tCtrl+?"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1975
+#: ../../src/wxMaximaFrame.cpp:1986
 msgid "Context-sensitive &Help\tF1"
 msgstr ""
 
@@ -2479,55 +2511,55 @@ msgstr ""
 msgid "Contour lines settings for the following 3d plots"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1638
+#: ../../src/wxMaximaFrame.cpp:1649
 msgid "Contract Logarithms"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1254
+#: ../../src/wxMaximaFrame.cpp:1265
 msgid "Conversions"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1322
+#: ../../src/wxMaximaFrame.cpp:1333
 msgid "Convert"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1323
+#: ../../src/wxMaximaFrame.cpp:1334
 msgid "Convert + Write to file"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1530
+#: ../../src/wxMaximaFrame.cpp:1541
 msgid "Convert Column to list..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1526
+#: ../../src/wxMaximaFrame.cpp:1537
 msgid "Convert Row to list..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1137
+#: ../../src/wxMaximaFrame.cpp:1148
 msgid "Convert a command to maxima code"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1414
+#: ../../src/wxMaximaFrame.cpp:1425
 msgid "Convert a list of lists to a matrix"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1670
+#: ../../src/wxMaximaFrame.cpp:1681
 msgid "Convert binomials, beta and gamma function to factorials"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1674
+#: ../../src/wxMaximaFrame.cpp:1685
 msgid "Convert binomials, factorials and beta function to gamma function"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1709
+#: ../../src/wxMaximaFrame.cpp:1720
 msgid "Convert complex expression to polar form"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1706
+#: ../../src/wxMaximaFrame.cpp:1717
 msgid "Convert complex expression to rect form"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1718
+#: ../../src/wxMaximaFrame.cpp:1729
 msgid "Convert exponential function of imaginary argument to trigonometric form"
 msgstr ""
 
@@ -2539,23 +2571,23 @@ msgstr ""
 msgid "Convert string to matching regex"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1639
+#: ../../src/wxMaximaFrame.cpp:1650
 msgid "Convert sum of logarithms to logarithm of product"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1669
+#: ../../src/wxMaximaFrame.cpp:1680
 msgid "Convert to &Factorials"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1673
+#: ../../src/wxMaximaFrame.cpp:1684
 msgid "Convert to &Gamma"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1708
+#: ../../src/wxMaximaFrame.cpp:1719
 msgid "Convert to &Polarform"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1705
+#: ../../src/wxMaximaFrame.cpp:1716
 msgid "Convert to &Rectform"
 msgstr ""
 
@@ -2587,7 +2619,7 @@ msgstr ""
 msgid "Convert to Title"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1259
+#: ../../src/wxMaximaFrame.cpp:1270
 msgid "Convert to downcase..."
 msgstr ""
 
@@ -2599,11 +2631,11 @@ msgstr ""
 msgid "Convert to programming language file"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1698
+#: ../../src/wxMaximaFrame.cpp:1709
 msgid "Convert trigonometric expression to canonical quasilinear form"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1723
+#: ../../src/wxMaximaFrame.cpp:1734
 msgid "Convert trigonometric functions to exponential form"
 msgstr ""
 
@@ -2615,16 +2647,16 @@ msgstr ""
 msgid "Converted to linear:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1858
+#: ../../src/wxMaximaFrame.cpp:1869
 msgid "Converts a matrix to a list of lists"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1856
+#: ../../src/wxMaximaFrame.cpp:1867
 msgid "Converts a nested list like [[1,2],[3,4]] to a matrix"
 msgstr ""
 
 #: ../../src/ToolBar.cpp:380 ../../src/ToolBar.cpp:384
-#: ../../src/dialogs/ConfigDialogue.cpp:285
+#: ../../src/dialogs/ConfigDialogue.cpp:286
 #: ../../src/worksheet/WorksheetContextMenu.cpp:48
 #: ../../src/worksheet/WorksheetContextMenu.cpp:122
 #: ../../src/worksheet/WorksheetContextMenu.cpp:271
@@ -2638,11 +2670,11 @@ msgstr ""
 msgid "Copy Animation"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:980
+#: ../../src/wxMaximaFrame.cpp:991
 msgid "Copy Previous Input\tCtrl+I"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:983
+#: ../../src/wxMaximaFrame.cpp:994
 msgid "Copy Previous Output\tCtrl+U"
 msgstr ""
 
@@ -2652,7 +2684,7 @@ msgstr ""
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:145
 #: ../../src/worksheet/WorksheetContextMenu.cpp:294
-#: ../../src/wxMaximaFrame.cpp:757
+#: ../../src/wxMaximaFrame.cpp:767
 msgid "Copy as EMF"
 msgstr ""
 
@@ -2663,17 +2695,17 @@ msgstr ""
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:135
 #: ../../src/worksheet/WorksheetContextMenu.cpp:284
-#: ../../src/wxMaximaFrame.cpp:746
+#: ../../src/wxMaximaFrame.cpp:756
 msgid "Copy as Image"
 msgstr ""
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:126
 #: ../../src/worksheet/WorksheetContextMenu.cpp:275
-#: ../../src/wxMaximaFrame.cpp:739
+#: ../../src/wxMaximaFrame.cpp:749
 msgid "Copy as LaTeX"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:742
+#: ../../src/wxMaximaFrame.cpp:752
 msgid "Copy as MathML"
 msgstr ""
 
@@ -2684,17 +2716,17 @@ msgstr ""
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:148
 #: ../../src/worksheet/WorksheetContextMenu.cpp:297
-#: ../../src/wxMaximaFrame.cpp:752
+#: ../../src/wxMaximaFrame.cpp:762
 msgid "Copy as RTF"
 msgstr ""
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:142
 #: ../../src/worksheet/WorksheetContextMenu.cpp:291
-#: ../../src/wxMaximaFrame.cpp:749
+#: ../../src/wxMaximaFrame.cpp:759
 msgid "Copy as SVG"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:734
+#: ../../src/wxMaximaFrame.cpp:744
 msgid "Copy as Text\tCtrl+Shift+C"
 msgstr ""
 
@@ -2707,13 +2739,13 @@ msgstr ""
 msgid "Copy file"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1307
+#: ../../src/wxMaximaFrame.cpp:1318
 msgid "Copy file..."
 msgstr ""
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:124
 #: ../../src/worksheet/WorksheetContextMenu.cpp:273
-#: ../../src/wxMaximaFrame.cpp:737
+#: ../../src/wxMaximaFrame.cpp:747
 msgid "Copy for Octave/Matlab"
 msgstr ""
 
@@ -2725,39 +2757,39 @@ msgid "Copy position (UUID)"
 msgstr ""
 
 #: ../../src/ToolBar.cpp:380 ../../src/ToolBar.cpp:384
-#: ../../src/wxMaximaFrame.cpp:732
+#: ../../src/wxMaximaFrame.cpp:742
 msgid "Copy selection"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:758
+#: ../../src/wxMaximaFrame.cpp:768
 msgid "Copy selection from document as an Enhanced Metafile"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:750
+#: ../../src/wxMaximaFrame.cpp:760
 msgid "Copy selection from document as an SVG image"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:747
+#: ../../src/wxMaximaFrame.cpp:757
 msgid "Copy selection from document as an image"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:753
+#: ../../src/wxMaximaFrame.cpp:763
 msgid "Copy selection from document as rtf that a word processor might understand"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:735
+#: ../../src/wxMaximaFrame.cpp:745
 msgid "Copy selection from document as text"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:740
+#: ../../src/wxMaximaFrame.cpp:750
 msgid "Copy selection from document in LaTeX format"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:738
+#: ../../src/wxMaximaFrame.cpp:748
 msgid "Copy selection from document in Matlab format"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:743
+#: ../../src/wxMaximaFrame.cpp:753
 msgid "Copy selection from document in a MathML format many word processors can display as 2d equation"
 msgstr ""
 
@@ -2765,7 +2797,7 @@ msgstr ""
 msgid "Copy string"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1258
+#: ../../src/wxMaximaFrame.cpp:1269
 msgid "Copy string..."
 msgstr ""
 
@@ -2773,28 +2805,32 @@ msgstr ""
 msgid "Copy, Cut and Paste button"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2566
+#: ../../src/dialogs/ConfigDialogue.cpp:2662
 #, c-format
 msgid "Copying config bool \"%s\""
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2576
+#: ../../src/dialogs/ConfigDialogue.cpp:2672
 #, c-format
 msgid "Copying config float \"%s\""
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2571
+#: ../../src/dialogs/ConfigDialogue.cpp:2667
 #, c-format
 msgid "Copying config int \"%s\""
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2561
+#: ../../src/dialogs/ConfigDialogue.cpp:2657
 #, c-format
 msgid "Copying config string \"%s\""
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:191
+#: ../../src/dialogs/ConfigDialogue.cpp:192
 msgid "Corsican"
+msgstr ""
+
+#: ../../src/ai/AiProvider.cpp:243
+msgid "Could not create the HTTP request."
 msgstr ""
 
 #: ../../src/WXMXformat.cpp:297
@@ -2813,6 +2849,11 @@ msgstr ""
 msgid "Could not parse the SVG image data."
 msgstr ""
 
+#: ../../src/ai/AiProvider.cpp:327
+#, c-format
+msgid "Could not reach %s (network error)."
+msgstr ""
+
 #: ../../src/MaximaProcessManager.cpp:891
 #: ../../src/MaximaProcessManager.cpp:934
 msgid "Could not send an interrupt signal to maxima."
@@ -2822,11 +2863,11 @@ msgstr ""
 msgid "Could not write the file's contents during saving => aborting."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1418
+#: ../../src/wxMaximaFrame.cpp:1429
 msgid "Create Matrix"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1784
+#: ../../src/wxMaximaFrame.cpp:1795
 msgid "Create a list"
 msgstr ""
 
@@ -2842,19 +2883,19 @@ msgstr ""
 msgid "Create a list from a rule"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1766
+#: ../../src/wxMaximaFrame.cpp:1777
 msgid "Create a list from comma-separated elements"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:981
+#: ../../src/wxMaximaFrame.cpp:992
 msgid "Create a new cell with previous input"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:984
+#: ../../src/wxMaximaFrame.cpp:995
 msgid "Create a new cell with previous output"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1441
+#: ../../src/wxMaximaFrame.cpp:1452
 msgid "Create copy, not clone..."
 msgstr ""
 
@@ -2862,7 +2903,7 @@ msgstr ""
 msgid "Create directory"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1296
+#: ../../src/wxMaximaFrame.cpp:1307
 msgid "Create directory..."
 msgstr ""
 
@@ -2870,11 +2911,11 @@ msgstr ""
 msgid "Create empty string"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1261
+#: ../../src/wxMaximaFrame.cpp:1272
 msgid "Create empty string..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1783
+#: ../../src/wxMaximaFrame.cpp:1794
 msgid "Create list"
 msgstr ""
 
@@ -2882,11 +2923,11 @@ msgstr ""
 msgid "Create list from comma-separated elements"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1392
+#: ../../src/dialogs/ConfigDialogue.cpp:1406
 msgid "Create scalable plots."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1175
+#: ../../src/wxMaximaFrame.cpp:1186
 msgid "Create struct..."
 msgstr ""
 
@@ -2894,11 +2935,11 @@ msgstr ""
 msgid "Created a .zip archive (the .wxmx file technically is a .zip file)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1442
+#: ../../src/wxMaximaFrame.cpp:1453
 msgid "Creates an independent matrix with the same contents"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:192
+#: ../../src/dialogs/ConfigDialogue.cpp:193
 msgid "Croatian"
 msgstr ""
 
@@ -2919,24 +2960,24 @@ msgstr ""
 msgid "Cut"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:730
+#: ../../src/wxMaximaFrame.cpp:740
 msgid "Cut\tCtrl+X"
 msgstr ""
 
 #: ../../src/ToolBar.cpp:379 ../../src/ToolBar.cpp:383
-#: ../../src/wxMaximaFrame.cpp:730
+#: ../../src/wxMaximaFrame.cpp:740
 msgid "Cut selection"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:193
+#: ../../src/dialogs/ConfigDialogue.cpp:194
 msgid "Czech"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:194
+#: ../../src/dialogs/ConfigDialogue.cpp:195
 msgid "Danish"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2109
+#: ../../src/dialogs/ConfigDialogue.cpp:2196
 msgid "Dark"
 msgstr ""
 
@@ -2961,11 +3002,11 @@ msgstr ""
 msgid "Data:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1150
+#: ../../src/wxMaximaFrame.cpp:1161
 msgid "Debugger trigger"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:875
+#: ../../src/wxMaximaFrame.cpp:886
 msgid "Declare Text to always be displayed as subscript"
 msgstr ""
 
@@ -2994,7 +3035,7 @@ msgstr ""
 msgid "Declare these chars as ordinary letters"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1596 ../../src/wxMaximaFrame.cpp:1632
+#: ../../src/wxMaximaFrame.cpp:1607 ../../src/wxMaximaFrame.cpp:1643
 msgid "Decompose rational function to partial fractions"
 msgstr ""
 
@@ -3002,15 +3043,15 @@ msgstr ""
 msgid "Decreasing function f(x)<x"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1339
+#: ../../src/dialogs/ConfigDialogue.cpp:1353
 msgid "Default animation framerate:"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:720
+#: ../../src/dialogs/ConfigDialogue.cpp:734
 msgid "Default plot size for new maxima sessions:"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1574
+#: ../../src/dialogs/ConfigDialogue.cpp:1588
 msgid "Default port for communication with wxMaxima:"
 msgstr ""
 
@@ -3034,31 +3075,31 @@ msgstr ""
 msgid "Define a variable"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1165
+#: ../../src/wxMaximaFrame.cpp:1176
 msgid "Define function..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1172
+#: ../../src/wxMaximaFrame.cpp:1183
 msgid "Define macro..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1170
+#: ../../src/wxMaximaFrame.cpp:1181
 msgid "Define parameter type..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1174
+#: ../../src/wxMaximaFrame.cpp:1185
 msgid "Define struct..."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:404
+#: ../../src/dialogs/ConfigDialogue.cpp:407
 msgid "Define the default speed (in frames per second) animations are played back with."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1173
+#: ../../src/wxMaximaFrame.cpp:1184
 msgid "Define variable..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1872
+#: ../../src/wxMaximaFrame.cpp:1883
 msgid "Defines if an animation is automatically started or only by clicking on it."
 msgstr ""
 
@@ -3066,7 +3107,7 @@ msgstr ""
 msgid "Degree:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1078
+#: ../../src/wxMaximaFrame.cpp:1089
 msgid "Delete F&unction..."
 msgstr ""
 
@@ -3075,23 +3116,23 @@ msgstr ""
 msgid "Delete Selection"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1080
+#: ../../src/wxMaximaFrame.cpp:1091
 msgid "Delete V&ariable..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1079
+#: ../../src/wxMaximaFrame.cpp:1090
 msgid "Delete a function"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1081
+#: ../../src/wxMaximaFrame.cpp:1092
 msgid "Delete a variable"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1075
+#: ../../src/wxMaximaFrame.cpp:1086
 msgid "Delete all objects with a given name"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1084
+#: ../../src/wxMaximaFrame.cpp:1095
 msgid "Delete all values from memory"
 msgstr ""
 
@@ -3099,7 +3140,7 @@ msgstr ""
 msgid "Delete file"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1309
+#: ../../src/wxMaximaFrame.cpp:1320
 msgid "Delete file..."
 msgstr ""
 
@@ -3111,7 +3152,7 @@ msgstr ""
 msgid "Delete named object(s)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1074
+#: ../../src/wxMaximaFrame.cpp:1085
 msgid "Delete named object..."
 msgstr ""
 
@@ -3133,7 +3174,7 @@ msgstr ""
 msgid "Demo for \"%s\""
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:2026
+#: ../../src/wxMaximaFrame.cpp:2037
 msgid "Demos"
 msgstr ""
 
@@ -3145,7 +3186,7 @@ msgstr ""
 msgid "Denominator:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1123
+#: ../../src/wxMaximaFrame.cpp:1134
 msgid "Dependencies"
 msgstr ""
 
@@ -3188,7 +3229,7 @@ msgstr ""
 msgid "Deviation..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1593
+#: ../../src/wxMaximaFrame.cpp:1604
 msgid "Di&vide Polynomials..."
 msgstr ""
 
@@ -3208,7 +3249,7 @@ msgstr ""
 msgid "Didn't find the maxima HTML manual."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:1715
+#: ../../src/wxMaxima.cpp:1716
 msgid "Didn't get a help browser launch program command line, but can request the system's default help browser."
 msgstr ""
 
@@ -3229,7 +3270,7 @@ msgstr ""
 msgid "Differentiate"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1563
+#: ../../src/wxMaximaFrame.cpp:1574
 msgid "Differentiate expression"
 msgstr ""
 
@@ -3249,7 +3290,7 @@ msgstr ""
 msgid "Direction:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1305
+#: ../../src/wxMaximaFrame.cpp:1316
 msgid "Directory operations"
 msgstr ""
 
@@ -3261,11 +3302,11 @@ msgstr ""
 msgid "Discrete plot"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:702
+#: ../../src/dialogs/ConfigDialogue.cpp:716
 msgid "Display"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1134
+#: ../../src/wxMaximaFrame.cpp:1145
 msgid "Display Te&X Form"
 msgstr ""
 
@@ -3273,23 +3314,23 @@ msgstr ""
 msgid "Display algorithm"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:830
+#: ../../src/dialogs/ConfigDialogue.cpp:844
 msgid "Display all and allow linebreaks in long numbers"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:823
+#: ../../src/dialogs/ConfigDialogue.cpp:837
 msgid "Display all digits"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:847
+#: ../../src/wxMaximaFrame.cpp:858
 msgid "Display an expression as maxima's internal lisp representation"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:850
+#: ../../src/wxMaximaFrame.cpp:861
 msgid "Display an expression as wxMaxima's internal XML representation"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:854
+#: ../../src/wxMaximaFrame.cpp:865
 msgid "Display equations"
 msgstr ""
 
@@ -3301,11 +3342,11 @@ msgstr ""
 msgid "Display expression in wxMaxima's internal representation"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1135
+#: ../../src/wxMaximaFrame.cpp:1146
 msgid "Display last result in TeX form"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:807
+#: ../../src/dialogs/ConfigDialogue.cpp:821
 msgid "Display of long numbers"
 msgstr ""
 
@@ -3314,11 +3355,11 @@ msgstr ""
 msgid "Display resolution according to wxWidgets: %li x %li ppi"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:898
+#: ../../src/wxMaximaFrame.cpp:909
 msgid "Display string quotation marks"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1129
+#: ../../src/wxMaximaFrame.cpp:1140
 msgid "Display time used for evaluation"
 msgstr ""
 
@@ -3326,32 +3367,32 @@ msgstr ""
 msgid "Displayed Precision"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:2009
+#: ../../src/wxMaximaFrame.cpp:2020
 msgid "Displaying 3d curves"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1558
+#: ../../src/wxMaximaFrame.cpp:1569
 msgid "Dito, and evaluate the result..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1541
+#: ../../src/wxMaximaFrame.cpp:1552
 msgid "Dito, but affect all clones of the Matrix..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1348
+#: ../../src/wxMaximaFrame.cpp:1359
 msgid "Dito, but as fraction (real only)..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1628
+#: ../../src/wxMaximaFrame.cpp:1639
 msgid "Dito, including denominator"
 msgstr ""
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:492
-#: ../../src/wxMaximaFrame.cpp:1037
+#: ../../src/wxMaximaFrame.cpp:1048
 msgid "Divide Cell"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1594
+#: ../../src/wxMaximaFrame.cpp:1605
 msgid "Divide numbers or polynomials"
 msgstr ""
 
@@ -3363,12 +3404,12 @@ msgstr ""
 msgid "Do for each list element"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3598
+#: ../../src/wxMaxima.cpp:3599
 #, c-format
 msgid "Do you want to save the changes you made in the document \"%s\"?"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:820
+#: ../../src/wxMaximaFrame.cpp:831
 msgid "Dock all Sidebars"
 msgstr ""
 
@@ -3384,19 +3425,19 @@ msgstr ""
 msgid "Document was saved using a newer version of wxMaxima. Please update your wxMaxima."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1173
+#: ../../src/dialogs/ConfigDialogue.cpp:1187
 msgid "Documentclass for TeX export:"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1181
+#: ../../src/dialogs/ConfigDialogue.cpp:1195
 msgid "Documentclass options:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:866
+#: ../../src/wxMaximaFrame.cpp:877
 msgid "Don't autosubscript after an underscore"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1179
+#: ../../src/wxMaximaFrame.cpp:1190
 msgid "Don't evaluate Expression..."
 msgstr ""
 
@@ -3418,7 +3459,7 @@ msgstr ""
 msgid "Don't mark this message text in yellow"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3604
+#: ../../src/wxMaxima.cpp:3605
 msgid "Don't save"
 msgstr ""
 
@@ -3430,7 +3471,7 @@ msgstr ""
 msgid "Don't use if unassigned"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:893
+#: ../../src/wxMaximaFrame.cpp:904
 msgid "Don't use parenthesis for matrices"
 msgstr ""
 
@@ -3458,39 +3499,39 @@ msgstr ""
 msgid "Drop the last n list elements"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:195
+#: ../../src/dialogs/ConfigDialogue.cpp:196
 msgid "Dutch"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1399
+#: ../../src/wxMaximaFrame.cpp:1410
 msgid "E&quations"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:715
+#: ../../src/wxMaximaFrame.cpp:725
 msgid "E&xit\tCtrl+Q"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1461
+#: ../../src/wxMaximaFrame.cpp:1472
 msgid "Eige&nvectors"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1458
+#: ../../src/wxMaximaFrame.cpp:1469
 msgid "Eigen&values"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1480
+#: ../../src/wxMaximaFrame.cpp:1491
 msgid "Eigenvalues (complex)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1477
+#: ../../src/wxMaximaFrame.cpp:1488
 msgid "Eigenvalues (real)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1486
+#: ../../src/wxMaximaFrame.cpp:1497
 msgid "Eigenvalues, left+right eigenvectors (complex)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1483
+#: ../../src/wxMaximaFrame.cpp:1494
 msgid "Eigenvalues, left+right eigenvectors (real)"
 msgstr ""
 
@@ -3532,7 +3573,7 @@ msgstr ""
 msgid "Element-by-element exponentiation of two matrices"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1435
+#: ../../src/wxMaximaFrame.cpp:1446
 msgid "Element-by-element multiplication"
 msgstr ""
 
@@ -3548,7 +3589,7 @@ msgstr ""
 msgid "Eliminate a variable"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1340
+#: ../../src/wxMaximaFrame.cpp:1351
 msgid "Eliminate a variable from a system of equations"
 msgstr ""
 
@@ -3598,11 +3639,11 @@ msgstr ""
 msgid "Ended lisp mode after receiving a maxima prompt!"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1924
+#: ../../src/wxMaximaFrame.cpp:1935
 msgid "Engineering format (12.1e6 etc.)"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:196
+#: ../../src/dialogs/ConfigDialogue.cpp:197
 msgid "English"
 msgstr ""
 
@@ -3610,7 +3651,7 @@ msgstr ""
 msgid "Enhanced 3D settings:"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1959
+#: ../../src/dialogs/ConfigDialogue.cpp:2046
 msgid "Enhanced meta file (emf)"
 msgstr ""
 
@@ -3622,11 +3663,11 @@ msgstr ""
 msgid "Enter UUID to jump to:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1412
+#: ../../src/wxMaximaFrame.cpp:1423
 msgid "Enter a matrix"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:928
+#: ../../src/dialogs/ConfigDialogue.cpp:942
 msgid "Enter adds newlines, Ctrl+Enter evaluates cells"
 msgstr ""
 
@@ -3638,7 +3679,7 @@ msgstr ""
 msgid "Enter comma separated list of variables."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:924
+#: ../../src/dialogs/ConfigDialogue.cpp:938
 msgid "Enter evaluates cells, Ctrl+Enter adds newlines"
 msgstr ""
 
@@ -3654,7 +3695,11 @@ msgstr ""
 msgid "Enter new precision for bigfloats:"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:388
+#: ../../src/sidebars/AiChatSidebar.cpp:56
+msgid "Enter sends; Shift+Enter inserts a newline."
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:391
 msgid "Enter the path to the Maxima executable."
 msgstr ""
 
@@ -3662,11 +3707,11 @@ msgstr ""
 msgid "Enumerator:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1313
+#: ../../src/wxMaximaFrame.cpp:1324
 msgid "Environment variables"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1645
+#: ../../src/dialogs/ConfigDialogue.cpp:1659
 msgid "Environment variables for maxima"
 msgstr ""
 
@@ -3678,11 +3723,11 @@ msgstr ""
 msgid "Epsilon:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1217 ../../src/wxMaximaFrame.cpp:1228
+#: ../../src/wxMaximaFrame.cpp:1228 ../../src/wxMaximaFrame.cpp:1239
 msgid "Equal, ignoring case?..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1226
+#: ../../src/wxMaximaFrame.cpp:1237
 msgid "Equal?..."
 msgstr ""
 
@@ -3721,9 +3766,9 @@ msgstr ""
 #: ../../src/WXMXformat.cpp:290 ../../src/WXMXformat.cpp:298
 #: ../../src/WXMXformat.cpp:313 ../../src/WXMXformat.cpp:334
 #: ../../src/WXMXformat.cpp:364 ../../src/dialogs/BinaryNameCtrl.cpp:78
-#: ../../src/main.cpp:772 ../../src/wxMaxima.cpp:3479
-#: ../../src/wxMaxima.cpp:3515 ../../src/wxMaxima.cpp:3533
-#: ../../src/wxMaxima.cpp:3567
+#: ../../src/main.cpp:772 ../../src/sidebars/AiChatSidebar.cpp:205
+#: ../../src/wxMaxima.cpp:3480 ../../src/wxMaxima.cpp:3516
+#: ../../src/wxMaxima.cpp:3534 ../../src/wxMaxima.cpp:3568
 msgid "Error"
 msgstr ""
 
@@ -3773,15 +3818,15 @@ msgstr ""
 msgid "Evaluate"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1748
+#: ../../src/wxMaximaFrame.cpp:1759
 msgid "Evaluate &Noun Forms..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:949
+#: ../../src/wxMaximaFrame.cpp:960
 msgid "Evaluate All Cells\tCtrl+Shift+R"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:944
+#: ../../src/wxMaximaFrame.cpp:955
 msgid "Evaluate All Visible Cells\tCtrl+R"
 msgstr ""
 
@@ -3790,7 +3835,7 @@ msgid "Evaluate Cell"
 msgstr ""
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:171
-#: ../../src/wxMaximaFrame.cpp:937
+#: ../../src/wxMaximaFrame.cpp:948
 msgid "Evaluate Cell(s)"
 msgstr ""
 
@@ -3799,13 +3844,13 @@ msgstr ""
 msgid "Evaluate Cells Above"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:959
+#: ../../src/wxMaximaFrame.cpp:970
 msgid "Evaluate Cells Above\tCtrl+Shift+P"
 msgstr ""
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:175
 #: ../../src/worksheet/WorksheetContextMenu.cpp:453
-#: ../../src/wxMaximaFrame.cpp:969
+#: ../../src/wxMaximaFrame.cpp:980
 msgid "Evaluate Cells Below"
 msgstr ""
 
@@ -3847,7 +3892,7 @@ msgstr ""
 msgid "Evaluate Subsection\tShift+Ctrl+Enter"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:938
+#: ../../src/wxMaximaFrame.cpp:949
 msgid "Evaluate active or selected cell(s)"
 msgstr ""
 
@@ -3855,15 +3900,15 @@ msgstr ""
 msgid "Evaluate all"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:950
+#: ../../src/wxMaximaFrame.cpp:961
 msgid "Evaluate all cells in the document"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1749
+#: ../../src/wxMaximaFrame.cpp:1760
 msgid "Evaluate all noun forms in expression"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:945
+#: ../../src/wxMaximaFrame.cpp:956
 msgid "Evaluate all visible cells in the document"
 msgstr ""
 
@@ -3875,7 +3920,7 @@ msgstr ""
 msgid "Evaluate string"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1244
+#: ../../src/wxMaximaFrame.cpp:1255
 msgid "Evaluate string..."
 msgstr ""
 
@@ -3903,15 +3948,15 @@ msgstr ""
 msgid "Even number"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2702
+#: ../../src/dialogs/ConfigDialogue.cpp:2798
 msgid "Example text"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1587
+#: ../../src/dialogs/ConfigDialogue.cpp:1601
 msgid "Examples:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1799
+#: ../../src/wxMaximaFrame.cpp:1810
 msgid "Execute a command for each element of the list"
 msgstr ""
 
@@ -3931,11 +3976,11 @@ msgstr ""
 msgid "Expand Expression"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1621
+#: ../../src/wxMaximaFrame.cpp:1632
 msgid "Expand an expression"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1627
+#: ../../src/wxMaximaFrame.cpp:1638
 msgid "Expand for given variables"
 msgstr ""
 
@@ -3947,24 +3992,24 @@ msgstr ""
 msgid "Expand for variable(s):"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1641
+#: ../../src/wxMaximaFrame.cpp:1652
 msgid "Expand log in previous expression"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1694
+#: ../../src/wxMaximaFrame.cpp:1705
 msgid "Expand trigonometric expression"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1884
+#: ../../src/wxMaximaFrame.cpp:1895
 msgid "Expect numbers harder to be complex"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1885
+#: ../../src/wxMaximaFrame.cpp:1896
 msgid "Expect variables to contain complex numbers"
 msgstr ""
 
 #: ../../src/MaximaCommandMenus.cpp:2277
-#: ../../src/dialogs/ConfigDialogue.cpp:283
+#: ../../src/dialogs/ConfigDialogue.cpp:284
 msgid "Export"
 msgstr ""
 
@@ -3972,15 +4017,15 @@ msgstr ""
 msgid "Export As"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1801
+#: ../../src/wxMaximaFrame.cpp:1812
 msgid "Export List to csv file..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1802
+#: ../../src/wxMaximaFrame.cpp:1813
 msgid "Export a list to a csv file"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1425
+#: ../../src/wxMaximaFrame.cpp:1436
 msgid "Export a matrix to a csv file"
 msgstr ""
 
@@ -3988,7 +4033,7 @@ msgstr ""
 msgid "Export all history to a .mac file"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1019
+#: ../../src/dialogs/ConfigDialogue.cpp:1033
 msgid "Export all settings"
 msgstr ""
 
@@ -3996,15 +4041,15 @@ msgstr ""
 msgid "Export commands from the current maxima session to a .mac file"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:709
+#: ../../src/wxMaximaFrame.cpp:719
 msgid "Export document to a HTML or LaTeX file"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1221
+#: ../../src/dialogs/ConfigDialogue.cpp:1235
 msgid "Export equations to HTML as:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:646
+#: ../../src/wxMaximaFrame.cpp:656
 msgid "Export failed."
 msgstr ""
 
@@ -4020,7 +4065,7 @@ msgstr ""
 msgid "Export selected commands to a .mac file"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:634
+#: ../../src/wxMaximaFrame.cpp:644
 msgid "Export successful."
 msgstr ""
 
@@ -4028,7 +4073,7 @@ msgstr ""
 msgid "Export the selected output(s) to this folder"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1025
+#: ../../src/dialogs/ConfigDialogue.cpp:1039
 msgid "Export the style settings"
 msgstr ""
 
@@ -4041,7 +4086,7 @@ msgstr ""
 msgid "Exported %d output image(s) to %s"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2231 ../../src/wxMaxima.cpp:2273
+#: ../../src/wxMaxima.cpp:2232 ../../src/wxMaxima.cpp:2274
 #, c-format
 msgid "Exported the worksheet to %s"
 msgstr ""
@@ -4062,7 +4107,7 @@ msgstr ""
 msgid "Exporting to maxima batch file failed!"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:628
+#: ../../src/wxMaximaFrame.cpp:638
 msgid "Exporting..."
 msgstr ""
 
@@ -4098,7 +4143,7 @@ msgstr ""
 msgid "Expression to plot"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1181
+#: ../../src/wxMaximaFrame.cpp:1192
 msgid "Expression to string..."
 msgstr ""
 
@@ -4121,23 +4166,23 @@ msgstr ""
 msgid "Expression:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1516
+#: ../../src/wxMaximaFrame.cpp:1527
 msgid "Extract Column..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1822
+#: ../../src/wxMaximaFrame.cpp:1833
 msgid "Extract Elements"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1514
+#: ../../src/wxMaximaFrame.cpp:1525
 msgid "Extract Row..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1517
+#: ../../src/wxMaximaFrame.cpp:1528
 msgid "Extract a column from the matrix"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1531
+#: ../../src/wxMaximaFrame.cpp:1542
 msgid "Extract a column from the matrix and convert it to a list"
 msgstr ""
 
@@ -4149,7 +4194,7 @@ msgstr ""
 msgid "Extract a matrix column as a list"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1406
+#: ../../src/wxMaximaFrame.cpp:1417
 msgid "Extract a matrix from a 2-dimensional array"
 msgstr ""
 
@@ -4161,11 +4206,11 @@ msgstr ""
 msgid "Extract a matrix row as a list"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1515
+#: ../../src/wxMaximaFrame.cpp:1526
 msgid "Extract a row from the matrix"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1527
+#: ../../src/wxMaximaFrame.cpp:1538
 msgid "Extract a row from the matrix and convert it to a list"
 msgstr ""
 
@@ -4173,15 +4218,15 @@ msgstr ""
 msgid "Extract a variable's value from a list of variable values"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1819
+#: ../../src/wxMaximaFrame.cpp:1830
 msgid "Extract an actual value for a variable"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1256
+#: ../../src/wxMaximaFrame.cpp:1267
 msgid "Extract char..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1300
+#: ../../src/wxMaximaFrame.cpp:1311
 msgid "Extract dir from path..."
 msgstr ""
 
@@ -4193,7 +4238,7 @@ msgstr ""
 msgid "Extract file type extension"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1302
+#: ../../src/wxMaximaFrame.cpp:1313
 msgid "Extract filename from path..."
 msgstr ""
 
@@ -4201,7 +4246,7 @@ msgstr ""
 msgid "Extract filename part"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1304
+#: ../../src/wxMaximaFrame.cpp:1315
 msgid "Extract filetype from path..."
 msgstr ""
 
@@ -4209,7 +4254,7 @@ msgstr ""
 msgid "Extract function arguments"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1823
+#: ../../src/wxMaximaFrame.cpp:1834
 msgid "Extract list Elements"
 msgstr ""
 
@@ -4217,7 +4262,7 @@ msgstr ""
 msgid "Extract matrix from 2D array"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1782
+#: ../../src/wxMaximaFrame.cpp:1793
 msgid "Extract the argument list from a function call"
 msgstr ""
 
@@ -4237,11 +4282,11 @@ msgstr ""
 msgid "Extract the nth list elements"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1820
+#: ../../src/wxMaximaFrame.cpp:1831
 msgid "Extract the value for one variable assigned in a list"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1535
+#: ../../src/wxMaximaFrame.cpp:1546
 msgid "Extract, append or delete rows or columns"
 msgstr ""
 
@@ -4253,7 +4298,7 @@ msgstr ""
 msgid "Factor"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1617
+#: ../../src/wxMaximaFrame.cpp:1628
 msgid "Factor Complex"
 msgstr ""
 
@@ -4261,19 +4306,19 @@ msgstr ""
 msgid "Factor Expression"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1615
+#: ../../src/wxMaximaFrame.cpp:1626
 msgid "Factor Expression including subexpressions"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1613 ../../src/wxMaximaFrame.cpp:1616
+#: ../../src/wxMaximaFrame.cpp:1624 ../../src/wxMaximaFrame.cpp:1627
 msgid "Factor an expression"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1618
+#: ../../src/wxMaximaFrame.cpp:1629
 msgid "Factor an expression in Gaussian numbers"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1683
+#: ../../src/wxMaximaFrame.cpp:1694
 msgid "Factorials and &Gamma"
 msgstr ""
 
@@ -4295,11 +4340,11 @@ msgstr ""
 msgid "Failed to write to Maxima's stdin (LDB)."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1511
+#: ../../src/wxMaximaFrame.cpp:1522
 msgid "Fast fortran routines that perform numerical tasks"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:2018
+#: ../../src/wxMaximaFrame.cpp:2029
 msgid "Fast list access"
 msgstr ""
 
@@ -4332,7 +4377,7 @@ msgstr ""
 msgid "File"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1426
+#: ../../src/wxMaximaFrame.cpp:1437
 msgid "File I/O"
 msgstr ""
 
@@ -4348,7 +4393,7 @@ msgstr ""
 msgid "File name:"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3090 ../../src/wxMaxima.cpp:3133
+#: ../../src/wxMaxima.cpp:3091 ../../src/wxMaxima.cpp:3134
 msgid "File not found"
 msgstr ""
 
@@ -4356,15 +4401,15 @@ msgstr ""
 msgid "File opened"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1310
+#: ../../src/wxMaximaFrame.cpp:1321
 msgid "File operations"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3089 ../../src/wxMaxima.cpp:3132
+#: ../../src/wxMaxima.cpp:3090 ../../src/wxMaxima.cpp:3133
 msgid "File you tried to open does not exist."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1314
+#: ../../src/wxMaximaFrame.cpp:1325
 msgid "File/directory functions"
 msgstr ""
 
@@ -4384,15 +4429,15 @@ msgstr ""
 msgid "Find"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:764
+#: ../../src/wxMaximaFrame.cpp:774
 msgid "Find\tCtrl+F"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1564
+#: ../../src/wxMaximaFrame.cpp:1575
 msgid "Find &Limit..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1566
+#: ../../src/wxMaximaFrame.cpp:1577
 msgid "Find Minimum..."
 msgstr ""
 
@@ -4400,48 +4445,48 @@ msgstr ""
 msgid "Find Root..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1567
+#: ../../src/wxMaximaFrame.cpp:1578
 msgid "Find a (unconstrained) minimum of an expression"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1900
+#: ../../src/wxMaximaFrame.cpp:1911
 msgid "Find a fraction that represents this float exactly"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1565
+#: ../../src/wxMaximaFrame.cpp:1576
 msgid "Find a limit of an expression"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1903
+#: ../../src/wxMaximaFrame.cpp:1914
 msgid "Find a nice fraction that is similar to this float"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1376
+#: ../../src/wxMaximaFrame.cpp:1387
 msgid "Find a numerical solution for a first degree ODE"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1345
+#: ../../src/wxMaximaFrame.cpp:1356
 msgid "Find a root of an equation on an interval"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1352
+#: ../../src/wxMaximaFrame.cpp:1363
 msgid "Find all roots of a polynomial"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1355
+#: ../../src/wxMaximaFrame.cpp:1366
 msgid "Find all roots of a polynomial (bfloat)"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:3129 ../../src/wxMaximaFrame.cpp:364
+#: ../../src/MaximaCommandMenus.cpp:3129 ../../src/wxMaximaFrame.cpp:374
 msgid "Find and Replace"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:808
+#: ../../src/wxMaximaFrame.cpp:818
 msgid "Find and Replace (if set to dockable)"
 msgstr ""
 
 #: ../../src/ToolBar.cpp:401 ../../src/ToolBar.cpp:403
-#: ../../src/wxMaximaFrame.cpp:764
+#: ../../src/wxMaximaFrame.cpp:774
 msgid "Find and replace"
 msgstr ""
 
@@ -4449,19 +4494,19 @@ msgstr ""
 msgid "Find char in string"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1265
+#: ../../src/wxMaximaFrame.cpp:1276
 msgid "Find char in string..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1630
+#: ../../src/wxMaximaFrame.cpp:1641
 msgid "Find common denominator"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1459
+#: ../../src/wxMaximaFrame.cpp:1470
 msgid "Find eigenvalues of a matrix"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1462
+#: ../../src/wxMaximaFrame.cpp:1473
 msgid "Find eigenvectors of a matrix"
 msgstr ""
 
@@ -4469,11 +4514,11 @@ msgstr ""
 msgid "Find first difference"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1263
+#: ../../src/wxMaximaFrame.cpp:1274
 msgid "Find first difference..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1349
+#: ../../src/wxMaximaFrame.cpp:1360
 msgid "Find fractions that real roots of a polynomial and "
 msgstr ""
 
@@ -4481,7 +4526,7 @@ msgstr ""
 msgid "Find minimum"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1344
+#: ../../src/wxMaximaFrame.cpp:1355
 msgid "Find numerical solution..."
 msgstr ""
 
@@ -4505,28 +4550,28 @@ msgstr ""
 msgid "Find:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1928
+#: ../../src/wxMaximaFrame.cpp:1939
 msgid "Fine-tune the display of engineering-format numbers"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:197
+#: ../../src/dialogs/ConfigDialogue.cpp:198
 msgid "Finnish"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1808
+#: ../../src/wxMaximaFrame.cpp:1819
 msgid "First"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:2014
+#: ../../src/wxMaximaFrame.cpp:2025
 msgid "Fitting curves to measurement data"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1407
+#: ../../src/dialogs/ConfigDialogue.cpp:1421
 #, c-format
 msgid "Fix reordered reference indices (of %i, %o) before saving"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:876
+#: ../../src/dialogs/ConfigDialogue.cpp:890
 msgid "Fixed font in text controls"
 msgstr ""
 
@@ -4534,15 +4579,15 @@ msgstr ""
 msgid "Flush stream"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1196
+#: ../../src/wxMaximaFrame.cpp:1207
 msgid "Flush..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1015
+#: ../../src/wxMaximaFrame.cpp:1026
 msgid "Fold All\tCtrl+Alt+["
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1016
+#: ../../src/wxMaximaFrame.cpp:1027
 msgid "Fold all sections"
 msgstr ""
 
@@ -4550,7 +4595,7 @@ msgstr ""
 msgid "Follow"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2110
+#: ../../src/dialogs/ConfigDialogue.cpp:2197
 msgid "Follow system"
 msgstr ""
 
@@ -4570,11 +4615,11 @@ msgstr ""
 msgid "Font cache misses:"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2087
+#: ../../src/dialogs/ConfigDialogue.cpp:2174
 msgid "Fonts"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:442
+#: ../../src/dialogs/ConfigDialogue.cpp:445
 msgid "For each Text-, Sectioning or code cell wxMaxima can display a bracket showing the extend of the cell and allowing to fold it. This setting now tells if this bracket is to be printed, as well."
 msgstr ""
 
@@ -4596,7 +4641,7 @@ msgstr ""
 msgid "For loop"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1155
+#: ../../src/wxMaximaFrame.cpp:1166
 msgid "For loop..."
 msgstr ""
 
@@ -4604,11 +4649,11 @@ msgstr ""
 msgid "Format:"
 msgstr ""
 
-#: ../../src/worksheet/Worksheet.cpp:306 ../../src/wxMaxima.cpp:3618
+#: ../../src/worksheet/Worksheet.cpp:306 ../../src/wxMaxima.cpp:3619
 msgid "Forwarding the keyboard focus to a text control"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3621
+#: ../../src/wxMaxima.cpp:3622
 msgid "Forwarding the keyboard focus to the worksheet"
 msgstr ""
 
@@ -4636,7 +4681,7 @@ msgstr ""
 msgid "Fourier coefficients"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1572
+#: ../../src/wxMaximaFrame.cpp:1583
 msgid "Fourier coefficients..."
 msgstr ""
 
@@ -4661,19 +4706,19 @@ msgstr ""
 msgid "Frame rate"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1098 ../../src/wxMaximaFrame.cpp:1102
+#: ../../src/wxMaximaFrame.cpp:1109 ../../src/wxMaximaFrame.cpp:1113
 msgid "Free all unused items now"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:198
+#: ../../src/dialogs/ConfigDialogue.cpp:199
 msgid "French"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1506
+#: ../../src/wxMaximaFrame.cpp:1517
 msgid "Frobenius Norm sqrt(sum((A(i,j))^2)) (complex)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1504
+#: ../../src/wxMaximaFrame.cpp:1515
 msgid "Frobenius Norm sqrt(sum((A(i,j))^2)) (real)"
 msgstr ""
 
@@ -4684,11 +4729,11 @@ msgstr ""
 msgid "From:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:923
+#: ../../src/wxMaximaFrame.cpp:934
 msgid "Full Screen\tAlt+Enter"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:920
+#: ../../src/wxMaximaFrame.cpp:931
 msgid "Full Screen\tF11"
 msgstr ""
 
@@ -4720,15 +4765,15 @@ msgstr ""
 msgid "Function:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1726
+#: ../../src/wxMaximaFrame.cpp:1737
 msgid "Functions for complex simplification"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1684
+#: ../../src/wxMaximaFrame.cpp:1695
 msgid "Functions for simplifying factorials and gamma function"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1702
+#: ../../src/wxMaximaFrame.cpp:1713
 msgid "Functions for simplifying trigonometric expressions"
 msgstr ""
 
@@ -4748,7 +4793,7 @@ msgstr ""
 msgid "GTK_IM_MODULE is set to \"xim\". Expect the program to hideously flicker and hotkeys to be broken, see for example https://github.com/wxWidgets/wxWidgets/issues/18462."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:199
+#: ../../src/dialogs/ConfigDialogue.cpp:200
 msgid "Galician"
 msgstr ""
 
@@ -4756,31 +4801,31 @@ msgstr ""
 msgid "Gamma"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:323
+#: ../../src/wxMaximaFrame.cpp:333
 msgid "General Math"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:791
+#: ../../src/wxMaximaFrame.cpp:801
 msgid "General Math\tAlt+Shift+M"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1409
+#: ../../src/wxMaximaFrame.cpp:1420
 msgid "Generate Matrix from Expression..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1410
+#: ../../src/wxMaximaFrame.cpp:1421
 msgid "Generate a matrix from a lambda expression"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1771
+#: ../../src/wxMaximaFrame.cpp:1782
 msgid "Generate a new list using a lists' elements"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1777
+#: ../../src/wxMaximaFrame.cpp:1788
 msgid "Generate a storage for variable values that can be introduced into equations at any time"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1768
+#: ../../src/wxMaximaFrame.cpp:1779
 msgid "Generate list elements using a rule"
 msgstr ""
 
@@ -4788,7 +4833,7 @@ msgstr ""
 msgid "Generate matrix from a rule"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1187
+#: ../../src/wxMaximaFrame.cpp:1198
 msgid "Generate unused symbol name"
 msgstr ""
 
@@ -4800,31 +4845,31 @@ msgstr ""
 msgid "Generates a matrix and fills each element with the result of the expression \"Rule\"."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:200
+#: ../../src/dialogs/ConfigDialogue.cpp:201
 msgid "Georgian"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:201
+#: ../../src/dialogs/ConfigDialogue.cpp:202
 msgid "German"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1715
+#: ../../src/wxMaximaFrame.cpp:1726
 msgid "Get &Imaginary Part"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1581
+#: ../../src/wxMaximaFrame.cpp:1592
 msgid "Get Laplace transformation of an expression"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1711
+#: ../../src/wxMaximaFrame.cpp:1722
 msgid "Get Real P&art"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1294
+#: ../../src/wxMaximaFrame.cpp:1305
 msgid "Get current directory"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1585
+#: ../../src/wxMaximaFrame.cpp:1596
 msgid "Get inverse Laplace transformation of an expression"
 msgstr ""
 
@@ -4832,15 +4877,15 @@ msgstr ""
 msgid "Get position in stream"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1195
+#: ../../src/wxMaximaFrame.cpp:1206
 msgid "Get position..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1716
+#: ../../src/wxMaximaFrame.cpp:1727
 msgid "Get the imaginary part of complex expression"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1712
+#: ../../src/wxMaximaFrame.cpp:1723
 msgid "Get the real part of complex expression"
 msgstr ""
 
@@ -4849,7 +4894,7 @@ msgstr ""
 msgid "Gnuplot (command line) found at: %s"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1669
+#: ../../src/dialogs/ConfigDialogue.cpp:1683
 msgid "Gnuplot flavour"
 msgstr ""
 
@@ -4875,7 +4920,7 @@ msgid ""
 "%s"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:2071 ../../src/wxMaximaFrame.cpp:1983
+#: ../../src/MaximaCommandMenus.cpp:2071 ../../src/wxMaximaFrame.cpp:1994
 msgid "Go to URL"
 msgstr ""
 
@@ -4887,7 +4932,7 @@ msgstr ""
 msgid "Got a request to undo an action that involves a delete which isn't possible at this moment."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1124
+#: ../../src/wxMaximaFrame.cpp:1135
 msgid "Gradefs"
 msgstr ""
 
@@ -4895,11 +4940,11 @@ msgstr ""
 msgid "Greater or less than a value"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1223
+#: ../../src/wxMaximaFrame.cpp:1234
 msgid "Greater, ignoring case?..."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:202
+#: ../../src/dialogs/ConfigDialogue.cpp:203
 msgid "Greek"
 msgstr ""
 
@@ -4907,7 +4952,7 @@ msgstr ""
 msgid "Greek Letters"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:795
+#: ../../src/wxMaximaFrame.cpp:805
 msgid "Greek Letters\tAlt+Shift+G"
 msgstr ""
 
@@ -4919,11 +4964,11 @@ msgstr ""
 msgid "Grid:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1911
+#: ../../src/wxMaximaFrame.cpp:1922
 msgid "Guess an exact number that could be meant by this float"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1218
+#: ../../src/dialogs/ConfigDialogue.cpp:1232
 msgid "HTML"
 msgstr ""
 
@@ -4931,7 +4976,7 @@ msgstr ""
 msgid "HTML file (*.html)|*.html|maxima batch file (*.mac)|*.mac|LaTeX file (*.tex)|*.tex"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1434
+#: ../../src/wxMaximaFrame.cpp:1445
 msgid "Hadamard (element-by-element) product..."
 msgstr ""
 
@@ -4943,7 +4988,7 @@ msgstr ""
 msgid "Hadamard exponent"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1438
+#: ../../src/wxMaximaFrame.cpp:1449
 msgid "Hadamard exponent..."
 msgstr ""
 
@@ -4962,16 +5007,16 @@ msgstr ""
 msgid "Heading 6"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:203
+#: ../../src/dialogs/ConfigDialogue.cpp:204
 msgid "Hebrew"
 msgstr ""
 
 #: ../../src/ToolBar.cpp:544 ../../src/ToolBar.cpp:546
-#: ../../src/wxMaximaFrame.cpp:377
+#: ../../src/wxMaximaFrame.cpp:387
 msgid "Help"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1501
+#: ../../src/dialogs/ConfigDialogue.cpp:1515
 msgid "Help browser:"
 msgstr ""
 
@@ -4998,7 +5043,7 @@ msgstr ""
 msgid "Hide Code"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:823
+#: ../../src/wxMaximaFrame.cpp:834
 msgid "Hide Code Cells\tAlt+Ctrl+H"
 msgstr ""
 
@@ -5026,15 +5071,15 @@ msgstr ""
 msgid "Hide Subsubsection"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:825
+#: ../../src/wxMaximaFrame.cpp:836
 msgid "Hide all Sidebars\tAlt+Shift+-"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:487
+#: ../../src/dialogs/ConfigDialogue.cpp:490
 msgid "Hide all multiplication signs that aren't really necessary for understanding the equation"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:826
+#: ../../src/wxMaximaFrame.cpp:837
 msgid "Hide all panes"
 msgstr ""
 
@@ -5050,7 +5095,7 @@ msgstr ""
 msgid "Hide multiplication dots"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:857
+#: ../../src/dialogs/ConfigDialogue.cpp:871
 msgid "Hide multiplication signs, if possible"
 msgstr ""
 
@@ -5058,7 +5103,7 @@ msgstr ""
 msgid "Hide objects behind the surface"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:502
+#: ../../src/dialogs/ConfigDialogue.cpp:505
 msgid "Hide the brackets that mark the extend of the worksheet cells at the worksheet's right side and that contain the \"hide\" button of the cell if the cells aren't active."
 msgstr ""
 
@@ -5076,15 +5121,15 @@ msgstr ""
 msgid "Highlight (box)"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:872
+#: ../../src/dialogs/ConfigDialogue.cpp:886
 msgid "Highlight the matching parenthesis"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:463
+#: ../../src/dialogs/ConfigDialogue.cpp:466
 msgid "Highlight the opening or closing parenthesis for the parenthesis the cursor is at."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:204
+#: ../../src/dialogs/ConfigDialogue.cpp:205
 msgid "Hindi"
 msgstr ""
 
@@ -5100,7 +5145,7 @@ msgstr ""
 msgid "History"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:801
+#: ../../src/wxMaximaFrame.cpp:811
 msgid "History\tAlt+Shift+I"
 msgstr ""
 
@@ -5108,11 +5153,11 @@ msgstr ""
 msgid "Horizontal cursor works like a normal cursor, but it operates on cells: press up or down arrow to move it, holding down Shift while moving will select cells, pressing backspace or delete twice will delete a cell next to it."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1622
+#: ../../src/wxMaximaFrame.cpp:1633
 msgid "Horner's rule"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:921
+#: ../../src/dialogs/ConfigDialogue.cpp:935
 msgid "Hotkeys for sending commands to maxima"
 msgstr ""
 
@@ -5120,15 +5165,15 @@ msgstr ""
 msgid "How many digits to show:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:855
+#: ../../src/wxMaximaFrame.cpp:866
 msgid "How to display new equations"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:205
+#: ../../src/dialogs/ConfigDialogue.cpp:206
 msgid "Hungarian"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1206
+#: ../../src/wxMaximaFrame.cpp:1217
 msgid "I/O"
 msgstr ""
 
@@ -5140,43 +5185,43 @@ msgstr ""
 msgid "If a program doesn't need local variables, Maxima allows putting the commands between parentheses. The result of the last operation is the return value of the program."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:145
+#: ../../src/dialogs/ConfigDialogue.cpp:146
 msgid "If maxima versions compiled with different lisps are installed: The name of the lisp to use by default"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:174
+#: ../../src/dialogs/ConfigDialogue.cpp:175
 msgid "If maxima was compiled by GCL: Garbage Collect at minimum allocation past this heapsize"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:171
+#: ../../src/dialogs/ConfigDialogue.cpp:172
 msgid "If maxima was compiled by GCL: Minimum allocation fraction between Garbage Collects"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:168
+#: ../../src/dialogs/ConfigDialogue.cpp:169
 msgid "If maxima was compiled by GCL: Only garbage collect past this heapsize fraction of working mem"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:180
+#: ../../src/dialogs/ConfigDialogue.cpp:181
 msgid "If maxima was compiled by GCL: Share the allocated memory between gcl processes. Allows more than one gcl-compiled maxima to run at the same time, but might provoke crashes."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:177
+#: ../../src/dialogs/ConfigDialogue.cpp:178
 msgid "If maxima was compiled by GCL: The fraction of the total installed RAM to reserve for maxima"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:375
+#: ../../src/dialogs/ConfigDialogue.cpp:378
 msgid "If multiple cells are evaluated in one go: Abort evaluation if wxMaxima detects that maxima has encountered any error."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:730
+#: ../../src/dialogs/ConfigDialogue.cpp:744
 msgid "If not extremely long"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:729
+#: ../../src/dialogs/ConfigDialogue.cpp:743
 msgid "If not very long"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:418
+#: ../../src/dialogs/ConfigDialogue.cpp:421
 msgid "If numbers are getting longer than this number of digits they will be displayed abbreviated by an ellipsis."
 msgstr ""
 
@@ -5184,7 +5229,7 @@ msgstr ""
 msgid "If the \"Autosave\" functionality is enabled in the configuration dialogue wxMaxima acts like mobile apps that backup the file every few minutes and save it on closing."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:396
+#: ../../src/dialogs/ConfigDialogue.cpp:399
 msgid "If the font provides big parenthesis symbols: Use them when big parenthesis are needed for maths display."
 msgstr ""
 
@@ -5200,15 +5245,15 @@ msgid ""
 "array, boolean, integer, fixnum (machine-length integer), float (machine-size floating-point numbers), real or any (which is useful for declaring arrays of any)"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:399
+#: ../../src/dialogs/ConfigDialogue.cpp:402
 msgid "If this checkbox is checked wxMaxima automatically saves the file closing and every few minutes giving wxMaxima a more cellphone-app-like feel as the file is virtually always saved. If this checkbox is unchecked from time to time a backup is made in the temp folder instead."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:378
+#: ../../src/dialogs/ConfigDialogue.cpp:381
 msgid "If this checkbox is set a new code cell is opened as soon as maxima requests data. If it isn't set a new code cell is opened in this case as soon as the user starts typing in code."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:372
+#: ../../src/dialogs/ConfigDialogue.cpp:375
 msgid "If this checkbox isn't checked the current command is sent to maxima only on pressing Ctrl+Enter"
 msgstr ""
 
@@ -5216,18 +5261,18 @@ msgstr ""
 msgid "If this isn't a function returning a lambda() expression a multiplication sign (*) between closing and opening parenthesis is missing here."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:945
+#: ../../src/dialogs/ConfigDialogue.cpp:959
 msgid ""
 "If this option is enabled, the filename and path of images inserted with \"Cell\" -> \"Insert Image...\" is stored in the worksheet file on save. This enables reloading of the image file via the context menu after re-opening the worksheet, but storing the filenames and paths may be an undesired data leak. If this option is disabled, reloading still works as long as the worksheet is not closed.\n"
 "\n"
 "Note: Storing the filenames for the reload functionality is independent of the automatically generated image captions."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:439
+#: ../../src/dialogs/ConfigDialogue.cpp:442
 msgid "If this option is set the .wxmx source of the current file is copied to a place a link to is put into the result of an export."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1913
+#: ../../src/dialogs/ConfigDialogue.cpp:1927
 msgid "If unset, Maxima's output is announced to the screen reader as maths in a linear text form. Set this option if your screen reader can speak MathML properly."
 msgstr ""
 
@@ -5273,11 +5318,11 @@ msgstr ""
 msgid "Implicit Plot"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1031
+#: ../../src/dialogs/ConfigDialogue.cpp:1045
 msgid "Import settings"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1016
+#: ../../src/dialogs/ConfigDialogue.cpp:1030
 msgid "Import+Export"
 msgstr ""
 
@@ -5318,7 +5363,7 @@ msgstr ""
 msgid "In text cells bullet lists can be created by beginning a line with \" * \". The number of spaces in front of the \"*\" determines the indentation level; Indentation can be continued in the next line by indenting the line using spaces."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:421
+#: ../../src/dialogs/ConfigDialogue.cpp:424
 msgid "In the LaTeX output: Put exponents after an eventual subscript instead of above it. Might increase readability for some fonts and short subscripts."
 msgstr ""
 
@@ -5330,15 +5375,15 @@ msgstr ""
 msgid "Increasing function f(x)>x"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:887
+#: ../../src/dialogs/ConfigDialogue.cpp:901
 msgid "Incremental Search"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:847
+#: ../../src/dialogs/ConfigDialogue.cpp:861
 msgid "Indent equations by the label width"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:512
+#: ../../src/dialogs/ConfigDialogue.cpp:515
 msgid "Indent maths so all lines are in par with the first line that starts after the label."
 msgstr ""
 
@@ -5362,7 +5407,7 @@ msgstr ""
 msgid "Index variable:"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:206
+#: ../../src/dialogs/ConfigDialogue.cpp:207
 msgid "Indonesian"
 msgstr ""
 
@@ -5383,7 +5428,7 @@ msgstr ""
 msgid "Infinity"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:2045
+#: ../../src/wxMaximaFrame.cpp:2056
 msgid "Info about Maxima build"
 msgstr ""
 
@@ -5399,11 +5444,11 @@ msgstr ""
 msgid "Initial Condition"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1363
+#: ../../src/wxMaximaFrame.cpp:1374
 msgid "Initial Value Problem (&1)..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1367
+#: ../../src/wxMaximaFrame.cpp:1378
 msgid "Initial Value Problem (&2)..."
 msgstr ""
 
@@ -5435,23 +5480,23 @@ msgid ""
 "Right-click for options!"
 msgstr ""
 
-#: ../../src/wizards/GenWizPanel.cpp:103 ../../src/wxMaximaFrame.cpp:342
+#: ../../src/wizards/GenWizPanel.cpp:103 ../../src/wxMaximaFrame.cpp:352
 msgid "Insert"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:892
+#: ../../src/dialogs/ConfigDialogue.cpp:906
 msgid "Insert % before an operator at the beginning of a cell"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:998
+#: ../../src/wxMaximaFrame.cpp:1009
 msgid "Insert &Section Cell\tCtrl+3"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:994
+#: ../../src/wxMaximaFrame.cpp:1005
 msgid "Insert &Text Cell\tCtrl+1"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:805
+#: ../../src/wxMaximaFrame.cpp:815
 msgid "Insert Cell\tAlt+Shift+C"
 msgstr ""
 
@@ -5467,23 +5512,23 @@ msgstr ""
 msgid "Insert Image"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1010
+#: ../../src/wxMaximaFrame.cpp:1021
 msgid "Insert Image..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:992
+#: ../../src/wxMaximaFrame.cpp:1003
 msgid "Insert Input &Cell\tCtrl+0"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1012
+#: ../../src/wxMaximaFrame.cpp:1023
 msgid "Insert Page Break"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1000
+#: ../../src/wxMaximaFrame.cpp:1011
 msgid "Insert S&ubsection Cell\tCtrl+4"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1003
+#: ../../src/wxMaximaFrame.cpp:1014
 msgid "Insert S&ubsubsection Cell\tCtrl+5"
 msgstr ""
 
@@ -5499,7 +5544,7 @@ msgstr ""
 msgid "Insert Subsubsection Cell"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:996
+#: ../../src/wxMaximaFrame.cpp:1007
 msgid "Insert T&itle Cell\tCtrl+2"
 msgstr ""
 
@@ -5511,39 +5556,39 @@ msgstr ""
 msgid "Insert Title Cell"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1006
+#: ../../src/wxMaximaFrame.cpp:1017
 msgid "Insert a new heading5 cell"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1008
+#: ../../src/wxMaximaFrame.cpp:1019
 msgid "Insert a new heading6 cell"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:993
+#: ../../src/wxMaximaFrame.cpp:1004
 msgid "Insert a new input cell"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:999
+#: ../../src/wxMaximaFrame.cpp:1010
 msgid "Insert a new section cell"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1001
+#: ../../src/wxMaximaFrame.cpp:1012
 msgid "Insert a new subsection cell"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1004
+#: ../../src/wxMaximaFrame.cpp:1015
 msgid "Insert a new subsubsection cell"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:995
+#: ../../src/wxMaximaFrame.cpp:1006
 msgid "Insert a new text cell"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:997
+#: ../../src/wxMaximaFrame.cpp:1008
 msgid "Insert a new title cell"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1013
+#: ../../src/wxMaximaFrame.cpp:1024
 msgid "Insert a page break"
 msgstr ""
 
@@ -5551,23 +5596,23 @@ msgstr ""
 msgid "Insert a string into another"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1257
+#: ../../src/wxMaximaFrame.cpp:1268
 msgid "Insert char..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1005
+#: ../../src/wxMaximaFrame.cpp:1016
 msgid "Insert heading5 Cell\tCtrl+6"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1007
+#: ../../src/wxMaximaFrame.cpp:1018
 msgid "Insert heading6 Cell\tCtrl+7"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1010
+#: ../../src/wxMaximaFrame.cpp:1021
 msgid "Insert image"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1009
+#: ../../src/wxMaximaFrame.cpp:1020
 msgid "Insert textbased cell"
 msgstr ""
 
@@ -5587,7 +5632,7 @@ msgstr ""
 msgid "Instructed to prefer wgnuplot over gnuplot"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:752
+#: ../../src/dialogs/ConfigDialogue.cpp:766
 msgid "Integers and single letters"
 msgstr ""
 
@@ -5608,15 +5653,15 @@ msgstr ""
 msgid "Integrate (risch)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1550
+#: ../../src/wxMaximaFrame.cpp:1561
 msgid "Integrate expression"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1552
+#: ../../src/wxMaximaFrame.cpp:1563
 msgid "Integrate expression with Risch algorithm"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1965
+#: ../../src/wxMaximaFrame.cpp:1976
 msgid "Integrate numerically (QUADPACK)"
 msgstr ""
 
@@ -5625,23 +5670,23 @@ msgstr ""
 msgid "Integrate..."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:837
+#: ../../src/dialogs/ConfigDialogue.cpp:851
 msgid "Intelligently hide cell brackets"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:884
+#: ../../src/dialogs/ConfigDialogue.cpp:898
 msgid "Interaction"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1352
+#: ../../src/dialogs/ConfigDialogue.cpp:1366
 msgid "Interactive popup memory limit [MB/plot]:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1833
+#: ../../src/wxMaximaFrame.cpp:1844
 msgid "Interleave"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1834
+#: ../../src/wxMaximaFrame.cpp:1845
 msgid "Interleave the values of two lists"
 msgstr ""
 
@@ -5649,11 +5694,11 @@ msgstr ""
 msgid "Interleave two lists"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1505
+#: ../../src/dialogs/ConfigDialogue.cpp:1519
 msgid "Internal"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1180
+#: ../../src/wxMaximaFrame.cpp:1191
 msgid "Interpret like input..."
 msgstr ""
 
@@ -5665,7 +5710,7 @@ msgstr ""
 msgid "Interpret string as maxima code"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1182
+#: ../../src/wxMaximaFrame.cpp:1193
 msgid "Interpret string..."
 msgstr ""
 
@@ -5673,7 +5718,7 @@ msgstr ""
 msgid "Interrupt"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1058
+#: ../../src/wxMaximaFrame.cpp:1069
 msgid "Interrupt current computation"
 msgstr ""
 
@@ -5690,7 +5735,7 @@ msgstr ""
 msgid "Introduce a list of actual values into an equation"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1793
+#: ../../src/wxMaximaFrame.cpp:1804
 msgid "Introduce the actual values for variables stored in the list"
 msgstr ""
 
@@ -5711,7 +5756,7 @@ msgstr ""
 msgid "Inverse Laplace"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1584
+#: ../../src/wxMaximaFrame.cpp:1595
 msgid "Inverse Laplace T&ransform..."
 msgstr ""
 
@@ -5739,7 +5784,7 @@ msgstr ""
 msgid "Is a char?"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1208
+#: ../../src/wxMaximaFrame.cpp:1219
 msgid "Is a char?..."
 msgstr ""
 
@@ -5751,7 +5796,7 @@ msgstr ""
 msgid "Is a digit?"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1211
+#: ../../src/wxMaximaFrame.cpp:1222
 msgid "Is a digit?..."
 msgstr ""
 
@@ -5771,11 +5816,11 @@ msgstr ""
 msgid "Is a uppercase char?"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1209
+#: ../../src/wxMaximaFrame.cpp:1220
 msgid "Is alphabetic?..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1210
+#: ../../src/wxMaximaFrame.cpp:1221
 msgid "Is alphanumeric?..."
 msgstr ""
 
@@ -5803,19 +5848,19 @@ msgstr ""
 msgid "Is an odd function"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1215
+#: ../../src/wxMaximaFrame.cpp:1226
 msgid "Is equal?..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1221
+#: ../../src/wxMaximaFrame.cpp:1232
 msgid "Is greater?..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1218
+#: ../../src/wxMaximaFrame.cpp:1229
 msgid "Is lower?..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1214
+#: ../../src/wxMaximaFrame.cpp:1225
 msgid "Is lowercase?..."
 msgstr ""
 
@@ -5823,15 +5868,15 @@ msgstr ""
 msgid "Is no integer variable"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1212
+#: ../../src/wxMaximaFrame.cpp:1223
 msgid "Is printable?..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1213
+#: ../../src/wxMaximaFrame.cpp:1224
 msgid "Is uppercase?..."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:498
+#: ../../src/dialogs/ConfigDialogue.cpp:501
 msgid "Issue a notification if maxima finishes calculating while the wxMaxima window isn't in focus."
 msgstr ""
 
@@ -5859,11 +5904,11 @@ msgstr ""
 msgid "It therefore makes sense to apply the known values for variables as late as possible."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:207
+#: ../../src/dialogs/ConfigDialogue.cpp:208
 msgid "Italian"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2151
+#: ../../src/dialogs/ConfigDialogue.cpp:2238
 msgid "Italic"
 msgstr ""
 
@@ -5875,7 +5920,7 @@ msgstr ""
 msgid "Iterator name:"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:208
+#: ../../src/dialogs/ConfigDialogue.cpp:209
 msgid "Japanese"
 msgstr ""
 
@@ -5883,11 +5928,11 @@ msgstr ""
 msgid "Jump to UUID"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:718
+#: ../../src/wxMaximaFrame.cpp:728
 msgid "Jump to UUID..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1141
+#: ../../src/wxMaximaFrame.cpp:1152
 msgid "Jump to last error"
 msgstr ""
 
@@ -5899,11 +5944,11 @@ msgstr ""
 msgid "Jump to previous difference"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1142
+#: ../../src/wxMaximaFrame.cpp:1153
 msgid "Jump to the last cell Maxima has reported an error in."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:210
+#: ../../src/dialogs/ConfigDialogue.cpp:211
 msgid "Kabyle"
 msgstr ""
 
@@ -5911,12 +5956,12 @@ msgstr ""
 msgid "Kappa"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:867
+#: ../../src/dialogs/ConfigDialogue.cpp:881
 #, c-format
 msgid "Keep percent sign with special symbols: %e, %i, etc."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:212
+#: ../../src/dialogs/ConfigDialogue.cpp:213
 msgid "Korean"
 msgstr ""
 
@@ -5924,39 +5969,39 @@ msgstr ""
 msgid "LCM"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1500
+#: ../../src/wxMaximaFrame.cpp:1511
 msgid "L[1] Norm (complex)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1499
+#: ../../src/wxMaximaFrame.cpp:1510
 msgid "L[1] Norm (real)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1502
+#: ../../src/wxMaximaFrame.cpp:1513
 msgid "L[inf] Norm (complex)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1501
+#: ../../src/wxMaximaFrame.cpp:1512
 msgid "L[inf] Norm (real)"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1169
+#: ../../src/dialogs/ConfigDialogue.cpp:1183
 msgid "LaTeX"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1202
+#: ../../src/dialogs/ConfigDialogue.cpp:1216
 msgid "LaTeX: Place exponents after, instead above subscripts"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1207
+#: ../../src/dialogs/ConfigDialogue.cpp:1221
 msgid "LaTeX: Use the \"partial derivative\" symbol to represent diff()"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:761
+#: ../../src/dialogs/ConfigDialogue.cpp:775
 msgid "Label width:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1118
+#: ../../src/wxMaximaFrame.cpp:1129
 msgid "Labels"
 msgstr ""
 
@@ -5972,11 +6017,11 @@ msgid ""
 "Also you can fill a variable with a lambda() construct, effectively generating a function pointer: A variable that can be used as a function, and filled with a different function, if needed."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:470
+#: ../../src/dialogs/ConfigDialogue.cpp:473
 msgid "Language used for wxMaxima GUI."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1314
+#: ../../src/dialogs/ConfigDialogue.cpp:1328
 msgid "Language:"
 msgstr ""
 
@@ -5984,11 +6029,11 @@ msgstr ""
 msgid "Laplace"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1580
+#: ../../src/wxMaximaFrame.cpp:1591
 msgid "Laplace &Transform..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1814
+#: ../../src/wxMaximaFrame.cpp:1825
 msgid "Last"
 msgstr ""
 
@@ -6002,24 +6047,24 @@ msgstr ""
 msgid "Last message from maxima's stdout: %s"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1816
+#: ../../src/wxMaximaFrame.cpp:1827
 msgid "Last n"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3182
+#: ../../src/wxMaxima.cpp:3183
 msgid "Last non-whitespace is a question mark"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:213
+#: ../../src/dialogs/ConfigDialogue.cpp:214
 msgid "Latvian"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:1705
+#: ../../src/wxMaxima.cpp:1706
 #, c-format
 msgid "Launching the system's default help browser as %s."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:1696 ../../src/wxMaxima.cpp:1717
+#: ../../src/wxMaxima.cpp:1697 ../../src/wxMaxima.cpp:1718
 msgid "Launching the system's default help browser failed."
 msgstr ""
 
@@ -6027,7 +6072,7 @@ msgstr ""
 msgid "Leads to"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1589
+#: ../../src/wxMaximaFrame.cpp:1600
 msgid "Least Common Multiple..."
 msgstr ""
 
@@ -6039,7 +6084,7 @@ msgstr ""
 msgid "Least Squares Fit..."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2047
+#: ../../src/dialogs/ConfigDialogue.cpp:2134
 msgid "Left"
 msgstr ""
 
@@ -6052,15 +6097,15 @@ msgstr ""
 msgid "Left end"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1390
+#: ../../src/wxMaximaFrame.cpp:1401
 msgid "Left side to the \"=\""
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1837
+#: ../../src/wxMaximaFrame.cpp:1848
 msgid "Length"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1197 ../../src/wxMaximaFrame.cpp:1260
+#: ../../src/wxMaximaFrame.cpp:1208 ../../src/wxMaximaFrame.cpp:1271
 msgid "Length..."
 msgstr ""
 
@@ -6068,11 +6113,11 @@ msgstr ""
 msgid "Length:"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1429
+#: ../../src/dialogs/ConfigDialogue.cpp:1443
 msgid "Let an AI tool read this worksheet (MCP server)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1125
+#: ../../src/wxMaximaFrame.cpp:1136
 msgid "Letrules"
 msgstr ""
 
@@ -6085,7 +6130,7 @@ msgstr ""
 msgid "License"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2108
+#: ../../src/dialogs/ConfigDialogue.cpp:2195
 msgid "Light"
 msgstr ""
 
@@ -6117,11 +6162,11 @@ msgstr ""
 msgid "Lisp format strings are more powerful than c++ format strings"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:1904
+#: ../../src/wxMaxima.cpp:1905
 msgid "Lisp mode."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1103 ../../src/wxMaximaFrame.cpp:1105
+#: ../../src/wxMaximaFrame.cpp:1114 ../../src/wxMaximaFrame.cpp:1116
 msgid "Lisp normally frees memory only when it has time or runs out of space"
 msgstr ""
 
@@ -6145,11 +6190,11 @@ msgstr ""
 msgid "List #2"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1293
+#: ../../src/wxMaximaFrame.cpp:1304
 msgid "List directory"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1298
+#: ../../src/wxMaximaFrame.cpp:1309
 msgid "List directory..."
 msgstr ""
 
@@ -6169,7 +6214,7 @@ msgstr ""
 msgid "List of char to String"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1243
+#: ../../src/wxMaximaFrame.cpp:1254
 msgid "List of chars to string..."
 msgstr ""
 
@@ -6234,11 +6279,11 @@ msgstr ""
 msgid "List:"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:214
+#: ../../src/dialogs/ConfigDialogue.cpp:215
 msgid "Lithuanian"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2202
+#: ../../src/dialogs/ConfigDialogue.cpp:2289
 msgid "Load"
 msgstr ""
 
@@ -6246,27 +6291,27 @@ msgstr ""
 msgid "Load Package"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:701
+#: ../../src/wxMaximaFrame.cpp:711
 msgid "Load Recent Package"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:704
+#: ../../src/wxMaximaFrame.cpp:714
 msgid "Load a Maxima file using the batch command"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:699
+#: ../../src/wxMaximaFrame.cpp:709
 msgid "Load a Maxima package file"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1417 ../../src/wxMaximaFrame.cpp:1423
+#: ../../src/wxMaximaFrame.cpp:1428 ../../src/wxMaximaFrame.cpp:1434
 msgid "Load a matrix from a csv file"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1774
+#: ../../src/wxMaximaFrame.cpp:1785
 msgid "Load a nested list from a csv file"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1474 ../../src/wxMaximaFrame.cpp:1475
+#: ../../src/wxMaximaFrame.cpp:1485 ../../src/wxMaximaFrame.cpp:1486
 msgid "Load lapack"
 msgstr ""
 
@@ -6274,23 +6319,23 @@ msgstr ""
 msgid "Load lisp code"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1185
+#: ../../src/wxMaximaFrame.cpp:1196
 msgid "Load lisp..."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2688
+#: ../../src/dialogs/ConfigDialogue.cpp:2784
 msgid "Load style from file"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1291
+#: ../../src/wxMaximaFrame.cpp:1302
 msgid "Load the file/dir operations (operatingsystem)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1280
+#: ../../src/wxMaximaFrame.cpp:1291
 msgid "Load the regular expression package (sregex)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1317
+#: ../../src/wxMaximaFrame.cpp:1328
 msgid "Load the translation generator (gentran)"
 msgstr ""
 
@@ -6306,11 +6351,11 @@ msgstr ""
 msgid "Lower bound:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1220
+#: ../../src/wxMaximaFrame.cpp:1231
 msgid "Lower, ignoring case?..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1544
+#: ../../src/wxMaximaFrame.cpp:1555
 msgid "M&atrix"
 msgstr ""
 
@@ -6318,7 +6363,7 @@ msgstr ""
 msgid "MAXIMA RESPONSE:"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1441
+#: ../../src/dialogs/ConfigDialogue.cpp:1455
 msgid "MCP server port:"
 msgstr ""
 
@@ -6340,11 +6385,11 @@ msgstr ""
 msgid "Macro name:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1117
+#: ../../src/wxMaximaFrame.cpp:1128
 msgid "Macros"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:928
+#: ../../src/wxMaximaFrame.cpp:939
 msgid "Main Toolbar\tShift+Alt+B"
 msgstr ""
 
@@ -6356,11 +6401,11 @@ msgstr ""
 msgid "Make an eventual ev() evaluate this"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1163
+#: ../../src/wxMaximaFrame.cpp:1174
 msgid "Make function local..."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:215
+#: ../../src/dialogs/ConfigDialogue.cpp:216
 msgid "Malay"
 msgstr ""
 
@@ -6384,11 +6429,11 @@ msgstr ""
 msgid "Map an expression"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1539
+#: ../../src/wxMaximaFrame.cpp:1550
 msgid "Map function to a matrix"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1542
+#: ../../src/wxMaximaFrame.cpp:1553
 msgid "Map function to a matrix, affecting all of its clones"
 msgstr ""
 
@@ -6400,7 +6445,7 @@ msgstr ""
 msgid "Math Default"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:792
+#: ../../src/dialogs/ConfigDialogue.cpp:806
 msgid "Math layout strategy"
 msgstr ""
 
@@ -6408,23 +6453,23 @@ msgstr ""
 msgid "Math output"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1224
+#: ../../src/dialogs/ConfigDialogue.cpp:1238
 msgid "MathML (rendered by the browser)"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1225
+#: ../../src/dialogs/ConfigDialogue.cpp:1239
 msgid "MathML + MathJaX fall-back for old browsers"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1946
+#: ../../src/dialogs/ConfigDialogue.cpp:2033
 msgid "MathML as HTML"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1942
+#: ../../src/dialogs/ConfigDialogue.cpp:2029
 msgid "MathML description"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:314
+#: ../../src/wxMaximaFrame.cpp:324
 msgid "Mathematical Symbols"
 msgstr ""
 
@@ -6448,15 +6493,15 @@ msgstr ""
 msgid "Matrix Exponent"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1432
+#: ../../src/wxMaximaFrame.cpp:1443
 msgid "Matrix exponent..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1422
+#: ../../src/wxMaximaFrame.cpp:1433
 msgid "Matrix from csv file"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1416
+#: ../../src/wxMaximaFrame.cpp:1427
 msgid "Matrix from csv file..."
 msgstr ""
 
@@ -6468,19 +6513,19 @@ msgstr ""
 msgid "Matrix name:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:894
+#: ../../src/wxMaximaFrame.cpp:905
 msgid "Matrix parenthesis"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1424
+#: ../../src/wxMaximaFrame.cpp:1435
 msgid "Matrix to csv file"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1427
+#: ../../src/wxMaximaFrame.cpp:1438
 msgid "Matrix to file or Matrix from file"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1857
+#: ../../src/wxMaximaFrame.cpp:1868
 msgid "Matrix to nested List"
 msgstr ""
 
@@ -6496,15 +6541,15 @@ msgstr ""
 msgid "Matrix:"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1373
+#: ../../src/dialogs/ConfigDialogue.cpp:1387
 msgid "Max. layout time [s] (0=no limit)"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:281
+#: ../../src/dialogs/ConfigDialogue.cpp:282
 msgid "Maxima"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1473
+#: ../../src/dialogs/ConfigDialogue.cpp:1487
 msgid "Maxima Location"
 msgstr ""
 
@@ -6529,7 +6574,7 @@ msgstr ""
 msgid "Maxima asks a question!"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:362
+#: ../../src/dialogs/ConfigDialogue.cpp:365
 #, c-format
 msgid "Maxima assigns each command/equation an automatic label (which looks like %i1 or %o1). If a command begins with a descriptive name followed by a : wxMaxima will call the descriptive name a \"user-defined label\" instead. This selection now allows telling wxMaxima whether to show only automatic labels, automatic labels if there aren't user-defined ones or no label at all until a user-defined label can be found by wxMaxima's heuristics. If automatic labels are suppressed extra vertical space is added between equations in order to ease discerning which line starts a new equation and which one only continues the one from the last line."
 msgstr ""
@@ -6544,15 +6589,15 @@ msgstr ""
 msgid "Maxima code"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1113
+#: ../../src/dialogs/ConfigDialogue.cpp:1127
 msgid "Maxima commands to be executed at every start of Maxima"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1066
+#: ../../src/dialogs/ConfigDialogue.cpp:1080
 msgid "Maxima commands to be executed every time wxMaxima starts Maxima"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1547
+#: ../../src/dialogs/ConfigDialogue.cpp:1561
 msgid "Maxima configuration"
 msgstr ""
 
@@ -6585,7 +6630,7 @@ msgstr ""
 msgid "Maxima has sent a new variable value."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2699
+#: ../../src/wxMaxima.cpp:2700
 #, c-format
 msgid ""
 "Maxima has started, but hasn't connected to wxMaxima within 5 seconds.\n"
@@ -6595,7 +6640,7 @@ msgid ""
 "Command: %s"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2673
+#: ../../src/wxMaxima.cpp:2674
 #, c-format
 msgid ""
 "Maxima has started, but hasn't connected to wxMaxima yet.\n"
@@ -6628,7 +6673,7 @@ msgstr ""
 msgid "Maxima help file not found!"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1136
+#: ../../src/wxMaximaFrame.cpp:1147
 msgid "Maxima input"
 msgstr ""
 
@@ -6636,11 +6681,11 @@ msgstr ""
 msgid "Maxima is calculating"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:1906
+#: ../../src/wxMaxima.cpp:1907
 msgid "Maxima is ready for input."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2695 ../../src/wxMaxima.cpp:2714
+#: ../../src/wxMaxima.cpp:2696 ../../src/wxMaxima.cpp:2715
 msgid "Maxima isn't connecting"
 msgstr ""
 
@@ -6661,11 +6706,11 @@ msgstr ""
 msgid "Maxima process terminated unexpectedly."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1477
+#: ../../src/dialogs/ConfigDialogue.cpp:1491
 msgid "Maxima program:"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:382
+#: ../../src/dialogs/ConfigDialogue.cpp:385
 msgid "Maxima provides no \"forget all\" command that flushes all settings a maxima session could make. wxMaxima therefore normally defaults to starting a fresh maxima process every time the worksheet is to be re-evaluated. As this needs a little bit of time this switch allows to disable this behavior."
 msgstr ""
 
@@ -6689,15 +6734,15 @@ msgstr ""
 msgid "Maxima session (*.mac)|*.mac"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1558 ../../src/wxMaximaFrame.cpp:2040
+#: ../../src/dialogs/ConfigDialogue.cpp:1572 ../../src/wxMaximaFrame.cpp:2051
 msgid "Maxima shows help in a browser"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1563 ../../src/wxMaximaFrame.cpp:2036
+#: ../../src/dialogs/ConfigDialogue.cpp:1577 ../../src/wxMaximaFrame.cpp:2047
 msgid "Maxima shows help in a sidebar"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1551 ../../src/wxMaximaFrame.cpp:2031
+#: ../../src/dialogs/ConfigDialogue.cpp:1565 ../../src/wxMaximaFrame.cpp:2042
 msgid "Maxima shows help in the console"
 msgstr ""
 
@@ -6717,7 +6762,7 @@ msgstr ""
 msgid "Maxima starts:"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1146
+#: ../../src/dialogs/ConfigDialogue.cpp:1160
 msgid "Maxima startup file location: "
 msgstr ""
 
@@ -6725,7 +6770,7 @@ msgstr ""
 msgid "Maxima supports three types of numbers: exact fractions (which can be generated for example by typing 1/10), IEEE floating-point numbers (0.2) and arbitrary precision big floats (1b-1). Note that, owing to their nature as binary (not decimal) numbers, there is for example no way to generate an IEEE floating-point number that exactly equals 0.1. If floating-point numbers are used instead of fractions, Maxima will therefore sometimes have to introduce a (very small) error and use things like 3602879701896397/36028797018963968 for 0.1."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1324
+#: ../../src/wxMaximaFrame.cpp:1335
 msgid "Maxima to other language"
 msgstr ""
 
@@ -6737,7 +6782,7 @@ msgstr ""
 msgid "Maxima tried to find out where between two points a curve crosses the zero line. Since the curve is on the same side of the zero line in both points its algorithms fails here. Set find_root_error to false if you want it to return false instead of an error."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1655
+#: ../../src/dialogs/ConfigDialogue.cpp:1669
 msgid "Maxima usage"
 msgstr ""
 
@@ -6780,7 +6825,7 @@ msgstr ""
 msgid "Maxima version: %s, Anchors cache version"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:2021
+#: ../../src/wxMaximaFrame.cpp:2032
 msgid "Maxima vs. Programming languages"
 msgstr ""
 
@@ -6841,7 +6886,7 @@ msgstr ""
 msgid "Maxima's power lies in symbolic operations."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2662
+#: ../../src/wxMaxima.cpp:2663
 msgid "Maxima's process is running, but hasn't connected back to wxMaxima within 5 seconds."
 msgstr ""
 
@@ -6891,7 +6936,7 @@ msgstr ""
 msgid "Maximum absolute value printed without exponent"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1971
+#: ../../src/dialogs/ConfigDialogue.cpp:2058
 msgid "Maximum bitmap size on clipboard [Mb]:"
 msgstr ""
 
@@ -6904,7 +6949,7 @@ msgstr ""
 msgid "Maximum number of digits to be displayed:"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:814
+#: ../../src/dialogs/ConfigDialogue.cpp:828
 msgid "Maximum number of displayed digits:"
 msgstr ""
 
@@ -6928,16 +6973,16 @@ msgstr ""
 msgid "Median..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:2020
+#: ../../src/wxMaximaFrame.cpp:2031
 msgid "Memoizing"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1106
+#: ../../src/wxMaximaFrame.cpp:1117
 msgid "Memory"
 msgstr ""
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:182
-#: ../../src/wxMaximaFrame.cpp:1028
+#: ../../src/wxMaximaFrame.cpp:1039
 msgid "Merge Cells"
 msgstr ""
 
@@ -6949,7 +6994,7 @@ msgstr ""
 msgid "Method:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1419
+#: ../../src/wxMaximaFrame.cpp:1430
 msgid "Methods of generating a matrix"
 msgstr ""
 
@@ -6972,20 +7017,24 @@ msgstr ""
 msgid "Minimum absolute value printed without exponent:"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1273
+#: ../../src/dialogs/ConfigDialogue.cpp:1287
 msgid "Misc"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2003
+#: ../../src/dialogs/ConfigDialogue.cpp:2090
 msgid "Misc settings"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3231 ../../src/wxMaxima.cpp:3233
+#: ../../src/wxMaxima.cpp:3232 ../../src/wxMaxima.cpp:3234
 msgid "Mismatched parenthesis"
 msgstr ""
 
 #: ../../src/cells/VisiblyInvalidCell.cpp:43
 msgid "Missing contents. Bug?"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1990
+msgid "Model:"
 msgstr ""
 
 #: ../../src/cells/TextCell.cpp:245
@@ -7018,7 +7067,7 @@ msgstr ""
 msgid "Mu"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1445
+#: ../../src/wxMaximaFrame.cpp:1456
 msgid "Multiplication, exponent and similar"
 msgstr ""
 
@@ -7026,7 +7075,7 @@ msgstr ""
 msgid "Multiplicative function: f(a*b)=f(a)*f(b)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1431
+#: ../../src/wxMaximaFrame.cpp:1442
 msgid "Multiply matrices..."
 msgstr ""
 
@@ -7050,11 +7099,11 @@ msgstr ""
 msgid "Name:"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:216
+#: ../../src/dialogs/ConfigDialogue.cpp:217
 msgid "Nepali"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1413 ../../src/wxMaximaFrame.cpp:1855
+#: ../../src/wxMaximaFrame.cpp:1424 ../../src/wxMaximaFrame.cpp:1866
 msgid "Nested list to Matrix"
 msgstr ""
 
@@ -7062,9 +7111,9 @@ msgstr ""
 msgid "Nested list to matrix"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:751
-#: ../../src/dialogs/ConfigDialogue.cpp:775 ../../src/wxMaximaFrame.cpp:865
-#: ../../src/wxMaximaFrame.cpp:1146
+#: ../../src/dialogs/ConfigDialogue.cpp:765
+#: ../../src/dialogs/ConfigDialogue.cpp:789 ../../src/wxMaximaFrame.cpp:876
+#: ../../src/wxMaximaFrame.cpp:1157
 msgid "Never"
 msgstr ""
 
@@ -7072,7 +7121,7 @@ msgstr ""
 msgid "Never autosubscript this variable"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:872
+#: ../../src/wxMaximaFrame.cpp:883
 msgid "Never display this variable with subscript"
 msgstr ""
 
@@ -7085,7 +7134,7 @@ msgstr ""
 msgid "New"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:685
+#: ../../src/wxMaximaFrame.cpp:695
 msgid "New\tCtrl+N"
 msgstr ""
 
@@ -7109,7 +7158,7 @@ msgstr ""
 msgid "New document"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:904
+#: ../../src/dialogs/ConfigDialogue.cpp:918
 msgid "New lines: Jump to text"
 msgstr ""
 
@@ -7131,7 +7180,7 @@ msgstr ""
 msgid "New variable:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1022
+#: ../../src/wxMaximaFrame.cpp:1033
 msgid "Next Command\tAlt+Down"
 msgstr ""
 
@@ -7139,13 +7188,21 @@ msgstr ""
 msgid "Next Difference"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:844
+#: ../../src/wxMaximaFrame.cpp:855
 msgid "Nice Graphical Equations"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:728
-#: ../../src/dialogs/ConfigDialogue.cpp:740 ../../src/wxMaximaFrame.cpp:1646
+#: ../../src/dialogs/ConfigDialogue.cpp:742
+#: ../../src/dialogs/ConfigDialogue.cpp:754 ../../src/wxMaximaFrame.cpp:1657
 msgid "No"
+msgstr ""
+
+#: ../../src/sidebars/AiChatSidebar.cpp:148
+msgid "No AI provider configured -- add an API key in Options."
+msgstr ""
+
+#: ../../src/sidebars/AiChatSidebar.cpp:180
+msgid "No AI provider is configured. Open Options to add an API key for one."
 msgstr ""
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:748
@@ -7168,7 +7225,7 @@ msgstr ""
 msgid "No differences"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3264
+#: ../../src/wxMaxima.cpp:3265
 msgid "No dollar ($) or semicolon (;) at the end of command"
 msgstr ""
 
@@ -7192,8 +7249,8 @@ msgstr ""
 msgid "No image to export"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2748 ../../src/wxMaxima.cpp:2756
-#: ../../src/wxMaxima.cpp:2777 ../../src/wxMaxima.cpp:2789
+#: ../../src/wxMaxima.cpp:2749 ../../src/wxMaxima.cpp:2757
+#: ../../src/wxMaxima.cpp:2778 ../../src/wxMaxima.cpp:2790
 msgid "No matches found!"
 msgstr ""
 
@@ -7221,8 +7278,12 @@ msgstr ""
 msgid "Non-builtin symbols"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:893
+#: ../../src/wxMaximaFrame.cpp:904
 msgid "None"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1964
+msgid "None (disabled)"
 msgstr ""
 
 #: ../../src/sidebars/StatSidebar.cpp:73
@@ -7238,11 +7299,11 @@ msgid ""
 "The info that numbers have automatically been converted can be suppressed by setting ratprint to false."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:431
+#: ../../src/dialogs/ConfigDialogue.cpp:434
 msgid "Normally html expects images to be rather low-res but space saving. These images tend to look rather blurry when viewed on modern screens. Therefore this setting was introduces that selects the factor by which the HTML export increases the resolution in respect to the default value."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:217
+#: ../../src/dialogs/ConfigDialogue.cpp:218
 msgid "Norwegian"
 msgstr ""
 
@@ -7298,11 +7359,11 @@ msgstr ""
 msgid "Number to octets"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1247
+#: ../../src/wxMaximaFrame.cpp:1258
 msgid "Number to octets..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:2002
+#: ../../src/wxMaximaFrame.cpp:2013
 msgid "Number types"
 msgstr ""
 
@@ -7310,7 +7371,7 @@ msgstr ""
 msgid "Number:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1882
+#: ../../src/wxMaximaFrame.cpp:1893
 msgid "Numeric output"
 msgstr ""
 
@@ -7318,7 +7379,7 @@ msgstr ""
 msgid "Numerical QR decomposition of a matrix"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1510
+#: ../../src/wxMaximaFrame.cpp:1521
 msgid "Numerical operations (lapack)"
 msgstr ""
 
@@ -7326,15 +7387,15 @@ msgstr ""
 msgid "Numerical solution for 1st degree ODE"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1375
+#: ../../src/wxMaximaFrame.cpp:1386
 msgid "Numerical solution..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1354
+#: ../../src/wxMaximaFrame.cpp:1365
 msgid "Numerical solutions of polynomial (bfloat)..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1351
+#: ../../src/wxMaximaFrame.cpp:1362
 msgid "Numerical solutions of polynomial..."
 msgstr ""
 
@@ -7405,11 +7466,11 @@ msgstr ""
 msgid "Octets to String"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1249
+#: ../../src/wxMaximaFrame.cpp:1260
 msgid "Octets to number..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1251
+#: ../../src/wxMaximaFrame.cpp:1262
 msgid "Octets to string..."
 msgstr ""
 
@@ -7421,7 +7482,7 @@ msgstr ""
 msgid "Odd number"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:913
+#: ../../src/dialogs/ConfigDialogue.cpp:927
 msgid "Offer answers for questions known from previous runs"
 msgstr ""
 
@@ -7446,11 +7507,11 @@ msgstr ""
 msgid "Omicron"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1148
+#: ../../src/wxMaximaFrame.cpp:1159
 msgid "On all errors"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1147
+#: ../../src/wxMaximaFrame.cpp:1158
 msgid "On lisp errors"
 msgstr ""
 
@@ -7458,15 +7519,15 @@ msgstr ""
 msgid "One sample t-test"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:2023
+#: ../../src/wxMaximaFrame.cpp:2034
 msgid "Online tutorials"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:862
+#: ../../src/wxMaximaFrame.cpp:873
 msgid "Only Integers and single letters"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:774
+#: ../../src/dialogs/ConfigDialogue.cpp:788
 msgid "Only user-defined labels"
 msgstr ""
 
@@ -7475,15 +7536,15 @@ msgstr ""
 msgid "Open"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:908
+#: ../../src/dialogs/ConfigDialogue.cpp:922
 msgid "Open a cell when Maxima expects input"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:686
+#: ../../src/wxMaximaFrame.cpp:696
 msgid "Open a document"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:685
+#: ../../src/wxMaximaFrame.cpp:695
 msgid "Open a new window"
 msgstr ""
 
@@ -7499,7 +7560,7 @@ msgstr ""
 msgid "Open for appending"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1192
+#: ../../src/wxMaximaFrame.cpp:1203
 msgid "Open for appending..."
 msgstr ""
 
@@ -7507,7 +7568,7 @@ msgstr ""
 msgid "Open for reading"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1191
+#: ../../src/wxMaximaFrame.cpp:1202
 msgid "Open for reading..."
 msgstr ""
 
@@ -7515,7 +7576,7 @@ msgstr ""
 msgid "Open for writing"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1193
+#: ../../src/wxMaximaFrame.cpp:1204
 msgid "Open for writing..."
 msgstr ""
 
@@ -7523,7 +7584,7 @@ msgstr ""
 msgid "Open matrix"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:688
+#: ../../src/wxMaximaFrame.cpp:698
 msgid "Open recent"
 msgstr ""
 
@@ -7536,16 +7597,16 @@ msgstr ""
 msgid "Opening file"
 msgstr ""
 
-#: ../../src/sidebars/HelpBrowser.cpp:175 ../../src/wxMaxima.cpp:1838
+#: ../../src/sidebars/HelpBrowser.cpp:175 ../../src/wxMaxima.cpp:1839
 #, c-format
 msgid "Opening help file %s"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1626
+#: ../../src/wxMaximaFrame.cpp:1637
 msgid "Optimize for CPU time"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1625
+#: ../../src/wxMaximaFrame.cpp:1636
 msgid "Optimize for memory"
 msgstr ""
 
@@ -7554,7 +7615,7 @@ msgid "Optional: A 2nd expression that defines a region to fill"
 msgstr ""
 
 #: ../../src/ToolBar.cpp:367 ../../src/ToolBar.cpp:369
-#: ../../src/dialogs/ConfigDialogue.cpp:284
+#: ../../src/dialogs/ConfigDialogue.cpp:285
 msgid "Options"
 msgstr ""
 
@@ -7566,15 +7627,15 @@ msgstr ""
 msgid "Output"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1318
+#: ../../src/wxMaximaFrame.cpp:1329
 msgid "Output C"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1319
+#: ../../src/wxMaximaFrame.cpp:1330
 msgid "Output Fortran"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1321
+#: ../../src/wxMaximaFrame.cpp:1332
 msgid "Output Rational Fortran"
 msgstr ""
 
@@ -7611,7 +7672,7 @@ msgstr ""
 msgid "Output: Variable names"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:842
+#: ../../src/dialogs/ConfigDialogue.cpp:856
 msgid "Overlay scrollbars (slow: repaints the worksheet while they fade)"
 msgstr ""
 
@@ -7619,7 +7680,7 @@ msgstr ""
 msgid "PNG image (*.png)|*.png|JPEG image (*.jpg)|*.jpg|Windows bitmap (*.bmp)|*.bmp|"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:458
+#: ../../src/dialogs/ConfigDialogue.cpp:461
 msgid "PNG images can be read by old wxMaxima versions - but aren't really scalable."
 msgstr ""
 
@@ -7627,7 +7688,7 @@ msgstr ""
 msgid "Pade approximation"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1574
+#: ../../src/wxMaximaFrame.cpp:1585
 msgid "Pade approximation of a Taylor series"
 msgstr ""
 
@@ -7635,7 +7696,7 @@ msgstr ""
 msgid "Pagebreak"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1733
+#: ../../src/wxMaximaFrame.cpp:1744
 msgid "Parallel Substitute..."
 msgstr ""
 
@@ -7667,7 +7728,7 @@ msgstr ""
 msgid "Parse string"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1245
+#: ../../src/wxMaximaFrame.cpp:1256
 msgid "Parse string only..."
 msgstr ""
 
@@ -7679,7 +7740,7 @@ msgstr ""
 msgid "Part:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1595 ../../src/wxMaximaFrame.cpp:1631
+#: ../../src/wxMaximaFrame.cpp:1606 ../../src/wxMaximaFrame.cpp:1642
 msgid "Partial &Fractions..."
 msgstr ""
 
@@ -7693,7 +7754,7 @@ msgstr ""
 msgid "Paste"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:761
+#: ../../src/wxMaximaFrame.cpp:771
 msgid "Paste\tCtrl+V"
 msgstr ""
 
@@ -7701,15 +7762,15 @@ msgstr ""
 msgid "Paste from clipboard"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:762
+#: ../../src/wxMaximaFrame.cpp:772
 msgid "Paste text from clipboard"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:275 ../../src/wxMaximaFrame.cpp:818
+#: ../../src/wxMaximaFrame.cpp:275 ../../src/wxMaximaFrame.cpp:829
 msgid "Performance Monitor"
 msgstr ""
 
-#: ../../src/Configuration.cpp:1392
+#: ../../src/Configuration.cpp:1415
 msgid "Performance Statistics:"
 msgstr ""
 
@@ -7717,7 +7778,7 @@ msgstr ""
 msgid "Perpendicular to"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:218
+#: ../../src/dialogs/ConfigDialogue.cpp:219
 msgid "Persian"
 msgstr ""
 
@@ -7733,11 +7794,11 @@ msgstr ""
 msgid "Piechart..."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:1617
+#: ../../src/wxMaxima.cpp:1618
 msgid "Please configure wxMaxima with 'Edit->Configure'."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2649
+#: ../../src/dialogs/ConfigDialogue.cpp:2745
 msgid "Please restart wxMaxima for changes to take effect!"
 msgstr ""
 
@@ -7745,15 +7806,15 @@ msgstr ""
 msgid "Please select exactly 2 or 3 files."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1864
+#: ../../src/wxMaximaFrame.cpp:1875
 msgid "Plot &2d..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1866
+#: ../../src/wxMaximaFrame.cpp:1877
 msgid "Plot &3d..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1868
+#: ../../src/wxMaximaFrame.cpp:1879
 msgid "Plot &Format..."
 msgstr ""
 
@@ -7803,11 +7864,11 @@ msgstr ""
 msgid "Plot format"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1864
+#: ../../src/wxMaximaFrame.cpp:1875
 msgid "Plot in 2 dimensions"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1866
+#: ../../src/wxMaximaFrame.cpp:1877
 msgid "Plot in 3 dimensions"
 msgstr ""
 
@@ -7819,7 +7880,7 @@ msgstr ""
 msgid "Plot to file:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:348 ../../src/wxMaximaFrame.cpp:806
+#: ../../src/wxMaximaFrame.cpp:358 ../../src/wxMaximaFrame.cpp:816
 msgid "Plot using Draw"
 msgstr ""
 
@@ -7849,7 +7910,7 @@ msgstr ""
 msgid "Points"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:219
+#: ../../src/dialogs/ConfigDialogue.cpp:220
 msgid "Polish"
 msgstr ""
 
@@ -7868,7 +7929,7 @@ msgstr ""
 msgid "Polynomial:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1850
+#: ../../src/wxMaximaFrame.cpp:1861
 msgid "Pop"
 msgstr ""
 
@@ -7881,15 +7942,15 @@ msgstr ""
 msgid "Portable anymap (*.pnm)|*.pnm|Tagged image file format (*.tif)|*.tif|X pixmap (*.xpm)|*.xpm"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:220
+#: ../../src/dialogs/ConfigDialogue.cpp:221
 msgid "Portuguese"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:221
+#: ../../src/dialogs/ConfigDialogue.cpp:222
 msgid "Portuguese (Brazilian)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1282
+#: ../../src/wxMaximaFrame.cpp:1293
 msgid "Position of a match"
 msgstr ""
 
@@ -7909,7 +7970,7 @@ msgstr ""
 msgid "Power series"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1571
+#: ../../src/wxMaximaFrame.cpp:1582
 msgid "Power series..."
 msgstr ""
 
@@ -7917,11 +7978,11 @@ msgstr ""
 msgid "Precision"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:790
+#: ../../src/dialogs/ConfigDialogue.cpp:804
 msgid "Prefer 1D"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1532
+#: ../../src/dialogs/ConfigDialogue.cpp:1546
 msgid "Prefer the all-in-one-file >1000 page manual"
 msgstr ""
 
@@ -7937,11 +7998,11 @@ msgstr ""
 msgid "Preferences button"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:779
+#: ../../src/wxMaximaFrame.cpp:789
 msgid "Preferences...\tCtrl+,"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1829
+#: ../../src/wxMaximaFrame.cpp:1840
 msgid "Prepend an element"
 msgstr ""
 
@@ -7953,7 +8014,7 @@ msgstr ""
 msgid "Pressing Ctrl+Space or Ctrl+Tab starts an autocomplete function that can not only complete all functions that are integrated into the Maxima core and their parameters: It also knows about parameters from currently loaded packages and from functions that are defined in the current file."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1020
+#: ../../src/wxMaximaFrame.cpp:1031
 msgid "Previous Command\tAlt+Up"
 msgstr ""
 
@@ -7965,7 +8026,7 @@ msgstr ""
 msgid "Print"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2028
+#: ../../src/dialogs/ConfigDialogue.cpp:2115
 msgid "Print Margins"
 msgstr ""
 
@@ -7978,23 +8039,23 @@ msgid "Print cell brackets"
 msgstr ""
 
 #: ../../src/ToolBar.cpp:343 ../../src/ToolBar.cpp:345
-#: ../../src/wxMaximaFrame.cpp:712
+#: ../../src/wxMaximaFrame.cpp:722
 msgid "Print document"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1925
+#: ../../src/wxMaximaFrame.cpp:1936
 msgid "Print floating-point numbers with exponents dividable by 3"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2008
+#: ../../src/dialogs/ConfigDialogue.cpp:2095
 msgid "Print scale:"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2021
+#: ../../src/dialogs/ConfigDialogue.cpp:2108
 msgid "Print the cell brackets [drawn to their left]"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:287
+#: ../../src/dialogs/ConfigDialogue.cpp:288
 msgid "Printout settings"
 msgstr ""
 
@@ -8040,7 +8101,7 @@ msgstr ""
 msgid "Printout: Setting the device origin to %lix%li"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:939
+#: ../../src/dialogs/ConfigDialogue.cpp:953
 msgid "Privacy settings"
 msgstr ""
 
@@ -8058,7 +8119,7 @@ msgstr ""
 msgid "Product sign"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1188
+#: ../../src/wxMaximaFrame.cpp:1199
 msgid "Program"
 msgstr ""
 
@@ -8070,11 +8131,11 @@ msgstr ""
 msgid "Program block"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1159
+#: ../../src/wxMaximaFrame.cpp:1170
 msgid "Program block with local variables..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1161
+#: ../../src/wxMaximaFrame.cpp:1172
 msgid "Program block, no local variables..."
 msgstr ""
 
@@ -8082,7 +8143,7 @@ msgstr ""
 msgid "Psi"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1847
+#: ../../src/wxMaximaFrame.cpp:1858
 msgid "Push"
 msgstr ""
 
@@ -8090,7 +8151,7 @@ msgstr ""
 msgid "Push an element to a list"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1488
+#: ../../src/wxMaximaFrame.cpp:1499
 msgid "QR decomposition"
 msgstr ""
 
@@ -8098,11 +8159,11 @@ msgstr ""
 msgid "Querying gnuplot which graphics drivers it supports."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:715
+#: ../../src/wxMaximaFrame.cpp:725
 msgid "Quit wxMaxima"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1950
+#: ../../src/dialogs/ConfigDialogue.cpp:2037
 msgid "RTF with OMML maths"
 msgstr ""
 
@@ -8110,28 +8171,28 @@ msgstr ""
 msgid "Range radius:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1467
+#: ../../src/wxMaximaFrame.cpp:1478
 msgid "Rank"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:263 ../../src/wxMaximaFrame.cpp:816
+#: ../../src/wxMaximaFrame.cpp:263 ../../src/wxMaximaFrame.cpp:827
 msgid "Raw XML monitor"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:2250
+#: ../../src/wxMaximaFrame.cpp:2261
 #, c-format
 msgid "Re-Reading the config from %s."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:2247
+#: ../../src/wxMaximaFrame.cpp:2258
 msgid "Re-Reading the config from the default location."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:960
+#: ../../src/wxMaximaFrame.cpp:971
 msgid "Re-evaluate all cells above the one the cursor is in"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:970
+#: ../../src/wxMaximaFrame.cpp:981
 msgid "Re-evaluate all cells below the one the cursor is in"
 msgstr ""
 
@@ -8147,7 +8208,7 @@ msgstr ""
 msgid "Re-opening STDOUT failed."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2984
+#: ../../src/wxMaxima.cpp:2985
 #, c-format
 msgid "Re-pointed the .wxmx file association at %s"
 msgstr ""
@@ -8180,7 +8241,7 @@ msgstr ""
 msgid "Read char"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2531
+#: ../../src/dialogs/ConfigDialogue.cpp:2627
 msgid "Read config to file"
 msgstr ""
 
@@ -8188,7 +8249,7 @@ msgstr ""
 msgid "Read environment variable"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1312
+#: ../../src/wxMaximaFrame.cpp:1323
 msgid "Read environment variable..."
 msgstr ""
 
@@ -8196,7 +8257,7 @@ msgstr ""
 msgid "Read line"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1773
+#: ../../src/wxMaximaFrame.cpp:1784
 msgid "Read nested list from csv file..."
 msgstr ""
 
@@ -8275,11 +8336,11 @@ msgstr ""
 msgid "Recalculation hit the end of the worksheet => Updating its size (Visited %d cells, recalculated %d, in %ld ms)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1023
+#: ../../src/wxMaximaFrame.cpp:1034
 msgid "Recall next command from history"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1021
+#: ../../src/wxMaximaFrame.cpp:1032
 msgid "Recall previous command from history"
 msgstr ""
 
@@ -8293,11 +8354,11 @@ msgstr ""
 msgid "Received maxima's first prompt: %s"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1330
+#: ../../src/dialogs/ConfigDialogue.cpp:1344
 msgid "Recent files list length:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:691
+#: ../../src/wxMaximaFrame.cpp:701
 msgid "Recover unsaved"
 msgstr ""
 
@@ -8305,7 +8366,7 @@ msgstr ""
 msgid "Rectform"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1736
+#: ../../src/wxMaximaFrame.cpp:1747
 msgid "Recursive Substitute..."
 msgstr ""
 
@@ -8317,11 +8378,11 @@ msgstr ""
 msgid "Redo"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:727
+#: ../../src/wxMaximaFrame.cpp:737
 msgid "Redo\tCtrl+Y"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:727
+#: ../../src/wxMaximaFrame.cpp:737
 msgid "Redo last change"
 msgstr ""
 
@@ -8329,7 +8390,7 @@ msgstr ""
 msgid "Reduce (tr)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1691
+#: ../../src/wxMaximaFrame.cpp:1702
 msgid "Reduce trigonometric expression"
 msgstr ""
 
@@ -8355,15 +8416,15 @@ msgstr ""
 msgid "Regex match position"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:2068
+#: ../../src/wxMaximaFrame.cpp:2079
 msgid "Register wxMaxima as the tool that compares .wxmx files in TortoiseSVN and TortoiseGit"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1288
+#: ../../src/wxMaximaFrame.cpp:1299
 msgid "Regular expression that matches a string"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1289
+#: ../../src/wxMaximaFrame.cpp:1300
 msgid "Regular expressions"
 msgstr ""
 
@@ -8376,11 +8437,11 @@ msgstr ""
 msgid "Reload Image \"%s\""
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1000
+#: ../../src/dialogs/ConfigDialogue.cpp:1014
 msgid "Reload all GUI settings from disc"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1007
+#: ../../src/dialogs/ConfigDialogue.cpp:1021
 msgid "Reload the style settings from disc"
 msgstr ""
 
@@ -8389,11 +8450,11 @@ msgstr ""
 msgid "Reloading image file %s."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2616
+#: ../../src/dialogs/ConfigDialogue.cpp:2712
 msgid "Reloading the configuration from disc"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2624
+#: ../../src/dialogs/ConfigDialogue.cpp:2720
 msgid "Reloading the styles from disc"
 msgstr ""
 
@@ -8401,15 +8462,15 @@ msgstr ""
 msgid "Remove"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:976
+#: ../../src/wxMaximaFrame.cpp:987
 msgid "Remove All Output"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1522
+#: ../../src/wxMaximaFrame.cpp:1533
 msgid "Remove Columns..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1519
+#: ../../src/wxMaximaFrame.cpp:1530
 msgid "Remove Rows..."
 msgstr ""
 
@@ -8417,11 +8478,11 @@ msgstr ""
 msgid "Remove all"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1844
+#: ../../src/wxMaximaFrame.cpp:1855
 msgid "Remove all list elements that appear twice in a row. Normally used in conjunction with sort."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1267
+#: ../../src/wxMaximaFrame.cpp:1278
 msgid "Remove all occurrences of a word..."
 msgstr ""
 
@@ -8437,7 +8498,7 @@ msgstr ""
 msgid "Remove and return the first element of a list"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1523
+#: ../../src/wxMaximaFrame.cpp:1534
 msgid "Remove columns from a matrix"
 msgstr ""
 
@@ -8445,15 +8506,15 @@ msgstr ""
 msgid "Remove directory"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1297
+#: ../../src/wxMaximaFrame.cpp:1308
 msgid "Remove directory..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1843
+#: ../../src/wxMaximaFrame.cpp:1854
 msgid "Remove duplicates"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1269
+#: ../../src/wxMaximaFrame.cpp:1280
 msgid "Remove first occurrence of a word..."
 msgstr ""
 
@@ -8469,11 +8530,11 @@ msgstr ""
 msgid "Remove matrix rows"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:977
+#: ../../src/wxMaximaFrame.cpp:988
 msgid "Remove output from input cells"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1520
+#: ../../src/wxMaximaFrame.cpp:1531
 msgid "Remove rows from the a matrix"
 msgstr ""
 
@@ -8481,15 +8542,15 @@ msgstr ""
 msgid "Rename file"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1308
+#: ../../src/wxMaximaFrame.cpp:1319
 msgid "Rename file..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1623
+#: ../../src/wxMaximaFrame.cpp:1634
 msgid "Reorganize an expression using horner's rule"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1439
+#: ../../src/wxMaximaFrame.cpp:1450
 msgid "Repetitive element-by-element multiplication"
 msgstr ""
 
@@ -8505,7 +8566,7 @@ msgstr ""
 msgid "Replace first regex match"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:2049
+#: ../../src/wxMaximaFrame.cpp:2060
 msgid "Replace non-builtin variable and function names in the selected code cells (or the whole document) with random names, so a worksheet can be shared without revealing its original names"
 msgstr ""
 
@@ -8513,11 +8574,11 @@ msgstr ""
 msgid "Replace the first occurrence of Part"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1273
+#: ../../src/wxMaximaFrame.cpp:1284
 msgid "Replace..."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2815
+#: ../../src/wxMaxima.cpp:2816
 #, c-format
 msgid "Replaced %li occurrences."
 msgstr ""
@@ -8530,29 +8591,33 @@ msgstr ""
 msgid "Replaces the subexpression that part(expr, n_1, n_2, ...) would select by a new value. The part numbers form a path: n_1 selects a part of the expression, n_2 a part of that, and so on."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:2046
+#: ../../src/wxMaximaFrame.cpp:2057
 msgid "Report bug"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:986
+#: ../../src/ai/AiProvider.cpp:332
+msgid "Request cancelled."
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:1000
 msgid "Reset all GUI settings"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1089
+#: ../../src/wxMaximaFrame.cpp:1100
 msgid "Reset option variables"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:993
+#: ../../src/dialogs/ConfigDialogue.cpp:1007
 msgid "Reset the Style settings"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2600
-#: ../../src/dialogs/ConfigDialogue.cpp:2608
+#: ../../src/dialogs/ConfigDialogue.cpp:2696
+#: ../../src/dialogs/ConfigDialogue.cpp:2704
 msgid "Resetting all configuration settings"
 msgstr ""
 
 #: ../../src/ToolBar.cpp:411 ../../src/ToolBar.cpp:417
-#: ../../src/wxMaximaFrame.cpp:1067
+#: ../../src/wxMaximaFrame.cpp:1078
 msgid "Restart Maxima"
 msgstr ""
 
@@ -8569,7 +8634,7 @@ msgstr ""
 msgid "Resulting Matrix name (may be empty):"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1283
+#: ../../src/wxMaximaFrame.cpp:1294
 msgid "Return a match"
 msgstr ""
 
@@ -8577,11 +8642,11 @@ msgstr ""
 msgid "Return from a block or loop"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1162
+#: ../../src/wxMaximaFrame.cpp:1173
 msgid "Return from current block/loop..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1851
+#: ../../src/wxMaximaFrame.cpp:1862
 msgid "Return the first item of the list and remove it from the list. Useful for creating stacks."
 msgstr ""
 
@@ -8597,7 +8662,7 @@ msgstr ""
 msgid "Return to the cell that is currently being evaluated"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1807
+#: ../../src/wxMaximaFrame.cpp:1818
 msgid "Returns an arbitrary list item"
 msgstr ""
 
@@ -8605,7 +8670,7 @@ msgstr ""
 msgid "Returns the first element of a list"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1809
+#: ../../src/wxMaximaFrame.cpp:1820
 msgid "Returns the first item of the list"
 msgstr ""
 
@@ -8613,23 +8678,23 @@ msgstr ""
 msgid "Returns the last element of a list"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1815
+#: ../../src/wxMaximaFrame.cpp:1826
 msgid "Returns the last item of the list"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1817
+#: ../../src/wxMaximaFrame.cpp:1828
 msgid "Returns the last n items of the list"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1838
+#: ../../src/wxMaximaFrame.cpp:1849
 msgid "Returns the length of the list"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1811
+#: ../../src/wxMaximaFrame.cpp:1822
 msgid "Returns the list without its first n elements"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1813
+#: ../../src/wxMaximaFrame.cpp:1824
 msgid "Returns the list without its last n elements"
 msgstr ""
 
@@ -8641,11 +8706,11 @@ msgstr ""
 msgid "Reuse last"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1839
+#: ../../src/wxMaximaFrame.cpp:1850
 msgid "Reverse"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1840
+#: ../../src/wxMaximaFrame.cpp:1851
 msgid "Reverse the order of the list items"
 msgstr ""
 
@@ -8653,11 +8718,11 @@ msgstr ""
 msgid "Reverses the order of the members of a list"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:295
+#: ../../src/dialogs/ConfigDialogue.cpp:298
 msgid "Revert all to defaults"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:983
+#: ../../src/dialogs/ConfigDialogue.cpp:997
 msgid "Revert changes"
 msgstr ""
 
@@ -8665,7 +8730,7 @@ msgstr ""
 msgid "Rho"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2055
+#: ../../src/dialogs/ConfigDialogue.cpp:2142
 msgid "Right"
 msgstr ""
 
@@ -8682,23 +8747,23 @@ msgstr ""
 msgid "Right end"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1394
+#: ../../src/wxMaximaFrame.cpp:1405
 msgid "Right side to the \"=\""
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1551
+#: ../../src/wxMaximaFrame.cpp:1562
 msgid "Risch Integration..."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:222
+#: ../../src/dialogs/ConfigDialogue.cpp:223
 msgid "Romanian"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:881
+#: ../../src/wxMaximaFrame.cpp:892
 msgid "Rounded"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1533
+#: ../../src/wxMaximaFrame.cpp:1544
 msgid "Row and column operations"
 msgstr ""
 
@@ -8726,11 +8791,11 @@ msgstr ""
 msgid "Rule:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1120
+#: ../../src/wxMaximaFrame.cpp:1131
 msgid "Rules"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1789
+#: ../../src/wxMaximaFrame.cpp:1800
 msgid "Run each element through an expression"
 msgstr ""
 
@@ -8768,7 +8833,7 @@ msgstr ""
 msgid "Running on the universal wxWidgets port"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1431
+#: ../../src/dialogs/ConfigDialogue.cpp:1445
 msgid "Runs a local, read-only MCP (Model Context Protocol) server an AI tool can connect to for context on this worksheet's cells, table of contents and watched variables. It only answers questions -- it can never insert, edit or evaluate anything itself. Only accepts connections from this same machine (localhost)."
 msgstr ""
 
@@ -8780,23 +8845,23 @@ msgstr ""
 msgid "Runs each element of an object (list, matrix, equation,...) through an expression individually"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1787
+#: ../../src/wxMaximaFrame.cpp:1798
 msgid "Runs each element through a function"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1790
+#: ../../src/wxMaximaFrame.cpp:1801
 msgid "Runs each element through an expression"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:223
+#: ../../src/dialogs/ConfigDialogue.cpp:224
 msgid "Russian"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1618
+#: ../../src/dialogs/ConfigDialogue.cpp:1632
 msgid "SBCL: use <int>Mbytes of heap"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1625
+#: ../../src/dialogs/ConfigDialogue.cpp:1639
 msgid "SBCL: use <int>Mbytes of stack for function calls"
 msgstr ""
 
@@ -8804,7 +8869,7 @@ msgstr ""
 msgid "SENT TO MAXIMA:"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1227
+#: ../../src/dialogs/ConfigDialogue.cpp:1241
 msgid "SVG graphics"
 msgstr ""
 
@@ -8837,7 +8902,7 @@ msgid "Samples on a line:"
 msgstr ""
 
 #: ../../src/ToolBar.cpp:331 ../../src/ToolBar.cpp:334
-#: ../../src/dialogs/ConfigDialogue.cpp:2203 ../../src/wxMaxima.cpp:3604
+#: ../../src/dialogs/ConfigDialogue.cpp:2290 ../../src/wxMaxima.cpp:3605
 msgid "Save"
 msgstr ""
 
@@ -8849,7 +8914,7 @@ msgstr ""
 msgid "Save As"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:697
+#: ../../src/wxMaximaFrame.cpp:707
 msgid "Save As...\tShift+Ctrl+S"
 msgstr ""
 
@@ -8861,7 +8926,7 @@ msgstr ""
 msgid "Save Selection to Image"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:769
+#: ../../src/wxMaximaFrame.cpp:779
 msgid "Save Selection to Image..."
 msgstr ""
 
@@ -8873,20 +8938,20 @@ msgstr ""
 msgid "Save as lisp code"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1184
+#: ../../src/wxMaximaFrame.cpp:1195
 msgid "Save as lisp..."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2521
+#: ../../src/dialogs/ConfigDialogue.cpp:2617
 msgid "Save config to file"
 msgstr ""
 
 #: ../../src/ToolBar.cpp:331 ../../src/ToolBar.cpp:334
-#: ../../src/wxMaximaFrame.cpp:696
+#: ../../src/wxMaximaFrame.cpp:706
 msgid "Save document"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:697
+#: ../../src/wxMaximaFrame.cpp:707
 msgid "Save document as"
 msgstr ""
 
@@ -8894,7 +8959,7 @@ msgstr ""
 msgid "Save plot to file"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:770
+#: ../../src/wxMaximaFrame.cpp:780
 msgid "Save selection from document to an image file"
 msgstr ""
 
@@ -8902,11 +8967,11 @@ msgstr ""
 msgid "Save selection to file"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2683
+#: ../../src/dialogs/ConfigDialogue.cpp:2779
 msgid "Save style to file"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1387
+#: ../../src/dialogs/ConfigDialogue.cpp:1401
 msgid "Save the worksheet automatically"
 msgstr ""
 
@@ -8914,7 +8979,7 @@ msgstr ""
 msgid "Saving failed!"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:640
+#: ../../src/wxMaximaFrame.cpp:650
 msgid "Saving failed."
 msgstr ""
 
@@ -8922,7 +8987,7 @@ msgstr ""
 msgid "Saving succeeded, but the resulting files has disappeared ?!?."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1954
+#: ../../src/dialogs/ConfigDialogue.cpp:2041
 msgid "Scalable Vector Graphics (svg)"
 msgstr ""
 
@@ -8946,11 +9011,11 @@ msgstr ""
 msgid "Scheduling a background task that scans for autocompletable file names."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1907
+#: ../../src/dialogs/ConfigDialogue.cpp:1921
 msgid "Screen reader"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:719
+#: ../../src/wxMaximaFrame.cpp:729
 msgid "Scroll to a cell with a certain UUID"
 msgstr ""
 
@@ -8966,7 +9031,7 @@ msgstr ""
 msgid "Search input / UUID"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1271
+#: ../../src/wxMaximaFrame.cpp:1282
 msgid "Search..."
 msgstr ""
 
@@ -9011,7 +9076,7 @@ msgstr ""
 msgid "Select All"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:767
+#: ../../src/wxMaximaFrame.cpp:777
 msgid "Select All\tCtrl+A"
 msgstr ""
 
@@ -9030,7 +9095,7 @@ msgid "Select a constant"
 msgstr ""
 
 #: ../../src/ToolBar.cpp:390 ../../src/ToolBar.cpp:392
-#: ../../src/wxMaximaFrame.cpp:767
+#: ../../src/wxMaximaFrame.cpp:777
 msgid "Select all"
 msgstr ""
 
@@ -9058,6 +9123,10 @@ msgstr ""
 msgid "Semicolon"
 msgstr ""
 
+#: ../../src/sidebars/AiChatSidebar.cpp:65
+msgid "Send"
+msgstr ""
+
 #: ../../src/ToolBar.cpp:446 ../../src/ToolBar.cpp:458
 msgid "Send all cells to maxima"
 msgstr ""
@@ -9082,7 +9151,7 @@ msgstr ""
 msgid "Sending an interrupt signal to Maxima."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:241
+#: ../../src/wxMaxima.cpp:242
 msgid "Sending configuration data to maxima."
 msgstr ""
 
@@ -9090,11 +9159,11 @@ msgstr ""
 msgid "Sending maxima the info how to express 2d maths as XML"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1629
+#: ../../src/wxMaximaFrame.cpp:1640
 msgid "Sequential Comparative Simplification"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:224
+#: ../../src/dialogs/ConfigDialogue.cpp:225
 msgid "Serbian"
 msgstr ""
 
@@ -9102,7 +9171,7 @@ msgstr ""
 msgid "Series"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1575
+#: ../../src/wxMaximaFrame.cpp:1586
 msgid "Series approximation"
 msgstr ""
 
@@ -9110,31 +9179,31 @@ msgstr ""
 msgid "Server started"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1920
+#: ../../src/wxMaximaFrame.cpp:1931
 msgid "Set &displayed Precision..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1659
+#: ../../src/wxMaximaFrame.cpp:1670
 msgid "Set Maxima option variable logexpand:all"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1663
+#: ../../src/wxMaximaFrame.cpp:1674
 msgid "Set Maxima option variable logexpand:super"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1656
+#: ../../src/wxMaximaFrame.cpp:1667
 msgid "Set Maxima option variable logexpand:true"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:918
+#: ../../src/wxMaximaFrame.cpp:929
 msgid "Set Zoom"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1915
+#: ../../src/wxMaximaFrame.cpp:1926
 msgid "Set bigfloat &Precision..."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:479
+#: ../../src/dialogs/ConfigDialogue.cpp:482
 msgid "Set fixed font in text controls."
 msgstr ""
 
@@ -9147,7 +9216,7 @@ msgstr ""
 msgid "Set image resolution [in ppi]"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1606
+#: ../../src/wxMaximaFrame.cpp:1617
 msgid "Set main variable..."
 msgstr ""
 
@@ -9155,15 +9224,15 @@ msgstr ""
 msgid "Set maximum image size [in mm]"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1869
+#: ../../src/wxMaximaFrame.cpp:1880
 msgid "Set plot format"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1194
+#: ../../src/wxMaximaFrame.cpp:1205
 msgid "Set position..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1752
+#: ../../src/wxMaximaFrame.cpp:1763
 msgid "Set the \"algebraic\" flag"
 msgstr ""
 
@@ -9171,7 +9240,7 @@ msgstr ""
 msgid "Set the diagram title"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1875
+#: ../../src/wxMaximaFrame.cpp:1886
 msgid "Set the frame rate for animations."
 msgstr ""
 
@@ -9183,35 +9252,35 @@ msgstr ""
 msgid "Set the next plot's title. Empty = no title."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1916
+#: ../../src/wxMaximaFrame.cpp:1927
 msgid "Set the precision for numbers that are defined as bigfloat. Such numbers can be generated by entering 1.5b12 or as bfloat(1.234)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:907
+#: ../../src/wxMaximaFrame.cpp:918
 msgid "Set zoom to 100%"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:909
+#: ../../src/wxMaximaFrame.cpp:920
 msgid "Set zoom to 120%"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:911
+#: ../../src/wxMaximaFrame.cpp:922
 msgid "Set zoom to 150%"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:913
+#: ../../src/wxMaximaFrame.cpp:924
 msgid "Set zoom to 200%"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:915
+#: ../../src/wxMaximaFrame.cpp:926
 msgid "Set zoom to 300%"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:905
+#: ../../src/wxMaximaFrame.cpp:916
 msgid "Set zoom to 80%"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:163
+#: ../../src/dialogs/ConfigDialogue.cpp:164
 msgid "Sets the language, line ending type and charset encoding programs will use"
 msgstr ""
 
@@ -9224,7 +9293,7 @@ msgstr ""
 msgid "Setting prompt and help format"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:165
+#: ../../src/dialogs/ConfigDialogue.cpp:166
 msgid "Setting this to \"cat\" causes gnuplot not to halt if there is much output"
 msgstr ""
 
@@ -9245,11 +9314,11 @@ msgstr ""
 msgid "Setup a 3D plot"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1385
+#: ../../src/wxMaximaFrame.cpp:1396
 msgid "Setup atvalues for solving ODE with Laplace transformation"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1757
+#: ../../src/wxMaximaFrame.cpp:1768
 msgid "Setup modulus computation"
 msgstr ""
 
@@ -9265,7 +9334,7 @@ msgstr ""
 msgid "Setup the engineering format"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1927
+#: ../../src/wxMaximaFrame.cpp:1938
 msgid "Setup the engineering format..."
 msgstr ""
 
@@ -9277,11 +9346,11 @@ msgstr ""
 msgid "Show \"%\" in special constants"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1419
+#: ../../src/dialogs/ConfigDialogue.cpp:1433
 msgid "Show \"Find and Replace\" as a dockable sidebar"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1985
+#: ../../src/wxMaximaFrame.cpp:1996
 msgid "Show &Tips..."
 msgstr ""
 
@@ -9289,15 +9358,15 @@ msgstr ""
 msgid "Show * as multiplication dot"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:988
+#: ../../src/wxMaximaFrame.cpp:999
 msgid "Show Template\tCtrl+Shift+Space"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:849
+#: ../../src/wxMaximaFrame.cpp:860
 msgid "Show XML representation"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1985
+#: ../../src/wxMaximaFrame.cpp:1996
 msgid "Show a tip"
 msgstr ""
 
@@ -9317,7 +9386,7 @@ msgstr ""
 msgid "Show an example for the command:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1979
+#: ../../src/wxMaximaFrame.cpp:1990
 msgid "Show an example of usage"
 msgstr ""
 
@@ -9325,31 +9394,31 @@ msgstr ""
 msgid "Show commands from current session only"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1980
+#: ../../src/wxMaximaFrame.cpp:1991
 msgid "Show commands similar to"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1113
+#: ../../src/wxMaximaFrame.cpp:1124
 msgid "Show defined functions"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1115
+#: ../../src/wxMaximaFrame.cpp:1126
 msgid "Show defined variables"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1167
+#: ../../src/wxMaximaFrame.cpp:1178
 msgid "Show definition of a function"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:836
+#: ../../src/wxMaximaFrame.cpp:847
 msgid "Show equations in their linear form"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1166
+#: ../../src/wxMaximaFrame.cpp:1177
 msgid "Show function &Definition..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:989
+#: ../../src/wxMaximaFrame.cpp:1000
 msgid "Show function template"
 msgstr ""
 
@@ -9357,19 +9426,19 @@ msgstr ""
 msgid "Show input labels"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:769
+#: ../../src/dialogs/ConfigDialogue.cpp:783
 msgid "Show labels:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:846
+#: ../../src/wxMaximaFrame.cpp:857
 msgid "Show lisp representation"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:465
+#: ../../src/dialogs/ConfigDialogue.cpp:468
 msgid "Show long expressions in wxMaxima document."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:725
+#: ../../src/dialogs/ConfigDialogue.cpp:739
 msgid "Show long expressions:"
 msgstr ""
 
@@ -9385,7 +9454,7 @@ msgstr ""
 msgid "Show max. 50 digits"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:927
+#: ../../src/wxMaximaFrame.cpp:938
 msgid "Show or hide the wxMaxima logging window"
 msgstr ""
 
@@ -9409,7 +9478,7 @@ msgstr ""
 msgid "Show the Copy, Cut and the Paste button?"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:707
+#: ../../src/wxMaximaFrame.cpp:717
 msgid "Show the differences between 2 or 3 files"
 msgstr ""
 
@@ -9437,24 +9506,24 @@ msgstr ""
 msgid "Show tips at Startup"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1099 ../../src/wxMaximaFrame.cpp:1104
+#: ../../src/wxMaximaFrame.cpp:1110 ../../src/wxMaximaFrame.cpp:1115
 msgid "Show used + to-be-freed memory"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1126
+#: ../../src/wxMaximaFrame.cpp:1137
 msgid "Show user definitions"
 msgstr ""
 
 #: ../../src/ToolBar.cpp:544 ../../src/ToolBar.cpp:546
-#: ../../src/wxMaximaFrame.cpp:1973 ../../src/wxMaximaFrame.cpp:1975
+#: ../../src/wxMaximaFrame.cpp:1984 ../../src/wxMaximaFrame.cpp:1986
 msgid "Show wxMaxima help"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1921
+#: ../../src/wxMaximaFrame.cpp:1932
 msgid "Shows how many digits of a numbers are displayed"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:828
+#: ../../src/wxMaximaFrame.cpp:839
 msgid "Sidebars"
 msgstr ""
 
@@ -9474,7 +9543,7 @@ msgstr ""
 msgid "Simplify"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1609
+#: ../../src/wxMaximaFrame.cpp:1620
 msgid "Simplify &Radicals..."
 msgstr ""
 
@@ -9490,19 +9559,19 @@ msgstr ""
 msgid "Simplify Expression"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1664
+#: ../../src/wxMaximaFrame.cpp:1675
 msgid "Simplify Logarithms"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1678
+#: ../../src/wxMaximaFrame.cpp:1689
 msgid "Simplify an expression containing factorials"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1635
+#: ../../src/wxMaximaFrame.cpp:1646
 msgid "Simplify equations"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1610
+#: ../../src/wxMaximaFrame.cpp:1621
 msgid "Simplify expression containing radicals"
 msgstr ""
 
@@ -9510,11 +9579,11 @@ msgstr ""
 msgid "Simplify radicals"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1608
+#: ../../src/wxMaximaFrame.cpp:1619
 msgid "Simplify rational expression"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1634
+#: ../../src/wxMaximaFrame.cpp:1645
 msgid "Simplify sum() commands..."
 msgstr ""
 
@@ -9526,7 +9595,7 @@ msgstr ""
 msgid "Simplify the sum"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1688
+#: ../../src/wxMaximaFrame.cpp:1699
 msgid "Simplify trigonometric expression"
 msgstr ""
 
@@ -9534,15 +9603,15 @@ msgstr ""
 msgid "Since wxMaxima 0.8.2 you can also insert images into your documents. Use 'Cell->Insert Image...' menu command."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1492
+#: ../../src/wxMaximaFrame.cpp:1503
 msgid "Singular Values"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1493 ../../src/wxMaximaFrame.cpp:1496
+#: ../../src/wxMaximaFrame.cpp:1504 ../../src/wxMaximaFrame.cpp:1507
 msgid "Singular values using dgesvd"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1495
+#: ../../src/wxMaximaFrame.cpp:1506
 msgid "Singular values, left + right vectors"
 msgstr ""
 
@@ -9562,19 +9631,19 @@ msgstr ""
 msgid "Size of internal work array. limit/2 is the maximum number of subintervals to use."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2153
+#: ../../src/dialogs/ConfigDialogue.cpp:2240
 msgid "Slanted"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:225
+#: ../../src/dialogs/ConfigDialogue.cpp:226
 msgid "Slovak"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:226
+#: ../../src/dialogs/ConfigDialogue.cpp:227
 msgid "Slovenian"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1731
+#: ../../src/wxMaximaFrame.cpp:1742
 msgid "Smart Substitute..."
 msgstr ""
 
@@ -9595,19 +9664,19 @@ msgstr ""
 msgid "Solve"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1337
+#: ../../src/wxMaximaFrame.cpp:1348
 msgid "Solve &Algebraic System..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1335
+#: ../../src/wxMaximaFrame.cpp:1346
 msgid "Solve &Linear System..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1359
+#: ../../src/wxMaximaFrame.cpp:1370
 msgid "Solve &ODE..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1333
+#: ../../src/wxMaximaFrame.cpp:1344
 msgid "Solve (to_poly)..."
 msgstr ""
 
@@ -9615,7 +9684,7 @@ msgstr ""
 msgid "Solve A*x=b numerically"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1490
+#: ../../src/wxMaximaFrame.cpp:1501
 msgid "Solve Ax=b"
 msgstr ""
 
@@ -9623,7 +9692,7 @@ msgstr ""
 msgid "Solve ODE"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1380
+#: ../../src/wxMaximaFrame.cpp:1391
 msgid "Solve ODE with Lapla&ce..."
 msgstr ""
 
@@ -9631,7 +9700,7 @@ msgstr ""
 msgid "Solve ODE..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1491
+#: ../../src/wxMaximaFrame.cpp:1502
 msgid "Solve a linear equation system using dgesv"
 msgstr ""
 
@@ -9639,11 +9708,11 @@ msgstr ""
 msgid "Solve algebraic system"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1338
+#: ../../src/wxMaximaFrame.cpp:1349
 msgid "Solve algebraic system of equations"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1372
+#: ../../src/wxMaximaFrame.cpp:1383
 msgid "Solve boundary value problem for second degree ODE"
 msgstr ""
 
@@ -9651,11 +9720,11 @@ msgstr ""
 msgid "Solve differential equations using laplace()"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:925 ../../src/wxMaximaFrame.cpp:1331
+#: ../../src/MaximaCommandMenus.cpp:925 ../../src/wxMaximaFrame.cpp:1342
 msgid "Solve equation(s)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1334
+#: ../../src/wxMaximaFrame.cpp:1345
 msgid "Solve equation(s) with to_poly_solve"
 msgstr ""
 
@@ -9667,11 +9736,11 @@ msgstr ""
 msgid "Solve equations to polynom"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1364
+#: ../../src/wxMaximaFrame.cpp:1375
 msgid "Solve initial value problem for first degree ODE"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1368
+#: ../../src/wxMaximaFrame.cpp:1379
 msgid "Solve initial value problem for second degree ODE"
 msgstr ""
 
@@ -9679,19 +9748,19 @@ msgstr ""
 msgid "Solve linear system"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1336
+#: ../../src/wxMaximaFrame.cpp:1347
 msgid "Solve linear system of equations"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1356
+#: ../../src/wxMaximaFrame.cpp:1367
 msgid "Solve numerical, 1 Variable"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1360
+#: ../../src/wxMaximaFrame.cpp:1371
 msgid "Solve ordinary differential equation of maximum degree 2"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1381
+#: ../../src/wxMaximaFrame.cpp:1392
 msgid "Solve ordinary differential equations with Laplace transformation"
 msgstr ""
 
@@ -9707,7 +9776,7 @@ msgstr ""
 msgid "Solve polynomials numerically (real roots)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1342
+#: ../../src/wxMaximaFrame.cpp:1353
 msgid "Solve symbolically"
 msgstr ""
 
@@ -9716,11 +9785,11 @@ msgstr ""
 msgid "Solve..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:2012
+#: ../../src/wxMaximaFrame.cpp:2023
 msgid "Solving differential equations"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:2000
+#: ../../src/wxMaximaFrame.cpp:2011
 msgid "Solving equations with Maxima"
 msgstr ""
 
@@ -9731,7 +9800,7 @@ msgid ""
 "In both cases the '' operator will do what is requested."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1842
+#: ../../src/wxMaximaFrame.cpp:1853
 msgid "Sort"
 msgstr ""
 
@@ -9747,7 +9816,7 @@ msgstr ""
 msgid "Sort all characters in string"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1272
+#: ../../src/wxMaximaFrame.cpp:1283
 msgid "Sort the characters..."
 msgstr ""
 
@@ -9755,7 +9824,7 @@ msgstr ""
 msgid "Source list:"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:227
+#: ../../src/dialogs/ConfigDialogue.cpp:228
 msgid "Spanish"
 msgstr ""
 
@@ -9772,7 +9841,7 @@ msgstr ""
 msgid "Split"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1284
+#: ../../src/wxMaximaFrame.cpp:1295
 msgid "Split on match"
 msgstr ""
 
@@ -9784,15 +9853,15 @@ msgstr ""
 msgid "Split string into tokens"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1264
+#: ../../src/wxMaximaFrame.cpp:1275
 msgid "Split..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:884
+#: ../../src/wxMaximaFrame.cpp:895
 msgid "Square"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1303
+#: ../../src/dialogs/ConfigDialogue.cpp:1317
 msgid "Standard Options"
 msgstr ""
 
@@ -9804,7 +9873,7 @@ msgstr ""
 msgid "Start Animation"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1662
+#: ../../src/dialogs/ConfigDialogue.cpp:1676
 msgid "Start a new maxima for each re-evaluation"
 msgstr ""
 
@@ -9832,7 +9901,7 @@ msgstr ""
 msgid "Start or stop the currently selected animation that has been created with the with_slider class of commands"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:496
+#: ../../src/dialogs/ConfigDialogue.cpp:499
 msgid "Start searching while the phrase to search for is still being typed."
 msgstr ""
 
@@ -9840,7 +9909,7 @@ msgstr ""
 msgid "Start value of the parameter"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:418
+#: ../../src/wxMaxima.cpp:419
 msgid "Starting Maxima process failed"
 msgstr ""
 
@@ -9848,7 +9917,7 @@ msgstr ""
 msgid "Starting a new wxMaxima process for a new window"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:1888 ../../src/wxMaxima.cpp:1914
+#: ../../src/wxMaxima.cpp:1889 ../../src/wxMaxima.cpp:1915
 msgid "Starting evaluation of the document"
 msgstr ""
 
@@ -9861,7 +9930,7 @@ msgstr ""
 msgid "Starting to save the worksheet as .wxmx. Filename: %s"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:286
+#: ../../src/dialogs/ConfigDialogue.cpp:287
 msgid "Startup commands"
 msgstr ""
 
@@ -9869,7 +9938,7 @@ msgstr ""
 msgid "Statistics"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:793
+#: ../../src/wxMaximaFrame.cpp:803
 msgid "Statistics\tAlt+Shift+S"
 msgstr ""
 
@@ -9877,15 +9946,15 @@ msgstr ""
 msgid "Step width:"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:942
+#: ../../src/dialogs/ConfigDialogue.cpp:956
 msgid "Store filenames in image cells to enable image reloading after re-opening the worksheet"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:890
+#: ../../src/wxMaximaFrame.cpp:901
 msgid "Straight lines"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1199
+#: ../../src/wxMaximaFrame.cpp:1210
 msgid "Stream"
 msgstr ""
 
@@ -9903,11 +9972,11 @@ msgstr ""
 msgid "Stream:"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2157
+#: ../../src/dialogs/ConfigDialogue.cpp:2244
 msgid "Strike Through"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1278
+#: ../../src/wxMaximaFrame.cpp:1289
 msgid "String"
 msgstr ""
 
@@ -9921,7 +9990,7 @@ msgstr ""
 msgid "String #2:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1229
+#: ../../src/wxMaximaFrame.cpp:1240
 msgid "String Tests"
 msgstr ""
 
@@ -9933,7 +10002,7 @@ msgstr ""
 msgid "String to list of char"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1241
+#: ../../src/wxMaximaFrame.cpp:1252
 msgid "String to list of chars..."
 msgstr ""
 
@@ -9941,7 +10010,7 @@ msgstr ""
 msgid "String to octets"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1253
+#: ../../src/wxMaximaFrame.cpp:1264
 msgid "String to octets..."
 msgstr ""
 
@@ -9967,15 +10036,15 @@ msgstr ""
 msgid "Struct type name:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1122
+#: ../../src/wxMaximaFrame.cpp:1133
 msgid "Structs"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:282
+#: ../../src/dialogs/ConfigDialogue.cpp:283
 msgid "Style"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2122
+#: ../../src/dialogs/ConfigDialogue.cpp:2209
 msgid "Styles"
 msgstr ""
 
@@ -9991,7 +10060,7 @@ msgstr ""
 msgid "Subsection cell (Heading 3)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1739
+#: ../../src/wxMaximaFrame.cpp:1750
 msgid "Subst constant t into eq with diff(x,t)..."
 msgstr ""
 
@@ -10005,15 +10074,15 @@ msgstr ""
 
 #: ../../src/MaximaCommandMenus.cpp:715 ../../src/MaximaCommandMenus.cpp:3580
 #: ../../src/MaximaCommandMenus.cpp:4590 ../../src/wizards/SubstituteWiz.cpp:53
-#: ../../src/wxMaximaFrame.cpp:1747
+#: ../../src/wxMaximaFrame.cpp:1758
 msgid "Substitute"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1286
+#: ../../src/wxMaximaFrame.cpp:1297
 msgid "Substitute all matches"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1285
+#: ../../src/wxMaximaFrame.cpp:1296
 msgid "Substitute first match"
 msgstr ""
 
@@ -10021,20 +10090,20 @@ msgstr ""
 msgid "Substitute only in a specific part"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1742
+#: ../../src/wxMaximaFrame.cpp:1753
 msgid "Substitute only in parts..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1743
+#: ../../src/wxMaximaFrame.cpp:1754
 msgid "Substitute only in the elements n_1, n_2,..."
 msgstr ""
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:362
-#: ../../src/wxMaximaFrame.cpp:1729
+#: ../../src/wxMaximaFrame.cpp:1740
 msgid "Substitute..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1737 ../../src/wxMaximaFrame.cpp:1740
+#: ../../src/wxMaximaFrame.cpp:1748 ../../src/wxMaximaFrame.cpp:1751
 msgid "Substitutes until the equation no more changes"
 msgstr ""
 
@@ -10051,7 +10120,7 @@ msgstr ""
 msgid "Substitutes, but makes sure that nothing is substituted into the other substituents."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1734
+#: ../../src/wxMaximaFrame.cpp:1745
 msgid "Substitutes, but not in the other substituents"
 msgstr ""
 
@@ -10079,11 +10148,11 @@ msgstr ""
 msgid "Sum sign"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:228
+#: ../../src/dialogs/ConfigDialogue.cpp:229
 msgid "Swedish"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1647
+#: ../../src/wxMaximaFrame.cpp:1658
 msgid "Switch off simplifications of log(). Set Maxima option variable logexpand:false"
 msgstr ""
 
@@ -10100,11 +10169,11 @@ msgstr ""
 msgid "Symbolic Constant"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:797
+#: ../../src/wxMaximaFrame.cpp:807
 msgid "Symbols\tAlt+Shift+Y"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:472
+#: ../../src/dialogs/ConfigDialogue.cpp:475
 msgid "Symbols that are entered or copied here will appear in the symbols sidebar so they can be entered into the worksheet easily."
 msgstr ""
 
@@ -10128,7 +10197,7 @@ msgstr ""
 msgid "Table of Contents"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:803
+#: ../../src/wxMaximaFrame.cpp:813
 msgid "Table of Contents\tAlt+Shift+T"
 msgstr ""
 
@@ -10136,7 +10205,7 @@ msgstr ""
 msgid "Take surface color from steepness"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:229
+#: ../../src/dialogs/ConfigDialogue.cpp:230
 msgid "Tamil"
 msgstr ""
 
@@ -10148,7 +10217,7 @@ msgstr ""
 msgid "Taylor series"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1570
+#: ../../src/wxMaximaFrame.cpp:1581
 msgid "Taylor series..."
 msgstr ""
 
@@ -10156,7 +10225,7 @@ msgstr ""
 msgid "Taylor series:"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:1518
+#: ../../src/wxMaxima.cpp:1519
 msgid "Telling maxima about the new working directory."
 msgstr ""
 
@@ -10164,19 +10233,19 @@ msgstr ""
 msgid "Tells maxima for an f(x), that f(x=t)=a"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:2041
+#: ../../src/wxMaximaFrame.cpp:2052
 msgid "Tells maxima to show the help for ?, ?? and describe() in a separate browser window"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:2037
+#: ../../src/wxMaximaFrame.cpp:2048
 msgid "Tells maxima to show the help for ?, ?? and describe() in a wxMaxima sidebar"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:2032
+#: ../../src/wxMaximaFrame.cpp:2043
 msgid "Tells maxima to show the help for ?, ?? and describe() on the console"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:148
+#: ../../src/dialogs/ConfigDialogue.cpp:149
 msgid "Tells maxima where to store the result of compiling libraries"
 msgstr ""
 
@@ -10184,11 +10253,11 @@ msgstr ""
 msgid "Text"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:742
+#: ../../src/dialogs/ConfigDialogue.cpp:756
 msgid "Text & Code"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:741
+#: ../../src/dialogs/ConfigDialogue.cpp:755
 msgid "Text Only"
 msgstr ""
 
@@ -10217,11 +10286,15 @@ msgstr ""
 msgid "The .xml file doesn't seem to be valid xml or isn't a content.xml extracted from a .wxmx zip archive"
 msgstr ""
 
+#: ../../src/dialogs/ConfigDialogue.cpp:1951
+msgid "The AI Chat sidebar sends the current worksheet's content (read-only -- the AI cannot insert, edit or evaluate anything) and your messages to whichever provider you pick below. This needs an internet connection and an API key from that provider, and nothing is sent unless you actually use the sidebar."
+msgstr ""
+
 #: ../../src/MaximaProcessManager.cpp:862
 msgid "The Maxima process doesn't offer a shared memory segment we can send an interrupt signal to."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:392
+#: ../../src/dialogs/ConfigDialogue.cpp:395
 msgid "The URL MathJaX.js should be downloaded from by our HTML export."
 msgstr ""
 
@@ -10249,7 +10322,7 @@ msgstr ""
 msgid "The cache for the subjects the manual contains is from a different Maxima version."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1472
+#: ../../src/wxMaximaFrame.cpp:1483
 msgid "The classic operations one typically uses matrices for"
 msgstr ""
 
@@ -10269,19 +10342,19 @@ msgstr ""
 msgid "The command local() allows telling Maxima which functions to make local to the current program when defined."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:331
+#: ../../src/wxMaximaFrame.cpp:341
 msgid "The current Wizard"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:415
+#: ../../src/dialogs/ConfigDialogue.cpp:418
 msgid "The default height for embedded plots. Can be read out or overridden by the maxima variable wxplot_size."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:492
+#: ../../src/dialogs/ConfigDialogue.cpp:495
 msgid "The default port used for communication between Maxima and wxMaxima."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:412
+#: ../../src/dialogs/ConfigDialogue.cpp:415
 msgid "The default width for embedded plots. Can be read out or overridden by the maxima variable wxplot_size"
 msgstr ""
 
@@ -10289,32 +10362,32 @@ msgstr ""
 msgid "The diagram title"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2444
+#: ../../src/dialogs/ConfigDialogue.cpp:2540
 #, c-format
 msgid "The directory %s with maxima's startup file doesn't exist. Trying to create it..."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:150
+#: ../../src/dialogs/ConfigDialogue.cpp:151
 msgid "The directory containing the startup files, any user libraries and, if MAXIMA_OBJDIR isn't set the subdirectory with the results from compiling maxima libraries."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:154
+#: ../../src/dialogs/ConfigDialogue.cpp:155
 msgid "The directory maxima places temporary files in, for example plots that are to be included in the worksheet."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:157
+#: ../../src/dialogs/ConfigDialogue.cpp:158
 msgid "The directory the compiled versions of maxima are placed in"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:159
+#: ../../src/dialogs/ConfigDialogue.cpp:160
 msgid "The directory the maxima manual can be found in"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:160
+#: ../../src/dialogs/ConfigDialogue.cpp:161
 msgid "The directory the user's home directory is in"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:475
+#: ../../src/dialogs/ConfigDialogue.cpp:478
 msgid "The document class LaTeX is instructed to use for our documents."
 msgstr ""
 
@@ -10347,11 +10420,11 @@ msgstr ""
 msgid "The grid in the background of the diagram"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1391
+#: ../../src/wxMaximaFrame.cpp:1402
 msgid "The half of the equation that is to the left of the \"=\""
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1395
+#: ../../src/wxMaximaFrame.cpp:1406
 msgid "The half of the equation that is to the right of the \"=\""
 msgstr ""
 
@@ -10370,7 +10443,7 @@ msgstr ""
 msgid "The image file \"%s\" cannot be found."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:812
+#: ../../src/wxMaximaFrame.cpp:822
 msgid "The integrated help browser"
 msgstr ""
 
@@ -10382,7 +10455,7 @@ msgstr ""
 msgid "The key combination Shift+Space results in a non-breakable space."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:162
+#: ../../src/dialogs/ConfigDialogue.cpp:163
 msgid "The list of directories the operating system looks for programs in"
 msgstr ""
 
@@ -10402,11 +10475,11 @@ msgstr ""
 msgid "The main toolbar"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1978
+#: ../../src/wxMaximaFrame.cpp:1989
 msgid "The manual of Maxima"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1977
+#: ../../src/wxMaximaFrame.cpp:1988
 msgid "The manual of wxMaxima"
 msgstr ""
 
@@ -10446,7 +10519,7 @@ msgstr ""
 msgid "The next plot's title"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:494
+#: ../../src/dialogs/ConfigDialogue.cpp:497
 msgid "The number of recently opened files that is to be remembered."
 msgstr ""
 
@@ -10454,12 +10527,12 @@ msgstr ""
 msgid "The number of the item which is stepped from \"Index Start\" to \"Index End\"."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:477
+#: ../../src/dialogs/ConfigDialogue.cpp:480
 msgid "The options the document class LaTeX is instructed to use for our documents gets."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1068
-#: ../../src/dialogs/ConfigDialogue.cpp:1115
+#: ../../src/dialogs/ConfigDialogue.cpp:1082
+#: ../../src/dialogs/ConfigDialogue.cpp:1129
 msgid "The part of the output of these commands that isn't declared as \"math\" might be suppressed by wxMaxima. As always maxima commands are required to end in a \";\" or a \"$\""
 msgstr ""
 
@@ -10624,6 +10697,15 @@ msgstr ""
 msgid "Third-party notices"
 msgstr ""
 
+#: ../../src/sidebars/AiChatSidebar.cpp:145
+#: ../../src/sidebars/AiChatSidebar.cpp:186
+msgid "This build of wxMaxima cannot make network requests."
+msgstr ""
+
+#: ../../src/ai/AiProvider.cpp:341
+msgid "This build of wxMaxima was compiled without wxWebRequest support, so it cannot talk to any AI provider."
+msgstr ""
+
 #: ../../src/cells/TextCell.cpp:312
 msgid ""
 "This error message is most probably caused by a try to assign a value to a number instead of a variable name.\n"
@@ -10637,7 +10719,7 @@ msgid ""
 "overwritten if maxima's version changes or the file cannot be read"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1100
+#: ../../src/dialogs/ConfigDialogue.cpp:1114
 msgid "This file won't be read by maxima if maxima is used without wxMaxima. In order to add startup commands that are executed in this case, too, please add them to maxima-init.mac, instead."
 msgstr ""
 
@@ -10682,7 +10764,7 @@ msgstr ""
 msgid "Ticks:"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1362
+#: ../../src/dialogs/ConfigDialogue.cpp:1376
 msgid "Time [in Minutes] between autosaves"
 msgstr ""
 
@@ -10710,11 +10792,11 @@ msgstr ""
 msgid "Title, section and subsection cells can be folded to hide their contents. To fold or unfold, click in the square next to the cell. If you shift-click, all sublevels of that cell will also fold/unfold."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1890
+#: ../../src/wxMaximaFrame.cpp:1901
 msgid "To &Bigfloat"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1887
+#: ../../src/wxMaximaFrame.cpp:1898
 msgid "To &Float"
 msgstr ""
 
@@ -10722,15 +10804,15 @@ msgstr ""
 msgid "To Float"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1893
+#: ../../src/wxMaximaFrame.cpp:1904
 msgid "To Numeri&c\tCtrl+Shift+N"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1899
+#: ../../src/wxMaximaFrame.cpp:1910
 msgid "To exact fraction"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1910
+#: ../../src/wxMaximaFrame.cpp:1921
 msgid "To exact number"
 msgstr ""
 
@@ -10761,7 +10843,7 @@ msgstr ""
 msgid "Toc levels shown here"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:921 ../../src/wxMaximaFrame.cpp:924
+#: ../../src/wxMaximaFrame.cpp:932 ../../src/wxMaximaFrame.cpp:935
 msgid "Toggle full screen editing"
 msgstr ""
 
@@ -10777,11 +10859,11 @@ msgstr ""
 msgid "Toggle vertical scroll synchronization"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1270
+#: ../../src/wxMaximaFrame.cpp:1281
 msgid "Tokenize..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:2005
+#: ../../src/wxMaximaFrame.cpp:2016
 msgid "Tolerance calculations with Maxima"
 msgstr ""
 
@@ -10789,7 +10871,7 @@ msgstr ""
 msgid "Toolbar"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2031
+#: ../../src/dialogs/ConfigDialogue.cpp:2118
 msgid "Top"
 msgstr ""
 
@@ -10797,11 +10879,11 @@ msgstr ""
 msgid "Top end"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2957
+#: ../../src/wxMaxima.cpp:2958
 msgid "Tortoise diff tool"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1171
+#: ../../src/wxMaximaFrame.cpp:1182
 msgid "Trace a function..."
 msgstr ""
 
@@ -10809,11 +10891,11 @@ msgstr ""
 msgid "Trace function(s)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1277
+#: ../../src/wxMaximaFrame.cpp:1288
 msgid "Transformations"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1469
+#: ../../src/wxMaximaFrame.cpp:1480
 msgid "Transpose a matrix"
 msgstr ""
 
@@ -10857,15 +10939,15 @@ msgid ""
 "See also guess_exact_value()"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1274
+#: ../../src/wxMaximaFrame.cpp:1285
 msgid "Trim both ends..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1275
+#: ../../src/wxMaximaFrame.cpp:1286
 msgid "Trim left..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1276
+#: ../../src/wxMaximaFrame.cpp:1287
 msgid "Trim right..."
 msgstr ""
 
@@ -10881,7 +10963,7 @@ msgstr ""
 msgid "Trim string right"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1607
+#: ../../src/wxMaximaFrame.cpp:1618
 msgid "Try to guess which form is &simple"
 msgstr ""
 
@@ -10933,11 +11015,11 @@ msgstr ""
 msgid "Trying to start the socket a Maxima on the local machine can connect to on port %i"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:230
+#: ../../src/dialogs/ConfigDialogue.cpp:231
 msgid "Turkish"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:2024
+#: ../../src/wxMaximaFrame.cpp:2035
 msgid "Tutorials"
 msgstr ""
 
@@ -10961,37 +11043,37 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1234
+#: ../../src/dialogs/ConfigDialogue.cpp:1248
 msgid "URL MathJaX.js is located at:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1239
+#: ../../src/wxMaximaFrame.cpp:1250
 msgid "UTF8 to Unicode code point..."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:231
+#: ../../src/dialogs/ConfigDialogue.cpp:232
 msgid "Ukrainian"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3261
+#: ../../src/wxMaxima.cpp:3262
 msgid "Un-closed parenthesis"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3249
+#: ../../src/wxMaxima.cpp:3250
 msgid "Un-closed parenthesis on encountering ; or $"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3563
+#: ../../src/wxMaxima.cpp:3564
 #, c-format
 msgid "Unable to interpret the version info I got from %s: %s"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3509
+#: ../../src/wxMaxima.cpp:3510
 #, c-format
 msgid "Unable to interpret the version info I got: %s"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1100
+#: ../../src/wxMaximaFrame.cpp:1111
 msgid "Undefine"
 msgstr ""
 
@@ -11000,11 +11082,11 @@ msgstr ""
 msgid "Undefined"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2155
+#: ../../src/dialogs/ConfigDialogue.cpp:2242
 msgid "Underlined"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:748
+#: ../../src/dialogs/ConfigDialogue.cpp:762
 msgid "Underscore converts to subscripts:"
 msgstr ""
 
@@ -11012,7 +11094,7 @@ msgstr ""
 msgid "Undo"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:725
+#: ../../src/wxMaximaFrame.cpp:735
 msgid "Undo\tCtrl+Z"
 msgstr ""
 
@@ -11020,7 +11102,7 @@ msgstr ""
 msgid "Undo and redo button"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:725
+#: ../../src/wxMaximaFrame.cpp:735
 msgid "Undo last change"
 msgstr ""
 
@@ -11029,11 +11111,11 @@ msgstr ""
 msgid "Unexpected text style %li for TextCell"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1017
+#: ../../src/wxMaximaFrame.cpp:1028
 msgid "Unfold All\tCtrl+Alt+]"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1018
+#: ../../src/wxMaximaFrame.cpp:1029
 msgid "Unfold all folded sections"
 msgstr ""
 
@@ -11073,11 +11155,11 @@ msgstr ""
 msgid "Unicode characters"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:799
+#: ../../src/wxMaximaFrame.cpp:809
 msgid "Unicode chars\tAlt+Shift+U"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1237
+#: ../../src/wxMaximaFrame.cpp:1248
 msgid "Unicode code point to UTF8..."
 msgstr ""
 
@@ -11085,7 +11167,7 @@ msgstr ""
 msgid "Unicode code point to char"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1235
+#: ../../src/wxMaximaFrame.cpp:1246
 msgid "Unicode code point to char..."
 msgstr ""
 
@@ -11101,11 +11183,11 @@ msgstr ""
 msgid "Unlike in other programming language return() only exits from the current loop or block(), not from the whole function."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3200
+#: ../../src/wxMaxima.cpp:3201
 msgid "Unterminated comment."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3243
+#: ../../src/wxMaxima.cpp:3244
 msgid "Unterminated string."
 msgstr ""
 
@@ -11121,9 +11203,9 @@ msgstr ""
 msgid "Updating maxima's configuration"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3502 ../../src/wxMaxima.cpp:3507
-#: ../../src/wxMaxima.cpp:3509 ../../src/wxMaxima.cpp:3556
-#: ../../src/wxMaxima.cpp:3561 ../../src/wxMaxima.cpp:3564
+#: ../../src/wxMaxima.cpp:3503 ../../src/wxMaxima.cpp:3508
+#: ../../src/wxMaxima.cpp:3510 ../../src/wxMaxima.cpp:3557
+#: ../../src/wxMaxima.cpp:3562 ../../src/wxMaxima.cpp:3565
 msgid "Upgrade"
 msgstr ""
 
@@ -11140,11 +11222,11 @@ msgstr ""
 msgid "Upsilon"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:888
+#: ../../src/wxMaximaFrame.cpp:899
 msgid "Use \"<\" and \">\" as parenthesis for matrices"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:507
+#: ../../src/dialogs/ConfigDialogue.cpp:510
 msgid "Use GTK's overlay scrollbars, which appear over the worksheet and fade out when unused. Looks modern, but GTK repaints the whole worksheet on every frame of the fade animation - which runs after every mouse movement - so classic scrollbars are much faster."
 msgstr ""
 
@@ -11160,7 +11242,7 @@ msgstr ""
 msgid "Use Text search filtering"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1804 ../../src/wxMaximaFrame.cpp:1835
+#: ../../src/wxMaximaFrame.cpp:1815 ../../src/wxMaximaFrame.cpp:1846
 msgid "Use a list"
 msgstr ""
 
@@ -11168,47 +11250,47 @@ msgstr ""
 msgid "Use a list as parameter list for a function"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:2067
+#: ../../src/wxMaximaFrame.cpp:2078
 msgid "Use as TortoiseSVN/Git diff tool"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:485
+#: ../../src/dialogs/ConfigDialogue.cpp:488
 msgid "Use centered dot and Minus, not Star and Hyphen"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:852
+#: ../../src/dialogs/ConfigDialogue.cpp:866
 msgid "Use centered dot character for multiplication"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1804
+#: ../../src/wxMaximaFrame.cpp:1815
 msgid "Use list"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1797
+#: ../../src/wxMaximaFrame.cpp:1808
 msgid "Use list as the arguments of a function"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:882
+#: ../../src/wxMaximaFrame.cpp:893
 msgid "Use rounded parenthesis for matrices"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:885
+#: ../../src/wxMaximaFrame.cpp:896
 msgid "Use square parenthesis for matrices"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1176
+#: ../../src/wxMaximaFrame.cpp:1187
 msgid "Use struct field..."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:425
+#: ../../src/dialogs/ConfigDialogue.cpp:428
 msgid "Use the \"partial derivative\" symbol to represent the fraction that represents a diff() when exporting LaTeX"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2092
+#: ../../src/dialogs/ConfigDialogue.cpp:2179
 msgid "Use unicode Math Symbols, if available"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:891
+#: ../../src/wxMaximaFrame.cpp:902
 msgid "Use vertical lines instead of parenthesis for matrices"
 msgstr ""
 
@@ -11216,9 +11298,9 @@ msgstr ""
 msgid "User labels only"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1251
-#: ../../src/dialogs/ConfigDialogue.cpp:1492
-#: ../../src/dialogs/ConfigDialogue.cpp:1520
+#: ../../src/dialogs/ConfigDialogue.cpp:1265
+#: ../../src/dialogs/ConfigDialogue.cpp:1506
+#: ../../src/dialogs/ConfigDialogue.cpp:1534
 #: ../../src/dialogs/MaximaNotStartingDialog.cpp:54
 msgid "User specified"
 msgstr ""
@@ -11227,7 +11309,7 @@ msgstr ""
 msgid "User-defined labels"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:773
+#: ../../src/dialogs/ConfigDialogue.cpp:787
 msgid "User-defined labels if available"
 msgstr ""
 
@@ -11235,11 +11317,11 @@ msgstr ""
 msgid "Using Maxima help file from wxMaxima configuration file (helpFile=...))"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:1596
+#: ../../src/wxMaxima.cpp:1597
 msgid "Using Maxima path from command line."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:1593
+#: ../../src/wxMaxima.cpp:1594
 msgid "Using configured Maxima path."
 msgstr ""
 
@@ -11266,7 +11348,7 @@ msgstr ""
 msgid "Validated that the XML representation of the document actually is valid XML"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:542
+#: ../../src/dialogs/ConfigDialogue.cpp:545
 #: ../../src/wizards/ActualValuesStorageWiz.cpp:49
 msgid "Value"
 msgstr ""
@@ -11302,7 +11384,7 @@ msgid "Var #2"
 msgstr ""
 
 #: ../../src/MaximaCommandMenus.cpp:1371 ../../src/MaximaCommandMenus.cpp:1755
-#: ../../src/dialogs/ConfigDialogue.cpp:541
+#: ../../src/dialogs/ConfigDialogue.cpp:544
 #: ../../src/sidebars/VariablesPane.cpp:54
 msgid "Variable"
 msgstr ""
@@ -11325,7 +11407,7 @@ msgstr ""
 msgid "Variable name"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1178
+#: ../../src/wxMaximaFrame.cpp:1189
 msgid "Variable name, not contents..."
 msgstr ""
 
@@ -11354,7 +11436,7 @@ msgstr ""
 msgid "Variable:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:301 ../../src/wxMaximaFrame.cpp:814
+#: ../../src/wxMaximaFrame.cpp:301 ../../src/wxMaximaFrame.cpp:824
 msgid "Variables"
 msgstr ""
 
@@ -11371,12 +11453,17 @@ msgstr ""
 msgid "Verified that we are able to read the whole .zip archive we produced."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:232
+#: ../../src/dialogs/ConfigDialogue.cpp:233
 msgid "Vietnamese"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:929
+#: ../../src/wxMaximaFrame.cpp:940
 msgid "View"
+msgstr ""
+
+#: ../../src/sidebars/AiChatSidebar.cpp:141
+#, c-format
+msgid "Waiting for %s..."
 msgstr ""
 
 #: ../../src/Autocomplete.cpp:305
@@ -11391,17 +11478,17 @@ msgstr ""
 msgid "Waiting for the thread that parses the maxima manual to finish"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1413
+#: ../../src/dialogs/ConfigDialogue.cpp:1427
 msgid "Warn if an inactive window is idle"
 msgstr ""
 
 #: ../../src/MathParser.cpp:1343 ../../src/MaximaFileIO.cpp:536
 #: ../../src/MaximaProcessManager.cpp:1118
-#: ../../src/MaximaResponseReader.cpp:361 ../../src/wxMaxima.cpp:1615
+#: ../../src/MaximaResponseReader.cpp:361 ../../src/wxMaxima.cpp:1616
 msgid "Warning"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1652
+#: ../../src/wxMaximaFrame.cpp:1663
 msgid "Warning:"
 msgstr ""
 
@@ -11416,7 +11503,7 @@ msgstr ""
 msgid "Warning: Lookalike chars: "
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1642
+#: ../../src/wxMaximaFrame.cpp:1653
 msgid "Warning: No test if the argument of the log is complex, positive or negative"
 msgstr ""
 
@@ -11435,7 +11522,7 @@ msgstr ""
 msgid "WebP (*.webp)|*.webp|"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:1901
+#: ../../src/wxMaxima.cpp:1902
 msgid "Welcome to wxMaxima"
 msgstr ""
 
@@ -11447,7 +11534,7 @@ msgstr ""
 msgid "When applying functions with one argument from menus, the default argument is '%'. To apply the function to some other value, select it in the document before executing a menu command."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1151
+#: ../../src/wxMaximaFrame.cpp:1162
 msgid "When to invoke the lisp compiler's debugger"
 msgstr ""
 
@@ -11455,7 +11542,7 @@ msgstr ""
 msgid "While loop"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1156
+#: ../../src/wxMaximaFrame.cpp:1167
 msgid "While loop..."
 msgstr ""
 
@@ -11467,11 +11554,11 @@ msgstr ""
 msgid "Whole document (*.wxmx)|*.wxmx|The input, readable by load() (maxima > 5.38) (*.wxm)|*.wxm|All Files (*.*)|*"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:332
+#: ../../src/wxMaxima.cpp:333
 msgid "Will try to generate a stack backtrace, if the program ever crashes"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:280
+#: ../../src/dialogs/ConfigDialogue.cpp:281
 msgid "Worksheet"
 msgstr ""
 
@@ -11492,7 +11579,7 @@ msgstr ""
 msgid "Worksheet repaints:"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:428
+#: ../../src/dialogs/ConfigDialogue.cpp:431
 msgid "Wrap equations exported by the \"copy as LaTeX\" feature between \\[ and \\] as equation markers"
 msgstr ""
 
@@ -11526,8 +11613,19 @@ msgstr ""
 msgid "Xi"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:731
+#: ../../src/dialogs/ConfigDialogue.cpp:745
 msgid "Yes"
+msgstr ""
+
+#: ../../src/sidebars/AiChatSidebar.cpp:191
+msgid "You"
+msgstr ""
+
+#: ../../src/sidebars/AiChatSidebar.cpp:161
+msgid ""
+"You are an assistant embedded in wxMaxima, a GUI front-end for the Maxima computer algebra system. Below is a read-only snapshot of the user's current worksheet -- you cannot edit, evaluate or otherwise change it; only the user can do that through the wxMaxima UI. Use it only as context.\n"
+"\n"
+"--- Worksheet snapshot ---\n"
 msgstr ""
 
 #: ../../src/dialogs/TipOfTheDay.cpp:64
@@ -11565,7 +11663,7 @@ msgstr ""
 msgid "You got an idea for an improvement of wxMaxima? Great! Please submit your idea at https://github.com/wxMaxima-developers/wxmaxima/issues. "
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3499 ../../src/wxMaxima.cpp:3553
+#: ../../src/wxMaxima.cpp:3500 ../../src/wxMaxima.cpp:3554
 #, c-format
 msgid ""
 "You have version %s. The newest wxMaxima release is %s.\n"
@@ -11573,11 +11671,11 @@ msgid ""
 "Select OK to visit the wxMaxima webpage."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3603
+#: ../../src/wxMaxima.cpp:3604
 msgid "Your changes will be lost if you don't save them."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3507 ../../src/wxMaxima.cpp:3561
+#: ../../src/wxMaxima.cpp:3508 ../../src/wxMaxima.cpp:3562
 msgid "Your version of wxMaxima is up to date."
 msgstr ""
 
@@ -11585,27 +11683,27 @@ msgstr ""
 msgid "Zeta"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:901
+#: ../../src/wxMaximaFrame.cpp:912
 msgid "Zoom &In\tCtrl++"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:902
+#: ../../src/wxMaximaFrame.cpp:913
 msgid "Zoom Ou&t\tCtrl+-"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:901
+#: ../../src/wxMaximaFrame.cpp:912
 msgid "Zoom in 10%"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:902
+#: ../../src/wxMaximaFrame.cpp:913
 msgid "Zoom out 10%"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3299 ../../src/wxMaximaFrame.cpp:205
+#: ../../src/wxMaxima.cpp:3300 ../../src/wxMaximaFrame.cpp:205
 msgid "[ unsaved ]"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3301
+#: ../../src/wxMaxima.cpp:3302
 msgid "[ unsaved* ]"
 msgstr ""
 
@@ -11633,23 +11731,23 @@ msgstr ""
 msgid "antisymmetric"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1786
+#: ../../src/wxMaximaFrame.cpp:1797
 msgid "apply function to each element"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:835
+#: ../../src/wxMaximaFrame.cpp:846
 msgid "as 1D ASCII"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:838
+#: ../../src/wxMaximaFrame.cpp:849
 msgid "as ASCII Art"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:841
+#: ../../src/wxMaximaFrame.cpp:852
 msgid "as ASCII+Unicode Art"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1776
+#: ../../src/wxMaximaFrame.cpp:1787
 msgid "as storage for actual values for variables"
 msgstr ""
 
@@ -11661,7 +11759,7 @@ msgstr ""
 msgid "both sides"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1232
+#: ../../src/wxMaximaFrame.cpp:1243
 msgid "char to Ascii code..."
 msgstr ""
 
@@ -11695,7 +11793,7 @@ msgstr ""
 msgid "diff(x,t)="
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1157 ../../src/wxMaximaFrame.cpp:1798
+#: ../../src/wxMaximaFrame.cpp:1168 ../../src/wxMaximaFrame.cpp:1809
 msgid "do for each element"
 msgstr ""
 
@@ -11731,7 +11829,7 @@ msgstr ""
 msgid "f(x) stays f(x) even if the value of f(x) is computable"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:467
+#: ../../src/dialogs/ConfigDialogue.cpp:470
 msgid ""
 "false=Don't generate subscripts\n"
 "true=Automatically convert underscores to subscript markers if the would-be subscript is a number or a single letter\n"
@@ -11742,19 +11840,19 @@ msgstr ""
 msgid "filename:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1770
+#: ../../src/wxMaximaFrame.cpp:1781
 msgid "from a list"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1767
+#: ../../src/wxMaximaFrame.cpp:1778
 msgid "from a rule"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1781
+#: ../../src/wxMaximaFrame.cpp:1792
 msgid "from function arguments"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1765
+#: ../../src/wxMaximaFrame.cpp:1776
 msgid "from individual elements"
 msgstr ""
 
@@ -11770,7 +11868,7 @@ msgstr ""
 msgid "general"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1670
+#: ../../src/dialogs/ConfigDialogue.cpp:1684
 msgid "gnuplot: Without command console"
 msgstr ""
 
@@ -11782,7 +11880,7 @@ msgstr ""
 msgid "in"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:843
+#: ../../src/wxMaximaFrame.cpp:854
 msgid "in 2D"
 msgstr ""
 
@@ -11829,11 +11927,11 @@ msgstr ""
 msgid "matrix([x_1,x_2,...],[y_1,y_2,...])"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1498
+#: ../../src/wxMaximaFrame.cpp:1509
 msgid "max(abs(A(i,j))) (complex)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1497
+#: ../../src/wxMaximaFrame.cpp:1508
 msgid "max(abs(A(i,j))) (real)"
 msgstr ""
 
@@ -11894,7 +11992,7 @@ msgstr ""
 msgid "noun: Not evaluated by default"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1806
+#: ../../src/wxMaximaFrame.cpp:1817
 msgid "nth"
 msgstr ""
 
@@ -11964,7 +12062,7 @@ msgstr ""
 msgid "printf"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1201
+#: ../../src/wxMaximaFrame.cpp:1212
 msgid "printf..."
 msgstr ""
 
@@ -11984,15 +12082,15 @@ msgstr ""
 msgid "ratsubst works like subst, but it knows some basic maths, if needed."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1204
+#: ../../src/wxMaximaFrame.cpp:1215
 msgid "readbyte..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1203
+#: ../../src/wxMaximaFrame.cpp:1214
 msgid "readchar..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1202
+#: ../../src/wxMaximaFrame.cpp:1213
 msgid "readline..."
 msgstr ""
 
@@ -12105,11 +12203,11 @@ msgstr ""
 msgid "union"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1168
+#: ../../src/wxMaximaFrame.cpp:1179
 msgid "unnamed function (lambda)..."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3591
+#: ../../src/wxMaxima.cpp:3592
 msgid "unsaved"
 msgstr ""
 
@@ -12122,23 +12220,25 @@ msgstr ""
 msgid "upsilon"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1796
+#: ../../src/wxMaximaFrame.cpp:1807
 msgid "use as function arguments"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1792
+#: ../../src/wxMaximaFrame.cpp:1803
 msgid "use the actual values stored"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1673
+#: ../../src/dialogs/ConfigDialogue.cpp:1687
 msgid "wgnuplot: Steals the mouse focus during plotting"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1205
+#: ../../src/wxMaximaFrame.cpp:1216
 msgid "writebyte..."
 msgstr ""
 
 #: ../../src/dialogs/AboutDialog.cpp:64 ../../src/main.cpp:843
+#: ../../src/sidebars/AiChatSidebar.cpp:179
+#: ../../src/sidebars/AiChatSidebar.cpp:185
 msgid "wxMaxima"
 msgstr ""
 
@@ -12147,7 +12247,7 @@ msgstr ""
 msgid "wxMaxima %ld"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3288 ../../src/wxMaximaFrame.cpp:203
+#: ../../src/wxMaxima.cpp:3289 ../../src/wxMaximaFrame.cpp:203
 #, c-format
 msgid "wxMaxima %s (%s) "
 msgstr ""
@@ -12164,8 +12264,8 @@ msgstr ""
 msgid "wxMaxima cannot read the xml contents of "
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:142
-#: ../../src/dialogs/ConfigDialogue.cpp:311
+#: ../../src/dialogs/ConfigDialogue.cpp:143
+#: ../../src/dialogs/ConfigDialogue.cpp:314
 msgid "wxMaxima configuration"
 msgstr ""
 
@@ -12194,7 +12294,7 @@ msgstr ""
 msgid "wxMaxima encountered an error loading "
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1977
+#: ../../src/wxMaximaFrame.cpp:1988
 msgid "wxMaxima help"
 msgstr ""
 
@@ -12202,7 +12302,7 @@ msgstr ""
 msgid "wxMaxima is a cross-platform graphical user interface for the computer algebra system Maxima based on wxWidgets.\n"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2949
+#: ../../src/wxMaxima.cpp:2950
 #, c-format
 msgid ""
 "wxMaxima is now the .wxmx diff tool for:%s\n"
@@ -12222,7 +12322,7 @@ msgstr ""
 msgid "wxMaxima needs more translators. We do not speak every language. Help us to translate wxMaxima and the manual to your language. Join the wxMaxima development at: https://github.com/wxMaxima-developers/wxmaxima"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:407
+#: ../../src/dialogs/ConfigDialogue.cpp:410
 msgid "wxMaxima normally stores the gnuplot sources for every plot made using draw() in order to be able to open plots interactively in gnuplot later. This setting defines the limit [in Megabytes per plot] for this feature."
 msgstr ""
 
@@ -12243,19 +12343,19 @@ msgstr ""
 msgid "wxMaxima remembers answers from the last run and is able to offer them as the default answer"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:481
+#: ../../src/dialogs/ConfigDialogue.cpp:484
 msgid "wxMaxima remembers the answers to maxima's questions. If this checkbox is set it automatically offers to enter the last answer to this question the user has input."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1992
+#: ../../src/wxMaximaFrame.cpp:2003
 msgid "wxMaxima shows help in a browser"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1990
+#: ../../src/wxMaximaFrame.cpp:2001
 msgid "wxMaxima shows help in the sidebar"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1098
+#: ../../src/dialogs/ConfigDialogue.cpp:1112
 msgid "wxMaxima startup file location: "
 msgstr ""
 
@@ -12268,11 +12368,11 @@ msgstr ""
 msgid "wxMaxima worksheet"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:2056
+#: ../../src/wxMaximaFrame.cpp:2067
 msgid "wxMaxima's ChangeLog"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:2054
+#: ../../src/wxMaximaFrame.cpp:2065
 msgid "wxMaxima's license"
 msgstr ""
 
@@ -12292,22 +12392,22 @@ msgstr ""
 msgid "wxworksheettohtml/totex: no target file name was given."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2235
+#: ../../src/wxMaxima.cpp:2236
 #, c-format
 msgid "wxworksheettohtml: could not write \"%s\"."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2209
+#: ../../src/wxMaxima.cpp:2210
 #, c-format
 msgid "wxworksheettohtml: unknown flavor \"%s\"; using native MathML. Known flavors: mathml, mathjax, svg, bitmap."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2277
+#: ../../src/wxMaxima.cpp:2278
 #, c-format
 msgid "wxworksheettotex: could not write \"%s\"."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:712
+#: ../../src/dialogs/ConfigDialogue.cpp:726
 msgid "x"
 msgstr ""
 

--- a/locales/wxMaxima/wxMaxima.pot
+++ b/locales/wxMaxima/wxMaxima.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-09-06 15:12+0000\n"
+"POT-Creation-Date: 2026-09-06 16:16+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -193,7 +193,7 @@ msgstr ""
 msgid " Returns the unique elements of the list"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1666
+#: ../../src/wxMaximaFrame.cpp:1673
 msgid " Wrong, if a is complex"
 msgstr ""
 
@@ -281,55 +281,55 @@ msgid ""
 "(Is the client installed?)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1762
+#: ../../src/wxMaximaFrame.cpp:1769
 msgid "&Algebraic Mode"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1991
+#: ../../src/wxMaximaFrame.cpp:1998
 msgid "&Apropos..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:713
+#: ../../src/wxMaximaFrame.cpp:720
 msgid "&Batch File...\tCtrl+B"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1382
+#: ../../src/wxMaximaFrame.cpp:1389
 msgid "&Boundary Value Problem..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:2057
+#: ../../src/wxMaximaFrame.cpp:2064
 msgid "&Bug Report"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1612
+#: ../../src/wxMaximaFrame.cpp:1619
 msgid "&Calculus"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1708
+#: ../../src/wxMaximaFrame.cpp:1715
 msgid "&Canonical Form"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1462
+#: ../../src/wxMaximaFrame.cpp:1469
 msgid "&Characteristic Polynomial..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1094
+#: ../../src/wxMaximaFrame.cpp:1101
 msgid "&Clear Memory"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1690
+#: ../../src/wxMaximaFrame.cpp:1697
 msgid "&Combine Factorials"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1735
+#: ../../src/wxMaximaFrame.cpp:1742
 msgid "&Complex Simplification"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1609
+#: ../../src/wxMaximaFrame.cpp:1616
 msgid "&Continued Fraction"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:742
+#: ../../src/wxMaximaFrame.cpp:749
 msgid "&Copy\tCtrl+C"
 msgstr ""
 
@@ -337,115 +337,115 @@ msgstr ""
 msgid "&Definite integration"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1728
+#: ../../src/wxMaximaFrame.cpp:1735
 msgid "&Demoivre"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1466
+#: ../../src/wxMaximaFrame.cpp:1473
 msgid "&Determinant"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1573
+#: ../../src/wxMaximaFrame.cpp:1580
 msgid "&Differentiate..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:793
+#: ../../src/wxMaximaFrame.cpp:800
 msgid "&Edit"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1350
+#: ../../src/wxMaximaFrame.cpp:1357
 msgid "&Eliminate Variable..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1422
+#: ../../src/wxMaximaFrame.cpp:1429
 msgid "&Enter Matrix..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1990
+#: ../../src/wxMaximaFrame.cpp:1997
 msgid "&Example..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1631
+#: ../../src/wxMaximaFrame.cpp:1638
 msgid "&Expand Expression"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1704
+#: ../../src/wxMaximaFrame.cpp:1711
 msgid "&Expand Trigonometric"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1733
+#: ../../src/wxMaximaFrame.cpp:1740
 msgid "&Exponentialize"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:718
+#: ../../src/wxMaximaFrame.cpp:725
 msgid "&Export..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1623
+#: ../../src/wxMaximaFrame.cpp:1630
 msgid "&Factor Expression"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:730
+#: ../../src/wxMaximaFrame.cpp:737
 msgid "&File"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1123
+#: ../../src/wxMaximaFrame.cpp:1130
 msgid "&Functions"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1597
+#: ../../src/wxMaximaFrame.cpp:1604
 msgid "&Greatest Common Divisor..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:2091
+#: ../../src/wxMaximaFrame.cpp:2098
 msgid "&Help"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1560
+#: ../../src/wxMaximaFrame.cpp:1567
 msgid "&Integrate..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1068
+#: ../../src/TrayIcon.cpp:111 ../../src/wxMaximaFrame.cpp:1075
 msgid "&Interrupt\tCtrl+G"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1459
+#: ../../src/wxMaximaFrame.cpp:1466
 msgid "&Invert Matrix"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:2065
+#: ../../src/wxMaximaFrame.cpp:2072
 msgid "&License"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1870
+#: ../../src/wxMaximaFrame.cpp:1877
 msgid "&List"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:708
+#: ../../src/wxMaximaFrame.cpp:715
 msgid "&Load Package...\tCtrl+L"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1336
+#: ../../src/wxMaximaFrame.cpp:1343
 msgid "&Maxima"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1989
+#: ../../src/wxMaximaFrame.cpp:1996
 msgid "&Maxima help"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1767
+#: ../../src/wxMaximaFrame.cpp:1774
 msgid "&Modulus Computation..."
 msgstr ""
 
-#: ../../src/main.cpp:721
+#: ../../src/main.cpp:737
 msgid "&New\tCtrl+N"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1977
+#: ../../src/wxMaximaFrame.cpp:1984
 msgid "&Numeric"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1892
+#: ../../src/wxMaximaFrame.cpp:1899
 msgid "&Numeric Output"
 msgstr ""
 
@@ -457,15 +457,15 @@ msgstr ""
 msgid "&Nusum"
 msgstr ""
 
-#: ../../src/main.cpp:722
+#: ../../src/main.cpp:738
 msgid "&Open\tCtrl+O"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:696
+#: ../../src/wxMaximaFrame.cpp:703
 msgid "&Open...\tCtrl+O"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1887
+#: ../../src/wxMaximaFrame.cpp:1894
 msgid "&Plot"
 msgstr ""
 
@@ -473,7 +473,7 @@ msgstr ""
 msgid "&Power series"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:722
+#: ../../src/wxMaximaFrame.cpp:729
 msgid "&Print...\tCtrl+P"
 msgstr ""
 
@@ -481,36 +481,35 @@ msgstr ""
 msgid "&Rational"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1701
+#: ../../src/wxMaximaFrame.cpp:1708
 msgid "&Reduce Trigonometric"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1078
+#: ../../src/wxMaximaFrame.cpp:1085
 msgid "&Restart Maxima\tCtrl+Alt+R"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:706
+#: ../../src/wxMaximaFrame.cpp:713
 msgid "&Save\tCtrl+S"
 msgstr ""
 
-#: ../../src/wizards/SumWiz.cpp:43 ../../src/wxMaximaFrame.cpp:1758
 #: ../../src/TrayIcon.cpp:113
 msgid "&Show wxMaxima"
 msgstr ""
 
-#: ../../src/wizards/SumWiz.cpp:43 ../../src/wxMaximaFrame.cpp:1748
+#: ../../src/wizards/SumWiz.cpp:43 ../../src/wxMaximaFrame.cpp:1776
 msgid "&Simplify"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1688
+#: ../../src/wxMaximaFrame.cpp:1695
 msgid "&Simplify Factorials"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1698
+#: ../../src/wxMaximaFrame.cpp:1705
 msgid "&Simplify Trigonometric"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1342
+#: ../../src/wxMaximaFrame.cpp:1349
 msgid "&Solve..."
 msgstr ""
 
@@ -522,19 +521,19 @@ msgstr ""
 msgid "&Taylor series"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1139
+#: ../../src/wxMaximaFrame.cpp:1146
 msgid "&Time Display"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1479
+#: ../../src/wxMaximaFrame.cpp:1486
 msgid "&Transpose Matrix"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1712
+#: ../../src/wxMaximaFrame.cpp:1719
 msgid "&Trigonometric Simplification"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1125
+#: ../../src/wxMaximaFrame.cpp:1132
 msgid "&Variables"
 msgstr ""
 
@@ -590,19 +589,19 @@ msgstr ""
 msgid "(f(x),x,a,b), (semi-) infinite interval"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1948
+#: ../../src/wxMaximaFrame.cpp:1955
 msgid "(f(x),x,a,b), Epsilon algorithm"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1950
+#: ../../src/wxMaximaFrame.cpp:1957
 msgid "(f(x),x,a,b), infinite interval"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1946
+#: ../../src/wxMaximaFrame.cpp:1953
 msgid "(f(x),x,a,b), strategy of Aind"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:596 ../../src/wxMaximaFrame.cpp:1974
+#: ../../src/MaximaCommandMenus.cpp:596 ../../src/wxMaximaFrame.cpp:1981
 msgid "(f(x),x,y) with singularities+discontinuities"
 msgstr ""
 
@@ -640,15 +639,15 @@ msgstr ""
 msgid "2D"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1416
+#: ../../src/wxMaximaFrame.cpp:1423
 msgid "2D Array to Matrix..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:850
+#: ../../src/wxMaximaFrame.cpp:857
 msgid "2D equations using ASCII Art"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:853
+#: ../../src/wxMaximaFrame.cpp:860
 msgid "2D equations using ASCII Art with unicode characters, if available"
 msgstr ""
 
@@ -760,7 +759,7 @@ msgstr ""
 msgid "A scale factor for the printout. Helpful for printing big equations on small pdf pages."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1741
+#: ../../src/wxMaximaFrame.cpp:1748
 msgid "A search-and-replace for equations"
 msgstr ""
 
@@ -788,7 +787,7 @@ msgstr ""
 msgid "A subsection heading"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1743
+#: ../../src/wxMaximaFrame.cpp:1750
 msgid "A subst with basic maths knowledge"
 msgstr ""
 
@@ -818,16 +817,16 @@ msgstr ""
 msgid "A worksheet cell"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1549
+#: ../../src/wxMaximaFrame.cpp:1556
 msgid "A&pply function to each Matrix element..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1395
+#: ../../src/wxMaximaFrame.cpp:1402
 msgid "A&t Value..."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:290 ../../src/wxMaximaFrame.cpp:314
-#: ../../src/wxMaximaFrame.cpp:825
+#: ../../src/dialogs/ConfigDialogue.cpp:290 ../../src/wxMaximaFrame.cpp:317
+#: ../../src/wxMaximaFrame.cpp:832
 msgid "AI Chat"
 msgstr ""
 
@@ -848,11 +847,11 @@ msgstr ""
 msgid "Aborting due to --exit-on-error (exit code %d). Cell: %s"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:2086
+#: ../../src/wxMaximaFrame.cpp:2093
 msgid "About"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:2086 ../../src/wxMaximaFrame.cpp:2088
+#: ../../src/wxMaximaFrame.cpp:2093 ../../src/wxMaximaFrame.cpp:2095
 msgid "About wxMaxima"
 msgstr ""
 
@@ -880,19 +879,19 @@ msgstr ""
 msgid "Active provider:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1475
+#: ../../src/wxMaximaFrame.cpp:1482
 msgid "Ad&joint Matrix"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1764
+#: ../../src/wxMaximaFrame.cpp:1771
 msgid "Add Algebraic E&quality..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1119
+#: ../../src/wxMaximaFrame.cpp:1126
 msgid "Add a directory to search path"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1859
+#: ../../src/wxMaximaFrame.cpp:1866
 msgid "Add a new item to the beginning of the list. Useful for creating stacks."
 msgstr ""
 
@@ -912,7 +911,7 @@ msgstr ""
 msgid "Add dir to path:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1765
+#: ../../src/wxMaximaFrame.cpp:1772
 msgid "Add equality to the rational simplifier"
 msgstr ""
 
@@ -924,7 +923,7 @@ msgstr ""
 msgid "Add the .wxmx file to the HTML export"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1119
+#: ../../src/wxMaximaFrame.cpp:1126
 msgid "Add to &Path..."
 msgstr ""
 
@@ -967,11 +966,11 @@ msgstr ""
 msgid "Additional symbols for the \"symbols\" sidebar:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1669
+#: ../../src/wxMaximaFrame.cpp:1676
 msgid "Additionally: log(a*b)=log(a)+log(b)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1673
+#: ../../src/wxMaximaFrame.cpp:1680
 msgid "Additionally: log(a/b)=log(a)-log(b), a and b positive integers"
 msgstr ""
 
@@ -979,15 +978,15 @@ msgstr ""
 msgid "Additive function: f(a+b)=f(a)+f(b)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:2018
+#: ../../src/wxMaximaFrame.cpp:2025
 msgid "Advanced 2d plotting"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1916
+#: ../../src/wxMaximaFrame.cpp:1923
 msgid "Advanced guess (PSLQ algorithm)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:2027
+#: ../../src/wxMaximaFrame.cpp:2034
 msgid "Advanced variable names"
 msgstr ""
 
@@ -1003,7 +1002,7 @@ msgstr ""
 msgid "Albanian"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1132
+#: ../../src/wxMaximaFrame.cpp:1139
 msgid "Aliases"
 msgstr ""
 
@@ -1011,15 +1010,15 @@ msgstr ""
 msgid "All Levels"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1821
+#: ../../src/wxMaximaFrame.cpp:1828
 msgid "All but the 1st n elements"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1823
+#: ../../src/wxMaximaFrame.cpp:1830
 msgid "All but the last n elements"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:2198 ../../src/main.cpp:930
+#: ../../src/MaximaCommandMenus.cpp:2198 ../../src/main.cpp:946
 msgid "All openable types (*.wxm, *.wxmx, *.mac, *.out, *.xml)|*.wxm;*.wxmx;*.mac;*.out;*.xml|wxMaxima document (*.wxm, *.wxmx)|*.wxm;*.wxmx|Maxima session (*.mac)|*.mac|Xmaxima session (*.out)|*.out|xml from broken .wxmx (*.xml)|*.xml"
 msgstr ""
 
@@ -1027,7 +1026,7 @@ msgstr ""
 msgid "All variable names"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:840
+#: ../../src/wxMaximaFrame.cpp:847
 msgid "All visible sidebars"
 msgstr ""
 
@@ -1035,7 +1034,7 @@ msgstr ""
 msgid "Allow access to an online manual?"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1757
+#: ../../src/wxMaximaFrame.cpp:1764
 msgid "Allow substituting operators"
 msgstr ""
 
@@ -1055,15 +1054,15 @@ msgstr ""
 msgid "All|*"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:870
+#: ../../src/wxMaximaFrame.cpp:877
 msgid "Always after underscores"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:871
+#: ../../src/wxMaximaFrame.cpp:878
 msgid "Always autosubscript after an underscore"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:881
+#: ../../src/wxMaximaFrame.cpp:888
 msgid "Always display this variable with subscript"
 msgstr ""
 
@@ -1091,7 +1090,7 @@ msgstr ""
 msgid "Anchors file has no top node."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:898
+#: ../../src/wxMaximaFrame.cpp:905
 msgid "Angles"
 msgstr ""
 
@@ -1100,11 +1099,11 @@ msgstr ""
 msgid "Animated Diagram"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1882
+#: ../../src/wxMaximaFrame.cpp:1889
 msgid "Animation autoplay"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1885
+#: ../../src/wxMaximaFrame.cpp:1892
 msgid "Animation framerate..."
 msgstr ""
 
@@ -1112,7 +1111,7 @@ msgstr ""
 msgid "Announce Maxima's output as MathML"
 msgstr ""
 
-#: ../../src/worksheet/Worksheet.cpp:5507 ../../src/wxMaximaFrame.cpp:2059
+#: ../../src/worksheet/Worksheet.cpp:5507 ../../src/wxMaximaFrame.cpp:2066
 msgid "Anonymize Code for Bug Report"
 msgstr ""
 
@@ -1124,15 +1123,15 @@ msgstr ""
 msgid "Appearance:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1846
+#: ../../src/wxMaximaFrame.cpp:1853
 msgid "Append"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1842
+#: ../../src/wxMaximaFrame.cpp:1849
 msgid "Append a list"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1843
+#: ../../src/wxMaximaFrame.cpp:1850
 msgid "Append a list to an existing list"
 msgstr ""
 
@@ -1140,15 +1139,15 @@ msgstr ""
 msgid "Append a list to another list"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1836
+#: ../../src/wxMaximaFrame.cpp:1843
 msgid "Append an element"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1841
+#: ../../src/wxMaximaFrame.cpp:1848
 msgid "Append an element to the beginning an existing list"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1837
+#: ../../src/wxMaximaFrame.cpp:1844
 msgid "Append an element to the end of an existing list"
 msgstr ""
 
@@ -1156,12 +1155,12 @@ msgstr ""
 msgid "Apply a function to each list element"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1917
+#: ../../src/wxMaximaFrame.cpp:1924
 #, c-format
 msgid "Approximate by a fraction using log(), sqrt() and %pi, when needed. Only available in maxima > 5.46.0"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1913
+#: ../../src/wxMaximaFrame.cpp:1920
 msgid "Approximate by nice fraction"
 msgstr ""
 
@@ -1207,7 +1206,7 @@ msgstr ""
 msgid "Array"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1127
+#: ../../src/wxMaximaFrame.cpp:1134
 msgid "Arrays"
 msgstr ""
 
@@ -1226,7 +1225,7 @@ msgstr ""
 msgid "Ascii code to char"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1242
+#: ../../src/wxMaximaFrame.cpp:1249
 msgid "Ascii code to char..."
 msgstr ""
 
@@ -1281,11 +1280,11 @@ msgstr ""
 msgid "Automatic labels (%i1, %o1,...)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1056
+#: ../../src/wxMaximaFrame.cpp:1063
 msgid "Automatically answer questions"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1057
+#: ../../src/wxMaximaFrame.cpp:1064
 msgid "Automatically fill in answers known from the last run"
 msgstr ""
 
@@ -1308,15 +1307,15 @@ msgstr ""
 msgid "Autosaving the .wxmx file as %s"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:888
+#: ../../src/wxMaximaFrame.cpp:895
 msgid "Autosubscript"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:889
+#: ../../src/wxMaximaFrame.cpp:896
 msgid "Autosubscript chars after an underscore"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:874
+#: ../../src/wxMaximaFrame.cpp:881
 msgid "Autosubscript numbers and text following single letters"
 msgstr ""
 
@@ -1344,7 +1343,7 @@ msgstr ""
 msgid "Barsplot..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1454
+#: ../../src/wxMaximaFrame.cpp:1461
 msgid "Basic matrix operations"
 msgstr ""
 
@@ -1562,7 +1561,7 @@ msgstr ""
 msgid "Bug: y position of cell is unknown!"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:2055
+#: ../../src/wxMaximaFrame.cpp:2062
 msgid "Build &Info"
 msgstr ""
 
@@ -1583,11 +1582,11 @@ msgstr ""
 msgid "Byte:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1565
+#: ../../src/wxMaximaFrame.cpp:1572
 msgid "C&hange Variable in Integrate..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:791
+#: ../../src/wxMaximaFrame.cpp:798
 msgid "C&onfigure"
 msgstr ""
 
@@ -1604,7 +1603,7 @@ msgstr ""
 msgid "Caching font variant: %s"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1589
+#: ../../src/wxMaximaFrame.cpp:1596
 msgid "Calculate &Product..."
 msgstr ""
 
@@ -1616,15 +1615,15 @@ msgstr ""
 msgid "Calculate Singular Value Decomposition, left and right singular vectors numerically"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1587
+#: ../../src/wxMaximaFrame.cpp:1594
 msgid "Calculate Su&m..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1902
+#: ../../src/wxMaximaFrame.cpp:1909
 msgid "Calculate bigfloat value of the last result"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1899
+#: ../../src/wxMaximaFrame.cpp:1906
 msgid "Calculate float value of the last result"
 msgstr ""
 
@@ -1640,11 +1639,11 @@ msgstr ""
 msgid "Calculate modulus:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1905
+#: ../../src/wxMaximaFrame.cpp:1912
 msgid "Calculate numeric value of the last result"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1590
+#: ../../src/wxMaximaFrame.cpp:1597
 msgid "Calculate products"
 msgstr ""
 
@@ -1652,7 +1651,7 @@ msgstr ""
 msgid "Calculate standard deviation"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1587
+#: ../../src/wxMaximaFrame.cpp:1594
 msgid "Calculate sums"
 msgstr ""
 
@@ -1814,6 +1813,7 @@ msgid "Cannot start the headless gnuplot warnings check"
 msgstr ""
 
 #: ../../src/MaximaProcessManager.cpp:342 ../../src/StatusBar.cpp:254
+#: ../../src/TrayIcon.cpp:57
 msgid "Cannot start the maxima binary"
 msgstr ""
 
@@ -1829,11 +1829,11 @@ msgstr ""
 msgid "Cauchy principal value of f(x)/(x-c), finite interval"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1952
+#: ../../src/wxMaximaFrame.cpp:1959
 msgid "Cauchy principal value, finite interval"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1059
+#: ../../src/wxMaximaFrame.cpp:1066
 msgid "Ce&ll"
 msgstr ""
 
@@ -1854,7 +1854,7 @@ msgstr ""
 msgid "Cell with UUID %s not found!"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1142
+#: ../../src/wxMaximaFrame.cpp:1149
 msgid "Change &2d Display"
 msgstr ""
 
@@ -1866,7 +1866,7 @@ msgstr ""
 msgid "Change Image..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:2067
+#: ../../src/wxMaximaFrame.cpp:2074
 msgid "Change Log"
 msgstr ""
 
@@ -1874,7 +1874,7 @@ msgstr ""
 msgid "Change directory"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1306
+#: ../../src/wxMaximaFrame.cpp:1313
 msgid "Change directory..."
 msgstr ""
 
@@ -1882,7 +1882,7 @@ msgstr ""
 msgid "Change names of greek letters to greek letters"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1143
+#: ../../src/wxMaximaFrame.cpp:1150
 msgid "Change the 2d display algorithm used to display math output"
 msgstr ""
 
@@ -1898,11 +1898,11 @@ msgstr ""
 msgid "Change variable and evaluate"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1566
+#: ../../src/wxMaximaFrame.cpp:1573
 msgid "Change variable in integral or sum"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1570
+#: ../../src/wxMaximaFrame.cpp:1577
 msgid "Change variable in integral or sum and evaluate the result"
 msgstr ""
 
@@ -1910,7 +1910,7 @@ msgstr ""
 msgid "ChangeLog"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1130
+#: ../../src/wxMaximaFrame.cpp:1137
 msgid "Changed option variables"
 msgstr ""
 
@@ -1931,7 +1931,7 @@ msgstr ""
 msgid "Char #2:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1244
+#: ../../src/wxMaximaFrame.cpp:1251
 msgid "Char to Unicode code point..."
 msgstr ""
 
@@ -1947,7 +1947,7 @@ msgstr ""
 msgid "Char:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1235
+#: ../../src/wxMaximaFrame.cpp:1242
 msgid "Character Tests"
 msgstr ""
 
@@ -1964,11 +1964,11 @@ msgstr ""
 msgid "Chatting with %s"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:2070
+#: ../../src/wxMaximaFrame.cpp:2077
 msgid "Check for Updates"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:2071
+#: ../../src/wxMaximaFrame.cpp:2078
 msgid "Check if a newer version of wxMaxima is available."
 msgstr ""
 
@@ -2017,7 +2017,7 @@ msgstr ""
 msgid "Choose the %s Font"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:907
+#: ../../src/wxMaximaFrame.cpp:914
 msgid "Choose the parenthesis type for Matrices"
 msgstr ""
 
@@ -2025,7 +2025,7 @@ msgstr ""
 msgid "Classes:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1482
+#: ../../src/wxMaximaFrame.cpp:1489
 msgid "Classic matrix operations"
 msgstr ""
 
@@ -2033,23 +2033,23 @@ msgstr ""
 msgid "Clear"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1102
+#: ../../src/wxMaximaFrame.cpp:1109
 msgid "Clear all aliases"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1099
+#: ../../src/wxMaximaFrame.cpp:1106
 msgid "Clear all arrays"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1096
+#: ../../src/wxMaximaFrame.cpp:1103
 msgid "Clear all dependencies"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1098
+#: ../../src/wxMaximaFrame.cpp:1105
 msgid "Clear all functions"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1105
+#: ../../src/wxMaximaFrame.cpp:1112
 msgid "Clear all gradefs"
 msgstr ""
 
@@ -2057,31 +2057,31 @@ msgstr ""
 msgid "Clear all history"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1104
+#: ../../src/wxMaximaFrame.cpp:1111
 msgid "Clear all labels"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1108
+#: ../../src/wxMaximaFrame.cpp:1115
 msgid "Clear all let rule packages"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1107
+#: ../../src/wxMaximaFrame.cpp:1114
 msgid "Clear all macros"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1106
+#: ../../src/wxMaximaFrame.cpp:1113
 msgid "Clear all props"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1101
+#: ../../src/wxMaximaFrame.cpp:1108
 msgid "Clear all rules"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1103
+#: ../../src/wxMaximaFrame.cpp:1110
 msgid "Clear all structures"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1097
+#: ../../src/wxMaximaFrame.cpp:1104
 msgid "Clear all variables"
 msgstr ""
 
@@ -2098,7 +2098,7 @@ msgstr ""
 msgid "Clipboard format parameters"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:704
+#: ../../src/wxMaximaFrame.cpp:711
 msgid "Close\tCtrl+W"
 msgstr ""
 
@@ -2106,11 +2106,11 @@ msgstr ""
 msgid "Close Stream"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:704
+#: ../../src/wxMaximaFrame.cpp:711
 msgid "Close window"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1209
+#: ../../src/wxMaximaFrame.cpp:1216
 msgid "Close..."
 msgstr ""
 
@@ -2190,7 +2190,7 @@ msgstr ""
 msgid "Columns:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1691
+#: ../../src/wxMaximaFrame.cpp:1698
 msgid "Combine factorials in an expression"
 msgstr ""
 
@@ -2304,11 +2304,11 @@ msgstr ""
 msgid "Comment Selection"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:785
+#: ../../src/wxMaximaFrame.cpp:792
 msgid "Comment out the currently selected text"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:784
+#: ../../src/wxMaximaFrame.cpp:791
 msgid "Comment selection\tCtrl+/"
 msgstr ""
 
@@ -2316,15 +2316,15 @@ msgstr ""
 msgid "Commutative function"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:716
+#: ../../src/wxMaximaFrame.cpp:723
 msgid "Compare files..."
 msgstr ""
 
-#: ../../src/main.cpp:770
+#: ../../src/main.cpp:786
 msgid "Comparing worksheets (the --diff option or the wxmxdiff command) needs 2 or 3 files to compare."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1500
+#: ../../src/wxMaximaFrame.cpp:1507
 msgid "Compile a QR decomposition using dgeqrf"
 msgstr ""
 
@@ -2332,27 +2332,27 @@ msgstr ""
 msgid "Compile a function"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1292
+#: ../../src/wxMaximaFrame.cpp:1299
 msgid "Compile a regular expression"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1489
+#: ../../src/wxMaximaFrame.cpp:1496
 msgid "Compile eigenvalues using dgeev"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1492
+#: ../../src/wxMaximaFrame.cpp:1499
 msgid "Compile eigenvalues using zgeev"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1495
+#: ../../src/wxMaximaFrame.cpp:1502
 msgid "Compile eigenvalues+eigenvectors using dgeev"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1498
+#: ../../src/wxMaximaFrame.cpp:1505
 msgid "Compile eigenvalues+eigenvectors using zgeev"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1180
+#: ../../src/wxMaximaFrame.cpp:1187
 msgid "Compile function..."
 msgstr ""
 
@@ -2373,11 +2373,11 @@ msgstr ""
 msgid "Compiling a function can generate a considerable speed boost if the types of the function parameters are made known to the function before it is compiled. Else the generated code has to be hideously generic."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:996
+#: ../../src/wxMaximaFrame.cpp:1003
 msgid "Complete Word\tCtrl+Space"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:997
+#: ../../src/wxMaximaFrame.cpp:1004
 msgid "Complete word"
 msgstr ""
 
@@ -2393,35 +2393,35 @@ msgstr ""
 msgid "Composing a list of the line starts we can use as page starts"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1610
+#: ../../src/wxMaximaFrame.cpp:1617
 msgid "Compute continued fraction of a value"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1476
+#: ../../src/wxMaximaFrame.cpp:1483
 msgid "Compute the adjoint matrix"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1463
+#: ../../src/wxMaximaFrame.cpp:1470
 msgid "Compute the characteristic polynomial of a matrix"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1467
+#: ../../src/wxMaximaFrame.cpp:1474
 msgid "Compute the determinant of a matrix"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1598
+#: ../../src/wxMaximaFrame.cpp:1605
 msgid "Compute the greatest common divisor"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1460
+#: ../../src/wxMaximaFrame.cpp:1467
 msgid "Compute the inverse of a matrix"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1601
+#: ../../src/wxMaximaFrame.cpp:1608
 msgid "Compute the least common multiple (do load(functs) before using)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1478
+#: ../../src/wxMaximaFrame.cpp:1485
 msgid "Compute the rank of a matrix"
 msgstr ""
 
@@ -2446,7 +2446,7 @@ msgid "Configuration warning"
 msgstr ""
 
 #: ../../src/ToolBar.cpp:367 ../../src/ToolBar.cpp:369
-#: ../../src/wxMaximaFrame.cpp:789 ../../src/wxMaximaFrame.cpp:791
+#: ../../src/wxMaximaFrame.cpp:796 ../../src/wxMaximaFrame.cpp:798
 msgid "Configure wxMaxima"
 msgstr ""
 
@@ -2472,7 +2472,7 @@ msgstr ""
 msgid "Construct a fraction"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1409
+#: ../../src/wxMaximaFrame.cpp:1416
 msgid "Construct fraction..."
 msgstr ""
 
@@ -2484,11 +2484,11 @@ msgstr ""
 msgid "Contents:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1984
+#: ../../src/wxMaximaFrame.cpp:1991
 msgid "Context-sensitive &Help\tCtrl+?"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1986
+#: ../../src/wxMaximaFrame.cpp:1993
 msgid "Context-sensitive &Help\tF1"
 msgstr ""
 
@@ -2516,55 +2516,55 @@ msgstr ""
 msgid "Contour lines settings for the following 3d plots"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1649
+#: ../../src/wxMaximaFrame.cpp:1656
 msgid "Contract Logarithms"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1265
+#: ../../src/wxMaximaFrame.cpp:1272
 msgid "Conversions"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1333
+#: ../../src/wxMaximaFrame.cpp:1340
 msgid "Convert"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1334
+#: ../../src/wxMaximaFrame.cpp:1341
 msgid "Convert + Write to file"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1541
+#: ../../src/wxMaximaFrame.cpp:1548
 msgid "Convert Column to list..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1537
+#: ../../src/wxMaximaFrame.cpp:1544
 msgid "Convert Row to list..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1148
+#: ../../src/wxMaximaFrame.cpp:1155
 msgid "Convert a command to maxima code"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1425
+#: ../../src/wxMaximaFrame.cpp:1432
 msgid "Convert a list of lists to a matrix"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1681
+#: ../../src/wxMaximaFrame.cpp:1688
 msgid "Convert binomials, beta and gamma function to factorials"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1685
+#: ../../src/wxMaximaFrame.cpp:1692
 msgid "Convert binomials, factorials and beta function to gamma function"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1720
+#: ../../src/wxMaximaFrame.cpp:1727
 msgid "Convert complex expression to polar form"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1717
+#: ../../src/wxMaximaFrame.cpp:1724
 msgid "Convert complex expression to rect form"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1729
+#: ../../src/wxMaximaFrame.cpp:1736
 msgid "Convert exponential function of imaginary argument to trigonometric form"
 msgstr ""
 
@@ -2576,23 +2576,23 @@ msgstr ""
 msgid "Convert string to matching regex"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1650
+#: ../../src/wxMaximaFrame.cpp:1657
 msgid "Convert sum of logarithms to logarithm of product"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1680
+#: ../../src/wxMaximaFrame.cpp:1687
 msgid "Convert to &Factorials"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1684
+#: ../../src/wxMaximaFrame.cpp:1691
 msgid "Convert to &Gamma"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1719
+#: ../../src/wxMaximaFrame.cpp:1726
 msgid "Convert to &Polarform"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1716
+#: ../../src/wxMaximaFrame.cpp:1723
 msgid "Convert to &Rectform"
 msgstr ""
 
@@ -2624,7 +2624,7 @@ msgstr ""
 msgid "Convert to Title"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1270
+#: ../../src/wxMaximaFrame.cpp:1277
 msgid "Convert to downcase..."
 msgstr ""
 
@@ -2636,11 +2636,11 @@ msgstr ""
 msgid "Convert to programming language file"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1709
+#: ../../src/wxMaximaFrame.cpp:1716
 msgid "Convert trigonometric expression to canonical quasilinear form"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1734
+#: ../../src/wxMaximaFrame.cpp:1741
 msgid "Convert trigonometric functions to exponential form"
 msgstr ""
 
@@ -2652,11 +2652,11 @@ msgstr ""
 msgid "Converted to linear:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1869
+#: ../../src/wxMaximaFrame.cpp:1876
 msgid "Converts a matrix to a list of lists"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1867
+#: ../../src/wxMaximaFrame.cpp:1874
 msgid "Converts a nested list like [[1,2],[3,4]] to a matrix"
 msgstr ""
 
@@ -2675,11 +2675,11 @@ msgstr ""
 msgid "Copy Animation"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:991
+#: ../../src/wxMaximaFrame.cpp:998
 msgid "Copy Previous Input\tCtrl+I"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:994
+#: ../../src/wxMaximaFrame.cpp:1001
 msgid "Copy Previous Output\tCtrl+U"
 msgstr ""
 
@@ -2689,7 +2689,7 @@ msgstr ""
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:145
 #: ../../src/worksheet/WorksheetContextMenu.cpp:294
-#: ../../src/wxMaximaFrame.cpp:767
+#: ../../src/wxMaximaFrame.cpp:774
 msgid "Copy as EMF"
 msgstr ""
 
@@ -2700,17 +2700,17 @@ msgstr ""
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:135
 #: ../../src/worksheet/WorksheetContextMenu.cpp:284
-#: ../../src/wxMaximaFrame.cpp:756
+#: ../../src/wxMaximaFrame.cpp:763
 msgid "Copy as Image"
 msgstr ""
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:126
 #: ../../src/worksheet/WorksheetContextMenu.cpp:275
-#: ../../src/wxMaximaFrame.cpp:749
+#: ../../src/wxMaximaFrame.cpp:756
 msgid "Copy as LaTeX"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:752
+#: ../../src/wxMaximaFrame.cpp:759
 msgid "Copy as MathML"
 msgstr ""
 
@@ -2721,17 +2721,17 @@ msgstr ""
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:148
 #: ../../src/worksheet/WorksheetContextMenu.cpp:297
-#: ../../src/wxMaximaFrame.cpp:762
+#: ../../src/wxMaximaFrame.cpp:769
 msgid "Copy as RTF"
 msgstr ""
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:142
 #: ../../src/worksheet/WorksheetContextMenu.cpp:291
-#: ../../src/wxMaximaFrame.cpp:759
+#: ../../src/wxMaximaFrame.cpp:766
 msgid "Copy as SVG"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:744
+#: ../../src/wxMaximaFrame.cpp:751
 msgid "Copy as Text\tCtrl+Shift+C"
 msgstr ""
 
@@ -2744,13 +2744,13 @@ msgstr ""
 msgid "Copy file"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1318
+#: ../../src/wxMaximaFrame.cpp:1325
 msgid "Copy file..."
 msgstr ""
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:124
 #: ../../src/worksheet/WorksheetContextMenu.cpp:273
-#: ../../src/wxMaximaFrame.cpp:747
+#: ../../src/wxMaximaFrame.cpp:754
 msgid "Copy for Octave/Matlab"
 msgstr ""
 
@@ -2762,39 +2762,39 @@ msgid "Copy position (UUID)"
 msgstr ""
 
 #: ../../src/ToolBar.cpp:380 ../../src/ToolBar.cpp:384
-#: ../../src/wxMaximaFrame.cpp:742
+#: ../../src/wxMaximaFrame.cpp:749
 msgid "Copy selection"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:768
+#: ../../src/wxMaximaFrame.cpp:775
 msgid "Copy selection from document as an Enhanced Metafile"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:760
+#: ../../src/wxMaximaFrame.cpp:767
 msgid "Copy selection from document as an SVG image"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:757
+#: ../../src/wxMaximaFrame.cpp:764
 msgid "Copy selection from document as an image"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:763
+#: ../../src/wxMaximaFrame.cpp:770
 msgid "Copy selection from document as rtf that a word processor might understand"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:745
+#: ../../src/wxMaximaFrame.cpp:752
 msgid "Copy selection from document as text"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:750
+#: ../../src/wxMaximaFrame.cpp:757
 msgid "Copy selection from document in LaTeX format"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:748
+#: ../../src/wxMaximaFrame.cpp:755
 msgid "Copy selection from document in Matlab format"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:753
+#: ../../src/wxMaximaFrame.cpp:760
 msgid "Copy selection from document in a MathML format many word processors can display as 2d equation"
 msgstr ""
 
@@ -2802,7 +2802,7 @@ msgstr ""
 msgid "Copy string"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1269
+#: ../../src/wxMaximaFrame.cpp:1276
 msgid "Copy string..."
 msgstr ""
 
@@ -2868,11 +2868,11 @@ msgstr ""
 msgid "Could not write the file's contents during saving => aborting."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1429
+#: ../../src/wxMaximaFrame.cpp:1436
 msgid "Create Matrix"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1795
+#: ../../src/wxMaximaFrame.cpp:1802
 msgid "Create a list"
 msgstr ""
 
@@ -2888,19 +2888,19 @@ msgstr ""
 msgid "Create a list from a rule"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1777
+#: ../../src/wxMaximaFrame.cpp:1784
 msgid "Create a list from comma-separated elements"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:992
+#: ../../src/wxMaximaFrame.cpp:999
 msgid "Create a new cell with previous input"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:995
+#: ../../src/wxMaximaFrame.cpp:1002
 msgid "Create a new cell with previous output"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1452
+#: ../../src/wxMaximaFrame.cpp:1459
 msgid "Create copy, not clone..."
 msgstr ""
 
@@ -2908,7 +2908,7 @@ msgstr ""
 msgid "Create directory"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1307
+#: ../../src/wxMaximaFrame.cpp:1314
 msgid "Create directory..."
 msgstr ""
 
@@ -2916,11 +2916,11 @@ msgstr ""
 msgid "Create empty string"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1272
+#: ../../src/wxMaximaFrame.cpp:1279
 msgid "Create empty string..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1794
+#: ../../src/wxMaximaFrame.cpp:1801
 msgid "Create list"
 msgstr ""
 
@@ -2932,7 +2932,7 @@ msgstr ""
 msgid "Create scalable plots."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1186
+#: ../../src/wxMaximaFrame.cpp:1193
 msgid "Create struct..."
 msgstr ""
 
@@ -2940,7 +2940,7 @@ msgstr ""
 msgid "Created a .zip archive (the .wxmx file technically is a .zip file)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1453
+#: ../../src/wxMaximaFrame.cpp:1460
 msgid "Creates an independent matrix with the same contents"
 msgstr ""
 
@@ -2965,12 +2965,12 @@ msgstr ""
 msgid "Cut"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:740
+#: ../../src/wxMaximaFrame.cpp:747
 msgid "Cut\tCtrl+X"
 msgstr ""
 
 #: ../../src/ToolBar.cpp:379 ../../src/ToolBar.cpp:383
-#: ../../src/wxMaximaFrame.cpp:740
+#: ../../src/wxMaximaFrame.cpp:747
 msgid "Cut selection"
 msgstr ""
 
@@ -3007,11 +3007,11 @@ msgstr ""
 msgid "Data:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1161
+#: ../../src/wxMaximaFrame.cpp:1168
 msgid "Debugger trigger"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:886
+#: ../../src/wxMaximaFrame.cpp:893
 msgid "Declare Text to always be displayed as subscript"
 msgstr ""
 
@@ -3040,7 +3040,7 @@ msgstr ""
 msgid "Declare these chars as ordinary letters"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1607 ../../src/wxMaximaFrame.cpp:1643
+#: ../../src/wxMaximaFrame.cpp:1614 ../../src/wxMaximaFrame.cpp:1650
 msgid "Decompose rational function to partial fractions"
 msgstr ""
 
@@ -3080,19 +3080,19 @@ msgstr ""
 msgid "Define a variable"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1176
+#: ../../src/wxMaximaFrame.cpp:1183
 msgid "Define function..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1183
+#: ../../src/wxMaximaFrame.cpp:1190
 msgid "Define macro..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1181
+#: ../../src/wxMaximaFrame.cpp:1188
 msgid "Define parameter type..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1185
+#: ../../src/wxMaximaFrame.cpp:1192
 msgid "Define struct..."
 msgstr ""
 
@@ -3100,11 +3100,11 @@ msgstr ""
 msgid "Define the default speed (in frames per second) animations are played back with."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1184
+#: ../../src/wxMaximaFrame.cpp:1191
 msgid "Define variable..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1883
+#: ../../src/wxMaximaFrame.cpp:1890
 msgid "Defines if an animation is automatically started or only by clicking on it."
 msgstr ""
 
@@ -3112,7 +3112,7 @@ msgstr ""
 msgid "Degree:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1089
+#: ../../src/wxMaximaFrame.cpp:1096
 msgid "Delete F&unction..."
 msgstr ""
 
@@ -3121,23 +3121,23 @@ msgstr ""
 msgid "Delete Selection"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1091
+#: ../../src/wxMaximaFrame.cpp:1098
 msgid "Delete V&ariable..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1090
+#: ../../src/wxMaximaFrame.cpp:1097
 msgid "Delete a function"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1092
+#: ../../src/wxMaximaFrame.cpp:1099
 msgid "Delete a variable"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1086
+#: ../../src/wxMaximaFrame.cpp:1093
 msgid "Delete all objects with a given name"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1095
+#: ../../src/wxMaximaFrame.cpp:1102
 msgid "Delete all values from memory"
 msgstr ""
 
@@ -3145,7 +3145,7 @@ msgstr ""
 msgid "Delete file"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1320
+#: ../../src/wxMaximaFrame.cpp:1327
 msgid "Delete file..."
 msgstr ""
 
@@ -3157,7 +3157,7 @@ msgstr ""
 msgid "Delete named object(s)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1085
+#: ../../src/wxMaximaFrame.cpp:1092
 msgid "Delete named object..."
 msgstr ""
 
@@ -3179,7 +3179,7 @@ msgstr ""
 msgid "Demo for \"%s\""
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:2037
+#: ../../src/wxMaximaFrame.cpp:2044
 msgid "Demos"
 msgstr ""
 
@@ -3191,7 +3191,7 @@ msgstr ""
 msgid "Denominator:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1134
+#: ../../src/wxMaximaFrame.cpp:1141
 msgid "Dependencies"
 msgstr ""
 
@@ -3234,7 +3234,7 @@ msgstr ""
 msgid "Deviation..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1604
+#: ../../src/wxMaximaFrame.cpp:1611
 msgid "Di&vide Polynomials..."
 msgstr ""
 
@@ -3275,7 +3275,7 @@ msgstr ""
 msgid "Differentiate"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1574
+#: ../../src/wxMaximaFrame.cpp:1581
 msgid "Differentiate expression"
 msgstr ""
 
@@ -3295,11 +3295,11 @@ msgstr ""
 msgid "Direction:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1316
+#: ../../src/wxMaximaFrame.cpp:1323
 msgid "Directory operations"
 msgstr ""
 
-#: ../../src/main.cpp:315
+#: ../../src/main.cpp:331
 msgid "Disabled the console's QuickEdit mode for this batch run so a click into the console cannot suspend wxMaxima."
 msgstr ""
 
@@ -3311,7 +3311,7 @@ msgstr ""
 msgid "Display"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1145
+#: ../../src/wxMaximaFrame.cpp:1152
 msgid "Display Te&X Form"
 msgstr ""
 
@@ -3327,15 +3327,15 @@ msgstr ""
 msgid "Display all digits"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:858
+#: ../../src/wxMaximaFrame.cpp:865
 msgid "Display an expression as maxima's internal lisp representation"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:861
+#: ../../src/wxMaximaFrame.cpp:868
 msgid "Display an expression as wxMaxima's internal XML representation"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:865
+#: ../../src/wxMaximaFrame.cpp:872
 msgid "Display equations"
 msgstr ""
 
@@ -3347,7 +3347,7 @@ msgstr ""
 msgid "Display expression in wxMaxima's internal representation"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1146
+#: ../../src/wxMaximaFrame.cpp:1153
 msgid "Display last result in TeX form"
 msgstr ""
 
@@ -3360,11 +3360,11 @@ msgstr ""
 msgid "Display resolution according to wxWidgets: %li x %li ppi"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:909
+#: ../../src/wxMaximaFrame.cpp:916
 msgid "Display string quotation marks"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1140
+#: ../../src/wxMaximaFrame.cpp:1147
 msgid "Display time used for evaluation"
 msgstr ""
 
@@ -3372,32 +3372,32 @@ msgstr ""
 msgid "Displayed Precision"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:2020
+#: ../../src/wxMaximaFrame.cpp:2027
 msgid "Displaying 3d curves"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1569
+#: ../../src/wxMaximaFrame.cpp:1576
 msgid "Dito, and evaluate the result..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1552
+#: ../../src/wxMaximaFrame.cpp:1559
 msgid "Dito, but affect all clones of the Matrix..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1359
+#: ../../src/wxMaximaFrame.cpp:1366
 msgid "Dito, but as fraction (real only)..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1639
+#: ../../src/wxMaximaFrame.cpp:1646
 msgid "Dito, including denominator"
 msgstr ""
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:492
-#: ../../src/wxMaximaFrame.cpp:1048
+#: ../../src/wxMaximaFrame.cpp:1055
 msgid "Divide Cell"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1605
+#: ../../src/wxMaximaFrame.cpp:1612
 msgid "Divide numbers or polynomials"
 msgstr ""
 
@@ -3414,7 +3414,7 @@ msgstr ""
 msgid "Do you want to save the changes you made in the document \"%s\"?"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:831
+#: ../../src/wxMaximaFrame.cpp:838
 msgid "Dock all Sidebars"
 msgstr ""
 
@@ -3438,11 +3438,11 @@ msgstr ""
 msgid "Documentclass options:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:877
+#: ../../src/wxMaximaFrame.cpp:884
 msgid "Don't autosubscript after an underscore"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1190
+#: ../../src/wxMaximaFrame.cpp:1197
 msgid "Don't evaluate Expression..."
 msgstr ""
 
@@ -3476,7 +3476,7 @@ msgstr ""
 msgid "Don't use if unassigned"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:904
+#: ../../src/wxMaximaFrame.cpp:911
 msgid "Don't use parenthesis for matrices"
 msgstr ""
 
@@ -3508,35 +3508,35 @@ msgstr ""
 msgid "Dutch"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1410
+#: ../../src/wxMaximaFrame.cpp:1417
 msgid "E&quations"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:725
+#: ../../src/TrayIcon.cpp:114 ../../src/wxMaximaFrame.cpp:732
 msgid "E&xit\tCtrl+Q"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1472
+#: ../../src/wxMaximaFrame.cpp:1479
 msgid "Eige&nvectors"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1469
+#: ../../src/wxMaximaFrame.cpp:1476
 msgid "Eigen&values"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1491
+#: ../../src/wxMaximaFrame.cpp:1498
 msgid "Eigenvalues (complex)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1488
+#: ../../src/wxMaximaFrame.cpp:1495
 msgid "Eigenvalues (real)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1497
+#: ../../src/wxMaximaFrame.cpp:1504
 msgid "Eigenvalues, left+right eigenvectors (complex)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1494
+#: ../../src/wxMaximaFrame.cpp:1501
 msgid "Eigenvalues, left+right eigenvectors (real)"
 msgstr ""
 
@@ -3578,7 +3578,7 @@ msgstr ""
 msgid "Element-by-element exponentiation of two matrices"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1446
+#: ../../src/wxMaximaFrame.cpp:1453
 msgid "Element-by-element multiplication"
 msgstr ""
 
@@ -3594,7 +3594,7 @@ msgstr ""
 msgid "Eliminate a variable"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1351
+#: ../../src/wxMaximaFrame.cpp:1358
 msgid "Eliminate a variable from a system of equations"
 msgstr ""
 
@@ -3644,7 +3644,7 @@ msgstr ""
 msgid "Ended lisp mode after receiving a maxima prompt!"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1935
+#: ../../src/wxMaximaFrame.cpp:1942
 msgid "Engineering format (12.1e6 etc.)"
 msgstr ""
 
@@ -3668,7 +3668,7 @@ msgstr ""
 msgid "Enter UUID to jump to:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1423
+#: ../../src/wxMaximaFrame.cpp:1430
 msgid "Enter a matrix"
 msgstr ""
 
@@ -3712,7 +3712,7 @@ msgstr ""
 msgid "Enumerator:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1324
+#: ../../src/wxMaximaFrame.cpp:1331
 msgid "Environment variables"
 msgstr ""
 
@@ -3728,11 +3728,11 @@ msgstr ""
 msgid "Epsilon:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1228 ../../src/wxMaximaFrame.cpp:1239
+#: ../../src/wxMaximaFrame.cpp:1235 ../../src/wxMaximaFrame.cpp:1246
 msgid "Equal, ignoring case?..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1237
+#: ../../src/wxMaximaFrame.cpp:1244
 msgid "Equal?..."
 msgstr ""
 
@@ -3771,7 +3771,7 @@ msgstr ""
 #: ../../src/WXMXformat.cpp:290 ../../src/WXMXformat.cpp:298
 #: ../../src/WXMXformat.cpp:313 ../../src/WXMXformat.cpp:334
 #: ../../src/WXMXformat.cpp:364 ../../src/dialogs/BinaryNameCtrl.cpp:78
-#: ../../src/main.cpp:772 ../../src/sidebars/AiChatSidebar.cpp:205
+#: ../../src/main.cpp:788 ../../src/sidebars/AiChatSidebar.cpp:205
 #: ../../src/wxMaxima.cpp:3480 ../../src/wxMaxima.cpp:3516
 #: ../../src/wxMaxima.cpp:3534 ../../src/wxMaxima.cpp:3568
 msgid "Error"
@@ -3823,15 +3823,15 @@ msgstr ""
 msgid "Evaluate"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1759
+#: ../../src/wxMaximaFrame.cpp:1766
 msgid "Evaluate &Noun Forms..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:960
+#: ../../src/wxMaximaFrame.cpp:967
 msgid "Evaluate All Cells\tCtrl+Shift+R"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:955
+#: ../../src/wxMaximaFrame.cpp:962
 msgid "Evaluate All Visible Cells\tCtrl+R"
 msgstr ""
 
@@ -3840,7 +3840,7 @@ msgid "Evaluate Cell"
 msgstr ""
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:171
-#: ../../src/wxMaximaFrame.cpp:948
+#: ../../src/wxMaximaFrame.cpp:955
 msgid "Evaluate Cell(s)"
 msgstr ""
 
@@ -3849,13 +3849,13 @@ msgstr ""
 msgid "Evaluate Cells Above"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:970
+#: ../../src/wxMaximaFrame.cpp:977
 msgid "Evaluate Cells Above\tCtrl+Shift+P"
 msgstr ""
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:175
 #: ../../src/worksheet/WorksheetContextMenu.cpp:453
-#: ../../src/wxMaximaFrame.cpp:980
+#: ../../src/wxMaximaFrame.cpp:987
 msgid "Evaluate Cells Below"
 msgstr ""
 
@@ -3897,7 +3897,7 @@ msgstr ""
 msgid "Evaluate Subsection\tShift+Ctrl+Enter"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:949
+#: ../../src/wxMaximaFrame.cpp:956
 msgid "Evaluate active or selected cell(s)"
 msgstr ""
 
@@ -3905,15 +3905,15 @@ msgstr ""
 msgid "Evaluate all"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:961
+#: ../../src/wxMaximaFrame.cpp:968
 msgid "Evaluate all cells in the document"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1760
+#: ../../src/wxMaximaFrame.cpp:1767
 msgid "Evaluate all noun forms in expression"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:956
+#: ../../src/wxMaximaFrame.cpp:963
 msgid "Evaluate all visible cells in the document"
 msgstr ""
 
@@ -3925,7 +3925,7 @@ msgstr ""
 msgid "Evaluate string"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1255
+#: ../../src/wxMaximaFrame.cpp:1262
 msgid "Evaluate string..."
 msgstr ""
 
@@ -3961,11 +3961,11 @@ msgstr ""
 msgid "Examples:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1810
+#: ../../src/wxMaximaFrame.cpp:1817
 msgid "Execute a command for each element of the list"
 msgstr ""
 
-#: ../../src/main.cpp:724
+#: ../../src/main.cpp:740
 msgid "Exit"
 msgstr ""
 
@@ -3981,11 +3981,11 @@ msgstr ""
 msgid "Expand Expression"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1632
+#: ../../src/wxMaximaFrame.cpp:1639
 msgid "Expand an expression"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1638
+#: ../../src/wxMaximaFrame.cpp:1645
 msgid "Expand for given variables"
 msgstr ""
 
@@ -3997,19 +3997,19 @@ msgstr ""
 msgid "Expand for variable(s):"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1652
+#: ../../src/wxMaximaFrame.cpp:1659
 msgid "Expand log in previous expression"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1705
+#: ../../src/wxMaximaFrame.cpp:1712
 msgid "Expand trigonometric expression"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1895
+#: ../../src/wxMaximaFrame.cpp:1902
 msgid "Expect numbers harder to be complex"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1896
+#: ../../src/wxMaximaFrame.cpp:1903
 msgid "Expect variables to contain complex numbers"
 msgstr ""
 
@@ -4022,15 +4022,15 @@ msgstr ""
 msgid "Export As"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1812
+#: ../../src/wxMaximaFrame.cpp:1819
 msgid "Export List to csv file..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1813
+#: ../../src/wxMaximaFrame.cpp:1820
 msgid "Export a list to a csv file"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1436
+#: ../../src/wxMaximaFrame.cpp:1443
 msgid "Export a matrix to a csv file"
 msgstr ""
 
@@ -4046,7 +4046,7 @@ msgstr ""
 msgid "Export commands from the current maxima session to a .mac file"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:719
+#: ../../src/wxMaximaFrame.cpp:726
 msgid "Export document to a HTML or LaTeX file"
 msgstr ""
 
@@ -4054,7 +4054,7 @@ msgstr ""
 msgid "Export equations to HTML as:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:656
+#: ../../src/wxMaximaFrame.cpp:663
 msgid "Export failed."
 msgstr ""
 
@@ -4070,7 +4070,7 @@ msgstr ""
 msgid "Export selected commands to a .mac file"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:644
+#: ../../src/wxMaximaFrame.cpp:651
 msgid "Export successful."
 msgstr ""
 
@@ -4112,7 +4112,7 @@ msgstr ""
 msgid "Exporting to maxima batch file failed!"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:638
+#: ../../src/wxMaximaFrame.cpp:645
 msgid "Exporting..."
 msgstr ""
 
@@ -4148,7 +4148,7 @@ msgstr ""
 msgid "Expression to plot"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1192
+#: ../../src/wxMaximaFrame.cpp:1199
 msgid "Expression to string..."
 msgstr ""
 
@@ -4171,23 +4171,23 @@ msgstr ""
 msgid "Expression:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1527
+#: ../../src/wxMaximaFrame.cpp:1534
 msgid "Extract Column..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1833
+#: ../../src/wxMaximaFrame.cpp:1840
 msgid "Extract Elements"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1525
+#: ../../src/wxMaximaFrame.cpp:1532
 msgid "Extract Row..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1528
+#: ../../src/wxMaximaFrame.cpp:1535
 msgid "Extract a column from the matrix"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1542
+#: ../../src/wxMaximaFrame.cpp:1549
 msgid "Extract a column from the matrix and convert it to a list"
 msgstr ""
 
@@ -4199,7 +4199,7 @@ msgstr ""
 msgid "Extract a matrix column as a list"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1417
+#: ../../src/wxMaximaFrame.cpp:1424
 msgid "Extract a matrix from a 2-dimensional array"
 msgstr ""
 
@@ -4211,11 +4211,11 @@ msgstr ""
 msgid "Extract a matrix row as a list"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1526
+#: ../../src/wxMaximaFrame.cpp:1533
 msgid "Extract a row from the matrix"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1538
+#: ../../src/wxMaximaFrame.cpp:1545
 msgid "Extract a row from the matrix and convert it to a list"
 msgstr ""
 
@@ -4223,15 +4223,15 @@ msgstr ""
 msgid "Extract a variable's value from a list of variable values"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1830
+#: ../../src/wxMaximaFrame.cpp:1837
 msgid "Extract an actual value for a variable"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1267
+#: ../../src/wxMaximaFrame.cpp:1274
 msgid "Extract char..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1311
+#: ../../src/wxMaximaFrame.cpp:1318
 msgid "Extract dir from path..."
 msgstr ""
 
@@ -4243,7 +4243,7 @@ msgstr ""
 msgid "Extract file type extension"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1313
+#: ../../src/wxMaximaFrame.cpp:1320
 msgid "Extract filename from path..."
 msgstr ""
 
@@ -4251,7 +4251,7 @@ msgstr ""
 msgid "Extract filename part"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1315
+#: ../../src/wxMaximaFrame.cpp:1322
 msgid "Extract filetype from path..."
 msgstr ""
 
@@ -4259,7 +4259,7 @@ msgstr ""
 msgid "Extract function arguments"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1834
+#: ../../src/wxMaximaFrame.cpp:1841
 msgid "Extract list Elements"
 msgstr ""
 
@@ -4267,7 +4267,7 @@ msgstr ""
 msgid "Extract matrix from 2D array"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1793
+#: ../../src/wxMaximaFrame.cpp:1800
 msgid "Extract the argument list from a function call"
 msgstr ""
 
@@ -4287,11 +4287,11 @@ msgstr ""
 msgid "Extract the nth list elements"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1831
+#: ../../src/wxMaximaFrame.cpp:1838
 msgid "Extract the value for one variable assigned in a list"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1546
+#: ../../src/wxMaximaFrame.cpp:1553
 msgid "Extract, append or delete rows or columns"
 msgstr ""
 
@@ -4303,7 +4303,7 @@ msgstr ""
 msgid "Factor"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1628
+#: ../../src/wxMaximaFrame.cpp:1635
 msgid "Factor Complex"
 msgstr ""
 
@@ -4311,19 +4311,19 @@ msgstr ""
 msgid "Factor Expression"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1626
+#: ../../src/wxMaximaFrame.cpp:1633
 msgid "Factor Expression including subexpressions"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1624 ../../src/wxMaximaFrame.cpp:1627
+#: ../../src/wxMaximaFrame.cpp:1631 ../../src/wxMaximaFrame.cpp:1634
 msgid "Factor an expression"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1629
+#: ../../src/wxMaximaFrame.cpp:1636
 msgid "Factor an expression in Gaussian numbers"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1694
+#: ../../src/wxMaximaFrame.cpp:1701
 msgid "Factorials and &Gamma"
 msgstr ""
 
@@ -4345,11 +4345,11 @@ msgstr ""
 msgid "Failed to write to Maxima's stdin (LDB)."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1522
+#: ../../src/wxMaximaFrame.cpp:1529
 msgid "Fast fortran routines that perform numerical tasks"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:2029
+#: ../../src/wxMaximaFrame.cpp:2036
 msgid "Fast list access"
 msgstr ""
 
@@ -4378,11 +4378,11 @@ msgstr ""
 msgid "Figure %d:"
 msgstr ""
 
-#: ../../src/main.cpp:725
+#: ../../src/main.cpp:741
 msgid "File"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1437
+#: ../../src/wxMaximaFrame.cpp:1444
 msgid "File I/O"
 msgstr ""
 
@@ -4406,7 +4406,7 @@ msgstr ""
 msgid "File opened"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1321
+#: ../../src/wxMaximaFrame.cpp:1328
 msgid "File operations"
 msgstr ""
 
@@ -4414,7 +4414,7 @@ msgstr ""
 msgid "File you tried to open does not exist."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1325
+#: ../../src/wxMaximaFrame.cpp:1332
 msgid "File/directory functions"
 msgstr ""
 
@@ -4434,15 +4434,15 @@ msgstr ""
 msgid "Find"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:774
+#: ../../src/wxMaximaFrame.cpp:781
 msgid "Find\tCtrl+F"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1575
+#: ../../src/wxMaximaFrame.cpp:1582
 msgid "Find &Limit..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1577
+#: ../../src/wxMaximaFrame.cpp:1584
 msgid "Find Minimum..."
 msgstr ""
 
@@ -4450,48 +4450,48 @@ msgstr ""
 msgid "Find Root..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1578
+#: ../../src/wxMaximaFrame.cpp:1585
 msgid "Find a (unconstrained) minimum of an expression"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1911
+#: ../../src/wxMaximaFrame.cpp:1918
 msgid "Find a fraction that represents this float exactly"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1576
+#: ../../src/wxMaximaFrame.cpp:1583
 msgid "Find a limit of an expression"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1914
+#: ../../src/wxMaximaFrame.cpp:1921
 msgid "Find a nice fraction that is similar to this float"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1387
+#: ../../src/wxMaximaFrame.cpp:1394
 msgid "Find a numerical solution for a first degree ODE"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1356
+#: ../../src/wxMaximaFrame.cpp:1363
 msgid "Find a root of an equation on an interval"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1363
+#: ../../src/wxMaximaFrame.cpp:1370
 msgid "Find all roots of a polynomial"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1366
+#: ../../src/wxMaximaFrame.cpp:1373
 msgid "Find all roots of a polynomial (bfloat)"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:3129 ../../src/wxMaximaFrame.cpp:374
+#: ../../src/MaximaCommandMenus.cpp:3129 ../../src/wxMaximaFrame.cpp:377
 msgid "Find and Replace"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:818
+#: ../../src/wxMaximaFrame.cpp:825
 msgid "Find and Replace (if set to dockable)"
 msgstr ""
 
 #: ../../src/ToolBar.cpp:401 ../../src/ToolBar.cpp:403
-#: ../../src/wxMaximaFrame.cpp:774
+#: ../../src/wxMaximaFrame.cpp:781
 msgid "Find and replace"
 msgstr ""
 
@@ -4499,19 +4499,19 @@ msgstr ""
 msgid "Find char in string"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1276
+#: ../../src/wxMaximaFrame.cpp:1283
 msgid "Find char in string..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1641
+#: ../../src/wxMaximaFrame.cpp:1648
 msgid "Find common denominator"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1470
+#: ../../src/wxMaximaFrame.cpp:1477
 msgid "Find eigenvalues of a matrix"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1473
+#: ../../src/wxMaximaFrame.cpp:1480
 msgid "Find eigenvectors of a matrix"
 msgstr ""
 
@@ -4519,11 +4519,11 @@ msgstr ""
 msgid "Find first difference"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1274
+#: ../../src/wxMaximaFrame.cpp:1281
 msgid "Find first difference..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1360
+#: ../../src/wxMaximaFrame.cpp:1367
 msgid "Find fractions that real roots of a polynomial and "
 msgstr ""
 
@@ -4531,7 +4531,7 @@ msgstr ""
 msgid "Find minimum"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1355
+#: ../../src/wxMaximaFrame.cpp:1362
 msgid "Find numerical solution..."
 msgstr ""
 
@@ -4555,7 +4555,7 @@ msgstr ""
 msgid "Find:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1939
+#: ../../src/wxMaximaFrame.cpp:1946
 msgid "Fine-tune the display of engineering-format numbers"
 msgstr ""
 
@@ -4563,11 +4563,11 @@ msgstr ""
 msgid "Finnish"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1819
+#: ../../src/wxMaximaFrame.cpp:1826
 msgid "First"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:2025
+#: ../../src/wxMaximaFrame.cpp:2032
 msgid "Fitting curves to measurement data"
 msgstr ""
 
@@ -4584,15 +4584,15 @@ msgstr ""
 msgid "Flush stream"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1207
+#: ../../src/wxMaximaFrame.cpp:1214
 msgid "Flush..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1026
+#: ../../src/wxMaximaFrame.cpp:1033
 msgid "Fold All\tCtrl+Alt+["
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1027
+#: ../../src/wxMaximaFrame.cpp:1034
 msgid "Fold all sections"
 msgstr ""
 
@@ -4646,7 +4646,7 @@ msgstr ""
 msgid "For loop"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1166
+#: ../../src/wxMaximaFrame.cpp:1173
 msgid "For loop..."
 msgstr ""
 
@@ -4686,7 +4686,7 @@ msgstr ""
 msgid "Fourier coefficients"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1583
+#: ../../src/wxMaximaFrame.cpp:1590
 msgid "Fourier coefficients..."
 msgstr ""
 
@@ -4711,7 +4711,7 @@ msgstr ""
 msgid "Frame rate"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1109 ../../src/wxMaximaFrame.cpp:1113
+#: ../../src/wxMaximaFrame.cpp:1116 ../../src/wxMaximaFrame.cpp:1120
 msgid "Free all unused items now"
 msgstr ""
 
@@ -4719,11 +4719,11 @@ msgstr ""
 msgid "French"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1517
+#: ../../src/wxMaximaFrame.cpp:1524
 msgid "Frobenius Norm sqrt(sum((A(i,j))^2)) (complex)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1515
+#: ../../src/wxMaximaFrame.cpp:1522
 msgid "Frobenius Norm sqrt(sum((A(i,j))^2)) (real)"
 msgstr ""
 
@@ -4734,11 +4734,11 @@ msgstr ""
 msgid "From:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:934
+#: ../../src/wxMaximaFrame.cpp:941
 msgid "Full Screen\tAlt+Enter"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:931
+#: ../../src/wxMaximaFrame.cpp:938
 msgid "Full Screen\tF11"
 msgstr ""
 
@@ -4770,15 +4770,15 @@ msgstr ""
 msgid "Function:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1737
+#: ../../src/wxMaximaFrame.cpp:1744
 msgid "Functions for complex simplification"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1695
+#: ../../src/wxMaximaFrame.cpp:1702
 msgid "Functions for simplifying factorials and gamma function"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1713
+#: ../../src/wxMaximaFrame.cpp:1720
 msgid "Functions for simplifying trigonometric expressions"
 msgstr ""
 
@@ -4806,31 +4806,31 @@ msgstr ""
 msgid "Gamma"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:333
+#: ../../src/wxMaximaFrame.cpp:336
 msgid "General Math"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:801
+#: ../../src/wxMaximaFrame.cpp:808
 msgid "General Math\tAlt+Shift+M"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1420
+#: ../../src/wxMaximaFrame.cpp:1427
 msgid "Generate Matrix from Expression..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1421
+#: ../../src/wxMaximaFrame.cpp:1428
 msgid "Generate a matrix from a lambda expression"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1782
+#: ../../src/wxMaximaFrame.cpp:1789
 msgid "Generate a new list using a lists' elements"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1788
+#: ../../src/wxMaximaFrame.cpp:1795
 msgid "Generate a storage for variable values that can be introduced into equations at any time"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1779
+#: ../../src/wxMaximaFrame.cpp:1786
 msgid "Generate list elements using a rule"
 msgstr ""
 
@@ -4838,7 +4838,7 @@ msgstr ""
 msgid "Generate matrix from a rule"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1198
+#: ../../src/wxMaximaFrame.cpp:1205
 msgid "Generate unused symbol name"
 msgstr ""
 
@@ -4858,23 +4858,23 @@ msgstr ""
 msgid "German"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1726
+#: ../../src/wxMaximaFrame.cpp:1733
 msgid "Get &Imaginary Part"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1592
+#: ../../src/wxMaximaFrame.cpp:1599
 msgid "Get Laplace transformation of an expression"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1722
+#: ../../src/wxMaximaFrame.cpp:1729
 msgid "Get Real P&art"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1305
+#: ../../src/wxMaximaFrame.cpp:1312
 msgid "Get current directory"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1596
+#: ../../src/wxMaximaFrame.cpp:1603
 msgid "Get inverse Laplace transformation of an expression"
 msgstr ""
 
@@ -4882,15 +4882,15 @@ msgstr ""
 msgid "Get position in stream"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1206
+#: ../../src/wxMaximaFrame.cpp:1213
 msgid "Get position..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1727
+#: ../../src/wxMaximaFrame.cpp:1734
 msgid "Get the imaginary part of complex expression"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1723
+#: ../../src/wxMaximaFrame.cpp:1730
 msgid "Get the real part of complex expression"
 msgstr ""
 
@@ -4925,7 +4925,7 @@ msgid ""
 "%s"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:2071 ../../src/wxMaximaFrame.cpp:1994
+#: ../../src/MaximaCommandMenus.cpp:2071 ../../src/wxMaximaFrame.cpp:2001
 msgid "Go to URL"
 msgstr ""
 
@@ -4937,7 +4937,7 @@ msgstr ""
 msgid "Got a request to undo an action that involves a delete which isn't possible at this moment."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1135
+#: ../../src/wxMaximaFrame.cpp:1142
 msgid "Gradefs"
 msgstr ""
 
@@ -4945,7 +4945,7 @@ msgstr ""
 msgid "Greater or less than a value"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1234
+#: ../../src/wxMaximaFrame.cpp:1241
 msgid "Greater, ignoring case?..."
 msgstr ""
 
@@ -4953,11 +4953,11 @@ msgstr ""
 msgid "Greek"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:284
+#: ../../src/wxMaximaFrame.cpp:287
 msgid "Greek Letters"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:805
+#: ../../src/wxMaximaFrame.cpp:812
 msgid "Greek Letters\tAlt+Shift+G"
 msgstr ""
 
@@ -4969,7 +4969,7 @@ msgstr ""
 msgid "Grid:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1922
+#: ../../src/wxMaximaFrame.cpp:1929
 msgid "Guess an exact number that could be meant by this float"
 msgstr ""
 
@@ -4981,7 +4981,7 @@ msgstr ""
 msgid "HTML file (*.html)|*.html|maxima batch file (*.mac)|*.mac|LaTeX file (*.tex)|*.tex"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1445
+#: ../../src/wxMaximaFrame.cpp:1452
 msgid "Hadamard (element-by-element) product..."
 msgstr ""
 
@@ -4993,7 +4993,7 @@ msgstr ""
 msgid "Hadamard exponent"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1449
+#: ../../src/wxMaximaFrame.cpp:1456
 msgid "Hadamard exponent..."
 msgstr ""
 
@@ -5017,7 +5017,7 @@ msgid "Hebrew"
 msgstr ""
 
 #: ../../src/ToolBar.cpp:544 ../../src/ToolBar.cpp:546
-#: ../../src/wxMaximaFrame.cpp:387
+#: ../../src/wxMaximaFrame.cpp:390
 msgid "Help"
 msgstr ""
 
@@ -5048,7 +5048,7 @@ msgstr ""
 msgid "Hide Code"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:834
+#: ../../src/wxMaximaFrame.cpp:841
 msgid "Hide Code Cells\tAlt+Ctrl+H"
 msgstr ""
 
@@ -5076,7 +5076,7 @@ msgstr ""
 msgid "Hide Subsubsection"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:836
+#: ../../src/wxMaximaFrame.cpp:843
 msgid "Hide all Sidebars\tAlt+Shift+-"
 msgstr ""
 
@@ -5084,7 +5084,7 @@ msgstr ""
 msgid "Hide all multiplication signs that aren't really necessary for understanding the equation"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:837
+#: ../../src/wxMaximaFrame.cpp:844
 msgid "Hide all panes"
 msgstr ""
 
@@ -5146,11 +5146,11 @@ msgstr ""
 msgid "Histogram..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:249
+#: ../../src/wxMaximaFrame.cpp:252
 msgid "History"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:811
+#: ../../src/wxMaximaFrame.cpp:818
 msgid "History\tAlt+Shift+I"
 msgstr ""
 
@@ -5158,7 +5158,7 @@ msgstr ""
 msgid "Horizontal cursor works like a normal cursor, but it operates on cells: press up or down arrow to move it, holding down Shift while moving will select cells, pressing backspace or delete twice will delete a cell next to it."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1633
+#: ../../src/wxMaximaFrame.cpp:1640
 msgid "Horner's rule"
 msgstr ""
 
@@ -5170,7 +5170,7 @@ msgstr ""
 msgid "How many digits to show:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:866
+#: ../../src/wxMaximaFrame.cpp:873
 msgid "How to display new equations"
 msgstr ""
 
@@ -5178,7 +5178,7 @@ msgstr ""
 msgid "Hungarian"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1217
+#: ../../src/wxMaximaFrame.cpp:1224
 msgid "I/O"
 msgstr ""
 
@@ -5433,7 +5433,7 @@ msgstr ""
 msgid "Infinity"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:2056
+#: ../../src/wxMaximaFrame.cpp:2063
 msgid "Info about Maxima build"
 msgstr ""
 
@@ -5449,11 +5449,11 @@ msgstr ""
 msgid "Initial Condition"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1374
+#: ../../src/wxMaximaFrame.cpp:1381
 msgid "Initial Value Problem (&1)..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1378
+#: ../../src/wxMaximaFrame.cpp:1385
 msgid "Initial Value Problem (&2)..."
 msgstr ""
 
@@ -5485,7 +5485,7 @@ msgid ""
 "Right-click for options!"
 msgstr ""
 
-#: ../../src/wizards/GenWizPanel.cpp:103 ../../src/wxMaximaFrame.cpp:352
+#: ../../src/wizards/GenWizPanel.cpp:103 ../../src/wxMaximaFrame.cpp:355
 msgid "Insert"
 msgstr ""
 
@@ -5493,15 +5493,15 @@ msgstr ""
 msgid "Insert % before an operator at the beginning of a cell"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1009
+#: ../../src/wxMaximaFrame.cpp:1016
 msgid "Insert &Section Cell\tCtrl+3"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1005
+#: ../../src/wxMaximaFrame.cpp:1012
 msgid "Insert &Text Cell\tCtrl+1"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:815
+#: ../../src/wxMaximaFrame.cpp:822
 msgid "Insert Cell\tAlt+Shift+C"
 msgstr ""
 
@@ -5517,23 +5517,23 @@ msgstr ""
 msgid "Insert Image"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1021
+#: ../../src/wxMaximaFrame.cpp:1028
 msgid "Insert Image..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1003
+#: ../../src/wxMaximaFrame.cpp:1010
 msgid "Insert Input &Cell\tCtrl+0"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1023
+#: ../../src/wxMaximaFrame.cpp:1030
 msgid "Insert Page Break"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1011
+#: ../../src/wxMaximaFrame.cpp:1018
 msgid "Insert S&ubsection Cell\tCtrl+4"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1014
+#: ../../src/wxMaximaFrame.cpp:1021
 msgid "Insert S&ubsubsection Cell\tCtrl+5"
 msgstr ""
 
@@ -5549,7 +5549,7 @@ msgstr ""
 msgid "Insert Subsubsection Cell"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1007
+#: ../../src/wxMaximaFrame.cpp:1014
 msgid "Insert T&itle Cell\tCtrl+2"
 msgstr ""
 
@@ -5561,39 +5561,39 @@ msgstr ""
 msgid "Insert Title Cell"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1017
+#: ../../src/wxMaximaFrame.cpp:1024
 msgid "Insert a new heading5 cell"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1019
+#: ../../src/wxMaximaFrame.cpp:1026
 msgid "Insert a new heading6 cell"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1004
+#: ../../src/wxMaximaFrame.cpp:1011
 msgid "Insert a new input cell"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1010
+#: ../../src/wxMaximaFrame.cpp:1017
 msgid "Insert a new section cell"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1012
+#: ../../src/wxMaximaFrame.cpp:1019
 msgid "Insert a new subsection cell"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1015
+#: ../../src/wxMaximaFrame.cpp:1022
 msgid "Insert a new subsubsection cell"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1006
+#: ../../src/wxMaximaFrame.cpp:1013
 msgid "Insert a new text cell"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1008
+#: ../../src/wxMaximaFrame.cpp:1015
 msgid "Insert a new title cell"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1024
+#: ../../src/wxMaximaFrame.cpp:1031
 msgid "Insert a page break"
 msgstr ""
 
@@ -5601,23 +5601,23 @@ msgstr ""
 msgid "Insert a string into another"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1268
+#: ../../src/wxMaximaFrame.cpp:1275
 msgid "Insert char..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1016
+#: ../../src/wxMaximaFrame.cpp:1023
 msgid "Insert heading5 Cell\tCtrl+6"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1018
+#: ../../src/wxMaximaFrame.cpp:1025
 msgid "Insert heading6 Cell\tCtrl+7"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1021
+#: ../../src/wxMaximaFrame.cpp:1028
 msgid "Insert image"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1020
+#: ../../src/wxMaximaFrame.cpp:1027
 msgid "Insert textbased cell"
 msgstr ""
 
@@ -5658,15 +5658,15 @@ msgstr ""
 msgid "Integrate (risch)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1561
+#: ../../src/wxMaximaFrame.cpp:1568
 msgid "Integrate expression"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1563
+#: ../../src/wxMaximaFrame.cpp:1570
 msgid "Integrate expression with Risch algorithm"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1976
+#: ../../src/wxMaximaFrame.cpp:1983
 msgid "Integrate numerically (QUADPACK)"
 msgstr ""
 
@@ -5687,11 +5687,11 @@ msgstr ""
 msgid "Interactive popup memory limit [MB/plot]:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1844
+#: ../../src/wxMaximaFrame.cpp:1851
 msgid "Interleave"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1845
+#: ../../src/wxMaximaFrame.cpp:1852
 msgid "Interleave the values of two lists"
 msgstr ""
 
@@ -5703,7 +5703,7 @@ msgstr ""
 msgid "Internal"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1191
+#: ../../src/wxMaximaFrame.cpp:1198
 msgid "Interpret like input..."
 msgstr ""
 
@@ -5715,7 +5715,7 @@ msgstr ""
 msgid "Interpret string as maxima code"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1193
+#: ../../src/wxMaximaFrame.cpp:1200
 msgid "Interpret string..."
 msgstr ""
 
@@ -5723,7 +5723,7 @@ msgstr ""
 msgid "Interrupt"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1069
+#: ../../src/wxMaximaFrame.cpp:1076
 msgid "Interrupt current computation"
 msgstr ""
 
@@ -5740,7 +5740,7 @@ msgstr ""
 msgid "Introduce a list of actual values into an equation"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1804
+#: ../../src/wxMaximaFrame.cpp:1811
 msgid "Introduce the actual values for variables stored in the list"
 msgstr ""
 
@@ -5761,7 +5761,7 @@ msgstr ""
 msgid "Inverse Laplace"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1595
+#: ../../src/wxMaximaFrame.cpp:1602
 msgid "Inverse Laplace T&ransform..."
 msgstr ""
 
@@ -5789,7 +5789,7 @@ msgstr ""
 msgid "Is a char?"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1219
+#: ../../src/wxMaximaFrame.cpp:1226
 msgid "Is a char?..."
 msgstr ""
 
@@ -5801,7 +5801,7 @@ msgstr ""
 msgid "Is a digit?"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1222
+#: ../../src/wxMaximaFrame.cpp:1229
 msgid "Is a digit?..."
 msgstr ""
 
@@ -5821,11 +5821,11 @@ msgstr ""
 msgid "Is a uppercase char?"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1220
+#: ../../src/wxMaximaFrame.cpp:1227
 msgid "Is alphabetic?..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1221
+#: ../../src/wxMaximaFrame.cpp:1228
 msgid "Is alphanumeric?..."
 msgstr ""
 
@@ -5853,19 +5853,19 @@ msgstr ""
 msgid "Is an odd function"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1226
+#: ../../src/wxMaximaFrame.cpp:1233
 msgid "Is equal?..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1232
+#: ../../src/wxMaximaFrame.cpp:1239
 msgid "Is greater?..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1229
+#: ../../src/wxMaximaFrame.cpp:1236
 msgid "Is lower?..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1225
+#: ../../src/wxMaximaFrame.cpp:1232
 msgid "Is lowercase?..."
 msgstr ""
 
@@ -5873,11 +5873,11 @@ msgstr ""
 msgid "Is no integer variable"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1223
+#: ../../src/wxMaximaFrame.cpp:1230
 msgid "Is printable?..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1224
+#: ../../src/wxMaximaFrame.cpp:1231
 msgid "Is uppercase?..."
 msgstr ""
 
@@ -5933,11 +5933,11 @@ msgstr ""
 msgid "Jump to UUID"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:728
+#: ../../src/wxMaximaFrame.cpp:735
 msgid "Jump to UUID..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1152
+#: ../../src/wxMaximaFrame.cpp:1159
 msgid "Jump to last error"
 msgstr ""
 
@@ -5949,7 +5949,7 @@ msgstr ""
 msgid "Jump to previous difference"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1153
+#: ../../src/wxMaximaFrame.cpp:1160
 msgid "Jump to the last cell Maxima has reported an error in."
 msgstr ""
 
@@ -5974,19 +5974,19 @@ msgstr ""
 msgid "LCM"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1511
+#: ../../src/wxMaximaFrame.cpp:1518
 msgid "L[1] Norm (complex)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1510
+#: ../../src/wxMaximaFrame.cpp:1517
 msgid "L[1] Norm (real)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1513
+#: ../../src/wxMaximaFrame.cpp:1520
 msgid "L[inf] Norm (complex)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1512
+#: ../../src/wxMaximaFrame.cpp:1519
 msgid "L[inf] Norm (real)"
 msgstr ""
 
@@ -6006,7 +6006,7 @@ msgstr ""
 msgid "Label width:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1129
+#: ../../src/wxMaximaFrame.cpp:1136
 msgid "Labels"
 msgstr ""
 
@@ -6034,11 +6034,11 @@ msgstr ""
 msgid "Laplace"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1591
+#: ../../src/wxMaximaFrame.cpp:1598
 msgid "Laplace &Transform..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1825
+#: ../../src/wxMaximaFrame.cpp:1832
 msgid "Last"
 msgstr ""
 
@@ -6052,7 +6052,7 @@ msgstr ""
 msgid "Last message from maxima's stdout: %s"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1827
+#: ../../src/wxMaximaFrame.cpp:1834
 msgid "Last n"
 msgstr ""
 
@@ -6077,7 +6077,7 @@ msgstr ""
 msgid "Leads to"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1600
+#: ../../src/wxMaximaFrame.cpp:1607
 msgid "Least Common Multiple..."
 msgstr ""
 
@@ -6102,15 +6102,15 @@ msgstr ""
 msgid "Left end"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1401
+#: ../../src/wxMaximaFrame.cpp:1408
 msgid "Left side to the \"=\""
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1848
+#: ../../src/wxMaximaFrame.cpp:1855
 msgid "Length"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1208 ../../src/wxMaximaFrame.cpp:1271
+#: ../../src/wxMaximaFrame.cpp:1215 ../../src/wxMaximaFrame.cpp:1278
 msgid "Length..."
 msgstr ""
 
@@ -6122,7 +6122,7 @@ msgstr ""
 msgid "Let an AI tool read this worksheet (MCP server)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1136
+#: ../../src/wxMaximaFrame.cpp:1143
 msgid "Letrules"
 msgstr ""
 
@@ -6171,7 +6171,7 @@ msgstr ""
 msgid "Lisp mode."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1114 ../../src/wxMaximaFrame.cpp:1116
+#: ../../src/wxMaximaFrame.cpp:1121 ../../src/wxMaximaFrame.cpp:1123
 msgid "Lisp normally frees memory only when it has time or runs out of space"
 msgstr ""
 
@@ -6195,11 +6195,11 @@ msgstr ""
 msgid "List #2"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1304
+#: ../../src/wxMaximaFrame.cpp:1311
 msgid "List directory"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1309
+#: ../../src/wxMaximaFrame.cpp:1316
 msgid "List directory..."
 msgstr ""
 
@@ -6219,7 +6219,7 @@ msgstr ""
 msgid "List of char to String"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1254
+#: ../../src/wxMaximaFrame.cpp:1261
 msgid "List of chars to string..."
 msgstr ""
 
@@ -6296,27 +6296,27 @@ msgstr ""
 msgid "Load Package"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:711
+#: ../../src/wxMaximaFrame.cpp:718
 msgid "Load Recent Package"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:714
+#: ../../src/wxMaximaFrame.cpp:721
 msgid "Load a Maxima file using the batch command"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:709
+#: ../../src/wxMaximaFrame.cpp:716
 msgid "Load a Maxima package file"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1428 ../../src/wxMaximaFrame.cpp:1434
+#: ../../src/wxMaximaFrame.cpp:1435 ../../src/wxMaximaFrame.cpp:1441
 msgid "Load a matrix from a csv file"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1785
+#: ../../src/wxMaximaFrame.cpp:1792
 msgid "Load a nested list from a csv file"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1485 ../../src/wxMaximaFrame.cpp:1486
+#: ../../src/wxMaximaFrame.cpp:1492 ../../src/wxMaximaFrame.cpp:1493
 msgid "Load lapack"
 msgstr ""
 
@@ -6324,7 +6324,7 @@ msgstr ""
 msgid "Load lisp code"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1196
+#: ../../src/wxMaximaFrame.cpp:1203
 msgid "Load lisp..."
 msgstr ""
 
@@ -6332,15 +6332,15 @@ msgstr ""
 msgid "Load style from file"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1302
+#: ../../src/wxMaximaFrame.cpp:1309
 msgid "Load the file/dir operations (operatingsystem)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1291
+#: ../../src/wxMaximaFrame.cpp:1298
 msgid "Load the regular expression package (sregex)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1328
+#: ../../src/wxMaximaFrame.cpp:1335
 msgid "Load the translation generator (gentran)"
 msgstr ""
 
@@ -6356,11 +6356,11 @@ msgstr ""
 msgid "Lower bound:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1231
+#: ../../src/wxMaximaFrame.cpp:1238
 msgid "Lower, ignoring case?..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1555
+#: ../../src/wxMaximaFrame.cpp:1562
 msgid "M&atrix"
 msgstr ""
 
@@ -6390,11 +6390,11 @@ msgstr ""
 msgid "Macro name:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1128
+#: ../../src/wxMaximaFrame.cpp:1135
 msgid "Macros"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:939
+#: ../../src/wxMaximaFrame.cpp:946
 msgid "Main Toolbar\tShift+Alt+B"
 msgstr ""
 
@@ -6406,7 +6406,7 @@ msgstr ""
 msgid "Make an eventual ev() evaluate this"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1174
+#: ../../src/wxMaximaFrame.cpp:1181
 msgid "Make function local..."
 msgstr ""
 
@@ -6434,11 +6434,11 @@ msgstr ""
 msgid "Map an expression"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1550
+#: ../../src/wxMaximaFrame.cpp:1557
 msgid "Map function to a matrix"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1553
+#: ../../src/wxMaximaFrame.cpp:1560
 msgid "Map function to a matrix, affecting all of its clones"
 msgstr ""
 
@@ -6474,7 +6474,7 @@ msgstr ""
 msgid "MathML description"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:324
+#: ../../src/wxMaximaFrame.cpp:327
 msgid "Mathematical Symbols"
 msgstr ""
 
@@ -6498,15 +6498,15 @@ msgstr ""
 msgid "Matrix Exponent"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1443
+#: ../../src/wxMaximaFrame.cpp:1450
 msgid "Matrix exponent..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1433
+#: ../../src/wxMaximaFrame.cpp:1440
 msgid "Matrix from csv file"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1427
+#: ../../src/wxMaximaFrame.cpp:1434
 msgid "Matrix from csv file..."
 msgstr ""
 
@@ -6518,19 +6518,19 @@ msgstr ""
 msgid "Matrix name:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:905
+#: ../../src/wxMaximaFrame.cpp:912
 msgid "Matrix parenthesis"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1435
+#: ../../src/wxMaximaFrame.cpp:1442
 msgid "Matrix to csv file"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1438
+#: ../../src/wxMaximaFrame.cpp:1445
 msgid "Matrix to file or Matrix from file"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1868
+#: ../../src/wxMaximaFrame.cpp:1875
 msgid "Matrix to nested List"
 msgstr ""
 
@@ -6571,7 +6571,7 @@ msgstr ""
 msgid "Maxima architecture: %s"
 msgstr ""
 
-#: ../../src/StatusBar.cpp:330
+#: ../../src/StatusBar.cpp:330 ../../src/TrayIcon.cpp:73
 msgid "Maxima asks a question"
 msgstr ""
 
@@ -6663,7 +6663,7 @@ msgid ""
 "Then restart wxMaxima. wxMaxima will keep waiting and periodically retry in the meantime."
 msgstr ""
 
-#: ../../src/StatusBar.cpp:349
+#: ../../src/StatusBar.cpp:349 ../../src/TrayIcon.cpp:80
 msgid ""
 "Maxima has stopped in a debugger and is waiting for a command.\n"
 "Common commands (type ':h' for the full list):\n"
@@ -6678,11 +6678,11 @@ msgstr ""
 msgid "Maxima help file not found!"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1147
+#: ../../src/wxMaximaFrame.cpp:1154
 msgid "Maxima input"
 msgstr ""
 
-#: ../../src/StatusBar.cpp:299
+#: ../../src/StatusBar.cpp:299 ../../src/TrayIcon.cpp:67
 msgid "Maxima is calculating"
 msgstr ""
 
@@ -6723,7 +6723,7 @@ msgstr ""
 msgid "Maxima question labels"
 msgstr ""
 
-#: ../../src/StatusBar.cpp:339
+#: ../../src/StatusBar.cpp:339 ../../src/TrayIcon.cpp:75
 msgid "Maxima returned an error message"
 msgstr ""
 
@@ -6739,27 +6739,27 @@ msgstr ""
 msgid "Maxima session (*.mac)|*.mac"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1572 ../../src/wxMaximaFrame.cpp:2051
+#: ../../src/dialogs/ConfigDialogue.cpp:1572 ../../src/wxMaximaFrame.cpp:2058
 msgid "Maxima shows help in a browser"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1577 ../../src/wxMaximaFrame.cpp:2047
+#: ../../src/dialogs/ConfigDialogue.cpp:1577 ../../src/wxMaximaFrame.cpp:2054
 msgid "Maxima shows help in a sidebar"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1565 ../../src/wxMaximaFrame.cpp:2042
+#: ../../src/dialogs/ConfigDialogue.cpp:1565 ../../src/wxMaximaFrame.cpp:2049
 msgid "Maxima shows help in the console"
 msgstr ""
 
-#: ../../src/StatusBar.cpp:290
+#: ../../src/StatusBar.cpp:290 ../../src/TrayIcon.cpp:65
 msgid "Maxima started. Waiting for authentication..."
 msgstr ""
 
-#: ../../src/StatusBar.cpp:245
+#: ../../src/StatusBar.cpp:245 ../../src/TrayIcon.cpp:55
 msgid "Maxima started. Waiting for connection..."
 msgstr ""
 
-#: ../../src/StatusBar.cpp:281
+#: ../../src/StatusBar.cpp:281 ../../src/TrayIcon.cpp:63
 msgid "Maxima started. Waiting for initial prompt..."
 msgstr ""
 
@@ -6775,7 +6775,7 @@ msgstr ""
 msgid "Maxima supports three types of numbers: exact fractions (which can be generated for example by typing 1/10), IEEE floating-point numbers (0.2) and arbitrary precision big floats (1b-1). Note that, owing to their nature as binary (not decimal) numbers, there is for example no way to generate an IEEE floating-point number that exactly equals 0.1. If floating-point numbers are used instead of fractions, Maxima will therefore sometimes have to introduce a (very small) error and use things like 3602879701896397/36028797018963968 for 0.1."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1335
+#: ../../src/wxMaximaFrame.cpp:1342
 msgid "Maxima to other language"
 msgstr ""
 
@@ -6830,7 +6830,7 @@ msgstr ""
 msgid "Maxima version: %s, Anchors cache version"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:2032
+#: ../../src/wxMaximaFrame.cpp:2039
 msgid "Maxima vs. Programming languages"
 msgstr ""
 
@@ -6895,7 +6895,7 @@ msgstr ""
 msgid "Maxima's process is running, but hasn't connected back to wxMaxima within 5 seconds."
 msgstr ""
 
-#: ../../src/StatusBar.cpp:365
+#: ../../src/StatusBar.cpp:365 ../../src/TrayIcon.cpp:88
 msgid ""
 "Maxima's reader is in Lisp mode (after to_lisp()).\n"
 "Type Lisp forms; enter (to-maxima) to return to Maxima mode."
@@ -6978,16 +6978,16 @@ msgstr ""
 msgid "Median..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:2031
+#: ../../src/wxMaximaFrame.cpp:2038
 msgid "Memoizing"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1117
+#: ../../src/wxMaximaFrame.cpp:1124
 msgid "Memory"
 msgstr ""
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:182
-#: ../../src/wxMaximaFrame.cpp:1039
+#: ../../src/wxMaximaFrame.cpp:1046
 msgid "Merge Cells"
 msgstr ""
 
@@ -6999,7 +6999,7 @@ msgstr ""
 msgid "Method:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1430
+#: ../../src/wxMaximaFrame.cpp:1437
 msgid "Methods of generating a matrix"
 msgstr ""
 
@@ -7072,7 +7072,7 @@ msgstr ""
 msgid "Mu"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1456
+#: ../../src/wxMaximaFrame.cpp:1463
 msgid "Multiplication, exponent and similar"
 msgstr ""
 
@@ -7080,7 +7080,7 @@ msgstr ""
 msgid "Multiplicative function: f(a*b)=f(a)*f(b)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1442
+#: ../../src/wxMaximaFrame.cpp:1449
 msgid "Multiply matrices..."
 msgstr ""
 
@@ -7108,7 +7108,7 @@ msgstr ""
 msgid "Nepali"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1424 ../../src/wxMaximaFrame.cpp:1866
+#: ../../src/wxMaximaFrame.cpp:1431 ../../src/wxMaximaFrame.cpp:1873
 msgid "Nested list to Matrix"
 msgstr ""
 
@@ -7117,8 +7117,8 @@ msgid "Nested list to matrix"
 msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:765
-#: ../../src/dialogs/ConfigDialogue.cpp:789 ../../src/wxMaximaFrame.cpp:876
-#: ../../src/wxMaximaFrame.cpp:1157
+#: ../../src/dialogs/ConfigDialogue.cpp:789 ../../src/wxMaximaFrame.cpp:883
+#: ../../src/wxMaximaFrame.cpp:1164
 msgid "Never"
 msgstr ""
 
@@ -7126,7 +7126,7 @@ msgstr ""
 msgid "Never autosubscript this variable"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:883
+#: ../../src/wxMaximaFrame.cpp:890
 msgid "Never display this variable with subscript"
 msgstr ""
 
@@ -7139,7 +7139,7 @@ msgstr ""
 msgid "New"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:695
+#: ../../src/wxMaximaFrame.cpp:702
 msgid "New\tCtrl+N"
 msgstr ""
 
@@ -7185,7 +7185,7 @@ msgstr ""
 msgid "New variable:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1033
+#: ../../src/wxMaximaFrame.cpp:1040
 msgid "Next Command\tAlt+Down"
 msgstr ""
 
@@ -7193,12 +7193,12 @@ msgstr ""
 msgid "Next Difference"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:855
+#: ../../src/wxMaximaFrame.cpp:862
 msgid "Nice Graphical Equations"
 msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:742
-#: ../../src/dialogs/ConfigDialogue.cpp:754 ../../src/wxMaximaFrame.cpp:1657
+#: ../../src/dialogs/ConfigDialogue.cpp:754 ../../src/wxMaximaFrame.cpp:1664
 msgid "No"
 msgstr ""
 
@@ -7283,7 +7283,7 @@ msgstr ""
 msgid "Non-builtin symbols"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:904
+#: ../../src/wxMaximaFrame.cpp:911
 msgid "None"
 msgstr ""
 
@@ -7320,7 +7320,7 @@ msgstr ""
 msgid "Not a valid number of equations!"
 msgstr ""
 
-#: ../../src/StatusBar.cpp:375
+#: ../../src/StatusBar.cpp:375 ../../src/TrayIcon.cpp:91
 msgid "Not connected to Maxima"
 msgstr ""
 
@@ -7364,11 +7364,11 @@ msgstr ""
 msgid "Number to octets"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1258
+#: ../../src/wxMaximaFrame.cpp:1265
 msgid "Number to octets..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:2013
+#: ../../src/wxMaximaFrame.cpp:2020
 msgid "Number types"
 msgstr ""
 
@@ -7376,7 +7376,7 @@ msgstr ""
 msgid "Number:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1893
+#: ../../src/wxMaximaFrame.cpp:1900
 msgid "Numeric output"
 msgstr ""
 
@@ -7384,7 +7384,7 @@ msgstr ""
 msgid "Numerical QR decomposition of a matrix"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1521
+#: ../../src/wxMaximaFrame.cpp:1528
 msgid "Numerical operations (lapack)"
 msgstr ""
 
@@ -7392,15 +7392,15 @@ msgstr ""
 msgid "Numerical solution for 1st degree ODE"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1386
+#: ../../src/wxMaximaFrame.cpp:1393
 msgid "Numerical solution..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1365
+#: ../../src/wxMaximaFrame.cpp:1372
 msgid "Numerical solutions of polynomial (bfloat)..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1362
+#: ../../src/wxMaximaFrame.cpp:1369
 msgid "Numerical solutions of polynomial..."
 msgstr ""
 
@@ -7471,11 +7471,11 @@ msgstr ""
 msgid "Octets to String"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1260
+#: ../../src/wxMaximaFrame.cpp:1267
 msgid "Octets to number..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1262
+#: ../../src/wxMaximaFrame.cpp:1269
 msgid "Octets to string..."
 msgstr ""
 
@@ -7512,11 +7512,11 @@ msgstr ""
 msgid "Omicron"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1159
+#: ../../src/wxMaximaFrame.cpp:1166
 msgid "On all errors"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1158
+#: ../../src/wxMaximaFrame.cpp:1165
 msgid "On lisp errors"
 msgstr ""
 
@@ -7524,11 +7524,11 @@ msgstr ""
 msgid "One sample t-test"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:2034
+#: ../../src/wxMaximaFrame.cpp:2041
 msgid "Online tutorials"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:873
+#: ../../src/wxMaximaFrame.cpp:880
 msgid "Only Integers and single letters"
 msgstr ""
 
@@ -7537,7 +7537,7 @@ msgid "Only user-defined labels"
 msgstr ""
 
 #: ../../src/MaximaCommandMenus.cpp:2197 ../../src/ToolBar.cpp:330
-#: ../../src/ToolBar.cpp:333 ../../src/main.cpp:929
+#: ../../src/ToolBar.cpp:333 ../../src/main.cpp:945
 msgid "Open"
 msgstr ""
 
@@ -7545,11 +7545,11 @@ msgstr ""
 msgid "Open a cell when Maxima expects input"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:696
+#: ../../src/wxMaximaFrame.cpp:703
 msgid "Open a document"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:695
+#: ../../src/wxMaximaFrame.cpp:702
 msgid "Open a new window"
 msgstr ""
 
@@ -7565,7 +7565,7 @@ msgstr ""
 msgid "Open for appending"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1203
+#: ../../src/wxMaximaFrame.cpp:1210
 msgid "Open for appending..."
 msgstr ""
 
@@ -7573,7 +7573,7 @@ msgstr ""
 msgid "Open for reading"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1202
+#: ../../src/wxMaximaFrame.cpp:1209
 msgid "Open for reading..."
 msgstr ""
 
@@ -7581,7 +7581,7 @@ msgstr ""
 msgid "Open for writing"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1204
+#: ../../src/wxMaximaFrame.cpp:1211
 msgid "Open for writing..."
 msgstr ""
 
@@ -7589,7 +7589,7 @@ msgstr ""
 msgid "Open matrix"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:698
+#: ../../src/wxMaximaFrame.cpp:705
 msgid "Open recent"
 msgstr ""
 
@@ -7607,11 +7607,11 @@ msgstr ""
 msgid "Opening help file %s"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1637
+#: ../../src/wxMaximaFrame.cpp:1644
 msgid "Optimize for CPU time"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1636
+#: ../../src/wxMaximaFrame.cpp:1643
 msgid "Optimize for memory"
 msgstr ""
 
@@ -7632,15 +7632,15 @@ msgstr ""
 msgid "Output"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1329
+#: ../../src/wxMaximaFrame.cpp:1336
 msgid "Output C"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1330
+#: ../../src/wxMaximaFrame.cpp:1337
 msgid "Output Fortran"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1332
+#: ../../src/wxMaximaFrame.cpp:1339
 msgid "Output Rational Fortran"
 msgstr ""
 
@@ -7693,7 +7693,7 @@ msgstr ""
 msgid "Pade approximation"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1585
+#: ../../src/wxMaximaFrame.cpp:1592
 msgid "Pade approximation of a Taylor series"
 msgstr ""
 
@@ -7701,7 +7701,7 @@ msgstr ""
 msgid "Pagebreak"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1744
+#: ../../src/wxMaximaFrame.cpp:1751
 msgid "Parallel Substitute..."
 msgstr ""
 
@@ -7733,11 +7733,11 @@ msgstr ""
 msgid "Parse string"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1256
+#: ../../src/wxMaximaFrame.cpp:1263
 msgid "Parse string only..."
 msgstr ""
 
-#: ../../src/StatusBar.cpp:308
+#: ../../src/StatusBar.cpp:308 ../../src/TrayIcon.cpp:69
 msgid "Parsing output"
 msgstr ""
 
@@ -7745,7 +7745,7 @@ msgstr ""
 msgid "Part:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1606 ../../src/wxMaximaFrame.cpp:1642
+#: ../../src/wxMaximaFrame.cpp:1613 ../../src/wxMaximaFrame.cpp:1649
 msgid "Partial &Fractions..."
 msgstr ""
 
@@ -7759,7 +7759,7 @@ msgstr ""
 msgid "Paste"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:771
+#: ../../src/wxMaximaFrame.cpp:778
 msgid "Paste\tCtrl+V"
 msgstr ""
 
@@ -7767,11 +7767,11 @@ msgstr ""
 msgid "Paste from clipboard"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:772
+#: ../../src/wxMaximaFrame.cpp:779
 msgid "Paste text from clipboard"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:275 ../../src/wxMaximaFrame.cpp:829
+#: ../../src/wxMaximaFrame.cpp:278 ../../src/wxMaximaFrame.cpp:836
 msgid "Performance Monitor"
 msgstr ""
 
@@ -7811,15 +7811,15 @@ msgstr ""
 msgid "Please select exactly 2 or 3 files."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1875
+#: ../../src/wxMaximaFrame.cpp:1882
 msgid "Plot &2d..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1877
+#: ../../src/wxMaximaFrame.cpp:1884
 msgid "Plot &3d..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1879
+#: ../../src/wxMaximaFrame.cpp:1886
 msgid "Plot &Format..."
 msgstr ""
 
@@ -7869,11 +7869,11 @@ msgstr ""
 msgid "Plot format"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1875
+#: ../../src/wxMaximaFrame.cpp:1882
 msgid "Plot in 2 dimensions"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1877
+#: ../../src/wxMaximaFrame.cpp:1884
 msgid "Plot in 3 dimensions"
 msgstr ""
 
@@ -7885,7 +7885,7 @@ msgstr ""
 msgid "Plot to file:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:358 ../../src/wxMaximaFrame.cpp:816
+#: ../../src/wxMaximaFrame.cpp:361 ../../src/wxMaximaFrame.cpp:823
 msgid "Plot using Draw"
 msgstr ""
 
@@ -7934,7 +7934,7 @@ msgstr ""
 msgid "Polynomial:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1861
+#: ../../src/wxMaximaFrame.cpp:1868
 msgid "Pop"
 msgstr ""
 
@@ -7955,7 +7955,7 @@ msgstr ""
 msgid "Portuguese (Brazilian)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1293
+#: ../../src/wxMaximaFrame.cpp:1300
 msgid "Position of a match"
 msgstr ""
 
@@ -7975,7 +7975,7 @@ msgstr ""
 msgid "Power series"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1582
+#: ../../src/wxMaximaFrame.cpp:1589
 msgid "Power series..."
 msgstr ""
 
@@ -7995,7 +7995,7 @@ msgstr ""
 msgid "Prefer user labels"
 msgstr ""
 
-#: ../../src/main.cpp:723
+#: ../../src/main.cpp:739
 msgid "Preferences"
 msgstr ""
 
@@ -8003,11 +8003,11 @@ msgstr ""
 msgid "Preferences button"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:789
+#: ../../src/wxMaximaFrame.cpp:796
 msgid "Preferences...\tCtrl+,"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1840
+#: ../../src/wxMaximaFrame.cpp:1847
 msgid "Prepend an element"
 msgstr ""
 
@@ -8019,7 +8019,7 @@ msgstr ""
 msgid "Pressing Ctrl+Space or Ctrl+Tab starts an autocomplete function that can not only complete all functions that are integrated into the Maxima core and their parameters: It also knows about parameters from currently loaded packages and from functions that are defined in the current file."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1031
+#: ../../src/wxMaximaFrame.cpp:1038
 msgid "Previous Command\tAlt+Up"
 msgstr ""
 
@@ -8044,11 +8044,11 @@ msgid "Print cell brackets"
 msgstr ""
 
 #: ../../src/ToolBar.cpp:343 ../../src/ToolBar.cpp:345
-#: ../../src/wxMaximaFrame.cpp:722
+#: ../../src/wxMaximaFrame.cpp:729
 msgid "Print document"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1936
+#: ../../src/wxMaximaFrame.cpp:1943
 msgid "Print floating-point numbers with exponents dividable by 3"
 msgstr ""
 
@@ -8124,7 +8124,7 @@ msgstr ""
 msgid "Product sign"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1199
+#: ../../src/wxMaximaFrame.cpp:1206
 msgid "Program"
 msgstr ""
 
@@ -8136,11 +8136,11 @@ msgstr ""
 msgid "Program block"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1170
+#: ../../src/wxMaximaFrame.cpp:1177
 msgid "Program block with local variables..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1172
+#: ../../src/wxMaximaFrame.cpp:1179
 msgid "Program block, no local variables..."
 msgstr ""
 
@@ -8148,7 +8148,7 @@ msgstr ""
 msgid "Psi"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1858
+#: ../../src/wxMaximaFrame.cpp:1865
 msgid "Push"
 msgstr ""
 
@@ -8156,7 +8156,7 @@ msgstr ""
 msgid "Push an element to a list"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1499
+#: ../../src/wxMaximaFrame.cpp:1506
 msgid "QR decomposition"
 msgstr ""
 
@@ -8164,7 +8164,7 @@ msgstr ""
 msgid "Querying gnuplot which graphics drivers it supports."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:725
+#: ../../src/wxMaximaFrame.cpp:732
 msgid "Quit wxMaxima"
 msgstr ""
 
@@ -8176,40 +8176,40 @@ msgstr ""
 msgid "Range radius:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1478
+#: ../../src/wxMaximaFrame.cpp:1485
 msgid "Rank"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:263 ../../src/wxMaximaFrame.cpp:827
+#: ../../src/wxMaximaFrame.cpp:266 ../../src/wxMaximaFrame.cpp:834
 msgid "Raw XML monitor"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:2261
+#: ../../src/wxMaximaFrame.cpp:2268
 #, c-format
 msgid "Re-Reading the config from %s."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:2258
+#: ../../src/wxMaximaFrame.cpp:2265
 msgid "Re-Reading the config from the default location."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:971
+#: ../../src/wxMaximaFrame.cpp:978
 msgid "Re-evaluate all cells above the one the cursor is in"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:981
+#: ../../src/wxMaximaFrame.cpp:988
 msgid "Re-evaluate all cells below the one the cursor is in"
 msgstr ""
 
-#: ../../src/main.cpp:652
+#: ../../src/main.cpp:668
 msgid "Re-opening STDERR failed."
 msgstr ""
 
-#: ../../src/main.cpp:653
+#: ../../src/main.cpp:669
 msgid "Re-opening STDIN failed."
 msgstr ""
 
-#: ../../src/main.cpp:651
+#: ../../src/main.cpp:667
 msgid "Re-opening STDOUT failed."
 msgstr ""
 
@@ -8254,7 +8254,7 @@ msgstr ""
 msgid "Read environment variable"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1323
+#: ../../src/wxMaximaFrame.cpp:1330
 msgid "Read environment variable..."
 msgstr ""
 
@@ -8262,7 +8262,7 @@ msgstr ""
 msgid "Read line"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1784
+#: ../../src/wxMaximaFrame.cpp:1791
 msgid "Read nested list from csv file..."
 msgstr ""
 
@@ -8271,7 +8271,7 @@ msgstr ""
 msgid "Read the entries the maxima manual offers from %s"
 msgstr ""
 
-#: ../../src/StatusBar.cpp:318
+#: ../../src/StatusBar.cpp:318 ../../src/TrayIcon.cpp:71
 msgid "Reading Maxima output"
 msgstr ""
 
@@ -8298,7 +8298,7 @@ msgstr ""
 msgid "Reading the config from the default location."
 msgstr ""
 
-#: ../../src/StatusBar.cpp:272
+#: ../../src/StatusBar.cpp:272 ../../src/TrayIcon.cpp:61
 msgid "Ready for user input"
 msgstr ""
 
@@ -8341,11 +8341,11 @@ msgstr ""
 msgid "Recalculation hit the end of the worksheet => Updating its size (Visited %d cells, recalculated %d, in %ld ms)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1034
+#: ../../src/wxMaximaFrame.cpp:1041
 msgid "Recall next command from history"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1032
+#: ../../src/wxMaximaFrame.cpp:1039
 msgid "Recall previous command from history"
 msgstr ""
 
@@ -8363,7 +8363,7 @@ msgstr ""
 msgid "Recent files list length:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:701
+#: ../../src/wxMaximaFrame.cpp:708
 msgid "Recover unsaved"
 msgstr ""
 
@@ -8371,7 +8371,7 @@ msgstr ""
 msgid "Rectform"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1747
+#: ../../src/wxMaximaFrame.cpp:1754
 msgid "Recursive Substitute..."
 msgstr ""
 
@@ -8383,11 +8383,11 @@ msgstr ""
 msgid "Redo"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:737
+#: ../../src/wxMaximaFrame.cpp:744
 msgid "Redo\tCtrl+Y"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:737
+#: ../../src/wxMaximaFrame.cpp:744
 msgid "Redo last change"
 msgstr ""
 
@@ -8395,7 +8395,7 @@ msgstr ""
 msgid "Reduce (tr)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1702
+#: ../../src/wxMaximaFrame.cpp:1709
 msgid "Reduce trigonometric expression"
 msgstr ""
 
@@ -8421,15 +8421,15 @@ msgstr ""
 msgid "Regex match position"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:2079
+#: ../../src/wxMaximaFrame.cpp:2086
 msgid "Register wxMaxima as the tool that compares .wxmx files in TortoiseSVN and TortoiseGit"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1299
+#: ../../src/wxMaximaFrame.cpp:1306
 msgid "Regular expression that matches a string"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1300
+#: ../../src/wxMaximaFrame.cpp:1307
 msgid "Regular expressions"
 msgstr ""
 
@@ -8467,15 +8467,15 @@ msgstr ""
 msgid "Remove"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:987
+#: ../../src/wxMaximaFrame.cpp:994
 msgid "Remove All Output"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1533
+#: ../../src/wxMaximaFrame.cpp:1540
 msgid "Remove Columns..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1530
+#: ../../src/wxMaximaFrame.cpp:1537
 msgid "Remove Rows..."
 msgstr ""
 
@@ -8483,11 +8483,11 @@ msgstr ""
 msgid "Remove all"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1855
+#: ../../src/wxMaximaFrame.cpp:1862
 msgid "Remove all list elements that appear twice in a row. Normally used in conjunction with sort."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1278
+#: ../../src/wxMaximaFrame.cpp:1285
 msgid "Remove all occurrences of a word..."
 msgstr ""
 
@@ -8503,7 +8503,7 @@ msgstr ""
 msgid "Remove and return the first element of a list"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1534
+#: ../../src/wxMaximaFrame.cpp:1541
 msgid "Remove columns from a matrix"
 msgstr ""
 
@@ -8511,15 +8511,15 @@ msgstr ""
 msgid "Remove directory"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1308
+#: ../../src/wxMaximaFrame.cpp:1315
 msgid "Remove directory..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1854
+#: ../../src/wxMaximaFrame.cpp:1861
 msgid "Remove duplicates"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1280
+#: ../../src/wxMaximaFrame.cpp:1287
 msgid "Remove first occurrence of a word..."
 msgstr ""
 
@@ -8535,11 +8535,11 @@ msgstr ""
 msgid "Remove matrix rows"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:988
+#: ../../src/wxMaximaFrame.cpp:995
 msgid "Remove output from input cells"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1531
+#: ../../src/wxMaximaFrame.cpp:1538
 msgid "Remove rows from the a matrix"
 msgstr ""
 
@@ -8547,15 +8547,15 @@ msgstr ""
 msgid "Rename file"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1319
+#: ../../src/wxMaximaFrame.cpp:1326
 msgid "Rename file..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1634
+#: ../../src/wxMaximaFrame.cpp:1641
 msgid "Reorganize an expression using horner's rule"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1450
+#: ../../src/wxMaximaFrame.cpp:1457
 msgid "Repetitive element-by-element multiplication"
 msgstr ""
 
@@ -8571,7 +8571,7 @@ msgstr ""
 msgid "Replace first regex match"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:2060
+#: ../../src/wxMaximaFrame.cpp:2067
 msgid "Replace non-builtin variable and function names in the selected code cells (or the whole document) with random names, so a worksheet can be shared without revealing its original names"
 msgstr ""
 
@@ -8579,7 +8579,7 @@ msgstr ""
 msgid "Replace the first occurrence of Part"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1284
+#: ../../src/wxMaximaFrame.cpp:1291
 msgid "Replace..."
 msgstr ""
 
@@ -8596,7 +8596,7 @@ msgstr ""
 msgid "Replaces the subexpression that part(expr, n_1, n_2, ...) would select by a new value. The part numbers form a path: n_1 selects a part of the expression, n_2 a part of that, and so on."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:2057
+#: ../../src/wxMaximaFrame.cpp:2064
 msgid "Report bug"
 msgstr ""
 
@@ -8608,7 +8608,7 @@ msgstr ""
 msgid "Reset all GUI settings"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1100
+#: ../../src/wxMaximaFrame.cpp:1107
 msgid "Reset option variables"
 msgstr ""
 
@@ -8622,7 +8622,7 @@ msgid "Resetting all configuration settings"
 msgstr ""
 
 #: ../../src/ToolBar.cpp:411 ../../src/ToolBar.cpp:417
-#: ../../src/wxMaximaFrame.cpp:1078
+#: ../../src/wxMaximaFrame.cpp:1085
 msgid "Restart Maxima"
 msgstr ""
 
@@ -8639,7 +8639,7 @@ msgstr ""
 msgid "Resulting Matrix name (may be empty):"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1294
+#: ../../src/wxMaximaFrame.cpp:1301
 msgid "Return a match"
 msgstr ""
 
@@ -8647,11 +8647,11 @@ msgstr ""
 msgid "Return from a block or loop"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1173
+#: ../../src/wxMaximaFrame.cpp:1180
 msgid "Return from current block/loop..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1862
+#: ../../src/wxMaximaFrame.cpp:1869
 msgid "Return the first item of the list and remove it from the list. Useful for creating stacks."
 msgstr ""
 
@@ -8667,7 +8667,7 @@ msgstr ""
 msgid "Return to the cell that is currently being evaluated"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1818
+#: ../../src/wxMaximaFrame.cpp:1825
 msgid "Returns an arbitrary list item"
 msgstr ""
 
@@ -8675,7 +8675,7 @@ msgstr ""
 msgid "Returns the first element of a list"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1820
+#: ../../src/wxMaximaFrame.cpp:1827
 msgid "Returns the first item of the list"
 msgstr ""
 
@@ -8683,23 +8683,23 @@ msgstr ""
 msgid "Returns the last element of a list"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1826
+#: ../../src/wxMaximaFrame.cpp:1833
 msgid "Returns the last item of the list"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1828
+#: ../../src/wxMaximaFrame.cpp:1835
 msgid "Returns the last n items of the list"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1849
+#: ../../src/wxMaximaFrame.cpp:1856
 msgid "Returns the length of the list"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1822
+#: ../../src/wxMaximaFrame.cpp:1829
 msgid "Returns the list without its first n elements"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1824
+#: ../../src/wxMaximaFrame.cpp:1831
 msgid "Returns the list without its last n elements"
 msgstr ""
 
@@ -8711,11 +8711,11 @@ msgstr ""
 msgid "Reuse last"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1850
+#: ../../src/wxMaximaFrame.cpp:1857
 msgid "Reverse"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1851
+#: ../../src/wxMaximaFrame.cpp:1858
 msgid "Reverse the order of the list items"
 msgstr ""
 
@@ -8752,11 +8752,11 @@ msgstr ""
 msgid "Right end"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1405
+#: ../../src/wxMaximaFrame.cpp:1412
 msgid "Right side to the \"=\""
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1562
+#: ../../src/wxMaximaFrame.cpp:1569
 msgid "Risch Integration..."
 msgstr ""
 
@@ -8764,11 +8764,11 @@ msgstr ""
 msgid "Romanian"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:892
+#: ../../src/wxMaximaFrame.cpp:899
 msgid "Rounded"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1544
+#: ../../src/wxMaximaFrame.cpp:1551
 msgid "Row and column operations"
 msgstr ""
 
@@ -8796,11 +8796,11 @@ msgstr ""
 msgid "Rule:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1131
+#: ../../src/wxMaximaFrame.cpp:1138
 msgid "Rules"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1800
+#: ../../src/wxMaximaFrame.cpp:1807
 msgid "Run each element through an expression"
 msgstr ""
 
@@ -8850,11 +8850,11 @@ msgstr ""
 msgid "Runs each element of an object (list, matrix, equation,...) through an expression individually"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1798
+#: ../../src/wxMaximaFrame.cpp:1805
 msgid "Runs each element through a function"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1801
+#: ../../src/wxMaximaFrame.cpp:1808
 msgid "Runs each element through an expression"
 msgstr ""
 
@@ -8919,7 +8919,7 @@ msgstr ""
 msgid "Save As"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:707
+#: ../../src/wxMaximaFrame.cpp:714
 msgid "Save As...\tShift+Ctrl+S"
 msgstr ""
 
@@ -8931,7 +8931,7 @@ msgstr ""
 msgid "Save Selection to Image"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:779
+#: ../../src/wxMaximaFrame.cpp:786
 msgid "Save Selection to Image..."
 msgstr ""
 
@@ -8943,7 +8943,7 @@ msgstr ""
 msgid "Save as lisp code"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1195
+#: ../../src/wxMaximaFrame.cpp:1202
 msgid "Save as lisp..."
 msgstr ""
 
@@ -8952,11 +8952,11 @@ msgid "Save config to file"
 msgstr ""
 
 #: ../../src/ToolBar.cpp:331 ../../src/ToolBar.cpp:334
-#: ../../src/wxMaximaFrame.cpp:706
+#: ../../src/wxMaximaFrame.cpp:713
 msgid "Save document"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:707
+#: ../../src/wxMaximaFrame.cpp:714
 msgid "Save document as"
 msgstr ""
 
@@ -8964,7 +8964,7 @@ msgstr ""
 msgid "Save plot to file"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:780
+#: ../../src/wxMaximaFrame.cpp:787
 msgid "Save selection from document to an image file"
 msgstr ""
 
@@ -8984,7 +8984,7 @@ msgstr ""
 msgid "Saving failed!"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:650
+#: ../../src/wxMaximaFrame.cpp:657
 msgid "Saving failed."
 msgstr ""
 
@@ -9020,7 +9020,7 @@ msgstr ""
 msgid "Screen reader"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:729
+#: ../../src/wxMaximaFrame.cpp:736
 msgid "Scroll to a cell with a certain UUID"
 msgstr ""
 
@@ -9036,7 +9036,7 @@ msgstr ""
 msgid "Search input / UUID"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1282
+#: ../../src/wxMaximaFrame.cpp:1289
 msgid "Search..."
 msgstr ""
 
@@ -9081,7 +9081,7 @@ msgstr ""
 msgid "Select All"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:777
+#: ../../src/wxMaximaFrame.cpp:784
 msgid "Select All\tCtrl+A"
 msgstr ""
 
@@ -9100,7 +9100,7 @@ msgid "Select a constant"
 msgstr ""
 
 #: ../../src/ToolBar.cpp:390 ../../src/ToolBar.cpp:392
-#: ../../src/wxMaximaFrame.cpp:777
+#: ../../src/wxMaximaFrame.cpp:784
 msgid "Select all"
 msgstr ""
 
@@ -9144,7 +9144,7 @@ msgstr ""
 msgid "Sending Maxima a SIGINT signal."
 msgstr ""
 
-#: ../../src/StatusBar.cpp:263
+#: ../../src/StatusBar.cpp:263 ../../src/TrayIcon.cpp:59
 msgid "Sending a command to Maxima"
 msgstr ""
 
@@ -9164,7 +9164,7 @@ msgstr ""
 msgid "Sending maxima the info how to express 2d maths as XML"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1640
+#: ../../src/wxMaximaFrame.cpp:1647
 msgid "Sequential Comparative Simplification"
 msgstr ""
 
@@ -9176,7 +9176,7 @@ msgstr ""
 msgid "Series"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1586
+#: ../../src/wxMaximaFrame.cpp:1593
 msgid "Series approximation"
 msgstr ""
 
@@ -9184,27 +9184,27 @@ msgstr ""
 msgid "Server started"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1931
+#: ../../src/wxMaximaFrame.cpp:1938
 msgid "Set &displayed Precision..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1670
+#: ../../src/wxMaximaFrame.cpp:1677
 msgid "Set Maxima option variable logexpand:all"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1674
+#: ../../src/wxMaximaFrame.cpp:1681
 msgid "Set Maxima option variable logexpand:super"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1667
+#: ../../src/wxMaximaFrame.cpp:1674
 msgid "Set Maxima option variable logexpand:true"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:929
+#: ../../src/wxMaximaFrame.cpp:936
 msgid "Set Zoom"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1926
+#: ../../src/wxMaximaFrame.cpp:1933
 msgid "Set bigfloat &Precision..."
 msgstr ""
 
@@ -9221,7 +9221,7 @@ msgstr ""
 msgid "Set image resolution [in ppi]"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1617
+#: ../../src/wxMaximaFrame.cpp:1624
 msgid "Set main variable..."
 msgstr ""
 
@@ -9229,15 +9229,15 @@ msgstr ""
 msgid "Set maximum image size [in mm]"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1880
+#: ../../src/wxMaximaFrame.cpp:1887
 msgid "Set plot format"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1205
+#: ../../src/wxMaximaFrame.cpp:1212
 msgid "Set position..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1763
+#: ../../src/wxMaximaFrame.cpp:1770
 msgid "Set the \"algebraic\" flag"
 msgstr ""
 
@@ -9245,7 +9245,7 @@ msgstr ""
 msgid "Set the diagram title"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1886
+#: ../../src/wxMaximaFrame.cpp:1893
 msgid "Set the frame rate for animations."
 msgstr ""
 
@@ -9257,31 +9257,31 @@ msgstr ""
 msgid "Set the next plot's title. Empty = no title."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1927
+#: ../../src/wxMaximaFrame.cpp:1934
 msgid "Set the precision for numbers that are defined as bigfloat. Such numbers can be generated by entering 1.5b12 or as bfloat(1.234)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:918
+#: ../../src/wxMaximaFrame.cpp:925
 msgid "Set zoom to 100%"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:920
+#: ../../src/wxMaximaFrame.cpp:927
 msgid "Set zoom to 120%"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:922
+#: ../../src/wxMaximaFrame.cpp:929
 msgid "Set zoom to 150%"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:924
+#: ../../src/wxMaximaFrame.cpp:931
 msgid "Set zoom to 200%"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:926
+#: ../../src/wxMaximaFrame.cpp:933
 msgid "Set zoom to 300%"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:916
+#: ../../src/wxMaximaFrame.cpp:923
 msgid "Set zoom to 80%"
 msgstr ""
 
@@ -9319,11 +9319,11 @@ msgstr ""
 msgid "Setup a 3D plot"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1396
+#: ../../src/wxMaximaFrame.cpp:1403
 msgid "Setup atvalues for solving ODE with Laplace transformation"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1768
+#: ../../src/wxMaximaFrame.cpp:1775
 msgid "Setup modulus computation"
 msgstr ""
 
@@ -9339,7 +9339,7 @@ msgstr ""
 msgid "Setup the engineering format"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1938
+#: ../../src/wxMaximaFrame.cpp:1945
 msgid "Setup the engineering format..."
 msgstr ""
 
@@ -9355,7 +9355,7 @@ msgstr ""
 msgid "Show \"Find and Replace\" as a dockable sidebar"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1996
+#: ../../src/wxMaximaFrame.cpp:2003
 msgid "Show &Tips..."
 msgstr ""
 
@@ -9363,15 +9363,15 @@ msgstr ""
 msgid "Show * as multiplication dot"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:999
+#: ../../src/wxMaximaFrame.cpp:1006
 msgid "Show Template\tCtrl+Shift+Space"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:860
+#: ../../src/wxMaximaFrame.cpp:867
 msgid "Show XML representation"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1996
+#: ../../src/wxMaximaFrame.cpp:2003
 msgid "Show a tip"
 msgstr ""
 
@@ -9391,7 +9391,7 @@ msgstr ""
 msgid "Show an example for the command:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1990
+#: ../../src/wxMaximaFrame.cpp:1997
 msgid "Show an example of usage"
 msgstr ""
 
@@ -9399,31 +9399,31 @@ msgstr ""
 msgid "Show commands from current session only"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1991
+#: ../../src/wxMaximaFrame.cpp:1998
 msgid "Show commands similar to"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1124
+#: ../../src/wxMaximaFrame.cpp:1131
 msgid "Show defined functions"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1126
+#: ../../src/wxMaximaFrame.cpp:1133
 msgid "Show defined variables"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1178
+#: ../../src/wxMaximaFrame.cpp:1185
 msgid "Show definition of a function"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:847
+#: ../../src/wxMaximaFrame.cpp:854
 msgid "Show equations in their linear form"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1177
+#: ../../src/wxMaximaFrame.cpp:1184
 msgid "Show function &Definition..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1000
+#: ../../src/wxMaximaFrame.cpp:1007
 msgid "Show function template"
 msgstr ""
 
@@ -9435,7 +9435,7 @@ msgstr ""
 msgid "Show labels:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:857
+#: ../../src/wxMaximaFrame.cpp:864
 msgid "Show lisp representation"
 msgstr ""
 
@@ -9459,7 +9459,7 @@ msgstr ""
 msgid "Show max. 50 digits"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:938
+#: ../../src/wxMaximaFrame.cpp:945
 msgid "Show or hide the wxMaxima logging window"
 msgstr ""
 
@@ -9483,7 +9483,7 @@ msgstr ""
 msgid "Show the Copy, Cut and the Paste button?"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:717
+#: ../../src/wxMaximaFrame.cpp:724
 msgid "Show the differences between 2 or 3 files"
 msgstr ""
 
@@ -9511,24 +9511,24 @@ msgstr ""
 msgid "Show tips at Startup"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1110 ../../src/wxMaximaFrame.cpp:1115
+#: ../../src/wxMaximaFrame.cpp:1117 ../../src/wxMaximaFrame.cpp:1122
 msgid "Show used + to-be-freed memory"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1137
+#: ../../src/wxMaximaFrame.cpp:1144
 msgid "Show user definitions"
 msgstr ""
 
 #: ../../src/ToolBar.cpp:544 ../../src/ToolBar.cpp:546
-#: ../../src/wxMaximaFrame.cpp:1984 ../../src/wxMaximaFrame.cpp:1986
+#: ../../src/wxMaximaFrame.cpp:1991 ../../src/wxMaximaFrame.cpp:1993
 msgid "Show wxMaxima help"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1932
+#: ../../src/wxMaximaFrame.cpp:1939
 msgid "Shows how many digits of a numbers are displayed"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:839
+#: ../../src/wxMaximaFrame.cpp:846
 msgid "Sidebars"
 msgstr ""
 
@@ -9548,7 +9548,7 @@ msgstr ""
 msgid "Simplify"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1620
+#: ../../src/wxMaximaFrame.cpp:1627
 msgid "Simplify &Radicals..."
 msgstr ""
 
@@ -9564,19 +9564,19 @@ msgstr ""
 msgid "Simplify Expression"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1675
+#: ../../src/wxMaximaFrame.cpp:1682
 msgid "Simplify Logarithms"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1689
+#: ../../src/wxMaximaFrame.cpp:1696
 msgid "Simplify an expression containing factorials"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1646
+#: ../../src/wxMaximaFrame.cpp:1653
 msgid "Simplify equations"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1621
+#: ../../src/wxMaximaFrame.cpp:1628
 msgid "Simplify expression containing radicals"
 msgstr ""
 
@@ -9584,11 +9584,11 @@ msgstr ""
 msgid "Simplify radicals"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1619
+#: ../../src/wxMaximaFrame.cpp:1626
 msgid "Simplify rational expression"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1645
+#: ../../src/wxMaximaFrame.cpp:1652
 msgid "Simplify sum() commands..."
 msgstr ""
 
@@ -9600,7 +9600,7 @@ msgstr ""
 msgid "Simplify the sum"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1699
+#: ../../src/wxMaximaFrame.cpp:1706
 msgid "Simplify trigonometric expression"
 msgstr ""
 
@@ -9608,15 +9608,15 @@ msgstr ""
 msgid "Since wxMaxima 0.8.2 you can also insert images into your documents. Use 'Cell->Insert Image...' menu command."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1503
+#: ../../src/wxMaximaFrame.cpp:1510
 msgid "Singular Values"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1504 ../../src/wxMaximaFrame.cpp:1507
+#: ../../src/wxMaximaFrame.cpp:1511 ../../src/wxMaximaFrame.cpp:1514
 msgid "Singular values using dgesvd"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1506
+#: ../../src/wxMaximaFrame.cpp:1513
 msgid "Singular values, left + right vectors"
 msgstr ""
 
@@ -9648,7 +9648,7 @@ msgstr ""
 msgid "Slovenian"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1742
+#: ../../src/wxMaximaFrame.cpp:1749
 msgid "Smart Substitute..."
 msgstr ""
 
@@ -9669,19 +9669,19 @@ msgstr ""
 msgid "Solve"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1348
+#: ../../src/wxMaximaFrame.cpp:1355
 msgid "Solve &Algebraic System..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1346
+#: ../../src/wxMaximaFrame.cpp:1353
 msgid "Solve &Linear System..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1370
+#: ../../src/wxMaximaFrame.cpp:1377
 msgid "Solve &ODE..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1344
+#: ../../src/wxMaximaFrame.cpp:1351
 msgid "Solve (to_poly)..."
 msgstr ""
 
@@ -9689,7 +9689,7 @@ msgstr ""
 msgid "Solve A*x=b numerically"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1501
+#: ../../src/wxMaximaFrame.cpp:1508
 msgid "Solve Ax=b"
 msgstr ""
 
@@ -9697,7 +9697,7 @@ msgstr ""
 msgid "Solve ODE"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1391
+#: ../../src/wxMaximaFrame.cpp:1398
 msgid "Solve ODE with Lapla&ce..."
 msgstr ""
 
@@ -9705,7 +9705,7 @@ msgstr ""
 msgid "Solve ODE..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1502
+#: ../../src/wxMaximaFrame.cpp:1509
 msgid "Solve a linear equation system using dgesv"
 msgstr ""
 
@@ -9713,11 +9713,11 @@ msgstr ""
 msgid "Solve algebraic system"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1349
+#: ../../src/wxMaximaFrame.cpp:1356
 msgid "Solve algebraic system of equations"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1383
+#: ../../src/wxMaximaFrame.cpp:1390
 msgid "Solve boundary value problem for second degree ODE"
 msgstr ""
 
@@ -9725,11 +9725,11 @@ msgstr ""
 msgid "Solve differential equations using laplace()"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:925 ../../src/wxMaximaFrame.cpp:1342
+#: ../../src/MaximaCommandMenus.cpp:925 ../../src/wxMaximaFrame.cpp:1349
 msgid "Solve equation(s)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1345
+#: ../../src/wxMaximaFrame.cpp:1352
 msgid "Solve equation(s) with to_poly_solve"
 msgstr ""
 
@@ -9741,11 +9741,11 @@ msgstr ""
 msgid "Solve equations to polynom"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1375
+#: ../../src/wxMaximaFrame.cpp:1382
 msgid "Solve initial value problem for first degree ODE"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1379
+#: ../../src/wxMaximaFrame.cpp:1386
 msgid "Solve initial value problem for second degree ODE"
 msgstr ""
 
@@ -9753,19 +9753,19 @@ msgstr ""
 msgid "Solve linear system"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1347
+#: ../../src/wxMaximaFrame.cpp:1354
 msgid "Solve linear system of equations"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1367
+#: ../../src/wxMaximaFrame.cpp:1374
 msgid "Solve numerical, 1 Variable"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1371
+#: ../../src/wxMaximaFrame.cpp:1378
 msgid "Solve ordinary differential equation of maximum degree 2"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1392
+#: ../../src/wxMaximaFrame.cpp:1399
 msgid "Solve ordinary differential equations with Laplace transformation"
 msgstr ""
 
@@ -9781,7 +9781,7 @@ msgstr ""
 msgid "Solve polynomials numerically (real roots)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1353
+#: ../../src/wxMaximaFrame.cpp:1360
 msgid "Solve symbolically"
 msgstr ""
 
@@ -9790,11 +9790,11 @@ msgstr ""
 msgid "Solve..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:2023
+#: ../../src/wxMaximaFrame.cpp:2030
 msgid "Solving differential equations"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:2011
+#: ../../src/wxMaximaFrame.cpp:2018
 msgid "Solving equations with Maxima"
 msgstr ""
 
@@ -9805,7 +9805,7 @@ msgid ""
 "In both cases the '' operator will do what is requested."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1853
+#: ../../src/wxMaximaFrame.cpp:1860
 msgid "Sort"
 msgstr ""
 
@@ -9821,7 +9821,7 @@ msgstr ""
 msgid "Sort all characters in string"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1283
+#: ../../src/wxMaximaFrame.cpp:1290
 msgid "Sort the characters..."
 msgstr ""
 
@@ -9846,7 +9846,7 @@ msgstr ""
 msgid "Split"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1295
+#: ../../src/wxMaximaFrame.cpp:1302
 msgid "Split on match"
 msgstr ""
 
@@ -9858,11 +9858,11 @@ msgstr ""
 msgid "Split string into tokens"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1275
+#: ../../src/wxMaximaFrame.cpp:1282
 msgid "Split..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:895
+#: ../../src/wxMaximaFrame.cpp:902
 msgid "Square"
 msgstr ""
 
@@ -9918,7 +9918,7 @@ msgstr ""
 msgid "Starting Maxima process failed"
 msgstr ""
 
-#: ../../src/main.cpp:1003
+#: ../../src/main.cpp:1019
 msgid "Starting a new wxMaxima process for a new window"
 msgstr ""
 
@@ -9939,11 +9939,11 @@ msgstr ""
 msgid "Startup commands"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:269
+#: ../../src/wxMaximaFrame.cpp:272
 msgid "Statistics"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:803
+#: ../../src/wxMaximaFrame.cpp:810
 msgid "Statistics\tAlt+Shift+S"
 msgstr ""
 
@@ -9955,11 +9955,11 @@ msgstr ""
 msgid "Store filenames in image cells to enable image reloading after re-opening the worksheet"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:901
+#: ../../src/wxMaximaFrame.cpp:908
 msgid "Straight lines"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1210
+#: ../../src/wxMaximaFrame.cpp:1217
 msgid "Stream"
 msgstr ""
 
@@ -9981,7 +9981,7 @@ msgstr ""
 msgid "Strike Through"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1289
+#: ../../src/wxMaximaFrame.cpp:1296
 msgid "String"
 msgstr ""
 
@@ -9995,7 +9995,7 @@ msgstr ""
 msgid "String #2:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1240
+#: ../../src/wxMaximaFrame.cpp:1247
 msgid "String Tests"
 msgstr ""
 
@@ -10007,7 +10007,7 @@ msgstr ""
 msgid "String to list of char"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1252
+#: ../../src/wxMaximaFrame.cpp:1259
 msgid "String to list of chars..."
 msgstr ""
 
@@ -10015,7 +10015,7 @@ msgstr ""
 msgid "String to octets"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1264
+#: ../../src/wxMaximaFrame.cpp:1271
 msgid "String to octets..."
 msgstr ""
 
@@ -10041,7 +10041,7 @@ msgstr ""
 msgid "Struct type name:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1133
+#: ../../src/wxMaximaFrame.cpp:1140
 msgid "Structs"
 msgstr ""
 
@@ -10065,7 +10065,7 @@ msgstr ""
 msgid "Subsection cell (Heading 3)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1750
+#: ../../src/wxMaximaFrame.cpp:1757
 msgid "Subst constant t into eq with diff(x,t)..."
 msgstr ""
 
@@ -10079,15 +10079,15 @@ msgstr ""
 
 #: ../../src/MaximaCommandMenus.cpp:715 ../../src/MaximaCommandMenus.cpp:3580
 #: ../../src/MaximaCommandMenus.cpp:4590 ../../src/wizards/SubstituteWiz.cpp:53
-#: ../../src/wxMaximaFrame.cpp:1758
+#: ../../src/wxMaximaFrame.cpp:1765
 msgid "Substitute"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1297
+#: ../../src/wxMaximaFrame.cpp:1304
 msgid "Substitute all matches"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1296
+#: ../../src/wxMaximaFrame.cpp:1303
 msgid "Substitute first match"
 msgstr ""
 
@@ -10095,20 +10095,20 @@ msgstr ""
 msgid "Substitute only in a specific part"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1753
+#: ../../src/wxMaximaFrame.cpp:1760
 msgid "Substitute only in parts..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1754
+#: ../../src/wxMaximaFrame.cpp:1761
 msgid "Substitute only in the elements n_1, n_2,..."
 msgstr ""
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:362
-#: ../../src/wxMaximaFrame.cpp:1740
+#: ../../src/wxMaximaFrame.cpp:1747
 msgid "Substitute..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1748 ../../src/wxMaximaFrame.cpp:1751
+#: ../../src/wxMaximaFrame.cpp:1755 ../../src/wxMaximaFrame.cpp:1758
 msgid "Substitutes until the equation no more changes"
 msgstr ""
 
@@ -10125,7 +10125,7 @@ msgstr ""
 msgid "Substitutes, but makes sure that nothing is substituted into the other substituents."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1745
+#: ../../src/wxMaximaFrame.cpp:1752
 msgid "Substitutes, but not in the other substituents"
 msgstr ""
 
@@ -10157,7 +10157,7 @@ msgstr ""
 msgid "Swedish"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1658
+#: ../../src/wxMaximaFrame.cpp:1665
 msgid "Switch off simplifications of log(). Set Maxima option variable logexpand:false"
 msgstr ""
 
@@ -10174,7 +10174,7 @@ msgstr ""
 msgid "Symbolic Constant"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:807
+#: ../../src/wxMaximaFrame.cpp:814
 msgid "Symbols\tAlt+Shift+Y"
 msgstr ""
 
@@ -10198,11 +10198,11 @@ msgstr ""
 msgid "Tab"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:255
+#: ../../src/wxMaximaFrame.cpp:258
 msgid "Table of Contents"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:813
+#: ../../src/wxMaximaFrame.cpp:820
 msgid "Table of Contents\tAlt+Shift+T"
 msgstr ""
 
@@ -10222,7 +10222,7 @@ msgstr ""
 msgid "Taylor series"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1581
+#: ../../src/wxMaximaFrame.cpp:1588
 msgid "Taylor series..."
 msgstr ""
 
@@ -10238,15 +10238,15 @@ msgstr ""
 msgid "Tells maxima for an f(x), that f(x=t)=a"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:2052
+#: ../../src/wxMaximaFrame.cpp:2059
 msgid "Tells maxima to show the help for ?, ?? and describe() in a separate browser window"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:2048
+#: ../../src/wxMaximaFrame.cpp:2055
 msgid "Tells maxima to show the help for ?, ?? and describe() in a wxMaxima sidebar"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:2043
+#: ../../src/wxMaximaFrame.cpp:2050
 msgid "Tells maxima to show the help for ?, ?? and describe() on the console"
 msgstr ""
 
@@ -10327,7 +10327,7 @@ msgstr ""
 msgid "The cache for the subjects the manual contains is from a different Maxima version."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1483
+#: ../../src/wxMaximaFrame.cpp:1490
 msgid "The classic operations one typically uses matrices for"
 msgstr ""
 
@@ -10347,7 +10347,7 @@ msgstr ""
 msgid "The command local() allows telling Maxima which functions to make local to the current program when defined."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:341
+#: ../../src/wxMaximaFrame.cpp:344
 msgid "The current Wizard"
 msgstr ""
 
@@ -10425,11 +10425,11 @@ msgstr ""
 msgid "The grid in the background of the diagram"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1402
+#: ../../src/wxMaximaFrame.cpp:1409
 msgid "The half of the equation that is to the left of the \"=\""
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1406
+#: ../../src/wxMaximaFrame.cpp:1413
 msgid "The half of the equation that is to the right of the \"=\""
 msgstr ""
 
@@ -10448,7 +10448,7 @@ msgstr ""
 msgid "The image file \"%s\" cannot be found."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:822
+#: ../../src/wxMaximaFrame.cpp:829
 msgid "The integrated help browser"
 msgstr ""
 
@@ -10476,15 +10476,15 @@ msgstr ""
 msgid "The load() command of Maxima versions >5.38 is able to load .wxm files as library of Maxima's commands."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:231
+#: ../../src/wxMaximaFrame.cpp:234
 msgid "The main toolbar"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1989
+#: ../../src/wxMaximaFrame.cpp:1996
 msgid "The manual of Maxima"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1988
+#: ../../src/wxMaximaFrame.cpp:1995
 msgid "The manual of wxMaxima"
 msgstr ""
 
@@ -10621,7 +10621,7 @@ msgstr ""
 msgid "The variables to search the optimum solution for"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:211
+#: ../../src/wxMaximaFrame.cpp:214
 msgid "The worksheet"
 msgstr ""
 
@@ -10797,11 +10797,11 @@ msgstr ""
 msgid "Title, section and subsection cells can be folded to hide their contents. To fold or unfold, click in the square next to the cell. If you shift-click, all sublevels of that cell will also fold/unfold."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1901
+#: ../../src/wxMaximaFrame.cpp:1908
 msgid "To &Bigfloat"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1898
+#: ../../src/wxMaximaFrame.cpp:1905
 msgid "To &Float"
 msgstr ""
 
@@ -10809,15 +10809,15 @@ msgstr ""
 msgid "To Float"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1904
+#: ../../src/wxMaximaFrame.cpp:1911
 msgid "To Numeri&c\tCtrl+Shift+N"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1910
+#: ../../src/wxMaximaFrame.cpp:1917
 msgid "To exact fraction"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1921
+#: ../../src/wxMaximaFrame.cpp:1928
 msgid "To exact number"
 msgstr ""
 
@@ -10848,7 +10848,7 @@ msgstr ""
 msgid "Toc levels shown here"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:932 ../../src/wxMaximaFrame.cpp:935
+#: ../../src/wxMaximaFrame.cpp:939 ../../src/wxMaximaFrame.cpp:942
 msgid "Toggle full screen editing"
 msgstr ""
 
@@ -10864,11 +10864,11 @@ msgstr ""
 msgid "Toggle vertical scroll synchronization"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1281
+#: ../../src/wxMaximaFrame.cpp:1288
 msgid "Tokenize..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:2016
+#: ../../src/wxMaximaFrame.cpp:2023
 msgid "Tolerance calculations with Maxima"
 msgstr ""
 
@@ -10888,7 +10888,7 @@ msgstr ""
 msgid "Tortoise diff tool"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1182
+#: ../../src/wxMaximaFrame.cpp:1189
 msgid "Trace a function..."
 msgstr ""
 
@@ -10896,11 +10896,11 @@ msgstr ""
 msgid "Trace function(s)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1288
+#: ../../src/wxMaximaFrame.cpp:1295
 msgid "Transformations"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1480
+#: ../../src/wxMaximaFrame.cpp:1487
 msgid "Transpose a matrix"
 msgstr ""
 
@@ -10944,15 +10944,15 @@ msgid ""
 "See also guess_exact_value()"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1285
+#: ../../src/wxMaximaFrame.cpp:1292
 msgid "Trim both ends..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1286
+#: ../../src/wxMaximaFrame.cpp:1293
 msgid "Trim left..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1287
+#: ../../src/wxMaximaFrame.cpp:1294
 msgid "Trim right..."
 msgstr ""
 
@@ -10968,7 +10968,7 @@ msgstr ""
 msgid "Trim string right"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1618
+#: ../../src/wxMaximaFrame.cpp:1625
 msgid "Try to guess which form is &simple"
 msgstr ""
 
@@ -11024,7 +11024,7 @@ msgstr ""
 msgid "Turkish"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:2035
+#: ../../src/wxMaximaFrame.cpp:2042
 msgid "Tutorials"
 msgstr ""
 
@@ -11052,7 +11052,7 @@ msgstr ""
 msgid "URL MathJaX.js is located at:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1250
+#: ../../src/wxMaximaFrame.cpp:1257
 msgid "UTF8 to Unicode code point..."
 msgstr ""
 
@@ -11078,7 +11078,7 @@ msgstr ""
 msgid "Unable to interpret the version info I got: %s"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1111
+#: ../../src/wxMaximaFrame.cpp:1118
 msgid "Undefine"
 msgstr ""
 
@@ -11099,7 +11099,7 @@ msgstr ""
 msgid "Undo"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:735
+#: ../../src/wxMaximaFrame.cpp:742
 msgid "Undo\tCtrl+Z"
 msgstr ""
 
@@ -11107,7 +11107,7 @@ msgstr ""
 msgid "Undo and redo button"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:735
+#: ../../src/wxMaximaFrame.cpp:742
 msgid "Undo last change"
 msgstr ""
 
@@ -11116,11 +11116,11 @@ msgstr ""
 msgid "Unexpected text style %li for TextCell"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1028
+#: ../../src/wxMaximaFrame.cpp:1035
 msgid "Unfold All\tCtrl+Alt+]"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1029
+#: ../../src/wxMaximaFrame.cpp:1036
 msgid "Unfold all folded sections"
 msgstr ""
 
@@ -11156,15 +11156,15 @@ msgstr ""
 msgid "Unhide contents"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:290
+#: ../../src/wxMaximaFrame.cpp:293
 msgid "Unicode characters"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:809
+#: ../../src/wxMaximaFrame.cpp:816
 msgid "Unicode chars\tAlt+Shift+U"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1248
+#: ../../src/wxMaximaFrame.cpp:1255
 msgid "Unicode code point to UTF8..."
 msgstr ""
 
@@ -11172,7 +11172,7 @@ msgstr ""
 msgid "Unicode code point to char"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1246
+#: ../../src/wxMaximaFrame.cpp:1253
 msgid "Unicode code point to char..."
 msgstr ""
 
@@ -11227,7 +11227,7 @@ msgstr ""
 msgid "Upsilon"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:899
+#: ../../src/wxMaximaFrame.cpp:906
 msgid "Use \"<\" and \">\" as parenthesis for matrices"
 msgstr ""
 
@@ -11247,7 +11247,7 @@ msgstr ""
 msgid "Use Text search filtering"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1815 ../../src/wxMaximaFrame.cpp:1846
+#: ../../src/wxMaximaFrame.cpp:1822 ../../src/wxMaximaFrame.cpp:1853
 msgid "Use a list"
 msgstr ""
 
@@ -11255,7 +11255,7 @@ msgstr ""
 msgid "Use a list as parameter list for a function"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:2078
+#: ../../src/wxMaximaFrame.cpp:2085
 msgid "Use as TortoiseSVN/Git diff tool"
 msgstr ""
 
@@ -11267,23 +11267,23 @@ msgstr ""
 msgid "Use centered dot character for multiplication"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1815
+#: ../../src/wxMaximaFrame.cpp:1822
 msgid "Use list"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1808
+#: ../../src/wxMaximaFrame.cpp:1815
 msgid "Use list as the arguments of a function"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:893
+#: ../../src/wxMaximaFrame.cpp:900
 msgid "Use rounded parenthesis for matrices"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:896
+#: ../../src/wxMaximaFrame.cpp:903
 msgid "Use square parenthesis for matrices"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1187
+#: ../../src/wxMaximaFrame.cpp:1194
 msgid "Use struct field..."
 msgstr ""
 
@@ -11295,7 +11295,7 @@ msgstr ""
 msgid "Use unicode Math Symbols, if available"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:902
+#: ../../src/wxMaximaFrame.cpp:909
 msgid "Use vertical lines instead of parenthesis for matrices"
 msgstr ""
 
@@ -11412,7 +11412,7 @@ msgstr ""
 msgid "Variable name"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1189
+#: ../../src/wxMaximaFrame.cpp:1196
 msgid "Variable name, not contents..."
 msgstr ""
 
@@ -11441,7 +11441,7 @@ msgstr ""
 msgid "Variable:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:301 ../../src/wxMaximaFrame.cpp:824
+#: ../../src/wxMaximaFrame.cpp:304 ../../src/wxMaximaFrame.cpp:831
 msgid "Variables"
 msgstr ""
 
@@ -11462,7 +11462,7 @@ msgstr ""
 msgid "Vietnamese"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:940
+#: ../../src/wxMaximaFrame.cpp:947
 msgid "View"
 msgstr ""
 
@@ -11493,7 +11493,7 @@ msgstr ""
 msgid "Warning"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1663
+#: ../../src/wxMaximaFrame.cpp:1670
 msgid "Warning:"
 msgstr ""
 
@@ -11508,7 +11508,7 @@ msgstr ""
 msgid "Warning: Lookalike chars: "
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1653
+#: ../../src/wxMaximaFrame.cpp:1660
 msgid "Warning: No test if the argument of the log is complex, positive or negative"
 msgstr ""
 
@@ -11539,7 +11539,7 @@ msgstr ""
 msgid "When applying functions with one argument from menus, the default argument is '%'. To apply the function to some other value, select it in the document before executing a menu command."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1162
+#: ../../src/wxMaximaFrame.cpp:1169
 msgid "When to invoke the lisp compiler's debugger"
 msgstr ""
 
@@ -11547,7 +11547,7 @@ msgstr ""
 msgid "While loop"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1167
+#: ../../src/wxMaximaFrame.cpp:1174
 msgid "While loop..."
 msgstr ""
 
@@ -11688,23 +11688,23 @@ msgstr ""
 msgid "Zeta"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:912
+#: ../../src/wxMaximaFrame.cpp:919
 msgid "Zoom &In\tCtrl++"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:913
+#: ../../src/wxMaximaFrame.cpp:920
 msgid "Zoom Ou&t\tCtrl+-"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:912
+#: ../../src/wxMaximaFrame.cpp:919
 msgid "Zoom in 10%"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:913
+#: ../../src/wxMaximaFrame.cpp:920
 msgid "Zoom out 10%"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3300 ../../src/wxMaximaFrame.cpp:205
+#: ../../src/wxMaxima.cpp:3300 ../../src/wxMaximaFrame.cpp:208
 msgid "[ unsaved ]"
 msgstr ""
 
@@ -11736,23 +11736,23 @@ msgstr ""
 msgid "antisymmetric"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1797
+#: ../../src/wxMaximaFrame.cpp:1804
 msgid "apply function to each element"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:846
+#: ../../src/wxMaximaFrame.cpp:853
 msgid "as 1D ASCII"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:849
+#: ../../src/wxMaximaFrame.cpp:856
 msgid "as ASCII Art"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:852
+#: ../../src/wxMaximaFrame.cpp:859
 msgid "as ASCII+Unicode Art"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1787
+#: ../../src/wxMaximaFrame.cpp:1794
 msgid "as storage for actual values for variables"
 msgstr ""
 
@@ -11764,7 +11764,7 @@ msgstr ""
 msgid "both sides"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1243
+#: ../../src/wxMaximaFrame.cpp:1250
 msgid "char to Ascii code..."
 msgstr ""
 
@@ -11798,7 +11798,7 @@ msgstr ""
 msgid "diff(x,t)="
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1168 ../../src/wxMaximaFrame.cpp:1809
+#: ../../src/wxMaximaFrame.cpp:1175 ../../src/wxMaximaFrame.cpp:1816
 msgid "do for each element"
 msgstr ""
 
@@ -11845,19 +11845,19 @@ msgstr ""
 msgid "filename:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1781
+#: ../../src/wxMaximaFrame.cpp:1788
 msgid "from a list"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1778
+#: ../../src/wxMaximaFrame.cpp:1785
 msgid "from a rule"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1792
+#: ../../src/wxMaximaFrame.cpp:1799
 msgid "from function arguments"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1776
+#: ../../src/wxMaximaFrame.cpp:1783
 msgid "from individual elements"
 msgstr ""
 
@@ -11885,7 +11885,7 @@ msgstr ""
 msgid "in"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:854
+#: ../../src/wxMaximaFrame.cpp:861
 msgid "in 2D"
 msgstr ""
 
@@ -11932,11 +11932,11 @@ msgstr ""
 msgid "matrix([x_1,x_2,...],[y_1,y_2,...])"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1509
+#: ../../src/wxMaximaFrame.cpp:1516
 msgid "max(abs(A(i,j))) (complex)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1508
+#: ../../src/wxMaximaFrame.cpp:1515
 msgid "max(abs(A(i,j))) (real)"
 msgstr ""
 
@@ -11997,7 +11997,7 @@ msgstr ""
 msgid "noun: Not evaluated by default"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1817
+#: ../../src/wxMaximaFrame.cpp:1824
 msgid "nth"
 msgstr ""
 
@@ -12067,7 +12067,7 @@ msgstr ""
 msgid "printf"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1212
+#: ../../src/wxMaximaFrame.cpp:1219
 msgid "printf..."
 msgstr ""
 
@@ -12087,15 +12087,15 @@ msgstr ""
 msgid "ratsubst works like subst, but it knows some basic maths, if needed."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1215
+#: ../../src/wxMaximaFrame.cpp:1222
 msgid "readbyte..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1214
+#: ../../src/wxMaximaFrame.cpp:1221
 msgid "readchar..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1213
+#: ../../src/wxMaximaFrame.cpp:1220
 msgid "readline..."
 msgstr ""
 
@@ -12208,7 +12208,7 @@ msgstr ""
 msgid "union"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1179
+#: ../../src/wxMaximaFrame.cpp:1186
 msgid "unnamed function (lambda)..."
 msgstr ""
 
@@ -12217,7 +12217,7 @@ msgid "unsaved"
 msgstr ""
 
 #: ../../src/MaximaCommandMenus.cpp:2270 ../../src/MaximaFileIO.cpp:774
-#: ../../src/wxMaximaFrame.cpp:207
+#: ../../src/wxMaximaFrame.cpp:210
 msgid "untitled"
 msgstr ""
 
@@ -12225,11 +12225,11 @@ msgstr ""
 msgid "upsilon"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1807
+#: ../../src/wxMaximaFrame.cpp:1814
 msgid "use as function arguments"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1803
+#: ../../src/wxMaximaFrame.cpp:1810
 msgid "use the actual values stored"
 msgstr ""
 
@@ -12237,22 +12237,22 @@ msgstr ""
 msgid "wgnuplot: Steals the mouse focus during plotting"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1216
+#: ../../src/wxMaximaFrame.cpp:1223
 msgid "writebyte..."
 msgstr ""
 
-#: ../../src/dialogs/AboutDialog.cpp:64 ../../src/main.cpp:843
-#: ../../src/sidebars/AiChatSidebar.cpp:179
+#: ../../src/TrayIcon.cpp:93 ../../src/dialogs/AboutDialog.cpp:64
+#: ../../src/main.cpp:859 ../../src/sidebars/AiChatSidebar.cpp:179
 #: ../../src/sidebars/AiChatSidebar.cpp:185
 msgid "wxMaxima"
 msgstr ""
 
-#: ../../src/main.cpp:852
+#: ../../src/main.cpp:868
 #, c-format
 msgid "wxMaxima %ld"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3289 ../../src/wxMaximaFrame.cpp:203
+#: ../../src/wxMaxima.cpp:3289 ../../src/wxMaximaFrame.cpp:206
 #, c-format
 msgid "wxMaxima %s (%s) "
 msgstr ""
@@ -12299,7 +12299,7 @@ msgstr ""
 msgid "wxMaxima encountered an error loading "
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1988
+#: ../../src/wxMaximaFrame.cpp:1995
 msgid "wxMaxima help"
 msgstr ""
 
@@ -12352,11 +12352,11 @@ msgstr ""
 msgid "wxMaxima remembers the answers to maxima's questions. If this checkbox is set it automatically offers to enter the last answer to this question the user has input."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:2003
+#: ../../src/wxMaximaFrame.cpp:2010
 msgid "wxMaxima shows help in a browser"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:2001
+#: ../../src/wxMaximaFrame.cpp:2008
 msgid "wxMaxima shows help in the sidebar"
 msgstr ""
 
@@ -12373,11 +12373,11 @@ msgstr ""
 msgid "wxMaxima worksheet"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:2067
+#: ../../src/wxMaximaFrame.cpp:2074
 msgid "wxMaxima's ChangeLog"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:2065
+#: ../../src/wxMaximaFrame.cpp:2072
 msgid "wxMaxima's license"
 msgstr ""
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -75,6 +75,7 @@ set(WIZARD_SOURCE_FILES
 list(TRANSFORM WIZARD_SOURCE_FILES PREPEND wizards/)
 
 set(SIDEBAR_SOURCE_FILES
+    AiChatSidebar.cpp
     GreekSidebar.cpp
     CharButton.cpp
     UnicodeSidebar.cpp
@@ -108,6 +109,11 @@ set(MCP_SOURCE_FILES
     McpTools.cpp
 )
 list(TRANSFORM MCP_SOURCE_FILES PREPEND mcp/)
+
+set(AI_SOURCE_FILES
+    AiProvider.cpp
+)
+list(TRANSFORM AI_SOURCE_FILES PREPEND ai/)
 
 set(DIALOG_SOURCE_FILES
     AboutDialog.cpp
@@ -202,6 +208,7 @@ list(APPEND SOURCE_FILES
   ${SIDEBAR_SOURCE_FILES}
   ${DIALOG_SOURCE_FILES}
   ${MCP_SOURCE_FILES}
+  ${AI_SOURCE_FILES}
 )
 
 # The git hash lives in its own tiny generated TU (see GitHash.h): keeping the

--- a/src/Configuration.cpp
+++ b/src/Configuration.cpp
@@ -121,6 +121,15 @@ Configuration::Configuration(const Configuration &o) :
   m_findDialogDockable(o.m_findDialogDockable),
   m_mcpServerEnabled(o.m_mcpServerEnabled),
   m_mcpServerPort(o.m_mcpServerPort),
+  m_aiChatProvider(o.m_aiChatProvider),
+  m_aiApiKeyAnthropic(o.m_aiApiKeyAnthropic),
+  m_aiApiKeyOpenAI(o.m_aiApiKeyOpenAI),
+  m_aiApiKeyGoogle(o.m_aiApiKeyGoogle),
+  m_aiApiKeyQwen(o.m_aiApiKeyQwen),
+  m_aiModelAnthropic(o.m_aiModelAnthropic),
+  m_aiModelOpenAI(o.m_aiModelOpenAI),
+  m_aiModelGoogle(o.m_aiModelGoogle),
+  m_aiModelQwen(o.m_aiModelQwen),
   m_displayedDigits(o.m_displayedDigits),
   m_autoWrap(o.m_autoWrap),
   m_autoIndent(o.m_autoIndent),
@@ -313,6 +322,11 @@ void Configuration::ResetAllToDefaults() {
   m_findDialogDockable = false;
   m_mcpServerEnabled = false;
   m_mcpServerPort = 8765;
+  m_aiChatProvider = 0; // AiProviderKind::None
+  m_aiModelAnthropic = wxS("claude-3-5-sonnet-20241022");
+  m_aiModelOpenAI = wxS("gpt-4o-mini");
+  m_aiModelGoogle = wxS("gemini-1.5-flash");
+  m_aiModelQwen = wxS("qwen-plus");
   m_fixReorderedIndices = true;
   m_rightToLeftDocument = false;
   m_showBrackets = true;
@@ -1288,6 +1302,15 @@ Configuration::ScalarConfigSettings() {
     {wxS("findDialogDockable"), &Configuration::m_findDialogDockable},
     {wxS("mcpServerEnabled"), &Configuration::m_mcpServerEnabled},
     {wxS("mcpServerPort"), &Configuration::m_mcpServerPort},
+    {wxS("aiChatProvider"), &Configuration::m_aiChatProvider},
+    {wxS("aiApiKeyAnthropic"), &Configuration::m_aiApiKeyAnthropic},
+    {wxS("aiApiKeyOpenAI"), &Configuration::m_aiApiKeyOpenAI},
+    {wxS("aiApiKeyGoogle"), &Configuration::m_aiApiKeyGoogle},
+    {wxS("aiApiKeyQwen"), &Configuration::m_aiApiKeyQwen},
+    {wxS("aiModelAnthropic"), &Configuration::m_aiModelAnthropic},
+    {wxS("aiModelOpenAI"), &Configuration::m_aiModelOpenAI},
+    {wxS("aiModelGoogle"), &Configuration::m_aiModelGoogle},
+    {wxS("aiModelQwen"), &Configuration::m_aiModelQwen},
     {wxS("numpadEnterEvaluates"), &Configuration::m_numpadEnterEvaluates},
     {wxS("offerKnownAnswers"), &Configuration::m_offerKnownAnswers},
     {wxS("openHCaret"), &Configuration::m_openHCaret},

--- a/src/Configuration.h
+++ b/src/Configuration.h
@@ -748,6 +748,40 @@ public:
   int McpServerPort() const { return m_mcpServerPort; }
   void McpServerPort(int port) { m_mcpServerPort = port; }
 
+  /*! Which AI provider the AI chat sidebar talks to, as an AiProviderKind
+    cast to int (0 = AiProviderKind::None, i.e. not configured/disabled).
+    Stored as a plain int, not the enum itself, so Configuration.h doesn't
+    need to include AiProvider.h just for this one field. */
+  int AiChatProvider() const { return m_aiChatProvider; }
+  void AiChatProvider(int provider) { m_aiChatProvider = provider; }
+
+  //! The user's API key for each provider, kept separate so switching
+  //! providers in Options doesn't lose the others. Plain-text in wxConfig's
+  //! backing store (the registry on Windows, a dotfile elsewhere) -- the
+  //! same tradeoff any desktop app that stores a local API key makes; there
+  //! is no portable, dependency-free OS-keychain wrapper this project
+  //! already pulls in to do better.
+  wxString AiApiKeyAnthropic() const { return m_aiApiKeyAnthropic; }
+  void AiApiKeyAnthropic(const wxString &key) { m_aiApiKeyAnthropic = key; }
+  wxString AiApiKeyOpenAI() const { return m_aiApiKeyOpenAI; }
+  void AiApiKeyOpenAI(const wxString &key) { m_aiApiKeyOpenAI = key; }
+  wxString AiApiKeyGoogle() const { return m_aiApiKeyGoogle; }
+  void AiApiKeyGoogle(const wxString &key) { m_aiApiKeyGoogle = key; }
+  wxString AiApiKeyQwen() const { return m_aiApiKeyQwen; }
+  void AiApiKeyQwen(const wxString &key) { m_aiApiKeyQwen = key; }
+
+  //! The model id to request from each provider; defaults to
+  //! AiProviderDefaultModel() but the user can override it in Options,
+  //! since model catalogs change far more often than this code does.
+  wxString AiModelAnthropic() const { return m_aiModelAnthropic; }
+  void AiModelAnthropic(const wxString &model) { m_aiModelAnthropic = model; }
+  wxString AiModelOpenAI() const { return m_aiModelOpenAI; }
+  void AiModelOpenAI(const wxString &model) { m_aiModelOpenAI = model; }
+  wxString AiModelGoogle() const { return m_aiModelGoogle; }
+  void AiModelGoogle(const wxString &model) { m_aiModelGoogle = model; }
+  wxString AiModelQwen() const { return m_aiModelQwen; }
+  void AiModelQwen(const wxString &model) { m_aiModelQwen = model; }
+
   /*! Returns the maximum number of displayed digits
 
     m_displayedDigits is always >= 20, so we can guarantee the number we return to be unsigned.
@@ -1428,6 +1462,16 @@ private:
   bool m_mcpServerEnabled;
   //! The localhost TCP port McpServer listens on, if enabled.
   int m_mcpServerPort;
+  //! Which AI provider the AI chat sidebar talks to. See AiChatProvider().
+  int m_aiChatProvider;
+  wxString m_aiApiKeyAnthropic;
+  wxString m_aiApiKeyOpenAI;
+  wxString m_aiApiKeyGoogle;
+  wxString m_aiApiKeyQwen;
+  wxString m_aiModelAnthropic;
+  wxString m_aiModelOpenAI;
+  wxString m_aiModelGoogle;
+  wxString m_aiModelQwen;
   //! How many digits of a number we show by default?
   long m_displayedDigits;
   //! Automatically wrap long lines?

--- a/src/EventIDs.cpp
+++ b/src/EventIDs.cpp
@@ -39,6 +39,7 @@ const wxWindowIDRef EventIDs::menu_pane_format(wxWindow::NewControlId());
 const wxWindowIDRef EventIDs::menu_pane_greek(wxWindow::NewControlId());
 const wxWindowIDRef EventIDs::menu_pane_unicode(wxWindow::NewControlId());
 const wxWindowIDRef EventIDs::menu_pane_variables(wxWindow::NewControlId());
+const wxWindowIDRef EventIDs::menu_pane_aichat(wxWindow::NewControlId());
 const wxWindowIDRef EventIDs::menu_pane_draw(wxWindow::NewControlId());
 const wxWindowIDRef EventIDs::menu_pane_help(wxWindow::NewControlId());
 const wxWindowIDRef EventIDs::menu_pane_symbols(wxWindow::NewControlId());

--- a/src/EventIDs.h
+++ b/src/EventIDs.h
@@ -98,6 +98,7 @@ public:
   static const wxWindowIDRef menu_pane_greek;     //!< Both the "toggle the greek pane" command and the "greek" pane
   static const wxWindowIDRef menu_pane_unicode;   //!< Both the "toggle the unicode pane" command and the "unicode" pane
   static const wxWindowIDRef menu_pane_variables; //!< Both the "toggle the variables pane" command and the "variables" pane
+  static const wxWindowIDRef menu_pane_aichat;    //!< Both the "toggle the AI chat pane" command and the AI chat pane
   static const wxWindowIDRef menu_pane_draw;      //!< Both the "toggle the draw pane" command for the "draw" pane
   static const wxWindowIDRef menu_pane_help;      //!< Both the "toggle the draw pane" command for the help browser
   static const wxWindowIDRef menu_pane_symbols;   //!< Both the "toggle the symbols pane" command for the "symbols" pane

--- a/src/ai/AiProvider.cpp
+++ b/src/ai/AiProvider.cpp
@@ -1,0 +1,344 @@
+// -*- mode: c++; c-file-style: "linux"; c-basic-offset: 2; indent-tabs-mode: nil -*-
+//
+//  Copyright (C) 2026 Gunter Königsmann <wxMaxima@physikbuch.de>
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation; either version 2 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program; if not, write to the Free Software
+//  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+//
+//  SPDX-License-Identifier: GPL-2.0+
+
+#include "AiProvider.h"
+#include <nlohmann/json.hpp>
+#if wxUSE_WEBREQUEST
+#include <wx/webrequest.h>
+#endif
+
+using json = nlohmann::json;
+
+namespace {
+std::string U8(const wxString &s) { return s.ToUTF8().data(); }
+wxString FromU8(const std::string &s) { return wxString::FromUTF8(s.c_str()); }
+
+//! Anthropic Messages API (https://api.anthropic.com/v1/messages).
+class AnthropicProvider : public AiProvider {
+public:
+  AnthropicProvider(const wxString &apiKey, const wxString &model)
+    : AiProvider("https://api.anthropic.com/v1/messages", apiKey, model) {}
+
+  AiProviderKind Kind() const override { return AiProviderKind::Anthropic; }
+
+  std::vector<std::pair<wxString, wxString>> AuthHeaders() const override {
+    return {{wxS("x-api-key"), m_apiKey}, {wxS("anthropic-version"), wxS("2023-06-01")}};
+  }
+
+  wxString BuildRequestBody(const wxString &context,
+                            const std::vector<AiChatMessage> &history) const override {
+    json body;
+    body["model"] = U8(m_model);
+    body["max_tokens"] = 2048;
+    if (!context.IsEmpty())
+      body["system"] = U8(context);
+    json messages = json::array();
+    for (const auto &m : history)
+      messages.push_back({{"role", U8(m.role)}, {"content", U8(m.content)}});
+    body["messages"] = messages;
+    return FromU8(body.dump());
+  }
+
+  wxString ParseReply(const wxString &responseBody) const override {
+    try {
+      json j = json::parse(U8(responseBody));
+      wxString reply;
+      for (const auto &block : j.at("content"))
+        if (block.value("type", std::string()) == "text")
+          reply += FromU8(block.value("text", std::string()));
+      if (reply.IsEmpty())
+        throw AiProviderError("Anthropic response had no text content block");
+      return reply;
+    } catch (const json::exception &e) {
+      throw AiProviderError(std::string("Could not parse Anthropic's response: ") + e.what());
+    }
+  }
+};
+
+//! The OpenAI Chat Completions request/response shape -- shared verbatim by
+//! OpenAI itself and by Alibaba's DashScope "OpenAI-compatible mode"
+//! endpoint for Qwen, per DashScope's own documented compatibility layer.
+//! Only the base URL, auth header and default model id actually differ.
+class OpenAiCompatibleProvider : public AiProvider {
+public:
+  OpenAiCompatibleProvider(AiProviderKind kind, wxString baseUrl,
+                           const wxString &apiKey, const wxString &model)
+    : AiProvider(std::move(baseUrl), apiKey, model), m_kind(kind) {}
+
+  AiProviderKind Kind() const override { return m_kind; }
+
+  std::vector<std::pair<wxString, wxString>> AuthHeaders() const override {
+    return {{wxS("Authorization"), wxS("Bearer ") + m_apiKey}};
+  }
+
+  wxString BuildRequestBody(const wxString &context,
+                            const std::vector<AiChatMessage> &history) const override {
+    json messages = json::array();
+    if (!context.IsEmpty())
+      messages.push_back({{"role", "system"}, {"content", U8(context)}});
+    for (const auto &m : history)
+      messages.push_back({{"role", U8(m.role)}, {"content", U8(m.content)}});
+    json body;
+    body["model"] = U8(m_model);
+    body["messages"] = messages;
+    return FromU8(body.dump());
+  }
+
+  wxString ParseReply(const wxString &responseBody) const override {
+    try {
+      json j = json::parse(U8(responseBody));
+      wxString reply = FromU8(
+        j.at("choices").at(0).at("message").value("content", std::string()));
+      if (reply.IsEmpty())
+        throw AiProviderError("Response had an empty message content");
+      return reply;
+    } catch (const json::exception &e) {
+      throw AiProviderError(std::string("Could not parse the response: ") + e.what());
+    }
+  }
+
+private:
+  AiProviderKind m_kind;
+};
+
+//! Google Gemini's generateContent REST API.
+class GoogleProvider : public AiProvider {
+public:
+  GoogleProvider(const wxString &apiKey, const wxString &model)
+    : AiProvider("https://generativelanguage.googleapis.com/v1beta/models/",
+                apiKey, model) {}
+
+  AiProviderKind Kind() const override { return AiProviderKind::Google; }
+
+  wxString RequestUrl() const override {
+    return m_baseUrl + m_model + wxS(":generateContent");
+  }
+
+  std::vector<std::pair<wxString, wxString>> AuthHeaders() const override {
+    return {{wxS("x-goog-api-key"), m_apiKey}};
+  }
+
+  wxString BuildRequestBody(const wxString &context,
+                            const std::vector<AiChatMessage> &history) const override {
+    json body;
+    if (!context.IsEmpty())
+      body["systemInstruction"] = {{"parts", json::array({{{"text", U8(context)}}})}};
+    json contents = json::array();
+    for (const auto &m : history) {
+      // Gemini calls the AI's own turn "model", not "assistant".
+      wxString role = (m.role == wxS("assistant")) ? wxString(wxS("model")) : m.role;
+      contents.push_back(
+        {{"role", U8(role)}, {"parts", json::array({{{"text", U8(m.content)}}})}});
+    }
+    body["contents"] = contents;
+    return FromU8(body.dump());
+  }
+
+  wxString ParseReply(const wxString &responseBody) const override {
+    try {
+      json j = json::parse(U8(responseBody));
+      wxString reply;
+      for (const auto &part : j.at("candidates").at(0).at("content").at("parts"))
+        reply += FromU8(part.value("text", std::string()));
+      if (reply.IsEmpty())
+        throw AiProviderError("Gemini response had no text part");
+      return reply;
+    } catch (const json::exception &e) {
+      throw AiProviderError(std::string("Could not parse Gemini's response: ") + e.what());
+    }
+  }
+};
+} // namespace
+
+wxString AiProviderKindName(AiProviderKind kind) {
+  switch (kind) {
+  case AiProviderKind::Anthropic: return wxS("Anthropic (Claude)");
+  case AiProviderKind::OpenAI: return wxS("OpenAI");
+  case AiProviderKind::Google: return wxS("Google (Gemini)");
+  case AiProviderKind::Qwen: return wxS("Qwen (Alibaba)");
+  default: return wxS("None");
+  }
+}
+
+wxString AiProviderDefaultModel(AiProviderKind kind) {
+  switch (kind) {
+  case AiProviderKind::Anthropic: return wxS("claude-3-5-sonnet-20241022");
+  case AiProviderKind::OpenAI: return wxS("gpt-4o-mini");
+  case AiProviderKind::Google: return wxS("gemini-1.5-flash");
+  case AiProviderKind::Qwen: return wxS("qwen-plus");
+  default: return wxEmptyString;
+  }
+}
+
+std::shared_ptr<AiProvider> MakeAiProvider(AiProviderKind kind, const wxString &apiKey,
+                                           const wxString &model) {
+  switch (kind) {
+  case AiProviderKind::Anthropic:
+    return std::make_shared<AnthropicProvider>(apiKey, model);
+  case AiProviderKind::OpenAI:
+    return std::make_shared<OpenAiCompatibleProvider>(
+      AiProviderKind::OpenAI, wxS("https://api.openai.com/v1/chat/completions"),
+      apiKey, model);
+  case AiProviderKind::Qwen:
+    return std::make_shared<OpenAiCompatibleProvider>(
+      AiProviderKind::Qwen,
+      wxS("https://dashscope.aliyuncs.com/compatible-mode/v1/chat/completions"),
+      apiKey, model);
+  case AiProviderKind::Google:
+    return std::make_shared<GoogleProvider>(apiKey, model);
+  default:
+    return nullptr;
+  }
+}
+
+bool AiProvider::NetworkingAvailable() {
+#if wxUSE_WEBREQUEST
+  return true;
+#else
+  return false;
+#endif
+}
+
+void AiProvider::SendChat(
+  std::shared_ptr<const AiProvider> self, wxEvtHandler *owner, const wxString &context,
+  const std::vector<AiChatMessage> &history,
+  std::function<void(bool ok, const wxString &replyOrError)> callback) {
+#if wxUSE_WEBREQUEST
+  wxString body = self->BuildRequestBody(context, history);
+  // A real, unique id is essential here, not just the default wxID_ANY:
+  // every wxWebRequestEvent this handler ever receives -- from any past or
+  // future request -- carries whatever id its own request was given, and
+  // the id-filtered Bind() below (plus the redundant in-lambda check) both
+  // rely on it to tell "my request completed" apart from "some other
+  // request completed." With the default wxID_ANY every request would
+  // share the same id and every stale lambda would refire on every new
+  // request's completion.
+  // A plain int here would permanently reserve an id from wx's finite
+  // auto-id pool (NewControlId()'s own contract: reserved until assigned to
+  // a wxWindowIDRef or explicitly unreserved) every single chat turn, for
+  // the lifetime of the app -- wxWindowIDRef is what releases it once
+  // nothing references it any more.
+  wxWindowIDRef requestId = wxWindow::NewControlId();
+  wxWebRequest request =
+    wxWebSession::GetDefault().CreateRequest(owner, self->RequestUrl(), requestId);
+  if (!request.IsOk()) {
+    callback(false, _("Could not create the HTTP request."));
+    return;
+  }
+  for (const auto &header : self->AuthHeaders())
+    request.SetHeader(header.first, header.second);
+  request.SetMethod(wxS("POST"));
+  request.SetData(body, wxS("application/json"), wxConvUTF8);
+
+  // Capture `self` (a shared_ptr) by value so the exact provider instance
+  // that built this request -- needed for ParseReply()/Name(), both
+  // virtual -- stays alive for the callback even if AiChatSidebar replaces
+  // its own current-provider pointer before the response arrives (e.g. the
+  // user changes provider/model in Options mid-request). Filtered to this
+  // request's own id so only its own event(s) reach this particular
+  // lambda; every other in-flight/future request's events are cheap
+  // early-returns here. Deliberately never unbound: wx's functor-based
+  // Bind() has no reliable matching Unbind() for a lambda (no identity to
+  // compare against), and the existing wxWebRequest use in this codebase
+  // (wxMaxima::CheckForUpdates()) has the same one-lambda-per-call,
+  // never-unbound shape -- one small permanently-bound no-op-after-firing
+  // lambda per chat turn is not a real leak for how few requests a chat
+  // session sends in practice.
+  // `done` guards against the callback firing twice: State_Unauthorized
+  // (see below) responds by calling request.Cancel(), which itself
+  // raises a *second* event (State_Cancelled) for this same requestId --
+  // without this guard that would invoke `callback` a second time for one
+  // chat turn.
+  auto done = std::make_shared<bool>(false);
+  owner->Bind(
+    wxEVT_WEBREQUEST_STATE,
+    [requestId, self, callback, done](wxWebRequestEvent &evt) {
+      if (evt.GetId() != requestId)
+        return;
+      if (*done)
+        return;
+      switch (evt.GetState()) {
+      case wxWebRequest::State_Completed: {
+        wxWebResponse response = evt.GetResponse();
+        int status = response.GetStatus();
+        wxString responseBody = response.AsString();
+        if ((status < 200) || (status >= 300)) {
+          *done = true;
+          callback(false, wxString::Format(
+                            _("%s returned HTTP %d: %s"), self->Name(), status,
+                            responseBody.Left(500)));
+          return;
+        }
+        *done = true;
+        try {
+          callback(true, self->ParseReply(responseBody));
+        } catch (const AiProviderError &e) {
+          callback(false, FromU8(e.what()));
+        }
+        break;
+      }
+      // A wrong/expired API key surfaces as an HTTP 401 -- every provider
+      // here authenticates via a plain header (x-api-key/Authorization/
+      // x-goog-api-key), not real HTTP Basic/Digest auth, so there is no
+      // wxWebAuthChallenge credential this app could ever supply in
+      // response. Left unhandled, the request just sits in this state
+      // forever (confirmed live: no further wxEVT_WEBREQUEST_STATE event
+      // arrives on its own) since nothing ever answers the challenge --
+      // so this must be treated as a terminal failure, the same as a
+      // non-2xx State_Completed, and the request explicitly cancelled so
+      // it doesn't dangle. GetResponse() is still valid here: the server's
+      // full 401 response (status/body) already arrived before wx
+      // reinterpreted it as an auth challenge.
+      case wxWebRequest::State_Unauthorized: {
+        wxWebResponse response = evt.GetResponse();
+        wxString detail = response.IsOk() ? response.AsString().Left(500) : wxString();
+        *done = true;
+        callback(false, wxString::Format(
+                          _("%s rejected the API key (HTTP 401): %s"),
+                          self->Name(), detail));
+        // GetRequest() returns a const reference; wxWebRequest's handle is
+        // ref-counted (like wxWebResponse/wxWebSession), so a plain copy
+        // shares the same underlying request and Cancel() on it still
+        // cancels the one this event is about.
+        wxWebRequest req = evt.GetRequest();
+        req.Cancel();
+        break;
+      }
+      case wxWebRequest::State_Failed:
+        *done = true;
+        callback(false, wxString::Format(_("Could not reach %s (network error)."),
+                                         self->Name()));
+        break;
+      case wxWebRequest::State_Cancelled:
+        *done = true;
+        callback(false, _("Request cancelled."));
+        break;
+      default:
+        break;
+      }
+    },
+    requestId);
+  request.Start();
+#else
+  callback(false, _("This build of wxMaxima was compiled without wxWebRequest "
+                    "support, so it cannot talk to any AI provider."));
+#endif
+}

--- a/src/ai/AiProvider.h
+++ b/src/ai/AiProvider.h
@@ -1,0 +1,148 @@
+// -*- mode: c++; c-file-style: "linux"; c-basic-offset: 2; indent-tabs-mode: nil -*-
+//
+//  Copyright (C) 2026 Gunter Königsmann <wxMaxima@physikbuch.de>
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation; either version 2 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program; if not, write to the Free Software
+//  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+//
+//  SPDX-License-Identifier: GPL-2.0+
+
+#ifndef AIPROVIDER_H
+#define AIPROVIDER_H
+
+#include "precomp.h"
+#include <wx/wx.h>
+#include <functional>
+#include <memory>
+#include <vector>
+
+/*! \file
+  Talks to one of a handful of external AI chat APIs for the AI chat sidebar
+  (AiChatSidebar). See that class for the safety scope (read-only worksheet
+  context, no tool-calling in this first pass).
+
+  Every provider here needs an internet connection to a third-party service
+  and an API key the user pastes into Options -- unlike the MCP server
+  (src/mcp/), which is entirely local and needs neither. The two features
+  are otherwise unrelated beyond both ultimately drawing on McpTools for
+  worksheet context.
+*/
+
+//! One turn of a chat conversation.
+struct AiChatMessage {
+  //! "user" or "assistant" -- never "system"/"model"/etc.; each provider's
+  //! own request-building maps this pair to whatever vocabulary its own API
+  //! actually expects (e.g. Google's Gemini calls the AI's own turn "model").
+  wxString role;
+  wxString content;
+};
+
+//! Which AI service to talk to. Persisted as a plain int in Configuration;
+//! keep existing values stable across releases (append only).
+enum class AiProviderKind { None = 0, Anthropic = 1, OpenAI = 2, Google = 3, Qwen = 4 };
+
+//! Human-readable name for Options/the sidebar's status line.
+wxString AiProviderKindName(AiProviderKind kind);
+
+//! This provider's built-in default model id, shown as Options' initial
+//! value for a not-yet-configured model field. Users can override it --
+//! model catalogs change far more often than this code does.
+wxString AiProviderDefaultModel(AiProviderKind kind);
+
+/*! Talks to one external AI provider's chat completion HTTP API.
+
+  Deliberately split into a stateless, directly-testable half (BuildRequestBody()/
+  ParseReply(), pure string/JSON in and out, no networking -- see
+  test/unit_tests/test_AiProvider.cpp) and the actual network call
+  (SendChat()), which needs a live wxWebRequest and can only really be
+  verified against a real or fake HTTP server (done live, see AGENTS.md).
+*/
+class AiProvider {
+public:
+  AiProvider(wxString baseUrl, wxString apiKey, wxString model)
+    : m_baseUrl(std::move(baseUrl)), m_apiKey(std::move(apiKey)),
+      m_model(std::move(model)) {}
+  virtual ~AiProvider() = default;
+
+  virtual AiProviderKind Kind() const = 0;
+  wxString Name() const { return AiProviderKindName(Kind()); }
+
+  //! The full URL SendChat() will POST to. Virtual so Google's provider can
+  //! append the model id (its endpoint is per-model, unlike the others).
+  virtual wxString RequestUrl() const { return m_baseUrl; }
+
+  //! Any additional headers this provider's auth scheme needs, name/value
+  //! pairs, beyond the "POST JSON" content-type SendChat() always sets.
+  virtual std::vector<std::pair<wxString, wxString>> AuthHeaders() const = 0;
+
+  /*! Builds the JSON request body for one chat turn. `context` is a
+    read-only worksheet snapshot (from McpTools), sent as a system/context
+    message ahead of the actual conversation; `history` is every prior turn
+    plus the new user message as its last entry. Pure function, no I/O --
+    unit-tested directly. */
+  virtual wxString BuildRequestBody(const wxString &context,
+                                    const std::vector<AiChatMessage> &history) const = 0;
+
+  /*! Extracts the assistant's reply text from a successful (2xx) response
+    body. Throws AiProviderError (see below) if the body doesn't parse or
+    doesn't have the shape this provider expects. Pure function, no I/O. */
+  virtual wxString ParseReply(const wxString &responseBody) const = 0;
+
+  /*! Sends one chat turn asynchronously via wxWebRequest and calls
+    `callback(ok, replyOrError)` exactly once, on the GUI thread, once the
+    HTTP request completes, fails, or errors out. `owner` is the
+    wxEvtHandler the completion event is delivered to -- must outlive the
+    request; the sidebar itself is the intended owner. No-op (calls back
+    with ok=false immediately) if wxUSE_WEBREQUEST is off in this build.
+
+    Static, taking `self` as an explicit shared_ptr rather than being a
+    plain instance method: the completion lambda needs the provider object
+    (for ParseReply()/Name(), both virtual) to still exist whenever the
+    response actually arrives, which can outlast the caller doing something
+    else entirely -- e.g. the user changing the configured provider/model in
+    Options while a request is still in flight. Capturing a shared_ptr
+    keeps the exact instance that sent the request alive for the callback
+    regardless of what AiChatSidebar does to its own current-provider
+    pointer in the meantime; capturing a raw `this` would not. */
+  static void SendChat(std::shared_ptr<const AiProvider> self, wxEvtHandler *owner,
+                       const wxString &context,
+                       const std::vector<AiChatMessage> &history,
+                       std::function<void(bool ok, const wxString &replyOrError)> callback);
+
+  //! True if this build of wxWidgets has wxWebRequest at all (>= 3.1.5,
+  //! built with a working backend) -- if false, the whole chat sidebar
+  //! feature has nothing to talk to and should say so rather than silently
+  //! failing every request.
+  static bool NetworkingAvailable();
+
+protected:
+  wxString m_baseUrl;
+  wxString m_apiKey;
+  wxString m_model;
+};
+
+//! Thrown by ParseReply() for a response that doesn't parse or doesn't have
+//! the expected shape -- distinct from a non-2xx HTTP status, which
+//! SendChat() reports directly from the response body/status line instead.
+class AiProviderError : public std::runtime_error {
+public:
+  explicit AiProviderError(const std::string &msg) : std::runtime_error(msg) {}
+};
+
+//! Builds the provider for this kind, or nullptr for AiProviderKind::None.
+std::shared_ptr<AiProvider> MakeAiProvider(AiProviderKind kind, const wxString &apiKey,
+                                           const wxString &model);
+
+#endif // AIPROVIDER_H

--- a/src/dialogs/ConfigDialogue.cpp
+++ b/src/dialogs/ConfigDialogue.cpp
@@ -29,6 +29,7 @@
 */
 
 #include "ConfigDialogue.h"
+#include "ai/AiProvider.h"
 #include "WXMformat.h"
 #include "BTextCtrl.h"
 #include "cells/Cell.h"
@@ -285,6 +286,8 @@ ConfigDialogue::ConfigDialogue(wxWindow *parent)
   m_notebook->AddPage(CreateClipboardPanel(), _("Copy"), false, 5);
   m_notebook->AddPage(CreateStartupPanel(), _("Startup commands"), false, 6);
   m_notebook->AddPage(CreatePrintPanel(), _("Printout settings"), false, 7);
+  // Re-uses the "options" tab icon -- no dedicated one exists for this tab.
+  m_notebook->AddPage(CreateAiChatPanel(), _("AI Chat"), false, 4);
 #if wxUSE_ACCESSIBILITY
   // Only offered when wxWidgets was compiled with accessibility support -
   // without it there is no screen-reader integration these settings could
@@ -606,6 +609,17 @@ void ConfigDialogue::SetCheckboxValues() {
   m_findDialogDockable->SetValue(configuration->FindDialogDockable());
   m_mcpServerEnabled->SetValue(configuration->McpServerEnabled());
   m_mcpServerPort->SetValue(configuration->McpServerPort());
+  // The enum's own values (AiProviderKind::None=0, Anthropic=1, ...) match
+  // the wxChoice's item order 1:1, so the raw stored int is a valid index.
+  m_aiChatProviderChoice->SetSelection(configuration->AiChatProvider());
+  m_aiKeyAnthropic->SetValue(configuration->AiApiKeyAnthropic());
+  m_aiKeyOpenAI->SetValue(configuration->AiApiKeyOpenAI());
+  m_aiKeyGoogle->SetValue(configuration->AiApiKeyGoogle());
+  m_aiKeyQwen->SetValue(configuration->AiApiKeyQwen());
+  m_aiModelAnthropicCtrl->SetValue(configuration->AiModelAnthropic());
+  m_aiModelOpenAICtrl->SetValue(configuration->AiModelOpenAI());
+  m_aiModelGoogleCtrl->SetValue(configuration->AiModelGoogle());
+  m_aiModelQwenCtrl->SetValue(configuration->AiModelQwen());
   m_fixedFontInTC->SetValue(configuration->FixedFontInTextControls());
   m_offerKnownAnswers->SetValue(m_configuration->OfferKnownAnswers());
 #if wxUSE_ACCESSIBILITY
@@ -1923,6 +1937,79 @@ wxWindow *ConfigDialogue::CreateAccessibilityPanel() {
 }
 #endif
 
+wxWindow *ConfigDialogue::CreateAiChatPanel() {
+  wxScrolled<wxPanel> *panel = new wxScrolled<wxPanel>(m_notebook, wxID_ANY);
+  panel->SetScrollRate(5 * GetContentScaleFactor(),
+                       5 * GetContentScaleFactor());
+  panel->SetMinSize(wxSize(GetContentScaleFactor() * mMinPanelWidth,
+                           GetContentScaleFactor() * mMinPanelHeight));
+
+  wxBoxSizer *vbox = new wxBoxSizer(wxVERTICAL);
+
+  WrappingStaticText *intro = new WrappingStaticText(
+    panel, wxID_ANY,
+    _("The AI Chat sidebar sends the current worksheet's content "
+      "(read-only -- the AI cannot insert, edit or evaluate anything) and "
+      "your messages to whichever provider you pick below. This needs an "
+      "internet connection and an API key from that provider, and nothing "
+      "is sent unless you actually use the sidebar."));
+  vbox->Add(intro, wxSizerFlags().Expand().Border(wxALL, 5 * GetContentScaleFactor()));
+
+  wxBoxSizer *providerBox = new wxBoxSizer(wxHORIZONTAL);
+  providerBox->Add(
+    new wxStaticText(panel, wxID_ANY, _("Active provider:")),
+    wxSizerFlags().Border(wxALL, 5 * GetContentScaleFactor())
+      .Align(wxALIGN_CENTER_VERTICAL));
+  wxArrayString providerChoices;
+  providerChoices.Add(_("None (disabled)"));
+  providerChoices.Add(AiProviderKindName(AiProviderKind::Anthropic));
+  providerChoices.Add(AiProviderKindName(AiProviderKind::OpenAI));
+  providerChoices.Add(AiProviderKindName(AiProviderKind::Google));
+  providerChoices.Add(AiProviderKindName(AiProviderKind::Qwen));
+  m_aiChatProviderChoice =
+    new wxChoice(panel, wxID_ANY, wxDefaultPosition, wxDefaultSize, providerChoices);
+  providerBox->Add(m_aiChatProviderChoice,
+                   wxSizerFlags().Border(wxALL, 5 * GetContentScaleFactor()));
+  vbox->Add(providerBox);
+
+  // One box per provider, always shown (not just the active one): this way
+  // switching providers never loses a key/model you already entered for
+  // another one.
+  auto addProviderBox = [&](const wxString &title, wxTextCtrl *&keyCtrl,
+                            wxTextCtrl *&modelCtrl) {
+    wxStaticBoxSizer *box = new wxStaticBoxSizer(wxVERTICAL, panel, title);
+    wxFlexGridSizer *grid = new wxFlexGridSizer(2, 2, 5, 5);
+    grid->AddGrowableCol(1);
+    grid->Add(new wxStaticText(box->GetStaticBox(), wxID_ANY, _("API key:")),
+             wxSizerFlags().Align(wxALIGN_CENTER_VERTICAL));
+    keyCtrl = new wxTextCtrl(box->GetStaticBox(), wxID_ANY, wxEmptyString,
+                             wxDefaultPosition,
+                             wxSize(300 * GetContentScaleFactor(), -1),
+                             wxTE_PASSWORD);
+    grid->Add(keyCtrl, wxSizerFlags().Expand());
+    grid->Add(new wxStaticText(box->GetStaticBox(), wxID_ANY, _("Model:")),
+             wxSizerFlags().Align(wxALIGN_CENTER_VERTICAL));
+    modelCtrl = new wxTextCtrl(box->GetStaticBox(), wxID_ANY, wxEmptyString,
+                               wxDefaultPosition,
+                               wxSize(300 * GetContentScaleFactor(), -1));
+    grid->Add(modelCtrl, wxSizerFlags().Expand());
+    box->Add(grid, wxSizerFlags().Expand().Border(wxALL, 5 * GetContentScaleFactor()));
+    vbox->Add(box, wxSizerFlags().Expand().Border(wxALL, 5 * GetContentScaleFactor()));
+  };
+  addProviderBox(AiProviderKindName(AiProviderKind::Anthropic), m_aiKeyAnthropic,
+                m_aiModelAnthropicCtrl);
+  addProviderBox(AiProviderKindName(AiProviderKind::OpenAI), m_aiKeyOpenAI,
+                m_aiModelOpenAICtrl);
+  addProviderBox(AiProviderKindName(AiProviderKind::Google), m_aiKeyGoogle,
+                m_aiModelGoogleCtrl);
+  addProviderBox(AiProviderKindName(AiProviderKind::Qwen), m_aiKeyQwen,
+                m_aiModelQwenCtrl);
+
+  panel->SetSizer(vbox);
+  panel->FitInside();
+  return panel;
+}
+
 wxWindow *ConfigDialogue::CreateClipboardPanel() {
   wxScrolled<wxPanel> *panel = new wxScrolled<wxPanel>(m_notebook, wxID_ANY);
   panel->SetScrollRate(5 * GetContentScaleFactor(),
@@ -2351,6 +2438,15 @@ void ConfigDialogue::WriteSettings() {
   configuration->FindDialogDockable(m_findDialogDockable->GetValue());
   configuration->McpServerEnabled(m_mcpServerEnabled->GetValue());
   configuration->McpServerPort(m_mcpServerPort->GetValue());
+  configuration->AiChatProvider(m_aiChatProviderChoice->GetSelection());
+  configuration->AiApiKeyAnthropic(m_aiKeyAnthropic->GetValue());
+  configuration->AiApiKeyOpenAI(m_aiKeyOpenAI->GetValue());
+  configuration->AiApiKeyGoogle(m_aiKeyGoogle->GetValue());
+  configuration->AiApiKeyQwen(m_aiKeyQwen->GetValue());
+  configuration->AiModelAnthropic(m_aiModelAnthropicCtrl->GetValue());
+  configuration->AiModelOpenAI(m_aiModelOpenAICtrl->GetValue());
+  configuration->AiModelGoogle(m_aiModelGoogleCtrl->GetValue());
+  configuration->AiModelQwen(m_aiModelQwenCtrl->GetValue());
   configuration->SetLabelChoice(
                                 (Configuration::showLabels)m_showUserDefinedLabels->GetSelection());
   configuration->DefaultPort(m_defaultPort->GetValue());

--- a/src/dialogs/ConfigDialogue.h
+++ b/src/dialogs/ConfigDialogue.h
@@ -182,6 +182,7 @@ private:
 
   //! The panel that allows to choose which formats to put on the clipboard
   wxWindow *CreateClipboardPanel();
+  wxWindow *CreateAiChatPanel();
 
   //! The panel that allows to change the print settings
   wxWindow *CreatePrintPanel();
@@ -342,6 +343,15 @@ protected:
   wxCheckBox *m_findDialogDockable;
   wxCheckBox *m_mcpServerEnabled;
   wxSpinCtrl *m_mcpServerPort;
+  wxChoice *m_aiChatProviderChoice;
+  wxTextCtrl *m_aiKeyAnthropic;
+  wxTextCtrl *m_aiKeyOpenAI;
+  wxTextCtrl *m_aiKeyGoogle;
+  wxTextCtrl *m_aiKeyQwen;
+  wxTextCtrl *m_aiModelAnthropicCtrl;
+  wxTextCtrl *m_aiModelOpenAICtrl;
+  wxTextCtrl *m_aiModelGoogleCtrl;
+  wxTextCtrl *m_aiModelQwenCtrl;
   wxChoice *m_showUserDefinedLabels;
   wxButton *m_getStyleFont;
   //! Light / Dark / Follow-system selector (also picks which set the editor edits).

--- a/src/sidebars/AiChatSidebar.cpp
+++ b/src/sidebars/AiChatSidebar.cpp
@@ -1,0 +1,208 @@
+// -*- mode: c++; c-file-style: "linux"; c-basic-offset: 2; indent-tabs-mode: nil -*-
+//
+//  Copyright (C) 2026 Gunter Königsmann <wxMaxima@physikbuch.de>
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation; either version 2 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program; if not, write to the Free Software
+//  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+//
+//  SPDX-License-Identifier: GPL-2.0+
+
+#include "AiChatSidebar.h"
+#include "Configuration.h"
+
+using json = nlohmann::json;
+
+AiChatSidebar::AiChatSidebar(wxWindow *parent, Configuration *configuration,
+                             Worksheet *worksheet, Variablespane *variablesPane,
+                             wxWindowID id)
+  : wxPanel(parent, id), m_configuration(configuration),
+    m_tools(worksheet, variablesPane) {
+  wxBoxSizer *vbox = new wxBoxSizer(wxVERTICAL);
+
+  m_statusText = new wxStaticText(this, wxID_ANY, wxEmptyString);
+  vbox->Add(m_statusText,
+           wxSizerFlags().Expand().Border(wxALL, 5 * GetContentScaleFactor()));
+
+  m_historyCtrl =
+    new wxTextCtrl(this, wxID_ANY, wxEmptyString, wxDefaultPosition,
+                   wxDefaultSize,
+                   wxTE_MULTILINE | wxTE_READONLY | wxTE_RICH2);
+  vbox->Add(m_historyCtrl,
+           wxSizerFlags(1).Expand().Border(wxALL, 5 * GetContentScaleFactor()));
+
+  // Stacked vertically -- input above, buttons in a row below -- rather than
+  // input-beside-buttons: this sidebar docks into a narrow column (shared
+  // with e.g. Table of Contents), and a horizontal layout let the
+  // fixed-width button column crowd the input box down to an invisible
+  // sliver there (confirmed live: swapping each control's background to a
+  // distinct debug colour showed the "input" area was really only a few
+  // pixels wide). A vertical stack has no such competition for width.
+  m_inputCtrl = new wxTextCtrl(
+    this, wxID_ANY, wxEmptyString, wxDefaultPosition,
+    wxSize(-1, 60 * GetContentScaleFactor()), wxTE_MULTILINE);
+  m_inputCtrl->SetToolTip(
+    _("Enter sends; Shift+Enter inserts a newline."));
+  vbox->Add(m_inputCtrl,
+           wxSizerFlags().Expand().Border(wxALL, 5 * GetContentScaleFactor()));
+
+  // Stacked vertically too, each full-width, rather than side by side: even
+  // two buttons side by side don't reliably both fit a docked sidebar this
+  // narrow without the same width-squeeze problem the input box just had
+  // (confirmed live: side by side, "Clear" was pushed down to an invisible
+  // sliver at the panel's edge).
+  m_sendButton = new wxButton(this, wxID_ANY, _("Send"));
+  m_clearButton = new wxButton(this, wxID_ANY, _("Clear"));
+  vbox->Add(m_sendButton,
+           wxSizerFlags().Expand().Border(wxALL, 5 * GetContentScaleFactor()));
+  vbox->Add(m_clearButton,
+           wxSizerFlags().Expand().Border(wxALL, 5 * GetContentScaleFactor()));
+
+  SetSizer(vbox);
+  Layout();
+
+  m_sendButton->Bind(wxEVT_BUTTON, &AiChatSidebar::OnSend, this);
+  m_clearButton->Bind(wxEVT_BUTTON,
+                      [this](wxCommandEvent &) { ClearConversation(); });
+  m_inputCtrl->Bind(wxEVT_KEY_DOWN, &AiChatSidebar::OnInputKeyDown, this);
+
+  ReloadProviderFromConfig();
+}
+
+void AiChatSidebar::ReloadProviderFromConfig() {
+  auto kind = static_cast<AiProviderKind>(m_configuration->AiChatProvider());
+  wxString apiKey, model;
+  switch (kind) {
+  case AiProviderKind::Anthropic:
+    apiKey = m_configuration->AiApiKeyAnthropic();
+    model = m_configuration->AiModelAnthropic();
+    break;
+  case AiProviderKind::OpenAI:
+    apiKey = m_configuration->AiApiKeyOpenAI();
+    model = m_configuration->AiModelOpenAI();
+    break;
+  case AiProviderKind::Google:
+    apiKey = m_configuration->AiApiKeyGoogle();
+    model = m_configuration->AiModelGoogle();
+    break;
+  case AiProviderKind::Qwen:
+    apiKey = m_configuration->AiApiKeyQwen();
+    model = m_configuration->AiModelQwen();
+    break;
+  default:
+    break;
+  }
+  m_provider = (apiKey.IsEmpty()) ? nullptr : MakeAiProvider(kind, apiKey, model);
+  UpdateStatusText();
+  m_sendButton->Enable(!m_requestInFlight && (m_provider != nullptr));
+}
+
+void AiChatSidebar::ClearConversation() {
+  m_history.clear();
+  m_historyCtrl->Clear();
+}
+
+void AiChatSidebar::OnInputKeyDown(wxKeyEvent &event) {
+  if (((event.GetKeyCode() == WXK_RETURN) ||
+      (event.GetKeyCode() == WXK_NUMPAD_ENTER)) &&
+      !event.ShiftDown()) {
+    wxCommandEvent dummy;
+    OnSend(dummy);
+    return; // Swallow the Enter -- don't Skip() -- so no newline is inserted.
+  }
+  event.Skip();
+}
+
+void AiChatSidebar::AppendToHistory(const wxString &speaker, const wxString &text) {
+  m_historyCtrl->AppendText(speaker + wxS(":\n") + text + wxS("\n\n"));
+}
+
+void AiChatSidebar::SetBusy(bool busy) {
+  m_requestInFlight = busy;
+  m_inputCtrl->Enable(!busy);
+  m_sendButton->Enable(!busy && (m_provider != nullptr));
+  UpdateStatusText();
+}
+
+void AiChatSidebar::UpdateStatusText() {
+  if (m_requestInFlight)
+    m_statusText->SetLabel(
+      wxString::Format(_("Waiting for %s..."),
+                       m_provider ? m_provider->Name() : wxString()));
+  else if (!AiProvider::NetworkingAvailable())
+    m_statusText->SetLabel(
+      _("This build of wxMaxima cannot make network requests."));
+  else if (!m_provider)
+    m_statusText->SetLabel(
+      _("No AI provider configured -- add an API key in Options."));
+  else
+    m_statusText->SetLabel(
+      wxString::Format(_("Chatting with %s"), m_provider->Name()));
+}
+
+wxString AiChatSidebar::BuildContextSnapshot() const {
+  json worksheet = m_tools.ReadWorksheet();
+  wxString text = wxString::FromUTF8(worksheet.value("text", std::string()).c_str());
+  if (text.Length() > MAX_CONTEXT_LENGTH) {
+    text = text.Left(MAX_CONTEXT_LENGTH);
+    text += wxS("\n... [truncated for the chat context]");
+  }
+  return _("You are an assistant embedded in wxMaxima, a GUI front-end for "
+          "the Maxima computer algebra system. Below is a read-only "
+          "snapshot of the user's current worksheet -- you cannot edit, "
+          "evaluate or otherwise change it; only the user can do that "
+          "through the wxMaxima UI. Use it only as context.\n\n"
+          "--- Worksheet snapshot ---\n") +
+    text;
+}
+
+void AiChatSidebar::OnSend(wxCommandEvent &) {
+  if (m_requestInFlight)
+    return;
+  wxString text = m_inputCtrl->GetValue();
+  text.Trim();
+  text.Trim(false);
+  if (text.IsEmpty())
+    return;
+  if (!m_provider) {
+    AppendToHistory(_("wxMaxima"),
+                    _("No AI provider is configured. Open Options to add an "
+                      "API key for one."));
+    return;
+  }
+  if (!AiProvider::NetworkingAvailable()) {
+    AppendToHistory(_("wxMaxima"),
+                    _("This build of wxMaxima cannot make network requests."));
+    return;
+  }
+
+  m_inputCtrl->Clear();
+  AppendToHistory(_("You"), text);
+  m_history.push_back({wxS("user"), text});
+  SetBusy(true);
+
+  wxString context = BuildContextSnapshot();
+  std::shared_ptr<AiProvider> provider = m_provider;
+  AiProvider::SendChat(
+    provider, this, context, m_history,
+    [this, provider](bool ok, const wxString &replyOrError) {
+      SetBusy(false);
+      if (ok) {
+        AppendToHistory(provider->Name(), replyOrError);
+        m_history.push_back({wxS("assistant"), replyOrError});
+      } else {
+        AppendToHistory(_("Error"), replyOrError);
+      }
+    });
+}

--- a/src/sidebars/AiChatSidebar.h
+++ b/src/sidebars/AiChatSidebar.h
@@ -1,0 +1,105 @@
+// -*- mode: c++; c-file-style: "linux"; c-basic-offset: 2; indent-tabs-mode: nil -*-
+//
+//  Copyright (C) 2026 Gunter Königsmann <wxMaxima@physikbuch.de>
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation; either version 2 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program; if not, write to the Free Software
+//  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+//
+//  SPDX-License-Identifier: GPL-2.0+
+
+#ifndef AICHATSIDEBAR_H
+#define AICHATSIDEBAR_H
+
+#include "precomp.h"
+#include "ai/AiProvider.h"
+#include "mcp/McpTools.h"
+#include <wx/wx.h>
+#include <memory>
+#include <vector>
+
+class Configuration;
+class Worksheet;
+class Variablespane;
+
+/*! A sidebar to chat with an external AI about the current worksheet
+  (follow-up to the MCP server, GH request: "a de facto standard AI sidebar
+  that ... gives it access to a worksheet").
+
+  Safety scope, same as the MCP server's (see McpTools.h): every message
+  sent to the AI is accompanied by a read-only worksheet snapshot (built via
+  McpTools, the same tool logic the MCP server itself uses), refreshed
+  before each turn -- but this first pass does NOT give the AI any tool-
+  calling ability to actively request a specific cell/section/variable
+  mid-conversation, and it cannot insert, edit, or evaluate anything in the
+  worksheet. It is a read-only-context chat, not an agent. A real
+  tool-calling loop (the AI deciding for itself to call read_cell/
+  read_section/watch_variable) is a natural follow-up once this ships, since
+  McpTools already implements every tool such a loop would need -- it just
+  isn't wired up to a provider's function-calling API yet.
+
+  Needs an internet connection and an API key the user pastes into Options
+  for one of a handful of providers (AiProvider.h) -- unlike the MCP server,
+  which is entirely local. Requires wxUSE_WEBREQUEST (wxWidgets >= 3.1.5
+  with a working backend); says so plainly and refuses to send anything
+  if that's not available in this build, rather than silently failing.
+*/
+class AiChatSidebar : public wxPanel {
+public:
+  AiChatSidebar(wxWindow *parent, Configuration *configuration,
+               Worksheet *worksheet, Variablespane *variablesPane,
+               wxWindowID id = wxID_ANY);
+
+  //! Re-reads Configuration for the selected provider/API key/model and
+  //! rebuilds this sidebar's provider accordingly. Call after the Options
+  //! dialog closes, in case the AI settings changed. Safe to call even
+  //! while a request is in flight -- see AiProvider::SendChat()'s own
+  //! shared_ptr-based lifetime handling for why that's safe.
+  void ReloadProviderFromConfig();
+
+  //! Clears the conversation history (but not the provider/API key setup).
+  void ClearConversation();
+
+private:
+  void OnSend(wxCommandEvent &event);
+  void OnInputKeyDown(wxKeyEvent &event);
+  void AppendToHistory(const wxString &speaker, const wxString &text);
+  void SetBusy(bool busy);
+  //! A compact, size-capped plain-text snapshot of the worksheet (table of
+  //! contents + a capped full-text dump), refreshed on every send -- see
+  //! the class comment for why this is a snapshot, not live tool-calling.
+  wxString BuildContextSnapshot() const;
+  void UpdateStatusText();
+
+  Configuration *m_configuration;
+  McpTools m_tools;
+  std::shared_ptr<AiProvider> m_provider;
+  std::vector<AiChatMessage> m_history;
+  bool m_requestInFlight = false;
+
+  wxTextCtrl *m_historyCtrl;
+  wxTextCtrl *m_inputCtrl;
+  wxButton *m_sendButton;
+  wxButton *m_clearButton;
+  wxStaticText *m_statusText;
+
+  //! A cap on the worksheet snapshot's size distinct from (and much
+  //! smaller than) McpTools::MAX_TEXT_LENGTH: that limit exists to bound a
+  //! single MCP tool response, not to size something that gets resent as
+  //! context on every single chat turn and counts against the provider's
+  //! own context window and the user's token bill.
+  static constexpr std::size_t MAX_CONTEXT_LENGTH = 8000;
+};
+
+#endif // AICHATSIDEBAR_H

--- a/src/wxMaxima.cpp
+++ b/src/wxMaxima.cpp
@@ -207,6 +207,7 @@ void wxMaxima::ConfigChanged() {
 
   ApplyAppearanceToApp(GetConfiguration().GetAppearance());
   ReconcileMcpServer();
+  ReloadAiChatProvider();
 
   if (GetWorksheet())
     GetWorksheet()->ApplyOverlayScrollbarsSetting();

--- a/src/wxMaximaFrame.cpp
+++ b/src/wxMaximaFrame.cpp
@@ -310,6 +310,16 @@ wxMaximaFrame::wxMaximaFrame(wxWindow *parent, int id,
       m_mcpServer = std::make_unique<McpServer>(GetWorksheet(), m_variablesPane);
       ReconcileMcpServer();
 
+      m_sidebarNames[EventIDs::menu_pane_aichat] = wxS("aichat");
+      m_sidebarCaption[EventIDs::menu_pane_aichat] = _("AI Chat");
+      m_aiChatSidebar = new AiChatSidebar(this, &GetConfiguration(), GetWorksheet(),
+                                         m_variablesPane);
+      m_manager.AddPane(
+                        m_aiChatSidebar,
+                        wxAuiPaneInfo()
+                        .Name(m_sidebarNames[EventIDs::menu_pane_aichat])
+                        .Right());
+
       m_sidebarNames[EventIDs::menu_pane_symbols] = wxS("symbols");
       m_sidebarCaption[EventIDs::menu_pane_symbols] = _("Mathematical Symbols");
       m_symbolsSidebar = new SymbolsSidebar(this, &GetConfiguration(), GetWorksheet());
@@ -812,6 +822,7 @@ void wxMaximaFrame::SetupViewMenu() {
                                       _("The integrated help browser"));
 #endif
   m_Maxima_Panes_Sub->AppendCheckItem(EventIDs::menu_pane_variables, _("Variables"));
+  m_Maxima_Panes_Sub->AppendCheckItem(EventIDs::menu_pane_aichat, _("AI Chat"));
   m_Maxima_Panes_Sub->AppendCheckItem(EventIDs::menu_pane_xmlInspector,
                                       _("Raw XML monitor"));
   m_Maxima_Panes_Sub->AppendCheckItem(EventIDs::menu_pane_performance,
@@ -2313,6 +2324,7 @@ void wxMaximaFrame::HideAllSidebars(wxCommandEvent &WXUNUSED(ev)) {
   m_manager.GetPane(m_sidebarNames[EventIDs::menu_pane_draw]).Hide();
   m_manager.GetPane(m_sidebarNames[EventIDs::menu_pane_help]).Hide();
   m_manager.GetPane(m_sidebarNames[EventIDs::menu_pane_variables]).Hide();;
+  m_manager.GetPane(m_sidebarNames[EventIDs::menu_pane_aichat]).Hide();
   m_manager.GetPane(m_sidebarNames[EventIDs::menu_pane_xmlInspector]).Hide();
   m_manager.GetPane(m_sidebarNames[EventIDs::menu_pane_find]).Hide();
   AuiManagerUpdate();

--- a/src/wxMaximaFrame.h
+++ b/src/wxMaximaFrame.h
@@ -58,6 +58,7 @@
 #include "StatusBar.h"
 #include "sidebars/ButtonWrapSizer.h"
 #include "mcp/McpServer.h"
+#include "sidebars/AiChatSidebar.h"
 #include <list>
 #include <memory>
 
@@ -199,9 +200,18 @@ public:
     if (m_mcpServer)
       m_mcpServer->ReconcileWithConfig(m_configuration);
   }
+
+  //! Re-reads the configured AI provider/API key/model for the AI chat
+  //! sidebar. Call after the Options dialog closes, in case they changed.
+  void ReloadAiChatProvider() {
+    if (m_aiChatSidebar)
+      m_aiChatSidebar->ReloadProviderFromConfig();
+  }
 protected:
   //! The panel the user can display variable contents in
   Variablespane *m_variablesPane = NULL;
+  //! The AI chat sidebar -- see src/sidebars/AiChatSidebar.h.
+  AiChatSidebar *m_aiChatSidebar = NULL;
   //! The table of contents pane
   TableOfContents *m_tableOfContents = NULL;
   Configuration m_configuration;

--- a/test/unit_tests/CMakeLists.txt
+++ b/test/unit_tests/CMakeLists.txt
@@ -135,6 +135,15 @@ target_include_directories(test_MaximaProtocol PRIVATE ${CMAKE_SOURCE_DIR}/src)
 target_link_libraries(test_MaximaProtocol PRIVATE ${wxWidgets_LIBRARIES})
 add_test(MaximaProtocol test_MaximaProtocol)
 
+# AiProvider's request-building/response-parsing (the AI chat sidebar's
+# per-provider HTTP shapes) is pure JSON in and out, so it is tested
+# directly, the same way as MaximaProtocol above -- the actual network call
+# (wxWebRequest-based) needs a live Xvfb session instead, see AGENTS.md.
+add_executable(test_AiProvider test_AiProvider.cpp ${WXM_TEST_SETUP} ${WXM_TEST_MANIFEST})
+target_include_directories(test_AiProvider PRIVATE ${CMAKE_SOURCE_DIR}/src)
+target_link_libraries(test_AiProvider PRIVATE ${wxWidgets_LIBRARIES})
+add_test(AiProvider test_AiProvider)
+
 # Guards the wxWidgets 3.3 "item" assert that wxMenu::GetHelpString() trips when
 # a highlighted menu id is not an item of that menu (seen mainly via the Windows
 # native menu code). MenuHelpString() is a tiny GUI-object helper, so it is

--- a/test/unit_tests/test_AiProvider.cpp
+++ b/test/unit_tests/test_AiProvider.cpp
@@ -1,0 +1,222 @@
+// -*- mode: c++; c-file-style: "linux"; c-basic-offset: 2; indent-tabs-mode: nil -*-
+//
+//  Copyright (C) 2026 Gunter Königsmann <wxMaxima@physikbuch.de>
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation; either version 2 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program; if not, write to the Free Software
+//  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+//
+//  SPDX-License-Identifier: GPL-2.0+
+
+/*! \file
+  Pins each AiProvider's request/response shape -- the stateless half of
+  AiProvider (BuildRequestBody()/ParseReply(), pure JSON in and out, see
+  AiProvider.h for why this split exists). The actual network call
+  (SendChat(), wxWebRequest-based) is not exercised here -- no live network
+  access or API keys are available in this sandbox; verified live instead
+  in a real Xvfb session (see AGENTS.md's AI chat sidebar entry).
+*/
+
+#include "ai/AiProvider.cpp"
+
+#define CATCH_CONFIG_RUNNER
+#include <catch2/catch.hpp>
+
+namespace {
+std::vector<AiChatMessage> OneUserTurn(const wxString &text) {
+  return {{wxS("user"), text}};
+}
+} // namespace
+
+SCENARIO("Anthropic's Messages API request/response shape") {
+  auto provider = MakeAiProvider(AiProviderKind::Anthropic, wxS("sk-ant-test"),
+                                 wxS("claude-3-5-sonnet-20241022"));
+  REQUIRE(provider);
+
+  GIVEN("a system context and one user message") {
+    wxString body = provider->BuildRequestBody(wxS("worksheet context"),
+                                               OneUserTurn(wxS("What is 2+2?")));
+    json parsed = json::parse(std::string(body.ToUTF8()));
+    THEN("the body has Anthropic's model/system/messages shape") {
+      CHECK(parsed.at("model") == "claude-3-5-sonnet-20241022");
+      CHECK(parsed.at("system") == "worksheet context");
+      REQUIRE(parsed.at("messages").size() == 1);
+      CHECK(parsed.at("messages")[0].at("role") == "user");
+      CHECK(parsed.at("messages")[0].at("content") == "What is 2+2?");
+    }
+  }
+
+  GIVEN("the x-api-key/anthropic-version headers") {
+    THEN("both are present with the right values") {
+      auto headers = provider->AuthHeaders();
+      bool sawKey = false, sawVersion = false;
+      for (const auto &h : headers) {
+        if (h.first == wxS("x-api-key")) {
+          CHECK(h.second == wxS("sk-ant-test"));
+          sawKey = true;
+        }
+        if (h.first == wxS("anthropic-version")) {
+          CHECK(h.second == wxS("2023-06-01"));
+          sawVersion = true;
+        }
+      }
+      CHECK(sawKey);
+      CHECK(sawVersion);
+    }
+  }
+
+  GIVEN("a realistic successful response") {
+    wxString response = wxS(
+      R"({"content":[{"type":"text","text":"4"}],"id":"msg_1","model":"claude-3-5-sonnet-20241022"})");
+    THEN("ParseReply() extracts the text block") {
+      CHECK(provider->ParseReply(response) == wxS("4"));
+    }
+  }
+
+  GIVEN("a response with no text content block") {
+    wxString response = wxS(R"({"content":[]})");
+    THEN("ParseReply() throws AiProviderError, not a crash or an empty reply") {
+      CHECK_THROWS_AS(provider->ParseReply(response), AiProviderError);
+    }
+  }
+
+  GIVEN("a response that isn't even valid JSON") {
+    THEN("ParseReply() throws AiProviderError") {
+      CHECK_THROWS_AS(provider->ParseReply(wxS("not json at all")), AiProviderError);
+    }
+  }
+}
+
+SCENARIO("OpenAI's (and Qwen's identical) chat/completions shape") {
+  auto provider = MakeAiProvider(AiProviderKind::OpenAI, wxS("sk-test"),
+                                 wxS("gpt-4o-mini"));
+  REQUIRE(provider);
+
+  GIVEN("a system context and one user message") {
+    wxString body = provider->BuildRequestBody(wxS("worksheet context"),
+                                               OneUserTurn(wxS("Hello")));
+    json parsed = json::parse(std::string(body.ToUTF8()));
+    THEN("context becomes the first, system-role message") {
+      CHECK(parsed.at("model") == "gpt-4o-mini");
+      REQUIRE(parsed.at("messages").size() == 2);
+      CHECK(parsed.at("messages")[0].at("role") == "system");
+      CHECK(parsed.at("messages")[0].at("content") == "worksheet context");
+      CHECK(parsed.at("messages")[1].at("role") == "user");
+    }
+  }
+
+  GIVEN("no context at all") {
+    wxString body = provider->BuildRequestBody(wxEmptyString, OneUserTurn(wxS("Hi")));
+    json parsed = json::parse(std::string(body.ToUTF8()));
+    THEN("no system message is added") {
+      REQUIRE(parsed.at("messages").size() == 1);
+      CHECK(parsed.at("messages")[0].at("role") == "user");
+    }
+  }
+
+  GIVEN("the Bearer auth header") {
+    THEN("it carries the API key") {
+      auto headers = provider->AuthHeaders();
+      REQUIRE(headers.size() == 1);
+      CHECK(headers[0].first == wxS("Authorization"));
+      CHECK(headers[0].second == wxS("Bearer sk-test"));
+    }
+  }
+
+  GIVEN("a realistic successful response") {
+    wxString response = wxS(
+      R"({"choices":[{"message":{"role":"assistant","content":"Hi there!"}}]})");
+    THEN("ParseReply() extracts choices[0].message.content") {
+      CHECK(provider->ParseReply(response) == wxS("Hi there!"));
+    }
+  }
+
+  GIVEN("Qwen, via DashScope's OpenAI-compatible endpoint") {
+    auto qwen = MakeAiProvider(AiProviderKind::Qwen, wxS("qwen-key"), wxS("qwen-plus"));
+    THEN("it points at DashScope's compatible-mode URL, not OpenAI's") {
+      CHECK(qwen->RequestUrl() ==
+           wxS("https://dashscope.aliyuncs.com/compatible-mode/v1/chat/completions"));
+    }
+    AND_THEN("its request/response shape is identical to OpenAI's") {
+      wxString body = qwen->BuildRequestBody(wxEmptyString, OneUserTurn(wxS("Hi")));
+      json parsed = json::parse(std::string(body.ToUTF8()));
+      CHECK(parsed.at("model") == "qwen-plus");
+      CHECK(qwen->ParseReply(
+              wxS(R"({"choices":[{"message":{"content":"ok"}}]})")) == wxS("ok"));
+    }
+  }
+}
+
+SCENARIO("Google Gemini's generateContent shape") {
+  auto provider = MakeAiProvider(AiProviderKind::Google, wxS("goog-key"),
+                                 wxS("gemini-1.5-flash"));
+  REQUIRE(provider);
+
+  GIVEN("the model-specific request URL") {
+    THEN("it embeds the model id and :generateContent") {
+      CHECK(provider->RequestUrl() ==
+           wxS("https://generativelanguage.googleapis.com/v1beta/models/"
+               "gemini-1.5-flash:generateContent"));
+    }
+  }
+
+  GIVEN("the x-goog-api-key header") {
+    THEN("it carries the API key") {
+      auto headers = provider->AuthHeaders();
+      REQUIRE(headers.size() == 1);
+      CHECK(headers[0].first == wxS("x-goog-api-key"));
+      CHECK(headers[0].second == wxS("goog-key"));
+    }
+  }
+
+  GIVEN("a system context and a two-turn conversation") {
+    std::vector<AiChatMessage> history = {{wxS("user"), wxS("Hi")},
+                                          {wxS("assistant"), wxS("Hello!")},
+                                          {wxS("user"), wxS("What's 2+2?")}};
+    wxString body = provider->BuildRequestBody(wxS("worksheet context"), history);
+    json parsed = json::parse(std::string(body.ToUTF8()));
+    THEN("context becomes systemInstruction, and 'assistant' becomes 'model'") {
+      CHECK(parsed.at("systemInstruction").at("parts")[0].at("text") ==
+           "worksheet context");
+      REQUIRE(parsed.at("contents").size() == 3);
+      CHECK(parsed.at("contents")[0].at("role") == "user");
+      CHECK(parsed.at("contents")[1].at("role") == "model");
+      CHECK(parsed.at("contents")[2].at("parts")[0].at("text") == "What's 2+2?");
+    }
+  }
+
+  GIVEN("a realistic successful response") {
+    wxString response = wxS(
+      R"({"candidates":[{"content":{"role":"model","parts":[{"text":"4"}]}}]})");
+    THEN("ParseReply() extracts candidates[0].content.parts[0].text") {
+      CHECK(provider->ParseReply(response) == wxS("4"));
+    }
+  }
+
+  GIVEN("multiple text parts in one candidate") {
+    wxString response = wxS(
+      R"({"candidates":[{"content":{"parts":[{"text":"foo"},{"text":"bar"}]}}]})");
+    THEN("ParseReply() concatenates every part's text") {
+      CHECK(provider->ParseReply(response) == wxS("foobar"));
+    }
+  }
+}
+
+SCENARIO("MakeAiProvider(AiProviderKind::None, ...) returns nullptr") {
+  THEN("no provider object is created for the disabled/unconfigured state") {
+    CHECK(MakeAiProvider(AiProviderKind::None, wxEmptyString, wxEmptyString) == nullptr);
+  }
+}
+
+int main(int argc, char *argv[]) { return Catch::Session().run(argc, argv); }


### PR DESCRIPTION
## Summary

- Adds a new docked sidebar (View -> Sidebars -> AI Chat) that lets the user chat about the current worksheet with an AI provider of their choice: Anthropic, OpenAI, Google Gemini, or Qwen (via DashScope's OpenAI-compatible endpoint), using their own pasted API key (Options -> AI Chat). No OAuth — none of these four providers offer a legitimate third-party OAuth flow for a desktop app.
- Follows up on the MCP server (#2290): it reuses the same read-only `McpTools::ReadWorksheet()` to build a plain-text worksheet snapshot as context. v1 is deliberately read-only and has no tool-calling — the AI can discuss the worksheet but cannot edit, evaluate, or otherwise act on it.
- `AiProvider` is a small per-provider abstraction (`RequestUrl()`/`AuthHeaders()`/`BuildRequestBody()`/`ParseReply()`, pure JSON logic, no networking of its own) so all four providers' request/response shapes are covered by `test_AiProvider` (54 assertions, no live network needed).

## Notable bug found and fixed during live testing

`wxWebRequest::State_Unauthorized` is not optional to handle: an invalid or expired API key surfaces as that state, not a normal `State_Completed` with HTTP 401. Left unhandled (the natural-looking implementation), the request just hangs forever with no further event — confirmed live against the real Anthropic API with a deliberately wrong key, the sidebar sat on "Waiting for Anthropic..." indefinitely. Fixed by handling that state explicitly, reporting the error, and cancelling the now-dangling request (with a guard against the resulting cancellation event double-firing the completion callback). Full root-cause writeup, plus the provider abstraction's lifetime-safety design and a docked-sidebar layout pitfall that was also hit and fixed, are in `AGENTS.md`.

## Test plan

- [x] `test_AiProvider` — 54 assertions across all four providers' request/response/error shapes
- [x] Full clean rebuild, zero new warnings
- [x] Full `ctest` suite (194 tests, excluding the known-flaky `tutorial_*`/`wxmaxima_version_string` batch tests) — 100% passing
- [x] `check-pot-coverage` passes; new translatable strings added to `wxMaxima.pot`
- [x] Live end-to-end verification in a real Xvfb session against the real Anthropic API: sending a message, the busy/status UI states, and the `State_Unauthorized` error path (before and after the fix)
- [ ] Not verified: a real, valid API key's successful reply for any of the four providers (no credentials available in this environment), and OpenAI/Google/Qwen's actual live endpoints (only Anthropic was reachable; the other three are covered only by `test_AiProvider`'s shape tests, not a live server)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011iszcZR49S3QXrTKUQjiu6)_