### PR TITLE
Give the AI worksheet context cursor/error awareness and output caps

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -703,6 +703,42 @@ a local TCP socket.
     (Gemini) API key..." Fixed by rewording to "Get an API key for %s...",
     which sidesteps the a/an agreement entirely rather than trying to track
     which of the four provider names needs which article.
+  - **Follow-up (2026-09-06): "do we need to hardcode the model names? they
+    tend to change over time"** -- a fair challenge, and the user's own
+    follow-up ("model auto detection feels like hunting a mechanism that
+    catches outdated strings with a mechanism that can get outdated") is
+    exactly why this wasn't turned into a live "fetch the model list from
+    each provider's API" feature: that mechanism would itself need
+    maintaining against four APIs just to answer a question a plain link
+    to each provider's own docs already answers, permanently, for free.
+    Two changes instead: (1) `AiProviderDefaultModel()`'s Anthropic entry
+    now uses `claude-3-5-sonnet-latest`, that provider's own "rolling"
+    alias, instead of the dated snapshot `claude-3-5-sonnet-20241022` it
+    used to be -- OpenAI/Google/Qwen's defaults (`gpt-4o-mini`/
+    `gemini-1.5-flash`/`qwen-plus`) were already un-dated in this same
+    sense, so only Anthropic's needed changing; this only pushes the
+    staleness problem up one level (from "this exact snapshot got retired"
+    to "this whole model line got superseded"), which a plain string
+    constant genuinely cannot solve by itself. (2) A new
+    `AiProviderModelListUrl()`, shown as a "See current models for %s..."
+    link next to each provider's Model field in Options, mirroring
+    `AiProviderApiKeyUrl()`'s own link added just above.
+    **A real, independent bug found live while verifying this, not by
+    reading the code**: after changing Anthropic's default in
+    `AiProvider.cpp`, Options kept showing the *old* `-20241022` value
+    regardless -- `AiProviderDefaultModel()` turned out to not be called
+    from anywhere at all; `Configuration::ResetAllToDefaults()` had its
+    *own*, completely separate hardcoded copy of all four model strings
+    (`m_aiModelAnthropic = wxS("claude-3-5-sonnet-20241022")` et al.),
+    silently disconnected from the function whose entire purpose is to be
+    the one place these live. Exactly the class of bug the user's original
+    question was worried about, already present in the code before this
+    session touched it, just latent until an actual edit exposed it (a
+    duplicated constant can drift silently for a long time if nothing
+    ever changes the value in only one of its two copies). Fixed by
+    having `ResetAllToDefaults()` call `AiProviderDefaultModel()` for all
+    four, removing the second copy entirely; re-verified live in Xvfb
+    that Options now genuinely shows `claude-3-5-sonnet-latest`.
 - **wxAuiManager:** The application uses `wxAuiManager` for its complex layout (sidebars, toolbars, worksheet).
   - **Linux/GTK Timing:** On Linux (especially KDE Plasma with Global Menus), calling `m_manager.Update()` can disrupt the menu bar if it's already attached. This is a known environmental issue in the interaction between wxWidgets, GTK3, and the KDE Global Menu proxy.
     - **Automated Fix:** On systems with wxWidgets <= 3.2 running on KDE, Unity, or with `appmenu-gtk-module` enabled, wxMaxima automatically sets `UBUNTU_MENUPROXY=0` at startup in `main.cpp` to force menus to remain within the window and prevent disappearance.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -674,6 +674,35 @@ a local TCP socket.
     and would have silently failed the check. Used `is_number_integer()`
     instead, which covers both representations, and simply ignores a
     negative value rather than rejecting the whole call.
+  - **Follow-up (2026-09-06): "would it be possible to provide it with a
+    'login' button or, if not, an info on how to obtain such an API key?"**
+    A real "log in" button isn't possible -- same reasoning as the sidebar's
+    original design (see the AI chat sidebar entry above): none of these
+    four providers offer a legitimate third-party OAuth flow a desktop app
+    could use, so there is no automated way to obtain a key. Added the next
+    best thing instead: `AiProviderApiKeyUrl(AiProviderKind)` (alongside
+    the existing `AiProviderKindName()`/`AiProviderDefaultModel()`) returns
+    each provider's own API-key page, shown as a `wxHyperlinkCtrl` under
+    that provider's key field in Options -> AI Chat. Also added an "Open
+    Options..." button to the sidebar itself, shown only while no provider
+    is configured (`ReloadProviderFromConfig()` toggles it), so a user who
+    opens the sidebar cold has one click to the exact place that both
+    explains the settings and links to where to get a key -- re-posting
+    `wxEVT_MENU`/`wxID_PREFERENCES` to `GetParent()`'s event handler rather
+    than constructing `ConfigDialogue` itself, reusing
+    `MaximaCommandMenus.cpp`'s existing handling (re-reading the config
+    file first, applying settings on OK, ...) instead of duplicating any of
+    it -- the same "re-post the menu event, don't reimplement the handler"
+    idiom `TrayIcon::OnInterrupt()`/`OnExit()` already use elsewhere.
+    **A real bug caught by looking at the live screenshot, not by reading
+    the code:** the four links were built from one shared format string,
+    `wxString::Format(_("Get an %s API key..."), AiProviderKindName(kind))`
+    -- grammatically fine for "Anthropic (Claude)"/"OpenAI" (both take
+    "an"), but wrong for "Google (Gemini)"/"Qwen (Alibaba)" (both need
+    "a"), rendering as the actually-shipped-then-caught "Get an Google
+    (Gemini) API key..." Fixed by rewording to "Get an API key for %s...",
+    which sidesteps the a/an agreement entirely rather than trying to track
+    which of the four provider names needs which article.
 - **wxAuiManager:** The application uses `wxAuiManager` for its complex layout (sidebars, toolbars, worksheet).
   - **Linux/GTK Timing:** On Linux (especially KDE Plasma with Global Menus), calling `m_manager.Update()` can disrupt the menu bar if it's already attached. This is a known environmental issue in the interaction between wxWidgets, GTK3, and the KDE Global Menu proxy.
     - **Automated Fix:** On systems with wxWidgets <= 3.2 running on KDE, Unity, or with `appmenu-gtk-module` enabled, wxMaxima automatically sets `UBUNTU_MENUPROXY=0` at startup in `main.cpp` to force menus to remain within the window and prevent disappearance.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -570,6 +570,110 @@ a local TCP socket.
     at all (only Anthropic was reachable from this sandbox; the other
     three were checked only against their documented request/response
     shapes in `test_AiProvider.cpp`, not against a live server).
+  - **Follow-up (2026-09-06): the worksheet context carried no notion of
+    "where the user is" or "which cell errored" at all** -- raised by the
+    user directly ("if a user asks the AI about the 'current' cell or the
+    cell above the cursor that output an error message... we provide
+    little to no info that allows the AI to navigate/find out where in
+    the worksheet the user currently is"), and confirmed exactly right by
+    reading `McpTools::ReadWorksheet()`/`CellSummary()`: neither carried
+    any cursor or error information, only cell type/input/output text.
+    Fixed by adding `McpTools::CurrentCell()` (thin wrapper over
+    `Worksheet::GetHCaret()`, which already resolves "where the user
+    is" -- active editor, h-caret, selection, or a last-resort fallback --
+    for the worksheet's own insertion-point logic, so this reuses an
+    existing, already-correct notion rather than inventing a second one)
+    and `McpTools::HasError()` (a thin wrapper over the existing
+    `DocumentCellPointers::ErrorList::Contains()`, the same mechanism
+    `Worksheet::ScrollToError()` already relies on -- see the GH #1952
+    entry above). Both are surfaced two ways: as `is_current`/`has_error`
+    booleans on `list_cells`/`read_cell`'s JSON, and -- since the AI chat
+    sidebar sends only `read_worksheet`'s plain-text dump, with no
+    tool-calling to fall back on -- as inline markers
+    (`"(CURRENT CELL -- the user's cursor is here)"`/`"(THIS CELL HAS AN
+    ERROR)"`) directly in that text, extracted into a new shared
+    `McpTools::CellText()` helper so `ReadWorksheet()` and `ReadSection()`
+    can't drift apart on this (an actual near-miss: the first pass only
+    patched `ReadWorksheet()`, and `ReadSection()`'s own near-identical
+    per-cell loop would have silently kept lacking both markers).
+    **A second, related bug found while fixing the first**:
+    `AiChatSidebar::BuildContextSnapshot()`'s truncation for
+    `MAX_CONTEXT_LENGTH` (8000 chars) took `text.Left(...)` -- for any
+    worksheet long enough to actually need truncating, this silently cuts
+    off content from the *end*, which is exactly where the new
+    "(CURRENT CELL...)" marker is most likely to sit in the first place
+    (a worksheet only needs truncating once it's already long, and a user
+    is far more likely to be asking about their current cell in a long
+    worksheet than a short one that never gets truncated at all) --
+    quietly defeating the very feature just added, for precisely the
+    worksheets where it matters most. Fixed by locating the marker first
+    and centering the kept window on it (falling back to the original
+    from-the-start behavior when there is no marker to center on, e.g. no
+    real cursor position could be determined). Verified live, not just by
+    reasoning about the arithmetic: loaded a real ~15KB synthetic
+    worksheet (60 filler cells plus one distinctively-named final cell) in
+    a live Xvfb session, moved the cursor to the very last cell
+    (Ctrl+End), and confirmed via temporary logging (removed before
+    committing, same discipline as the `State_Unauthorized` investigation
+    above) that the ~8KB snapshot actually sent still contained both the
+    `(CURRENT CELL` marker and the final cell's distinctive text -- on
+    unfixed code this exact scenario reproduces the bug (the marker sits
+    at the very end of a >8000-character document, so a plain `Left()`
+    truncation cuts it every time, deterministically, not intermittently).
+  - **Follow-up (2026-09-06): a variable's value can be empty just because
+    Maxima hasn't answered yet, not because it's undefined -- and nothing
+    told a tool-calling AI that.** `Variablespane::GetWatchedValues()`
+    returns whatever the grid's value column currently holds, which starts
+    empty the instant a variable is watched and only updates once Maxima's
+    asynchronous response for that query actually arrives -- there is no
+    "pending" state distinct from "empty," so `read_variables` right after
+    `watch_variable` (a completely natural sequence for a tool-calling AI)
+    can read back an empty value and have no way to tell "not answered
+    yet" apart from "genuinely undefined." Fixed by adding
+    `McpTools::MaximaIsBusy()` (`Worksheet::GetWorkingGroup(false) !=
+    nullptr` -- something is actively being evaluated right now -- or a
+    non-empty `Worksheet::GetEvaluationQueue()` -- more work is queued
+    behind it) and surfacing it as `read_variables`' own `maxima_busy`
+    field, with both tools' descriptions in `ListTools()` updated to spell
+    out the implication (an empty/unchanged value while `maxima_busy` is
+    true may just mean "not answered yet").
+  - **Follow-up (2026-09-06): `read_cell` had no cap on a single cell's
+    output at all, and `read_worksheet`/`read_section` only capped the
+    *aggregate* text, not each cell's own contribution to it** -- raised
+    by the user directly ("if a cell produced way too much output... do
+    we provide the AI with methods to only read the input/only read the
+    beginning or only read the end of the output?"), and confirmed exactly
+    right by reading `OutputText()`/`CapLength()`: a single pathological
+    cell (a huge matrix, a long list, ...) could return an unbounded
+    response via `read_cell`, or silently crowd out every other cell's
+    info in a `read_worksheet`/`read_section` response (worse: since that
+    aggregate cap truncates from the *start*, one huge cell early in the
+    document could crowd out not just later cells' content but the
+    `(CURRENT CELL...)`/`(THIS CELL HAS AN ERROR)` markers just added
+    above too, the same "truncate from the wrong end" bug shape as the AI
+    chat sidebar's own truncation, independently). Fixed with a new shared
+    `McpTools::TruncateText(text, maxLen, fromEnd, wasTruncated)` used two
+    ways: (1) `read_cell` gained optional `output_length`/`output_from_end`
+    arguments (defaulting to the full `MAX_TEXT_LENGTH` hard cap, i.e. no
+    real-world limit for any normal cell, but never unbounded) plus an
+    `output_truncated` result field, so an AI can ask for just a preview or
+    specifically the tail (e.g. "did this converge") instead of the whole
+    thing; (2) `ReadWorksheet()`/`ReadSection()` now cap *each* cell's own
+    output to a smaller `OUTPUT_PREVIEW_LENGTH` (2000 chars) before
+    concatenating, with an inline note pointing at `read_cell` when a
+    cell's own output was individually truncated -- extracted into the
+    same `CellText()` helper the current-cell/error markers already use,
+    so the two follow-ups share one place to get right rather than two.
+    **A real nlohmann::json gotcha hit while writing this, worth keeping in
+    mind for any future tool argument parsing here**: `is_number_unsigned()`
+    only returns true for a value that was *already* typed unsigned (e.g.
+    text-parsed JSON with no leading minus sign) -- the identical positive
+    value built from a plain C++ `int` literal, as any hand-constructed
+    `json` object (including every test in `test_McpTools.cpp`) does, is
+    classified `number_integer` (signed) instead despite being positive,
+    and would have silently failed the check. Used `is_number_integer()`
+    instead, which covers both representations, and simply ignores a
+    negative value rather than rejecting the whole call.
 - **wxAuiManager:** The application uses `wxAuiManager` for its complex layout (sidebars, toolbars, worksheet).
   - **Linux/GTK Timing:** On Linux (especially KDE Plasma with Global Menus), calling `m_manager.Update()` can disrupt the menu bar if it's already attached. This is a known environmental issue in the interaction between wxWidgets, GTK3, and the KDE Global Menu proxy.
     - **Automated Fix:** On systems with wxWidgets <= 3.2 running on KDE, Unity, or with `appmenu-gtk-module` enabled, wxMaxima automatically sets `UBUNTU_MENUPROXY=0` at startup in `main.cpp` to force menus to remain within the window and prevent disappearance.

--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,15 @@
   in the worksheet -- every tool only reads, except adding/removing a
   variable from the watchlist, which only changes what that sidebar
   displays, the same as typing a name into it by hand.
+- The MCP server and AI Chat sidebar's worksheet context now tell an AI
+  where the user's cursor is and which cell (if any) has an error, so it
+  can actually answer "what's wrong with my current cell" or "the cell
+  above the cursor" -- both were previously invisible to it. Also capped
+  how much of a single cell's output can dominate a response (a huge
+  matrix or list no longer crowds out every other cell), with a way to
+  ask for just a preview or specifically the end of a long output, and
+  made read_variables report when Maxima is still busy so an empty value
+  isn't mistaken for "undefined" when it's really just "not answered yet."
 - Added an "AI Chat" sidebar (View -> Sidebars -> AI Chat) that lets you
   chat about the current worksheet with Anthropic, OpenAI, Google Gemini or
   Qwen, using your own API key (configured in Options -> AI Chat). It sends

--- a/NEWS.md
+++ b/NEWS.md
@@ -18,6 +18,9 @@
   ask for just a preview or specifically the end of a long output, and
   made read_variables report when Maxima is still busy so an empty value
   isn't mistaken for "undefined" when it's really just "not answered yet."
+- Options -> AI Chat now links directly to each provider's own page for
+  getting an API key, and the AI Chat sidebar itself shows an "Open
+  Options..." button whenever none is configured yet.
 - Added an "AI Chat" sidebar (View -> Sidebars -> AI Chat) that lets you
   chat about the current worksheet with Anthropic, OpenAI, Google Gemini or
   Qwen, using your own API key (configured in Options -> AI Chat). It sends

--- a/locales/wxMaxima/wxMaxima.pot
+++ b/locales/wxMaxima/wxMaxima.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-09-06 18:21+0000\n"
+"POT-Creation-Date: 2026-09-06 18:32+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -81,87 +81,87 @@ msgstr ""
 msgid "      -u <versionnumber>"
 msgstr ""
 
-#: ../../src/Configuration.cpp:1429
+#: ../../src/Configuration.cpp:1435
 #, c-format
 msgid "  Cells converted to 2D: %ld"
 msgstr ""
 
-#: ../../src/Configuration.cpp:1428
+#: ../../src/Configuration.cpp:1434
 #, c-format
 msgid "  Cells converted to linear: %ld"
 msgstr ""
 
-#: ../../src/Configuration.cpp:1430
+#: ../../src/Configuration.cpp:1436
 #, c-format
 msgid "  Cells drawn at the wrong font size: %ld"
 msgstr ""
 
-#: ../../src/Configuration.cpp:1420
+#: ../../src/Configuration.cpp:1426
 #, c-format
 msgid "  Font cache hits: %ld"
 msgstr ""
 
-#: ../../src/Configuration.cpp:1421
+#: ../../src/Configuration.cpp:1427
 #, c-format
 msgid "  Font cache misses: %ld"
 msgstr ""
 
-#: ../../src/Configuration.cpp:1432
+#: ../../src/Configuration.cpp:1438
 #, c-format
 msgid "  Full-window worksheet repaints: %ld"
 msgstr ""
 
-#: ../../src/Configuration.cpp:1416
+#: ../../src/Configuration.cpp:1422
 #, c-format
 msgid "  Manual anchors from built-in: %ld"
 msgstr ""
 
-#: ../../src/Configuration.cpp:1417
+#: ../../src/Configuration.cpp:1423
 #, c-format
 msgid "  Manual anchors from cache: %ld"
 msgstr ""
 
-#: ../../src/Configuration.cpp:1418
+#: ../../src/Configuration.cpp:1424
 #, c-format
 msgid "  Manual anchors self-compiled: %ld"
 msgstr ""
 
-#: ../../src/Configuration.cpp:1419
+#: ../../src/Configuration.cpp:1425
 #, c-format
 msgid "  Maxima processes spawned: %ld"
 msgstr ""
 
-#: ../../src/Configuration.cpp:1426
+#: ../../src/Configuration.cpp:1432
 #, c-format
 msgid "  Recalculation needed - Cells appended: %ld"
 msgstr ""
 
-#: ../../src/Configuration.cpp:1425
+#: ../../src/Configuration.cpp:1431
 #, c-format
 msgid "  Recalculation needed - Config changed: %ld"
 msgstr ""
 
-#: ../../src/Configuration.cpp:1427
+#: ../../src/Configuration.cpp:1433
 #, c-format
 msgid "  Recalculation needed - Editor dirty: %ld"
 msgstr ""
 
-#: ../../src/Configuration.cpp:1422
+#: ../../src/Configuration.cpp:1428
 #, c-format
 msgid "  Recalculation needed - Font invalid: %ld"
 msgstr ""
 
-#: ../../src/Configuration.cpp:1424
+#: ../../src/Configuration.cpp:1430
 #, c-format
 msgid "  Recalculation needed - Font mismatch: %ld"
 msgstr ""
 
-#: ../../src/Configuration.cpp:1423
+#: ../../src/Configuration.cpp:1429
 #, c-format
 msgid "  Recalculation needed - Size invalid: %ld"
 msgstr ""
 
-#: ../../src/Configuration.cpp:1431
+#: ../../src/Configuration.cpp:1437
 #, c-format
 msgid "  Worksheet repaints: %ld"
 msgstr ""
@@ -259,12 +259,12 @@ msgstr ""
 msgid "%s image, %li×%li, %li ppi"
 msgstr ""
 
-#: ../../src/ai/AiProvider.cpp:325
+#: ../../src/ai/AiProvider.cpp:347
 #, c-format
 msgid "%s rejected the API key (HTTP 401): %s"
 msgstr ""
 
-#: ../../src/ai/AiProvider.cpp:296
+#: ../../src/ai/AiProvider.cpp:318
 #, c-format
 msgid "%s returned HTTP %d: %s"
 msgstr ""
@@ -942,7 +942,7 @@ msgstr ""
 msgid "Added much text (%li chars) to the XML inspector."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2038
+#: ../../src/dialogs/ConfigDialogue.cpp:2053
 msgid "Additional clipboard formats to put on the clipboard on ordinary copy"
 msgstr ""
 
@@ -1119,7 +1119,7 @@ msgstr ""
 msgid "Antisymmetric function: f(x)=-f(-x)"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2206
+#: ../../src/dialogs/ConfigDialogue.cpp:2221
 msgid "Appearance:"
 msgstr ""
 
@@ -1386,7 +1386,7 @@ msgstr ""
 msgid "Beta"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2040
+#: ../../src/dialogs/ConfigDialogue.cpp:2055
 msgid "Bitmap"
 msgstr ""
 
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Bitmaps"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2251
+#: ../../src/dialogs/ConfigDialogue.cpp:2266
 msgid "Bold"
 msgstr ""
 
@@ -1406,7 +1406,7 @@ msgstr ""
 msgid "Both horizontal and vertical cursor active at the same time"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2141
+#: ../../src/dialogs/ConfigDialogue.cpp:2156
 msgid "Bottom"
 msgstr ""
 
@@ -1996,7 +1996,7 @@ msgstr ""
 msgid "Choose between the following help topics:"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2242
+#: ../../src/dialogs/ConfigDialogue.cpp:2257
 msgid "Choose font"
 msgstr ""
 
@@ -2012,7 +2012,7 @@ msgstr ""
 msgid "Choose new plot format:"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2586
+#: ../../src/dialogs/ConfigDialogue.cpp:2601
 #, c-format
 msgid "Choose the %s Font"
 msgstr ""
@@ -2094,7 +2094,7 @@ msgstr ""
 msgid "Cleared font cache for font %s"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2068
+#: ../../src/dialogs/ConfigDialogue.cpp:2083
 msgid "Clipboard format parameters"
 msgstr ""
 
@@ -2429,19 +2429,19 @@ msgstr ""
 msgid "Condition:"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2633
-#: ../../src/dialogs/ConfigDialogue.cpp:2643
-#: ../../src/dialogs/ConfigDialogue.cpp:2795
-#: ../../src/dialogs/ConfigDialogue.cpp:2801
+#: ../../src/dialogs/ConfigDialogue.cpp:2648
+#: ../../src/dialogs/ConfigDialogue.cpp:2658
+#: ../../src/dialogs/ConfigDialogue.cpp:2810
+#: ../../src/dialogs/ConfigDialogue.cpp:2816
 msgid "Config file (*.ini)|*.ini"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2693
+#: ../../src/dialogs/ConfigDialogue.cpp:2708
 #, c-format
 msgid "Config item \"%s\" was of an unknown type"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2761
+#: ../../src/dialogs/ConfigDialogue.cpp:2776
 msgid "Configuration warning"
 msgstr ""
 
@@ -2810,22 +2810,22 @@ msgstr ""
 msgid "Copy, Cut and Paste button"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2677
+#: ../../src/dialogs/ConfigDialogue.cpp:2692
 #, c-format
 msgid "Copying config bool \"%s\""
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2687
+#: ../../src/dialogs/ConfigDialogue.cpp:2702
 #, c-format
 msgid "Copying config float \"%s\""
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2682
+#: ../../src/dialogs/ConfigDialogue.cpp:2697
 #, c-format
 msgid "Copying config int \"%s\""
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2672
+#: ../../src/dialogs/ConfigDialogue.cpp:2687
 #, c-format
 msgid "Copying config string \"%s\""
 msgstr ""
@@ -2834,7 +2834,7 @@ msgstr ""
 msgid "Corsican"
 msgstr ""
 
-#: ../../src/ai/AiProvider.cpp:253
+#: ../../src/ai/AiProvider.cpp:275
 msgid "Could not create the HTTP request."
 msgstr ""
 
@@ -2854,7 +2854,7 @@ msgstr ""
 msgid "Could not parse the SVG image data."
 msgstr ""
 
-#: ../../src/ai/AiProvider.cpp:337
+#: ../../src/ai/AiProvider.cpp:359
 #, c-format
 msgid "Could not reach %s (network error)."
 msgstr ""
@@ -2982,7 +2982,7 @@ msgstr ""
 msgid "Danish"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2211
+#: ../../src/dialogs/ConfigDialogue.cpp:2226
 msgid "Dark"
 msgstr ""
 
@@ -3656,7 +3656,7 @@ msgstr ""
 msgid "Enhanced 3D settings:"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2061
+#: ../../src/dialogs/ConfigDialogue.cpp:2076
 msgid "Enhanced meta file (emf)"
 msgstr ""
 
@@ -3953,7 +3953,7 @@ msgstr ""
 msgid "Even number"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2813
+#: ../../src/dialogs/ConfigDialogue.cpp:2828
 msgid "Example text"
 msgstr ""
 
@@ -4600,7 +4600,7 @@ msgstr ""
 msgid "Follow"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2212
+#: ../../src/dialogs/ConfigDialogue.cpp:2227
 msgid "Follow system"
 msgstr ""
 
@@ -4620,7 +4620,7 @@ msgstr ""
 msgid "Font cache misses:"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2189
+#: ../../src/dialogs/ConfigDialogue.cpp:2204
 msgid "Fonts"
 msgstr ""
 
@@ -5918,7 +5918,7 @@ msgstr ""
 msgid "Italian"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2253
+#: ../../src/dialogs/ConfigDialogue.cpp:2268
 msgid "Italic"
 msgstr ""
 
@@ -6094,7 +6094,7 @@ msgstr ""
 msgid "Least Squares Fit..."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2149
+#: ../../src/dialogs/ConfigDialogue.cpp:2164
 msgid "Left"
 msgstr ""
 
@@ -6140,7 +6140,7 @@ msgstr ""
 msgid "License"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2210
+#: ../../src/dialogs/ConfigDialogue.cpp:2225
 msgid "Light"
 msgstr ""
 
@@ -6293,7 +6293,7 @@ msgstr ""
 msgid "Lithuanian"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2304
+#: ../../src/dialogs/ConfigDialogue.cpp:2319
 msgid "Load"
 msgstr ""
 
@@ -6333,7 +6333,7 @@ msgstr ""
 msgid "Load lisp..."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2799
+#: ../../src/dialogs/ConfigDialogue.cpp:2814
 msgid "Load style from file"
 msgstr ""
 
@@ -6471,11 +6471,11 @@ msgstr ""
 msgid "MathML + MathJaX fall-back for old browsers"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2048
+#: ../../src/dialogs/ConfigDialogue.cpp:2063
 msgid "MathML as HTML"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2044
+#: ../../src/dialogs/ConfigDialogue.cpp:2059
 msgid "MathML description"
 msgstr ""
 
@@ -6946,7 +6946,7 @@ msgstr ""
 msgid "Maximum absolute value printed without exponent"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2073
+#: ../../src/dialogs/ConfigDialogue.cpp:2088
 msgid "Maximum bitmap size on clipboard [Mb]:"
 msgstr ""
 
@@ -7031,7 +7031,7 @@ msgstr ""
 msgid "Misc"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2105
+#: ../../src/dialogs/ConfigDialogue.cpp:2120
 msgid "Misc settings"
 msgstr ""
 
@@ -7784,7 +7784,7 @@ msgstr ""
 msgid "Performance Monitor"
 msgstr ""
 
-#: ../../src/Configuration.cpp:1415
+#: ../../src/Configuration.cpp:1421
 msgid "Performance Statistics:"
 msgstr ""
 
@@ -7812,7 +7812,7 @@ msgstr ""
 msgid "Please configure wxMaxima with 'Edit->Configure'."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2760
+#: ../../src/dialogs/ConfigDialogue.cpp:2775
 msgid "Please restart wxMaxima for changes to take effect!"
 msgstr ""
 
@@ -8040,7 +8040,7 @@ msgstr ""
 msgid "Print"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2130
+#: ../../src/dialogs/ConfigDialogue.cpp:2145
 msgid "Print Margins"
 msgstr ""
 
@@ -8061,11 +8061,11 @@ msgstr ""
 msgid "Print floating-point numbers with exponents dividable by 3"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2110
+#: ../../src/dialogs/ConfigDialogue.cpp:2125
 msgid "Print scale:"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2123
+#: ../../src/dialogs/ConfigDialogue.cpp:2138
 msgid "Print the cell brackets [drawn to their left]"
 msgstr ""
 
@@ -8177,7 +8177,7 @@ msgstr ""
 msgid "Quit wxMaxima"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2052
+#: ../../src/dialogs/ConfigDialogue.cpp:2067
 msgid "RTF with OMML maths"
 msgstr ""
 
@@ -8255,7 +8255,7 @@ msgstr ""
 msgid "Read char"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2642
+#: ../../src/dialogs/ConfigDialogue.cpp:2657
 msgid "Read config to file"
 msgstr ""
 
@@ -8464,11 +8464,11 @@ msgstr ""
 msgid "Reloading image file %s."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2727
+#: ../../src/dialogs/ConfigDialogue.cpp:2742
 msgid "Reloading the configuration from disc"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2735
+#: ../../src/dialogs/ConfigDialogue.cpp:2750
 msgid "Reloading the styles from disc"
 msgstr ""
 
@@ -8609,7 +8609,7 @@ msgstr ""
 msgid "Report bug"
 msgstr ""
 
-#: ../../src/ai/AiProvider.cpp:342
+#: ../../src/ai/AiProvider.cpp:364
 msgid "Request cancelled."
 msgstr ""
 
@@ -8625,8 +8625,8 @@ msgstr ""
 msgid "Reset the Style settings"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2711
-#: ../../src/dialogs/ConfigDialogue.cpp:2719
+#: ../../src/dialogs/ConfigDialogue.cpp:2726
+#: ../../src/dialogs/ConfigDialogue.cpp:2734
 msgid "Resetting all configuration settings"
 msgstr ""
 
@@ -8744,7 +8744,7 @@ msgstr ""
 msgid "Rho"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2157
+#: ../../src/dialogs/ConfigDialogue.cpp:2172
 msgid "Right"
 msgstr ""
 
@@ -8916,7 +8916,7 @@ msgid "Samples on a line:"
 msgstr ""
 
 #: ../../src/ToolBar.cpp:331 ../../src/ToolBar.cpp:334
-#: ../../src/dialogs/ConfigDialogue.cpp:2305 ../../src/wxMaxima.cpp:3605
+#: ../../src/dialogs/ConfigDialogue.cpp:2320 ../../src/wxMaxima.cpp:3605
 msgid "Save"
 msgstr ""
 
@@ -8956,7 +8956,7 @@ msgstr ""
 msgid "Save as lisp..."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2632
+#: ../../src/dialogs/ConfigDialogue.cpp:2647
 msgid "Save config to file"
 msgstr ""
 
@@ -8981,7 +8981,7 @@ msgstr ""
 msgid "Save selection to file"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2794
+#: ../../src/dialogs/ConfigDialogue.cpp:2809
 msgid "Save style to file"
 msgstr ""
 
@@ -9001,7 +9001,7 @@ msgstr ""
 msgid "Saving succeeded, but the resulting files has disappeared ?!?."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2056
+#: ../../src/dialogs/ConfigDialogue.cpp:2071
 msgid "Scalable Vector Graphics (svg)"
 msgstr ""
 
@@ -9063,6 +9063,11 @@ msgstr ""
 
 #: ../../src/wizards/DrawWiz.cpp:158
 msgid "See also the speed <-> accuracy button."
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:2027
+#, c-format
+msgid "See current models for %s..."
 msgstr ""
 
 #: ../../src/MaximaCommandMenus.cpp:4120
@@ -9645,7 +9650,7 @@ msgstr ""
 msgid "Size of internal work array. limit/2 is the maximum number of subintervals to use."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2255
+#: ../../src/dialogs/ConfigDialogue.cpp:2270
 msgid "Slanted"
 msgstr ""
 
@@ -9986,7 +9991,7 @@ msgstr ""
 msgid "Stream:"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2259
+#: ../../src/dialogs/ConfigDialogue.cpp:2274
 msgid "Strike Through"
 msgstr ""
 
@@ -10058,7 +10063,7 @@ msgstr ""
 msgid "Style"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2224
+#: ../../src/dialogs/ConfigDialogue.cpp:2239
 msgid "Styles"
 msgstr ""
 
@@ -10376,7 +10381,7 @@ msgstr ""
 msgid "The diagram title"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2555
+#: ../../src/dialogs/ConfigDialogue.cpp:2570
 #, c-format
 msgid "The directory %s with maxima's startup file doesn't exist. Trying to create it..."
 msgstr ""
@@ -10716,7 +10721,7 @@ msgstr ""
 msgid "This build of wxMaxima cannot make network requests."
 msgstr ""
 
-#: ../../src/ai/AiProvider.cpp:351
+#: ../../src/ai/AiProvider.cpp:373
 msgid "This build of wxMaxima was compiled without wxWebRequest support, so it cannot talk to any AI provider."
 msgstr ""
 
@@ -10885,7 +10890,7 @@ msgstr ""
 msgid "Toolbar"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2133
+#: ../../src/dialogs/ConfigDialogue.cpp:2148
 msgid "Top"
 msgstr ""
 
@@ -11096,7 +11101,7 @@ msgstr ""
 msgid "Undefined"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2257
+#: ../../src/dialogs/ConfigDialogue.cpp:2272
 msgid "Underlined"
 msgstr ""
 
@@ -11300,7 +11305,7 @@ msgstr ""
 msgid "Use the \"partial derivative\" symbol to represent the fraction that represents a diff() when exporting LaTeX"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2194
+#: ../../src/dialogs/ConfigDialogue.cpp:2209
 msgid "Use unicode Math Symbols, if available"
 msgstr ""
 

--- a/locales/wxMaxima/wxMaxima.pot
+++ b/locales/wxMaxima/wxMaxima.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-09-06 17:14+0000\n"
+"POT-Creation-Date: 2026-09-06 18:21+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -57,27 +57,27 @@ msgid ""
 "Use the menu \"View->Toggle log window\" to show/hide a log window with all debug messages."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1623
+#: ../../src/dialogs/ConfigDialogue.cpp:1624
 msgid "      -X \"--control-stack-size <int>\""
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1622
+#: ../../src/dialogs/ConfigDialogue.cpp:1623
 msgid "      -X \"--dynamic-space-size <int>\""
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1626
+#: ../../src/dialogs/ConfigDialogue.cpp:1627
 msgid "      -X '--control-stack-size <int>'"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1625
+#: ../../src/dialogs/ConfigDialogue.cpp:1626
 msgid "      -X '--dynamic-space-size <int>'"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1605
+#: ../../src/dialogs/ConfigDialogue.cpp:1606
 msgid "      -l <name>"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1611
+#: ../../src/dialogs/ConfigDialogue.cpp:1612
 msgid "      -u <versionnumber>"
 msgstr ""
 
@@ -220,18 +220,18 @@ msgstr ""
 msgid "\"..\" means \"one directory up\"."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1225
+#: ../../src/dialogs/ConfigDialogue.cpp:1226
 msgid "\"Copy LaTeX\" adds equation markers"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:449
+#: ../../src/dialogs/ConfigDialogue.cpp:450
 msgid ""
 "\"MathML (rendered by the browser)\" is the recommended choice: every current browser renders MathML natively and instantly, and the exported page needs no JavaScript and makes no requests to any external server.\n"
 "\"MathML + MathJaX fall-back for old browsers\" behaves the same on current browsers, but additionally downloads MathJaX from an external server (a CDN) as a fall-back on browsers too old to support MathML. Only choose this if you need to support such browsers and accept the external dependency.\n"
 "Bitmaps tend to need more band width than the other options. They lack support for advanced features like drag-and-drop or accessibility. Also they have problems aligning and scaling with the rest of the text and might use fonts that don't match the rest of the document."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:947
+#: ../../src/dialogs/ConfigDialogue.cpp:948
 msgid "\"Numpad Enter\" always evaluates cells"
 msgstr ""
 
@@ -259,12 +259,12 @@ msgstr ""
 msgid "%s image, %li×%li, %li ppi"
 msgstr ""
 
-#: ../../src/ai/AiProvider.cpp:315
+#: ../../src/ai/AiProvider.cpp:325
 #, c-format
 msgid "%s rejected the API key (HTTP 401): %s"
 msgstr ""
 
-#: ../../src/ai/AiProvider.cpp:286
+#: ../../src/ai/AiProvider.cpp:296
 #, c-format
 msgid "%s returned HTTP %d: %s"
 msgstr ""
@@ -573,7 +573,7 @@ msgstr ""
 msgid "(Not a valid variable name)"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:184
+#: ../../src/dialogs/ConfigDialogue.cpp:185
 msgid "(Use default language)"
 msgstr ""
 
@@ -651,11 +651,11 @@ msgstr ""
 msgid "2D equations using ASCII Art with unicode characters, if available"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:803
+#: ../../src/dialogs/ConfigDialogue.cpp:804
 msgid "2D if it fits on the page width"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:802
+#: ../../src/dialogs/ConfigDialogue.cpp:803
 msgid "2D, whenever possible"
 msgstr ""
 
@@ -755,7 +755,7 @@ msgstr ""
 msgid "A right-associative function"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:439
+#: ../../src/dialogs/ConfigDialogue.cpp:440
 msgid "A scale factor for the printout. Helpful for printing big equations on small pdf pages."
 msgstr ""
 
@@ -825,12 +825,12 @@ msgstr ""
 msgid "A&t Value..."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:290 ../../src/wxMaximaFrame.cpp:317
+#: ../../src/dialogs/ConfigDialogue.cpp:291 ../../src/wxMaximaFrame.cpp:317
 #: ../../src/wxMaximaFrame.cpp:832
 msgid "AI Chat"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1983
+#: ../../src/dialogs/ConfigDialogue.cpp:1985
 msgid "API key:"
 msgstr ""
 
@@ -838,7 +838,7 @@ msgstr ""
 msgid "ASCII maths"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1672
+#: ../../src/dialogs/ConfigDialogue.cpp:1673
 msgid "Abort evaluation on error"
 msgstr ""
 
@@ -867,7 +867,7 @@ msgstr ""
 msgid "Accepts one variable or a list in the format [var1,var2,...]"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:295
+#: ../../src/dialogs/ConfigDialogue.cpp:296
 msgid "Accessibility"
 msgstr ""
 
@@ -875,7 +875,7 @@ msgstr ""
 msgid "Accuracy"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1960
+#: ../../src/dialogs/ConfigDialogue.cpp:1961
 msgid "Active provider:"
 msgstr ""
 
@@ -919,7 +919,7 @@ msgstr ""
 msgid "Add more symbols"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1279
+#: ../../src/dialogs/ConfigDialogue.cpp:1280
 msgid "Add the .wxmx file to the HTML export"
 msgstr ""
 
@@ -942,27 +942,27 @@ msgstr ""
 msgid "Added much text (%li chars) to the XML inspector."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2023
+#: ../../src/dialogs/ConfigDialogue.cpp:2038
 msgid "Additional clipboard formats to put on the clipboard on ordinary copy"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:396
+#: ../../src/dialogs/ConfigDialogue.cpp:397
 msgid "Additional commands to be added to the preamble of LaTeX output for pdftex."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1204
+#: ../../src/dialogs/ConfigDialogue.cpp:1205
 msgid "Additional lines for the TeX preamble:"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:392
+#: ../../src/dialogs/ConfigDialogue.cpp:393
 msgid "Additional parameters for Maxima (e.g. -l clisp)."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1597
+#: ../../src/dialogs/ConfigDialogue.cpp:1598
 msgid "Additional parameters for Maxima (restart Maxima after changes)"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1335
+#: ../../src/dialogs/ConfigDialogue.cpp:1336
 msgid "Additional symbols for the \"symbols\" sidebar:"
 msgstr ""
 
@@ -990,7 +990,7 @@ msgstr ""
 msgid "Advanced variable names"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:185
+#: ../../src/dialogs/ConfigDialogue.cpp:186
 msgid "Afrikaans"
 msgstr ""
 
@@ -998,7 +998,7 @@ msgstr ""
 msgid "After clicking on animations created with with_slider_draw() or similar, this slider allows changing the current frame."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:186
+#: ../../src/dialogs/ConfigDialogue.cpp:187
 msgid "Albanian"
 msgstr ""
 
@@ -1022,7 +1022,7 @@ msgstr ""
 msgid "All openable types (*.wxm, *.wxmx, *.mac, *.out, *.xml)|*.wxm;*.wxmx;*.mac;*.out;*.xml|wxMaxima document (*.wxm, *.wxmx)|*.wxm;*.wxmx|Maxima session (*.mac)|*.mac|Xmaxima session (*.out)|*.out|xml from broken .wxmx (*.xml)|*.xml"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:767
+#: ../../src/dialogs/ConfigDialogue.cpp:768
 msgid "All variable names"
 msgstr ""
 
@@ -1107,7 +1107,7 @@ msgstr ""
 msgid "Animation framerate..."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1925
+#: ../../src/dialogs/ConfigDialogue.cpp:1926
 msgid "Announce Maxima's output as MathML"
 msgstr ""
 
@@ -1119,7 +1119,7 @@ msgstr ""
 msgid "Antisymmetric function: f(x)=-f(-x)"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2191
+#: ../../src/dialogs/ConfigDialogue.cpp:2206
 msgid "Appearance:"
 msgstr ""
 
@@ -1178,7 +1178,7 @@ msgstr ""
 msgid "Apropos"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:187
+#: ../../src/dialogs/ConfigDialogue.cpp:188
 msgid "Arabic"
 msgstr ""
 
@@ -1229,7 +1229,7 @@ msgstr ""
 msgid "Ascii code to char..."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1414
+#: ../../src/dialogs/ConfigDialogue.cpp:1415
 msgid "Ask to save untitled documents"
 msgstr ""
 
@@ -1253,21 +1253,21 @@ msgstr ""
 msgid "Attention: Extracting a random list element isn't efficient for long lists.Iterating over lists using makelist() or for loops is way faster."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:914
+#: ../../src/dialogs/ConfigDialogue.cpp:915
 msgid "Auto-indent new lines"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:910
+#: ../../src/dialogs/ConfigDialogue.cpp:911
 msgid "Auto-insert closing parenthesis"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1495
-#: ../../src/dialogs/ConfigDialogue.cpp:1526
+#: ../../src/dialogs/ConfigDialogue.cpp:1496
+#: ../../src/dialogs/ConfigDialogue.cpp:1527
 #: ../../src/dialogs/MaximaNotStartingDialog.cpp:43
 msgid "Autodetect"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1253
+#: ../../src/dialogs/ConfigDialogue.cpp:1254
 msgid "Automatic"
 msgstr ""
 
@@ -1275,7 +1275,7 @@ msgstr ""
 msgid "Automatic labels"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:786
+#: ../../src/dialogs/ConfigDialogue.cpp:787
 #, c-format
 msgid "Automatic labels (%i1, %o1,...)"
 msgstr ""
@@ -1288,7 +1288,7 @@ msgstr ""
 msgid "Automatically fill in answers known from the last run"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:463
+#: ../../src/dialogs/ConfigDialogue.cpp:464
 msgid "Automatically insert a closing parenthesis the moment the user enters an opening one."
 msgstr ""
 
@@ -1323,7 +1323,7 @@ msgstr ""
 msgid "Autosubscript this variable"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:751
+#: ../../src/dialogs/ConfigDialogue.cpp:752
 msgid "Autowrap long lines:"
 msgstr ""
 
@@ -1347,7 +1347,7 @@ msgstr ""
 msgid "Basic matrix operations"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:188
+#: ../../src/dialogs/ConfigDialogue.cpp:189
 msgid "Basque"
 msgstr ""
 
@@ -1386,19 +1386,19 @@ msgstr ""
 msgid "Beta"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2025
+#: ../../src/dialogs/ConfigDialogue.cpp:2040
 msgid "Bitmap"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1290
+#: ../../src/dialogs/ConfigDialogue.cpp:1291
 msgid "Bitmap scale for export:"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1240
+#: ../../src/dialogs/ConfigDialogue.cpp:1241
 msgid "Bitmaps"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2236
+#: ../../src/dialogs/ConfigDialogue.cpp:2251
 msgid "Bold"
 msgstr ""
 
@@ -1406,7 +1406,7 @@ msgstr ""
 msgid "Both horizontal and vertical cursor active at the same time"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2126
+#: ../../src/dialogs/ConfigDialogue.cpp:2141
 msgid "Bottom"
 msgstr ""
 
@@ -1570,7 +1570,7 @@ msgstr ""
 msgid "Build from Git version: %s\n"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1435
+#: ../../src/dialogs/ConfigDialogue.cpp:1436
 msgid "By default \"Find and Replace\" (Ctrl+F) opens as a floating window. Enable this to make it a sidebar you can dock, like the other sidebars, instead."
 msgstr ""
 
@@ -1821,7 +1821,7 @@ msgstr ""
 msgid "Canonical (tr)"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:189
+#: ../../src/dialogs/ConfigDialogue.cpp:190
 msgid "Catalan"
 msgstr ""
 
@@ -1878,7 +1878,7 @@ msgstr ""
 msgid "Change directory..."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:876
+#: ../../src/dialogs/ConfigDialogue.cpp:877
 msgid "Change names of greek letters to greek letters"
 msgstr ""
 
@@ -1886,7 +1886,7 @@ msgstr ""
 msgid "Change the 2d display algorithm used to display math output"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:492
+#: ../../src/dialogs/ConfigDialogue.cpp:493
 msgid "Change the text \"alpha\" and \"beta\" to the corresponding greek letter?"
 msgstr ""
 
@@ -1959,7 +1959,7 @@ msgstr ""
 msgid "Chars are strings that are one character long"
 msgstr ""
 
-#: ../../src/sidebars/AiChatSidebar.cpp:151
+#: ../../src/sidebars/AiChatSidebar.cpp:168
 #, c-format
 msgid "Chatting with %s"
 msgstr ""
@@ -1976,19 +1976,19 @@ msgstr ""
 msgid "Chi"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:190
+#: ../../src/dialogs/ConfigDialogue.cpp:191
 msgid "Chinese (Simplified)"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:191
+#: ../../src/dialogs/ConfigDialogue.cpp:192
 msgid "Chinese (traditional)"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1608
+#: ../../src/dialogs/ConfigDialogue.cpp:1609
 msgid "Choose a Lisp Maxima was compiled with"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1614
+#: ../../src/dialogs/ConfigDialogue.cpp:1615
 msgid "Choose between installed Maxima versions"
 msgstr ""
 
@@ -1996,11 +1996,11 @@ msgstr ""
 msgid "Choose between the following help topics:"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2227
+#: ../../src/dialogs/ConfigDialogue.cpp:2242
 msgid "Choose font"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:810
+#: ../../src/dialogs/ConfigDialogue.cpp:811
 msgid ""
 "Choose how mathematical output is formatted:\n"
 "\"2D, whenever possible\" keeps all expressions in two-dimensional form (fractions stacked, matrices drawn as boxes), even if they overflow the page width.\n"
@@ -2012,7 +2012,7 @@ msgstr ""
 msgid "Choose new plot format:"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2571
+#: ../../src/dialogs/ConfigDialogue.cpp:2586
 #, c-format
 msgid "Choose the %s Font"
 msgstr ""
@@ -2029,7 +2029,7 @@ msgstr ""
 msgid "Classic matrix operations"
 msgstr ""
 
-#: ../../src/sidebars/AiChatSidebar.cpp:66
+#: ../../src/sidebars/AiChatSidebar.cpp:75
 msgid "Clear"
 msgstr ""
 
@@ -2094,7 +2094,7 @@ msgstr ""
 msgid "Cleared font cache for font %s"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2053
+#: ../../src/dialogs/ConfigDialogue.cpp:2068
 msgid "Clipboard format parameters"
 msgstr ""
 
@@ -2292,7 +2292,7 @@ msgstr ""
 msgid "Command:"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1162
+#: ../../src/dialogs/ConfigDialogue.cpp:1163
 msgid "Commands that are executed at every start of maxima."
 msgstr ""
 
@@ -2429,19 +2429,19 @@ msgstr ""
 msgid "Condition:"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2618
-#: ../../src/dialogs/ConfigDialogue.cpp:2628
-#: ../../src/dialogs/ConfigDialogue.cpp:2780
-#: ../../src/dialogs/ConfigDialogue.cpp:2786
+#: ../../src/dialogs/ConfigDialogue.cpp:2633
+#: ../../src/dialogs/ConfigDialogue.cpp:2643
+#: ../../src/dialogs/ConfigDialogue.cpp:2795
+#: ../../src/dialogs/ConfigDialogue.cpp:2801
 msgid "Config file (*.ini)|*.ini"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2678
+#: ../../src/dialogs/ConfigDialogue.cpp:2693
 #, c-format
 msgid "Config item \"%s\" was of an unknown type"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2746
+#: ../../src/dialogs/ConfigDialogue.cpp:2761
 msgid "Configuration warning"
 msgstr ""
 
@@ -2661,7 +2661,7 @@ msgid "Converts a nested list like [[1,2],[3,4]] to a matrix"
 msgstr ""
 
 #: ../../src/ToolBar.cpp:380 ../../src/ToolBar.cpp:384
-#: ../../src/dialogs/ConfigDialogue.cpp:286
+#: ../../src/dialogs/ConfigDialogue.cpp:287
 #: ../../src/worksheet/WorksheetContextMenu.cpp:48
 #: ../../src/worksheet/WorksheetContextMenu.cpp:122
 #: ../../src/worksheet/WorksheetContextMenu.cpp:271
@@ -2810,31 +2810,31 @@ msgstr ""
 msgid "Copy, Cut and Paste button"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2662
+#: ../../src/dialogs/ConfigDialogue.cpp:2677
 #, c-format
 msgid "Copying config bool \"%s\""
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2672
+#: ../../src/dialogs/ConfigDialogue.cpp:2687
 #, c-format
 msgid "Copying config float \"%s\""
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2667
+#: ../../src/dialogs/ConfigDialogue.cpp:2682
 #, c-format
 msgid "Copying config int \"%s\""
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2657
+#: ../../src/dialogs/ConfigDialogue.cpp:2672
 #, c-format
 msgid "Copying config string \"%s\""
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:192
+#: ../../src/dialogs/ConfigDialogue.cpp:193
 msgid "Corsican"
 msgstr ""
 
-#: ../../src/ai/AiProvider.cpp:243
+#: ../../src/ai/AiProvider.cpp:253
 msgid "Could not create the HTTP request."
 msgstr ""
 
@@ -2854,7 +2854,7 @@ msgstr ""
 msgid "Could not parse the SVG image data."
 msgstr ""
 
-#: ../../src/ai/AiProvider.cpp:327
+#: ../../src/ai/AiProvider.cpp:337
 #, c-format
 msgid "Could not reach %s (network error)."
 msgstr ""
@@ -2928,7 +2928,7 @@ msgstr ""
 msgid "Create list from comma-separated elements"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1406
+#: ../../src/dialogs/ConfigDialogue.cpp:1407
 msgid "Create scalable plots."
 msgstr ""
 
@@ -2944,7 +2944,7 @@ msgstr ""
 msgid "Creates an independent matrix with the same contents"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:193
+#: ../../src/dialogs/ConfigDialogue.cpp:194
 msgid "Croatian"
 msgstr ""
 
@@ -2974,15 +2974,15 @@ msgstr ""
 msgid "Cut selection"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:194
+#: ../../src/dialogs/ConfigDialogue.cpp:195
 msgid "Czech"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:195
+#: ../../src/dialogs/ConfigDialogue.cpp:196
 msgid "Danish"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2196
+#: ../../src/dialogs/ConfigDialogue.cpp:2211
 msgid "Dark"
 msgstr ""
 
@@ -3048,15 +3048,15 @@ msgstr ""
 msgid "Decreasing function f(x)<x"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1353
+#: ../../src/dialogs/ConfigDialogue.cpp:1354
 msgid "Default animation framerate:"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:734
+#: ../../src/dialogs/ConfigDialogue.cpp:735
 msgid "Default plot size for new maxima sessions:"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1588
+#: ../../src/dialogs/ConfigDialogue.cpp:1589
 msgid "Default port for communication with wxMaxima:"
 msgstr ""
 
@@ -3096,7 +3096,7 @@ msgstr ""
 msgid "Define struct..."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:407
+#: ../../src/dialogs/ConfigDialogue.cpp:408
 msgid "Define the default speed (in frames per second) animations are played back with."
 msgstr ""
 
@@ -3307,7 +3307,7 @@ msgstr ""
 msgid "Discrete plot"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:716
+#: ../../src/dialogs/ConfigDialogue.cpp:717
 msgid "Display"
 msgstr ""
 
@@ -3319,11 +3319,11 @@ msgstr ""
 msgid "Display algorithm"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:844
+#: ../../src/dialogs/ConfigDialogue.cpp:845
 msgid "Display all and allow linebreaks in long numbers"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:837
+#: ../../src/dialogs/ConfigDialogue.cpp:838
 msgid "Display all digits"
 msgstr ""
 
@@ -3351,7 +3351,7 @@ msgstr ""
 msgid "Display last result in TeX form"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:821
+#: ../../src/dialogs/ConfigDialogue.cpp:822
 msgid "Display of long numbers"
 msgstr ""
 
@@ -3430,11 +3430,11 @@ msgstr ""
 msgid "Document was saved using a newer version of wxMaxima. Please update your wxMaxima."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1187
+#: ../../src/dialogs/ConfigDialogue.cpp:1188
 msgid "Documentclass for TeX export:"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1195
+#: ../../src/dialogs/ConfigDialogue.cpp:1196
 msgid "Documentclass options:"
 msgstr ""
 
@@ -3504,7 +3504,7 @@ msgstr ""
 msgid "Drop the last n list elements"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:196
+#: ../../src/dialogs/ConfigDialogue.cpp:197
 msgid "Dutch"
 msgstr ""
 
@@ -3648,7 +3648,7 @@ msgstr ""
 msgid "Engineering format (12.1e6 etc.)"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:197
+#: ../../src/dialogs/ConfigDialogue.cpp:198
 msgid "English"
 msgstr ""
 
@@ -3656,7 +3656,7 @@ msgstr ""
 msgid "Enhanced 3D settings:"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2046
+#: ../../src/dialogs/ConfigDialogue.cpp:2061
 msgid "Enhanced meta file (emf)"
 msgstr ""
 
@@ -3672,7 +3672,7 @@ msgstr ""
 msgid "Enter a matrix"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:942
+#: ../../src/dialogs/ConfigDialogue.cpp:943
 msgid "Enter adds newlines, Ctrl+Enter evaluates cells"
 msgstr ""
 
@@ -3684,7 +3684,7 @@ msgstr ""
 msgid "Enter comma separated list of variables."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:938
+#: ../../src/dialogs/ConfigDialogue.cpp:939
 msgid "Enter evaluates cells, Ctrl+Enter adds newlines"
 msgstr ""
 
@@ -3700,11 +3700,11 @@ msgstr ""
 msgid "Enter new precision for bigfloats:"
 msgstr ""
 
-#: ../../src/sidebars/AiChatSidebar.cpp:56
+#: ../../src/sidebars/AiChatSidebar.cpp:65
 msgid "Enter sends; Shift+Enter inserts a newline."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:391
+#: ../../src/dialogs/ConfigDialogue.cpp:392
 msgid "Enter the path to the Maxima executable."
 msgstr ""
 
@@ -3716,7 +3716,7 @@ msgstr ""
 msgid "Environment variables"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1659
+#: ../../src/dialogs/ConfigDialogue.cpp:1660
 msgid "Environment variables for maxima"
 msgstr ""
 
@@ -3771,7 +3771,7 @@ msgstr ""
 #: ../../src/WXMXformat.cpp:290 ../../src/WXMXformat.cpp:298
 #: ../../src/WXMXformat.cpp:313 ../../src/WXMXformat.cpp:334
 #: ../../src/WXMXformat.cpp:364 ../../src/dialogs/BinaryNameCtrl.cpp:78
-#: ../../src/main.cpp:788 ../../src/sidebars/AiChatSidebar.cpp:226
+#: ../../src/main.cpp:788 ../../src/sidebars/AiChatSidebar.cpp:243
 #: ../../src/wxMaxima.cpp:3480 ../../src/wxMaxima.cpp:3516
 #: ../../src/wxMaxima.cpp:3534 ../../src/wxMaxima.cpp:3568
 msgid "Error"
@@ -3953,11 +3953,11 @@ msgstr ""
 msgid "Even number"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2798
+#: ../../src/dialogs/ConfigDialogue.cpp:2813
 msgid "Example text"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1601
+#: ../../src/dialogs/ConfigDialogue.cpp:1602
 msgid "Examples:"
 msgstr ""
 
@@ -4014,7 +4014,7 @@ msgid "Expect variables to contain complex numbers"
 msgstr ""
 
 #: ../../src/MaximaCommandMenus.cpp:2277
-#: ../../src/dialogs/ConfigDialogue.cpp:284
+#: ../../src/dialogs/ConfigDialogue.cpp:285
 msgid "Export"
 msgstr ""
 
@@ -4038,7 +4038,7 @@ msgstr ""
 msgid "Export all history to a .mac file"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1033
+#: ../../src/dialogs/ConfigDialogue.cpp:1034
 msgid "Export all settings"
 msgstr ""
 
@@ -4050,7 +4050,7 @@ msgstr ""
 msgid "Export document to a HTML or LaTeX file"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1235
+#: ../../src/dialogs/ConfigDialogue.cpp:1236
 msgid "Export equations to HTML as:"
 msgstr ""
 
@@ -4078,7 +4078,7 @@ msgstr ""
 msgid "Export the selected output(s) to this folder"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1039
+#: ../../src/dialogs/ConfigDialogue.cpp:1040
 msgid "Export the style settings"
 msgstr ""
 
@@ -4559,7 +4559,7 @@ msgstr ""
 msgid "Fine-tune the display of engineering-format numbers"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:198
+#: ../../src/dialogs/ConfigDialogue.cpp:199
 msgid "Finnish"
 msgstr ""
 
@@ -4571,12 +4571,12 @@ msgstr ""
 msgid "Fitting curves to measurement data"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1421
+#: ../../src/dialogs/ConfigDialogue.cpp:1422
 #, c-format
 msgid "Fix reordered reference indices (of %i, %o) before saving"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:890
+#: ../../src/dialogs/ConfigDialogue.cpp:891
 msgid "Fixed font in text controls"
 msgstr ""
 
@@ -4600,7 +4600,7 @@ msgstr ""
 msgid "Follow"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2197
+#: ../../src/dialogs/ConfigDialogue.cpp:2212
 msgid "Follow system"
 msgstr ""
 
@@ -4620,11 +4620,11 @@ msgstr ""
 msgid "Font cache misses:"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2174
+#: ../../src/dialogs/ConfigDialogue.cpp:2189
 msgid "Fonts"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:445
+#: ../../src/dialogs/ConfigDialogue.cpp:446
 msgid "For each Text-, Sectioning or code cell wxMaxima can display a bracket showing the extend of the cell and allowing to fold it. This setting now tells if this bracket is to be printed, as well."
 msgstr ""
 
@@ -4715,7 +4715,7 @@ msgstr ""
 msgid "Free all unused items now"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:199
+#: ../../src/dialogs/ConfigDialogue.cpp:200
 msgid "French"
 msgstr ""
 
@@ -4798,7 +4798,7 @@ msgstr ""
 msgid "GTK_IM_MODULE is set to \"xim\". Expect the program to hideously flicker and hotkeys to be broken, see for example https://github.com/wxWidgets/wxWidgets/issues/18462."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:200
+#: ../../src/dialogs/ConfigDialogue.cpp:201
 msgid "Galician"
 msgstr ""
 
@@ -4850,11 +4850,11 @@ msgstr ""
 msgid "Generates a matrix and fills each element with the result of the expression \"Rule\"."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:201
+#: ../../src/dialogs/ConfigDialogue.cpp:202
 msgid "Georgian"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:202
+#: ../../src/dialogs/ConfigDialogue.cpp:203
 msgid "German"
 msgstr ""
 
@@ -4868,6 +4868,11 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1729
 msgid "Get Real P&art"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:2012
+#, c-format
+msgid "Get an API key for %s..."
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1312
@@ -4899,7 +4904,7 @@ msgstr ""
 msgid "Gnuplot (command line) found at: %s"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1683
+#: ../../src/dialogs/ConfigDialogue.cpp:1684
 msgid "Gnuplot flavour"
 msgstr ""
 
@@ -4949,7 +4954,7 @@ msgstr ""
 msgid "Greater, ignoring case?..."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:203
+#: ../../src/dialogs/ConfigDialogue.cpp:204
 msgid "Greek"
 msgstr ""
 
@@ -4973,7 +4978,7 @@ msgstr ""
 msgid "Guess an exact number that could be meant by this float"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1232
+#: ../../src/dialogs/ConfigDialogue.cpp:1233
 msgid "HTML"
 msgstr ""
 
@@ -5012,7 +5017,7 @@ msgstr ""
 msgid "Heading 6"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:204
+#: ../../src/dialogs/ConfigDialogue.cpp:205
 msgid "Hebrew"
 msgstr ""
 
@@ -5021,7 +5026,7 @@ msgstr ""
 msgid "Help"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1515
+#: ../../src/dialogs/ConfigDialogue.cpp:1516
 msgid "Help browser:"
 msgstr ""
 
@@ -5080,7 +5085,7 @@ msgstr ""
 msgid "Hide all Sidebars\tAlt+Shift+-"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:490
+#: ../../src/dialogs/ConfigDialogue.cpp:491
 msgid "Hide all multiplication signs that aren't really necessary for understanding the equation"
 msgstr ""
 
@@ -5100,7 +5105,7 @@ msgstr ""
 msgid "Hide multiplication dots"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:871
+#: ../../src/dialogs/ConfigDialogue.cpp:872
 msgid "Hide multiplication signs, if possible"
 msgstr ""
 
@@ -5108,7 +5113,7 @@ msgstr ""
 msgid "Hide objects behind the surface"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:505
+#: ../../src/dialogs/ConfigDialogue.cpp:506
 msgid "Hide the brackets that mark the extend of the worksheet cells at the worksheet's right side and that contain the \"hide\" button of the cell if the cells aren't active."
 msgstr ""
 
@@ -5126,15 +5131,15 @@ msgstr ""
 msgid "Highlight (box)"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:886
+#: ../../src/dialogs/ConfigDialogue.cpp:887
 msgid "Highlight the matching parenthesis"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:466
+#: ../../src/dialogs/ConfigDialogue.cpp:467
 msgid "Highlight the opening or closing parenthesis for the parenthesis the cursor is at."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:205
+#: ../../src/dialogs/ConfigDialogue.cpp:206
 msgid "Hindi"
 msgstr ""
 
@@ -5162,7 +5167,7 @@ msgstr ""
 msgid "Horner's rule"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:935
+#: ../../src/dialogs/ConfigDialogue.cpp:936
 msgid "Hotkeys for sending commands to maxima"
 msgstr ""
 
@@ -5174,7 +5179,7 @@ msgstr ""
 msgid "How to display new equations"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:206
+#: ../../src/dialogs/ConfigDialogue.cpp:207
 msgid "Hungarian"
 msgstr ""
 
@@ -5190,43 +5195,43 @@ msgstr ""
 msgid "If a program doesn't need local variables, Maxima allows putting the commands between parentheses. The result of the last operation is the return value of the program."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:146
+#: ../../src/dialogs/ConfigDialogue.cpp:147
 msgid "If maxima versions compiled with different lisps are installed: The name of the lisp to use by default"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:175
+#: ../../src/dialogs/ConfigDialogue.cpp:176
 msgid "If maxima was compiled by GCL: Garbage Collect at minimum allocation past this heapsize"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:172
+#: ../../src/dialogs/ConfigDialogue.cpp:173
 msgid "If maxima was compiled by GCL: Minimum allocation fraction between Garbage Collects"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:169
+#: ../../src/dialogs/ConfigDialogue.cpp:170
 msgid "If maxima was compiled by GCL: Only garbage collect past this heapsize fraction of working mem"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:181
+#: ../../src/dialogs/ConfigDialogue.cpp:182
 msgid "If maxima was compiled by GCL: Share the allocated memory between gcl processes. Allows more than one gcl-compiled maxima to run at the same time, but might provoke crashes."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:178
+#: ../../src/dialogs/ConfigDialogue.cpp:179
 msgid "If maxima was compiled by GCL: The fraction of the total installed RAM to reserve for maxima"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:378
+#: ../../src/dialogs/ConfigDialogue.cpp:379
 msgid "If multiple cells are evaluated in one go: Abort evaluation if wxMaxima detects that maxima has encountered any error."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:744
+#: ../../src/dialogs/ConfigDialogue.cpp:745
 msgid "If not extremely long"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:743
+#: ../../src/dialogs/ConfigDialogue.cpp:744
 msgid "If not very long"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:421
+#: ../../src/dialogs/ConfigDialogue.cpp:422
 msgid "If numbers are getting longer than this number of digits they will be displayed abbreviated by an ellipsis."
 msgstr ""
 
@@ -5234,7 +5239,7 @@ msgstr ""
 msgid "If the \"Autosave\" functionality is enabled in the configuration dialogue wxMaxima acts like mobile apps that backup the file every few minutes and save it on closing."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:399
+#: ../../src/dialogs/ConfigDialogue.cpp:400
 msgid "If the font provides big parenthesis symbols: Use them when big parenthesis are needed for maths display."
 msgstr ""
 
@@ -5250,15 +5255,15 @@ msgid ""
 "array, boolean, integer, fixnum (machine-length integer), float (machine-size floating-point numbers), real or any (which is useful for declaring arrays of any)"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:402
+#: ../../src/dialogs/ConfigDialogue.cpp:403
 msgid "If this checkbox is checked wxMaxima automatically saves the file closing and every few minutes giving wxMaxima a more cellphone-app-like feel as the file is virtually always saved. If this checkbox is unchecked from time to time a backup is made in the temp folder instead."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:381
+#: ../../src/dialogs/ConfigDialogue.cpp:382
 msgid "If this checkbox is set a new code cell is opened as soon as maxima requests data. If it isn't set a new code cell is opened in this case as soon as the user starts typing in code."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:375
+#: ../../src/dialogs/ConfigDialogue.cpp:376
 msgid "If this checkbox isn't checked the current command is sent to maxima only on pressing Ctrl+Enter"
 msgstr ""
 
@@ -5266,18 +5271,18 @@ msgstr ""
 msgid "If this isn't a function returning a lambda() expression a multiplication sign (*) between closing and opening parenthesis is missing here."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:959
+#: ../../src/dialogs/ConfigDialogue.cpp:960
 msgid ""
 "If this option is enabled, the filename and path of images inserted with \"Cell\" -> \"Insert Image...\" is stored in the worksheet file on save. This enables reloading of the image file via the context menu after re-opening the worksheet, but storing the filenames and paths may be an undesired data leak. If this option is disabled, reloading still works as long as the worksheet is not closed.\n"
 "\n"
 "Note: Storing the filenames for the reload functionality is independent of the automatically generated image captions."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:442
+#: ../../src/dialogs/ConfigDialogue.cpp:443
 msgid "If this option is set the .wxmx source of the current file is copied to a place a link to is put into the result of an export."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1927
+#: ../../src/dialogs/ConfigDialogue.cpp:1928
 msgid "If unset, Maxima's output is announced to the screen reader as maths in a linear text form. Set this option if your screen reader can speak MathML properly."
 msgstr ""
 
@@ -5323,11 +5328,11 @@ msgstr ""
 msgid "Implicit Plot"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1045
+#: ../../src/dialogs/ConfigDialogue.cpp:1046
 msgid "Import settings"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1030
+#: ../../src/dialogs/ConfigDialogue.cpp:1031
 msgid "Import+Export"
 msgstr ""
 
@@ -5368,7 +5373,7 @@ msgstr ""
 msgid "In text cells bullet lists can be created by beginning a line with \" * \". The number of spaces in front of the \"*\" determines the indentation level; Indentation can be continued in the next line by indenting the line using spaces."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:424
+#: ../../src/dialogs/ConfigDialogue.cpp:425
 msgid "In the LaTeX output: Put exponents after an eventual subscript instead of above it. Might increase readability for some fonts and short subscripts."
 msgstr ""
 
@@ -5380,15 +5385,15 @@ msgstr ""
 msgid "Increasing function f(x)>x"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:901
+#: ../../src/dialogs/ConfigDialogue.cpp:902
 msgid "Incremental Search"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:861
+#: ../../src/dialogs/ConfigDialogue.cpp:862
 msgid "Indent equations by the label width"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:515
+#: ../../src/dialogs/ConfigDialogue.cpp:516
 msgid "Indent maths so all lines are in par with the first line that starts after the label."
 msgstr ""
 
@@ -5412,7 +5417,7 @@ msgstr ""
 msgid "Index variable:"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:207
+#: ../../src/dialogs/ConfigDialogue.cpp:208
 msgid "Indonesian"
 msgstr ""
 
@@ -5489,7 +5494,7 @@ msgstr ""
 msgid "Insert"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:906
+#: ../../src/dialogs/ConfigDialogue.cpp:907
 msgid "Insert % before an operator at the beginning of a cell"
 msgstr ""
 
@@ -5637,7 +5642,7 @@ msgstr ""
 msgid "Instructed to prefer wgnuplot over gnuplot"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:766
+#: ../../src/dialogs/ConfigDialogue.cpp:767
 msgid "Integers and single letters"
 msgstr ""
 
@@ -5675,15 +5680,15 @@ msgstr ""
 msgid "Integrate..."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:851
+#: ../../src/dialogs/ConfigDialogue.cpp:852
 msgid "Intelligently hide cell brackets"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:898
+#: ../../src/dialogs/ConfigDialogue.cpp:899
 msgid "Interaction"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1366
+#: ../../src/dialogs/ConfigDialogue.cpp:1367
 msgid "Interactive popup memory limit [MB/plot]:"
 msgstr ""
 
@@ -5699,7 +5704,7 @@ msgstr ""
 msgid "Interleave two lists"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1519
+#: ../../src/dialogs/ConfigDialogue.cpp:1520
 msgid "Internal"
 msgstr ""
 
@@ -5881,7 +5886,7 @@ msgstr ""
 msgid "Is uppercase?..."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:501
+#: ../../src/dialogs/ConfigDialogue.cpp:502
 msgid "Issue a notification if maxima finishes calculating while the wxMaxima window isn't in focus."
 msgstr ""
 
@@ -5909,11 +5914,11 @@ msgstr ""
 msgid "It therefore makes sense to apply the known values for variables as late as possible."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:208
+#: ../../src/dialogs/ConfigDialogue.cpp:209
 msgid "Italian"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2238
+#: ../../src/dialogs/ConfigDialogue.cpp:2253
 msgid "Italic"
 msgstr ""
 
@@ -5925,7 +5930,7 @@ msgstr ""
 msgid "Iterator name:"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:209
+#: ../../src/dialogs/ConfigDialogue.cpp:210
 msgid "Japanese"
 msgstr ""
 
@@ -5953,7 +5958,7 @@ msgstr ""
 msgid "Jump to the last cell Maxima has reported an error in."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:211
+#: ../../src/dialogs/ConfigDialogue.cpp:212
 msgid "Kabyle"
 msgstr ""
 
@@ -5961,12 +5966,12 @@ msgstr ""
 msgid "Kappa"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:881
+#: ../../src/dialogs/ConfigDialogue.cpp:882
 #, c-format
 msgid "Keep percent sign with special symbols: %e, %i, etc."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:213
+#: ../../src/dialogs/ConfigDialogue.cpp:214
 msgid "Korean"
 msgstr ""
 
@@ -5990,19 +5995,19 @@ msgstr ""
 msgid "L[inf] Norm (real)"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1183
+#: ../../src/dialogs/ConfigDialogue.cpp:1184
 msgid "LaTeX"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1216
+#: ../../src/dialogs/ConfigDialogue.cpp:1217
 msgid "LaTeX: Place exponents after, instead above subscripts"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1221
+#: ../../src/dialogs/ConfigDialogue.cpp:1222
 msgid "LaTeX: Use the \"partial derivative\" symbol to represent diff()"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:775
+#: ../../src/dialogs/ConfigDialogue.cpp:776
 msgid "Label width:"
 msgstr ""
 
@@ -6022,11 +6027,11 @@ msgid ""
 "Also you can fill a variable with a lambda() construct, effectively generating a function pointer: A variable that can be used as a function, and filled with a different function, if needed."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:473
+#: ../../src/dialogs/ConfigDialogue.cpp:474
 msgid "Language used for wxMaxima GUI."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1328
+#: ../../src/dialogs/ConfigDialogue.cpp:1329
 msgid "Language:"
 msgstr ""
 
@@ -6060,7 +6065,7 @@ msgstr ""
 msgid "Last non-whitespace is a question mark"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:214
+#: ../../src/dialogs/ConfigDialogue.cpp:215
 msgid "Latvian"
 msgstr ""
 
@@ -6089,7 +6094,7 @@ msgstr ""
 msgid "Least Squares Fit..."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2134
+#: ../../src/dialogs/ConfigDialogue.cpp:2149
 msgid "Left"
 msgstr ""
 
@@ -6118,7 +6123,7 @@ msgstr ""
 msgid "Length:"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1443
+#: ../../src/dialogs/ConfigDialogue.cpp:1444
 msgid "Let an AI tool read this worksheet (MCP server)"
 msgstr ""
 
@@ -6135,7 +6140,7 @@ msgstr ""
 msgid "License"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2195
+#: ../../src/dialogs/ConfigDialogue.cpp:2210
 msgid "Light"
 msgstr ""
 
@@ -6284,11 +6289,11 @@ msgstr ""
 msgid "List:"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:215
+#: ../../src/dialogs/ConfigDialogue.cpp:216
 msgid "Lithuanian"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2289
+#: ../../src/dialogs/ConfigDialogue.cpp:2304
 msgid "Load"
 msgstr ""
 
@@ -6328,7 +6333,7 @@ msgstr ""
 msgid "Load lisp..."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2784
+#: ../../src/dialogs/ConfigDialogue.cpp:2799
 msgid "Load style from file"
 msgstr ""
 
@@ -6368,7 +6373,7 @@ msgstr ""
 msgid "MAXIMA RESPONSE:"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1455
+#: ../../src/dialogs/ConfigDialogue.cpp:1456
 msgid "MCP server port:"
 msgstr ""
 
@@ -6410,7 +6415,7 @@ msgstr ""
 msgid "Make function local..."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:216
+#: ../../src/dialogs/ConfigDialogue.cpp:217
 msgid "Malay"
 msgstr ""
 
@@ -6450,7 +6455,7 @@ msgstr ""
 msgid "Math Default"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:806
+#: ../../src/dialogs/ConfigDialogue.cpp:807
 msgid "Math layout strategy"
 msgstr ""
 
@@ -6458,19 +6463,19 @@ msgstr ""
 msgid "Math output"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1238
+#: ../../src/dialogs/ConfigDialogue.cpp:1239
 msgid "MathML (rendered by the browser)"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1239
+#: ../../src/dialogs/ConfigDialogue.cpp:1240
 msgid "MathML + MathJaX fall-back for old browsers"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2033
+#: ../../src/dialogs/ConfigDialogue.cpp:2048
 msgid "MathML as HTML"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2029
+#: ../../src/dialogs/ConfigDialogue.cpp:2044
 msgid "MathML description"
 msgstr ""
 
@@ -6546,15 +6551,15 @@ msgstr ""
 msgid "Matrix:"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1387
+#: ../../src/dialogs/ConfigDialogue.cpp:1388
 msgid "Max. layout time [s] (0=no limit)"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:282
+#: ../../src/dialogs/ConfigDialogue.cpp:283
 msgid "Maxima"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1487
+#: ../../src/dialogs/ConfigDialogue.cpp:1488
 msgid "Maxima Location"
 msgstr ""
 
@@ -6579,7 +6584,7 @@ msgstr ""
 msgid "Maxima asks a question!"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:365
+#: ../../src/dialogs/ConfigDialogue.cpp:366
 #, c-format
 msgid "Maxima assigns each command/equation an automatic label (which looks like %i1 or %o1). If a command begins with a descriptive name followed by a : wxMaxima will call the descriptive name a \"user-defined label\" instead. This selection now allows telling wxMaxima whether to show only automatic labels, automatic labels if there aren't user-defined ones or no label at all until a user-defined label can be found by wxMaxima's heuristics. If automatic labels are suppressed extra vertical space is added between equations in order to ease discerning which line starts a new equation and which one only continues the one from the last line."
 msgstr ""
@@ -6594,15 +6599,15 @@ msgstr ""
 msgid "Maxima code"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1127
+#: ../../src/dialogs/ConfigDialogue.cpp:1128
 msgid "Maxima commands to be executed at every start of Maxima"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1080
+#: ../../src/dialogs/ConfigDialogue.cpp:1081
 msgid "Maxima commands to be executed every time wxMaxima starts Maxima"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1561
+#: ../../src/dialogs/ConfigDialogue.cpp:1562
 msgid "Maxima configuration"
 msgstr ""
 
@@ -6711,11 +6716,11 @@ msgstr ""
 msgid "Maxima process terminated unexpectedly."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1491
+#: ../../src/dialogs/ConfigDialogue.cpp:1492
 msgid "Maxima program:"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:385
+#: ../../src/dialogs/ConfigDialogue.cpp:386
 msgid "Maxima provides no \"forget all\" command that flushes all settings a maxima session could make. wxMaxima therefore normally defaults to starting a fresh maxima process every time the worksheet is to be re-evaluated. As this needs a little bit of time this switch allows to disable this behavior."
 msgstr ""
 
@@ -6739,15 +6744,15 @@ msgstr ""
 msgid "Maxima session (*.mac)|*.mac"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1572 ../../src/wxMaximaFrame.cpp:2058
+#: ../../src/dialogs/ConfigDialogue.cpp:1573 ../../src/wxMaximaFrame.cpp:2058
 msgid "Maxima shows help in a browser"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1577 ../../src/wxMaximaFrame.cpp:2054
+#: ../../src/dialogs/ConfigDialogue.cpp:1578 ../../src/wxMaximaFrame.cpp:2054
 msgid "Maxima shows help in a sidebar"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1565 ../../src/wxMaximaFrame.cpp:2049
+#: ../../src/dialogs/ConfigDialogue.cpp:1566 ../../src/wxMaximaFrame.cpp:2049
 msgid "Maxima shows help in the console"
 msgstr ""
 
@@ -6767,7 +6772,7 @@ msgstr ""
 msgid "Maxima starts:"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1160
+#: ../../src/dialogs/ConfigDialogue.cpp:1161
 msgid "Maxima startup file location: "
 msgstr ""
 
@@ -6787,7 +6792,7 @@ msgstr ""
 msgid "Maxima tried to find out where between two points a curve crosses the zero line. Since the curve is on the same side of the zero line in both points its algorithms fails here. Set find_root_error to false if you want it to return false instead of an error."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1669
+#: ../../src/dialogs/ConfigDialogue.cpp:1670
 msgid "Maxima usage"
 msgstr ""
 
@@ -6941,7 +6946,7 @@ msgstr ""
 msgid "Maximum absolute value printed without exponent"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2058
+#: ../../src/dialogs/ConfigDialogue.cpp:2073
 msgid "Maximum bitmap size on clipboard [Mb]:"
 msgstr ""
 
@@ -6954,7 +6959,7 @@ msgstr ""
 msgid "Maximum number of digits to be displayed:"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:828
+#: ../../src/dialogs/ConfigDialogue.cpp:829
 msgid "Maximum number of displayed digits:"
 msgstr ""
 
@@ -7022,11 +7027,11 @@ msgstr ""
 msgid "Minimum absolute value printed without exponent:"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1287
+#: ../../src/dialogs/ConfigDialogue.cpp:1288
 msgid "Misc"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2090
+#: ../../src/dialogs/ConfigDialogue.cpp:2105
 msgid "Misc settings"
 msgstr ""
 
@@ -7038,7 +7043,7 @@ msgstr ""
 msgid "Missing contents. Bug?"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1990
+#: ../../src/dialogs/ConfigDialogue.cpp:1992
 msgid "Model:"
 msgstr ""
 
@@ -7104,7 +7109,7 @@ msgstr ""
 msgid "Name:"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:217
+#: ../../src/dialogs/ConfigDialogue.cpp:218
 msgid "Nepali"
 msgstr ""
 
@@ -7116,8 +7121,8 @@ msgstr ""
 msgid "Nested list to matrix"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:765
-#: ../../src/dialogs/ConfigDialogue.cpp:789 ../../src/wxMaximaFrame.cpp:883
+#: ../../src/dialogs/ConfigDialogue.cpp:766
+#: ../../src/dialogs/ConfigDialogue.cpp:790 ../../src/wxMaximaFrame.cpp:883
 #: ../../src/wxMaximaFrame.cpp:1164
 msgid "Never"
 msgstr ""
@@ -7163,7 +7168,7 @@ msgstr ""
 msgid "New document"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:918
+#: ../../src/dialogs/ConfigDialogue.cpp:919
 msgid "New lines: Jump to text"
 msgstr ""
 
@@ -7197,16 +7202,16 @@ msgstr ""
 msgid "Nice Graphical Equations"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:742
-#: ../../src/dialogs/ConfigDialogue.cpp:754 ../../src/wxMaximaFrame.cpp:1664
+#: ../../src/dialogs/ConfigDialogue.cpp:743
+#: ../../src/dialogs/ConfigDialogue.cpp:755 ../../src/wxMaximaFrame.cpp:1664
 msgid "No"
 msgstr ""
 
-#: ../../src/sidebars/AiChatSidebar.cpp:148
+#: ../../src/sidebars/AiChatSidebar.cpp:165
 msgid "No AI provider configured -- add an API key in Options."
 msgstr ""
 
-#: ../../src/sidebars/AiChatSidebar.cpp:201
+#: ../../src/sidebars/AiChatSidebar.cpp:218
 msgid "No AI provider is configured. Open Options to add an API key for one."
 msgstr ""
 
@@ -7287,7 +7292,7 @@ msgstr ""
 msgid "None"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1964
+#: ../../src/dialogs/ConfigDialogue.cpp:1965
 msgid "None (disabled)"
 msgstr ""
 
@@ -7304,11 +7309,11 @@ msgid ""
 "The info that numbers have automatically been converted can be suppressed by setting ratprint to false."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:434
+#: ../../src/dialogs/ConfigDialogue.cpp:435
 msgid "Normally html expects images to be rather low-res but space saving. These images tend to look rather blurry when viewed on modern screens. Therefore this setting was introduces that selects the factor by which the HTML export increases the resolution in respect to the default value."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:218
+#: ../../src/dialogs/ConfigDialogue.cpp:219
 msgid "Norwegian"
 msgstr ""
 
@@ -7487,7 +7492,7 @@ msgstr ""
 msgid "Odd number"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:927
+#: ../../src/dialogs/ConfigDialogue.cpp:928
 msgid "Offer answers for questions known from previous runs"
 msgstr ""
 
@@ -7532,7 +7537,7 @@ msgstr ""
 msgid "Only Integers and single letters"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:788
+#: ../../src/dialogs/ConfigDialogue.cpp:789
 msgid "Only user-defined labels"
 msgstr ""
 
@@ -7541,7 +7546,11 @@ msgstr ""
 msgid "Open"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:922
+#: ../../src/sidebars/AiChatSidebar.cpp:43
+msgid "Open Options..."
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:923
 msgid "Open a cell when Maxima expects input"
 msgstr ""
 
@@ -7620,7 +7629,7 @@ msgid "Optional: A 2nd expression that defines a region to fill"
 msgstr ""
 
 #: ../../src/ToolBar.cpp:367 ../../src/ToolBar.cpp:369
-#: ../../src/dialogs/ConfigDialogue.cpp:285
+#: ../../src/dialogs/ConfigDialogue.cpp:286
 msgid "Options"
 msgstr ""
 
@@ -7677,7 +7686,7 @@ msgstr ""
 msgid "Output: Variable names"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:856
+#: ../../src/dialogs/ConfigDialogue.cpp:857
 msgid "Overlay scrollbars (slow: repaints the worksheet while they fade)"
 msgstr ""
 
@@ -7685,7 +7694,7 @@ msgstr ""
 msgid "PNG image (*.png)|*.png|JPEG image (*.jpg)|*.jpg|Windows bitmap (*.bmp)|*.bmp|"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:461
+#: ../../src/dialogs/ConfigDialogue.cpp:462
 msgid "PNG images can be read by old wxMaxima versions - but aren't really scalable."
 msgstr ""
 
@@ -7783,7 +7792,7 @@ msgstr ""
 msgid "Perpendicular to"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:219
+#: ../../src/dialogs/ConfigDialogue.cpp:220
 msgid "Persian"
 msgstr ""
 
@@ -7803,7 +7812,7 @@ msgstr ""
 msgid "Please configure wxMaxima with 'Edit->Configure'."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2745
+#: ../../src/dialogs/ConfigDialogue.cpp:2760
 msgid "Please restart wxMaxima for changes to take effect!"
 msgstr ""
 
@@ -7915,7 +7924,7 @@ msgstr ""
 msgid "Points"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:220
+#: ../../src/dialogs/ConfigDialogue.cpp:221
 msgid "Polish"
 msgstr ""
 
@@ -7947,11 +7956,11 @@ msgstr ""
 msgid "Portable anymap (*.pnm)|*.pnm|Tagged image file format (*.tif)|*.tif|X pixmap (*.xpm)|*.xpm"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:221
+#: ../../src/dialogs/ConfigDialogue.cpp:222
 msgid "Portuguese"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:222
+#: ../../src/dialogs/ConfigDialogue.cpp:223
 msgid "Portuguese (Brazilian)"
 msgstr ""
 
@@ -7983,11 +7992,11 @@ msgstr ""
 msgid "Precision"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:804
+#: ../../src/dialogs/ConfigDialogue.cpp:805
 msgid "Prefer 1D"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1546
+#: ../../src/dialogs/ConfigDialogue.cpp:1547
 msgid "Prefer the all-in-one-file >1000 page manual"
 msgstr ""
 
@@ -8031,7 +8040,7 @@ msgstr ""
 msgid "Print"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2115
+#: ../../src/dialogs/ConfigDialogue.cpp:2130
 msgid "Print Margins"
 msgstr ""
 
@@ -8052,15 +8061,15 @@ msgstr ""
 msgid "Print floating-point numbers with exponents dividable by 3"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2095
+#: ../../src/dialogs/ConfigDialogue.cpp:2110
 msgid "Print scale:"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2108
+#: ../../src/dialogs/ConfigDialogue.cpp:2123
 msgid "Print the cell brackets [drawn to their left]"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:288
+#: ../../src/dialogs/ConfigDialogue.cpp:289
 msgid "Printout settings"
 msgstr ""
 
@@ -8106,7 +8115,7 @@ msgstr ""
 msgid "Printout: Setting the device origin to %lix%li"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:953
+#: ../../src/dialogs/ConfigDialogue.cpp:954
 msgid "Privacy settings"
 msgstr ""
 
@@ -8168,7 +8177,7 @@ msgstr ""
 msgid "Quit wxMaxima"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2037
+#: ../../src/dialogs/ConfigDialogue.cpp:2052
 msgid "RTF with OMML maths"
 msgstr ""
 
@@ -8246,7 +8255,7 @@ msgstr ""
 msgid "Read char"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2627
+#: ../../src/dialogs/ConfigDialogue.cpp:2642
 msgid "Read config to file"
 msgstr ""
 
@@ -8359,7 +8368,7 @@ msgstr ""
 msgid "Received maxima's first prompt: %s"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1344
+#: ../../src/dialogs/ConfigDialogue.cpp:1345
 msgid "Recent files list length:"
 msgstr ""
 
@@ -8442,11 +8451,11 @@ msgstr ""
 msgid "Reload Image \"%s\""
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1014
+#: ../../src/dialogs/ConfigDialogue.cpp:1015
 msgid "Reload all GUI settings from disc"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1021
+#: ../../src/dialogs/ConfigDialogue.cpp:1022
 msgid "Reload the style settings from disc"
 msgstr ""
 
@@ -8455,11 +8464,11 @@ msgstr ""
 msgid "Reloading image file %s."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2712
+#: ../../src/dialogs/ConfigDialogue.cpp:2727
 msgid "Reloading the configuration from disc"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2720
+#: ../../src/dialogs/ConfigDialogue.cpp:2735
 msgid "Reloading the styles from disc"
 msgstr ""
 
@@ -8600,11 +8609,11 @@ msgstr ""
 msgid "Report bug"
 msgstr ""
 
-#: ../../src/ai/AiProvider.cpp:332
+#: ../../src/ai/AiProvider.cpp:342
 msgid "Request cancelled."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1000
+#: ../../src/dialogs/ConfigDialogue.cpp:1001
 msgid "Reset all GUI settings"
 msgstr ""
 
@@ -8612,12 +8621,12 @@ msgstr ""
 msgid "Reset option variables"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1007
+#: ../../src/dialogs/ConfigDialogue.cpp:1008
 msgid "Reset the Style settings"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2696
-#: ../../src/dialogs/ConfigDialogue.cpp:2704
+#: ../../src/dialogs/ConfigDialogue.cpp:2711
+#: ../../src/dialogs/ConfigDialogue.cpp:2719
 msgid "Resetting all configuration settings"
 msgstr ""
 
@@ -8723,11 +8732,11 @@ msgstr ""
 msgid "Reverses the order of the members of a list"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:298
+#: ../../src/dialogs/ConfigDialogue.cpp:299
 msgid "Revert all to defaults"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:997
+#: ../../src/dialogs/ConfigDialogue.cpp:998
 msgid "Revert changes"
 msgstr ""
 
@@ -8735,7 +8744,7 @@ msgstr ""
 msgid "Rho"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2142
+#: ../../src/dialogs/ConfigDialogue.cpp:2157
 msgid "Right"
 msgstr ""
 
@@ -8760,7 +8769,7 @@ msgstr ""
 msgid "Risch Integration..."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:223
+#: ../../src/dialogs/ConfigDialogue.cpp:224
 msgid "Romanian"
 msgstr ""
 
@@ -8838,7 +8847,7 @@ msgstr ""
 msgid "Running on the universal wxWidgets port"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1445
+#: ../../src/dialogs/ConfigDialogue.cpp:1446
 msgid "Runs a local, read-only MCP (Model Context Protocol) server an AI tool can connect to for context on this worksheet's cells, table of contents and watched variables. It only answers questions -- it can never insert, edit or evaluate anything itself. Only accepts connections from this same machine (localhost)."
 msgstr ""
 
@@ -8858,15 +8867,15 @@ msgstr ""
 msgid "Runs each element through an expression"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:224
+#: ../../src/dialogs/ConfigDialogue.cpp:225
 msgid "Russian"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1632
+#: ../../src/dialogs/ConfigDialogue.cpp:1633
 msgid "SBCL: use <int>Mbytes of heap"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1639
+#: ../../src/dialogs/ConfigDialogue.cpp:1640
 msgid "SBCL: use <int>Mbytes of stack for function calls"
 msgstr ""
 
@@ -8874,7 +8883,7 @@ msgstr ""
 msgid "SENT TO MAXIMA:"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1241
+#: ../../src/dialogs/ConfigDialogue.cpp:1242
 msgid "SVG graphics"
 msgstr ""
 
@@ -8907,7 +8916,7 @@ msgid "Samples on a line:"
 msgstr ""
 
 #: ../../src/ToolBar.cpp:331 ../../src/ToolBar.cpp:334
-#: ../../src/dialogs/ConfigDialogue.cpp:2290 ../../src/wxMaxima.cpp:3605
+#: ../../src/dialogs/ConfigDialogue.cpp:2305 ../../src/wxMaxima.cpp:3605
 msgid "Save"
 msgstr ""
 
@@ -8947,7 +8956,7 @@ msgstr ""
 msgid "Save as lisp..."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2617
+#: ../../src/dialogs/ConfigDialogue.cpp:2632
 msgid "Save config to file"
 msgstr ""
 
@@ -8972,11 +8981,11 @@ msgstr ""
 msgid "Save selection to file"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2779
+#: ../../src/dialogs/ConfigDialogue.cpp:2794
 msgid "Save style to file"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1401
+#: ../../src/dialogs/ConfigDialogue.cpp:1402
 msgid "Save the worksheet automatically"
 msgstr ""
 
@@ -8992,7 +9001,7 @@ msgstr ""
 msgid "Saving succeeded, but the resulting files has disappeared ?!?."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2041
+#: ../../src/dialogs/ConfigDialogue.cpp:2056
 msgid "Scalable Vector Graphics (svg)"
 msgstr ""
 
@@ -9016,7 +9025,7 @@ msgstr ""
 msgid "Scheduling a background task that scans for autocompletable file names."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1921
+#: ../../src/dialogs/ConfigDialogue.cpp:1922
 msgid "Screen reader"
 msgstr ""
 
@@ -9128,7 +9137,7 @@ msgstr ""
 msgid "Semicolon"
 msgstr ""
 
-#: ../../src/sidebars/AiChatSidebar.cpp:65
+#: ../../src/sidebars/AiChatSidebar.cpp:74
 msgid "Send"
 msgstr ""
 
@@ -9168,7 +9177,7 @@ msgstr ""
 msgid "Sequential Comparative Simplification"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:225
+#: ../../src/dialogs/ConfigDialogue.cpp:226
 msgid "Serbian"
 msgstr ""
 
@@ -9208,7 +9217,7 @@ msgstr ""
 msgid "Set bigfloat &Precision..."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:482
+#: ../../src/dialogs/ConfigDialogue.cpp:483
 msgid "Set fixed font in text controls."
 msgstr ""
 
@@ -9285,7 +9294,7 @@ msgstr ""
 msgid "Set zoom to 80%"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:164
+#: ../../src/dialogs/ConfigDialogue.cpp:165
 msgid "Sets the language, line ending type and charset encoding programs will use"
 msgstr ""
 
@@ -9298,7 +9307,7 @@ msgstr ""
 msgid "Setting prompt and help format"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:166
+#: ../../src/dialogs/ConfigDialogue.cpp:167
 msgid "Setting this to \"cat\" causes gnuplot not to halt if there is much output"
 msgstr ""
 
@@ -9351,7 +9360,7 @@ msgstr ""
 msgid "Show \"%\" in special constants"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1433
+#: ../../src/dialogs/ConfigDialogue.cpp:1434
 msgid "Show \"Find and Replace\" as a dockable sidebar"
 msgstr ""
 
@@ -9431,7 +9440,7 @@ msgstr ""
 msgid "Show input labels"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:783
+#: ../../src/dialogs/ConfigDialogue.cpp:784
 msgid "Show labels:"
 msgstr ""
 
@@ -9439,11 +9448,11 @@ msgstr ""
 msgid "Show lisp representation"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:468
+#: ../../src/dialogs/ConfigDialogue.cpp:469
 msgid "Show long expressions in wxMaxima document."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:739
+#: ../../src/dialogs/ConfigDialogue.cpp:740
 msgid "Show long expressions:"
 msgstr ""
 
@@ -9636,15 +9645,15 @@ msgstr ""
 msgid "Size of internal work array. limit/2 is the maximum number of subintervals to use."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2240
+#: ../../src/dialogs/ConfigDialogue.cpp:2255
 msgid "Slanted"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:226
+#: ../../src/dialogs/ConfigDialogue.cpp:227
 msgid "Slovak"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:227
+#: ../../src/dialogs/ConfigDialogue.cpp:228
 msgid "Slovenian"
 msgstr ""
 
@@ -9829,7 +9838,7 @@ msgstr ""
 msgid "Source list:"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:228
+#: ../../src/dialogs/ConfigDialogue.cpp:229
 msgid "Spanish"
 msgstr ""
 
@@ -9866,7 +9875,7 @@ msgstr ""
 msgid "Square"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1317
+#: ../../src/dialogs/ConfigDialogue.cpp:1318
 msgid "Standard Options"
 msgstr ""
 
@@ -9878,7 +9887,7 @@ msgstr ""
 msgid "Start Animation"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1676
+#: ../../src/dialogs/ConfigDialogue.cpp:1677
 msgid "Start a new maxima for each re-evaluation"
 msgstr ""
 
@@ -9906,7 +9915,7 @@ msgstr ""
 msgid "Start or stop the currently selected animation that has been created with the with_slider class of commands"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:499
+#: ../../src/dialogs/ConfigDialogue.cpp:500
 msgid "Start searching while the phrase to search for is still being typed."
 msgstr ""
 
@@ -9935,7 +9944,7 @@ msgstr ""
 msgid "Starting to save the worksheet as .wxmx. Filename: %s"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:287
+#: ../../src/dialogs/ConfigDialogue.cpp:288
 msgid "Startup commands"
 msgstr ""
 
@@ -9951,7 +9960,7 @@ msgstr ""
 msgid "Step width:"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:956
+#: ../../src/dialogs/ConfigDialogue.cpp:957
 msgid "Store filenames in image cells to enable image reloading after re-opening the worksheet"
 msgstr ""
 
@@ -9977,7 +9986,7 @@ msgstr ""
 msgid "Stream:"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2244
+#: ../../src/dialogs/ConfigDialogue.cpp:2259
 msgid "Strike Through"
 msgstr ""
 
@@ -10045,11 +10054,11 @@ msgstr ""
 msgid "Structs"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:283
+#: ../../src/dialogs/ConfigDialogue.cpp:284
 msgid "Style"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2209
+#: ../../src/dialogs/ConfigDialogue.cpp:2224
 msgid "Styles"
 msgstr ""
 
@@ -10153,7 +10162,7 @@ msgstr ""
 msgid "Sum sign"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:229
+#: ../../src/dialogs/ConfigDialogue.cpp:230
 msgid "Swedish"
 msgstr ""
 
@@ -10178,7 +10187,7 @@ msgstr ""
 msgid "Symbols\tAlt+Shift+Y"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:475
+#: ../../src/dialogs/ConfigDialogue.cpp:476
 msgid "Symbols that are entered or copied here will appear in the symbols sidebar so they can be entered into the worksheet easily."
 msgstr ""
 
@@ -10210,7 +10219,7 @@ msgstr ""
 msgid "Take surface color from steepness"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:230
+#: ../../src/dialogs/ConfigDialogue.cpp:231
 msgid "Tamil"
 msgstr ""
 
@@ -10250,7 +10259,7 @@ msgstr ""
 msgid "Tells maxima to show the help for ?, ?? and describe() on the console"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:149
+#: ../../src/dialogs/ConfigDialogue.cpp:150
 msgid "Tells maxima where to store the result of compiling libraries"
 msgstr ""
 
@@ -10258,11 +10267,11 @@ msgstr ""
 msgid "Text"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:756
+#: ../../src/dialogs/ConfigDialogue.cpp:757
 msgid "Text & Code"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:755
+#: ../../src/dialogs/ConfigDialogue.cpp:756
 msgid "Text Only"
 msgstr ""
 
@@ -10291,7 +10300,7 @@ msgstr ""
 msgid "The .xml file doesn't seem to be valid xml or isn't a content.xml extracted from a .wxmx zip archive"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1951
+#: ../../src/dialogs/ConfigDialogue.cpp:1952
 msgid "The AI Chat sidebar sends the current worksheet's content (read-only -- the AI cannot insert, edit or evaluate anything) and your messages to whichever provider you pick below. This needs an internet connection and an API key from that provider, and nothing is sent unless you actually use the sidebar."
 msgstr ""
 
@@ -10299,7 +10308,7 @@ msgstr ""
 msgid "The Maxima process doesn't offer a shared memory segment we can send an interrupt signal to."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:395
+#: ../../src/dialogs/ConfigDialogue.cpp:396
 msgid "The URL MathJaX.js should be downloaded from by our HTML export."
 msgstr ""
 
@@ -10351,15 +10360,15 @@ msgstr ""
 msgid "The current Wizard"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:418
+#: ../../src/dialogs/ConfigDialogue.cpp:419
 msgid "The default height for embedded plots. Can be read out or overridden by the maxima variable wxplot_size."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:495
+#: ../../src/dialogs/ConfigDialogue.cpp:496
 msgid "The default port used for communication between Maxima and wxMaxima."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:415
+#: ../../src/dialogs/ConfigDialogue.cpp:416
 msgid "The default width for embedded plots. Can be read out or overridden by the maxima variable wxplot_size"
 msgstr ""
 
@@ -10367,32 +10376,32 @@ msgstr ""
 msgid "The diagram title"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2540
+#: ../../src/dialogs/ConfigDialogue.cpp:2555
 #, c-format
 msgid "The directory %s with maxima's startup file doesn't exist. Trying to create it..."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:151
+#: ../../src/dialogs/ConfigDialogue.cpp:152
 msgid "The directory containing the startup files, any user libraries and, if MAXIMA_OBJDIR isn't set the subdirectory with the results from compiling maxima libraries."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:155
+#: ../../src/dialogs/ConfigDialogue.cpp:156
 msgid "The directory maxima places temporary files in, for example plots that are to be included in the worksheet."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:158
+#: ../../src/dialogs/ConfigDialogue.cpp:159
 msgid "The directory the compiled versions of maxima are placed in"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:160
+#: ../../src/dialogs/ConfigDialogue.cpp:161
 msgid "The directory the maxima manual can be found in"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:161
+#: ../../src/dialogs/ConfigDialogue.cpp:162
 msgid "The directory the user's home directory is in"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:478
+#: ../../src/dialogs/ConfigDialogue.cpp:479
 msgid "The document class LaTeX is instructed to use for our documents."
 msgstr ""
 
@@ -10460,7 +10469,7 @@ msgstr ""
 msgid "The key combination Shift+Space results in a non-breakable space."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:163
+#: ../../src/dialogs/ConfigDialogue.cpp:164
 msgid "The list of directories the operating system looks for programs in"
 msgstr ""
 
@@ -10524,7 +10533,7 @@ msgstr ""
 msgid "The next plot's title"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:497
+#: ../../src/dialogs/ConfigDialogue.cpp:498
 msgid "The number of recently opened files that is to be remembered."
 msgstr ""
 
@@ -10532,12 +10541,12 @@ msgstr ""
 msgid "The number of the item which is stepped from \"Index Start\" to \"Index End\"."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:480
+#: ../../src/dialogs/ConfigDialogue.cpp:481
 msgid "The options the document class LaTeX is instructed to use for our documents gets."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1082
-#: ../../src/dialogs/ConfigDialogue.cpp:1129
+#: ../../src/dialogs/ConfigDialogue.cpp:1083
+#: ../../src/dialogs/ConfigDialogue.cpp:1130
 msgid "The part of the output of these commands that isn't declared as \"math\" might be suppressed by wxMaxima. As always maxima commands are required to end in a \";\" or a \"$\""
 msgstr ""
 
@@ -10702,12 +10711,12 @@ msgstr ""
 msgid "Third-party notices"
 msgstr ""
 
-#: ../../src/sidebars/AiChatSidebar.cpp:145
-#: ../../src/sidebars/AiChatSidebar.cpp:207
+#: ../../src/sidebars/AiChatSidebar.cpp:162
+#: ../../src/sidebars/AiChatSidebar.cpp:224
 msgid "This build of wxMaxima cannot make network requests."
 msgstr ""
 
-#: ../../src/ai/AiProvider.cpp:341
+#: ../../src/ai/AiProvider.cpp:351
 msgid "This build of wxMaxima was compiled without wxWebRequest support, so it cannot talk to any AI provider."
 msgstr ""
 
@@ -10724,7 +10733,7 @@ msgid ""
 "overwritten if maxima's version changes or the file cannot be read"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1114
+#: ../../src/dialogs/ConfigDialogue.cpp:1115
 msgid "This file won't be read by maxima if maxima is used without wxMaxima. In order to add startup commands that are executed in this case, too, please add them to maxima-init.mac, instead."
 msgstr ""
 
@@ -10769,7 +10778,7 @@ msgstr ""
 msgid "Ticks:"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1376
+#: ../../src/dialogs/ConfigDialogue.cpp:1377
 msgid "Time [in Minutes] between autosaves"
 msgstr ""
 
@@ -10876,7 +10885,7 @@ msgstr ""
 msgid "Toolbar"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2118
+#: ../../src/dialogs/ConfigDialogue.cpp:2133
 msgid "Top"
 msgstr ""
 
@@ -11020,7 +11029,7 @@ msgstr ""
 msgid "Trying to start the socket a Maxima on the local machine can connect to on port %i"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:231
+#: ../../src/dialogs/ConfigDialogue.cpp:232
 msgid "Turkish"
 msgstr ""
 
@@ -11048,7 +11057,7 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1248
+#: ../../src/dialogs/ConfigDialogue.cpp:1249
 msgid "URL MathJaX.js is located at:"
 msgstr ""
 
@@ -11056,7 +11065,7 @@ msgstr ""
 msgid "UTF8 to Unicode code point..."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:232
+#: ../../src/dialogs/ConfigDialogue.cpp:233
 msgid "Ukrainian"
 msgstr ""
 
@@ -11087,11 +11096,11 @@ msgstr ""
 msgid "Undefined"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2242
+#: ../../src/dialogs/ConfigDialogue.cpp:2257
 msgid "Underlined"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:762
+#: ../../src/dialogs/ConfigDialogue.cpp:763
 msgid "Underscore converts to subscripts:"
 msgstr ""
 
@@ -11231,7 +11240,7 @@ msgstr ""
 msgid "Use \"<\" and \">\" as parenthesis for matrices"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:510
+#: ../../src/dialogs/ConfigDialogue.cpp:511
 msgid "Use GTK's overlay scrollbars, which appear over the worksheet and fade out when unused. Looks modern, but GTK repaints the whole worksheet on every frame of the fade animation - which runs after every mouse movement - so classic scrollbars are much faster."
 msgstr ""
 
@@ -11259,11 +11268,11 @@ msgstr ""
 msgid "Use as TortoiseSVN/Git diff tool"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:488
+#: ../../src/dialogs/ConfigDialogue.cpp:489
 msgid "Use centered dot and Minus, not Star and Hyphen"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:866
+#: ../../src/dialogs/ConfigDialogue.cpp:867
 msgid "Use centered dot character for multiplication"
 msgstr ""
 
@@ -11287,11 +11296,11 @@ msgstr ""
 msgid "Use struct field..."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:428
+#: ../../src/dialogs/ConfigDialogue.cpp:429
 msgid "Use the \"partial derivative\" symbol to represent the fraction that represents a diff() when exporting LaTeX"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2179
+#: ../../src/dialogs/ConfigDialogue.cpp:2194
 msgid "Use unicode Math Symbols, if available"
 msgstr ""
 
@@ -11303,9 +11312,9 @@ msgstr ""
 msgid "User labels only"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1265
-#: ../../src/dialogs/ConfigDialogue.cpp:1506
-#: ../../src/dialogs/ConfigDialogue.cpp:1534
+#: ../../src/dialogs/ConfigDialogue.cpp:1266
+#: ../../src/dialogs/ConfigDialogue.cpp:1507
+#: ../../src/dialogs/ConfigDialogue.cpp:1535
 #: ../../src/dialogs/MaximaNotStartingDialog.cpp:54
 msgid "User specified"
 msgstr ""
@@ -11314,7 +11323,7 @@ msgstr ""
 msgid "User-defined labels"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:787
+#: ../../src/dialogs/ConfigDialogue.cpp:788
 msgid "User-defined labels if available"
 msgstr ""
 
@@ -11353,7 +11362,7 @@ msgstr ""
 msgid "Validated that the XML representation of the document actually is valid XML"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:545
+#: ../../src/dialogs/ConfigDialogue.cpp:546
 #: ../../src/wizards/ActualValuesStorageWiz.cpp:49
 msgid "Value"
 msgstr ""
@@ -11389,7 +11398,7 @@ msgid "Var #2"
 msgstr ""
 
 #: ../../src/MaximaCommandMenus.cpp:1371 ../../src/MaximaCommandMenus.cpp:1755
-#: ../../src/dialogs/ConfigDialogue.cpp:544
+#: ../../src/dialogs/ConfigDialogue.cpp:545
 #: ../../src/sidebars/VariablesPane.cpp:54
 msgid "Variable"
 msgstr ""
@@ -11458,7 +11467,7 @@ msgstr ""
 msgid "Verified that we are able to read the whole .zip archive we produced."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:233
+#: ../../src/dialogs/ConfigDialogue.cpp:234
 msgid "Vietnamese"
 msgstr ""
 
@@ -11466,7 +11475,7 @@ msgstr ""
 msgid "View"
 msgstr ""
 
-#: ../../src/sidebars/AiChatSidebar.cpp:141
+#: ../../src/sidebars/AiChatSidebar.cpp:158
 #, c-format
 msgid "Waiting for %s..."
 msgstr ""
@@ -11483,7 +11492,7 @@ msgstr ""
 msgid "Waiting for the thread that parses the maxima manual to finish"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1427
+#: ../../src/dialogs/ConfigDialogue.cpp:1428
 msgid "Warn if an inactive window is idle"
 msgstr ""
 
@@ -11563,7 +11572,7 @@ msgstr ""
 msgid "Will try to generate a stack backtrace, if the program ever crashes"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:281
+#: ../../src/dialogs/ConfigDialogue.cpp:282
 msgid "Worksheet"
 msgstr ""
 
@@ -11584,7 +11593,7 @@ msgstr ""
 msgid "Worksheet repaints:"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:431
+#: ../../src/dialogs/ConfigDialogue.cpp:432
 msgid "Wrap equations exported by the \"copy as LaTeX\" feature between \\[ and \\] as equation markers"
 msgstr ""
 
@@ -11618,15 +11627,15 @@ msgstr ""
 msgid "Xi"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:745
+#: ../../src/dialogs/ConfigDialogue.cpp:746
 msgid "Yes"
 msgstr ""
 
-#: ../../src/sidebars/AiChatSidebar.cpp:212
+#: ../../src/sidebars/AiChatSidebar.cpp:229
 msgid "You"
 msgstr ""
 
-#: ../../src/sidebars/AiChatSidebar.cpp:177
+#: ../../src/sidebars/AiChatSidebar.cpp:194
 msgid ""
 "You are an assistant embedded in wxMaxima, a GUI front-end for the Maxima computer algebra system. Below is a read-only snapshot of the user's current worksheet -- you cannot edit, evaluate or otherwise change it; only the user can do that through the wxMaxima UI. A cell marked \"(CURRENT CELL -- the user's cursor is here)\" is where the user's cursor currently is -- that is what they mean by \"this cell,\" \"the current cell,\" or \"the cell above/here.\" A cell marked \"(THIS CELL HAS AN ERROR)\" is one Maxima reported an error in. Use the snapshot only as context.\n"
 "\n"
@@ -11834,7 +11843,7 @@ msgstr ""
 msgid "f(x) stays f(x) even if the value of f(x) is computable"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:470
+#: ../../src/dialogs/ConfigDialogue.cpp:471
 msgid ""
 "false=Don't generate subscripts\n"
 "true=Automatically convert underscores to subscript markers if the would-be subscript is a number or a single letter\n"
@@ -11873,7 +11882,7 @@ msgstr ""
 msgid "general"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1684
+#: ../../src/dialogs/ConfigDialogue.cpp:1685
 msgid "gnuplot: Without command console"
 msgstr ""
 
@@ -12233,7 +12242,7 @@ msgstr ""
 msgid "use the actual values stored"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1687
+#: ../../src/dialogs/ConfigDialogue.cpp:1688
 msgid "wgnuplot: Steals the mouse focus during plotting"
 msgstr ""
 
@@ -12242,8 +12251,8 @@ msgid "writebyte..."
 msgstr ""
 
 #: ../../src/TrayIcon.cpp:93 ../../src/dialogs/AboutDialog.cpp:64
-#: ../../src/main.cpp:859 ../../src/sidebars/AiChatSidebar.cpp:200
-#: ../../src/sidebars/AiChatSidebar.cpp:206
+#: ../../src/main.cpp:859 ../../src/sidebars/AiChatSidebar.cpp:217
+#: ../../src/sidebars/AiChatSidebar.cpp:223
 msgid "wxMaxima"
 msgstr ""
 
@@ -12269,8 +12278,8 @@ msgstr ""
 msgid "wxMaxima cannot read the xml contents of "
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:143
-#: ../../src/dialogs/ConfigDialogue.cpp:314
+#: ../../src/dialogs/ConfigDialogue.cpp:144
+#: ../../src/dialogs/ConfigDialogue.cpp:315
 msgid "wxMaxima configuration"
 msgstr ""
 
@@ -12327,7 +12336,7 @@ msgstr ""
 msgid "wxMaxima needs more translators. We do not speak every language. Help us to translate wxMaxima and the manual to your language. Join the wxMaxima development at: https://github.com/wxMaxima-developers/wxmaxima"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:410
+#: ../../src/dialogs/ConfigDialogue.cpp:411
 msgid "wxMaxima normally stores the gnuplot sources for every plot made using draw() in order to be able to open plots interactively in gnuplot later. This setting defines the limit [in Megabytes per plot] for this feature."
 msgstr ""
 
@@ -12348,7 +12357,7 @@ msgstr ""
 msgid "wxMaxima remembers answers from the last run and is able to offer them as the default answer"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:484
+#: ../../src/dialogs/ConfigDialogue.cpp:485
 msgid "wxMaxima remembers the answers to maxima's questions. If this checkbox is set it automatically offers to enter the last answer to this question the user has input."
 msgstr ""
 
@@ -12360,7 +12369,7 @@ msgstr ""
 msgid "wxMaxima shows help in the sidebar"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1112
+#: ../../src/dialogs/ConfigDialogue.cpp:1113
 msgid "wxMaxima startup file location: "
 msgstr ""
 
@@ -12412,7 +12421,7 @@ msgstr ""
 msgid "wxworksheettotex: could not write \"%s\"."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:726
+#: ../../src/dialogs/ConfigDialogue.cpp:727
 msgid "x"
 msgstr ""
 

--- a/locales/wxMaxima/wxMaxima.pot
+++ b/locales/wxMaxima/wxMaxima.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-09-06 16:16+0000\n"
+"POT-Creation-Date: 2026-09-06 17:14+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -3771,7 +3771,7 @@ msgstr ""
 #: ../../src/WXMXformat.cpp:290 ../../src/WXMXformat.cpp:298
 #: ../../src/WXMXformat.cpp:313 ../../src/WXMXformat.cpp:334
 #: ../../src/WXMXformat.cpp:364 ../../src/dialogs/BinaryNameCtrl.cpp:78
-#: ../../src/main.cpp:788 ../../src/sidebars/AiChatSidebar.cpp:205
+#: ../../src/main.cpp:788 ../../src/sidebars/AiChatSidebar.cpp:226
 #: ../../src/wxMaxima.cpp:3480 ../../src/wxMaxima.cpp:3516
 #: ../../src/wxMaxima.cpp:3534 ../../src/wxMaxima.cpp:3568
 msgid "Error"
@@ -7206,7 +7206,7 @@ msgstr ""
 msgid "No AI provider configured -- add an API key in Options."
 msgstr ""
 
-#: ../../src/sidebars/AiChatSidebar.cpp:180
+#: ../../src/sidebars/AiChatSidebar.cpp:201
 msgid "No AI provider is configured. Open Options to add an API key for one."
 msgstr ""
 
@@ -10703,7 +10703,7 @@ msgid "Third-party notices"
 msgstr ""
 
 #: ../../src/sidebars/AiChatSidebar.cpp:145
-#: ../../src/sidebars/AiChatSidebar.cpp:186
+#: ../../src/sidebars/AiChatSidebar.cpp:207
 msgid "This build of wxMaxima cannot make network requests."
 msgstr ""
 
@@ -11622,13 +11622,13 @@ msgstr ""
 msgid "Yes"
 msgstr ""
 
-#: ../../src/sidebars/AiChatSidebar.cpp:191
+#: ../../src/sidebars/AiChatSidebar.cpp:212
 msgid "You"
 msgstr ""
 
-#: ../../src/sidebars/AiChatSidebar.cpp:161
+#: ../../src/sidebars/AiChatSidebar.cpp:177
 msgid ""
-"You are an assistant embedded in wxMaxima, a GUI front-end for the Maxima computer algebra system. Below is a read-only snapshot of the user's current worksheet -- you cannot edit, evaluate or otherwise change it; only the user can do that through the wxMaxima UI. Use it only as context.\n"
+"You are an assistant embedded in wxMaxima, a GUI front-end for the Maxima computer algebra system. Below is a read-only snapshot of the user's current worksheet -- you cannot edit, evaluate or otherwise change it; only the user can do that through the wxMaxima UI. A cell marked \"(CURRENT CELL -- the user's cursor is here)\" is where the user's cursor currently is -- that is what they mean by \"this cell,\" \"the current cell,\" or \"the cell above/here.\" A cell marked \"(THIS CELL HAS AN ERROR)\" is one Maxima reported an error in. Use the snapshot only as context.\n"
 "\n"
 "--- Worksheet snapshot ---\n"
 msgstr ""
@@ -12242,8 +12242,8 @@ msgid "writebyte..."
 msgstr ""
 
 #: ../../src/TrayIcon.cpp:93 ../../src/dialogs/AboutDialog.cpp:64
-#: ../../src/main.cpp:859 ../../src/sidebars/AiChatSidebar.cpp:179
-#: ../../src/sidebars/AiChatSidebar.cpp:185
+#: ../../src/main.cpp:859 ../../src/sidebars/AiChatSidebar.cpp:200
+#: ../../src/sidebars/AiChatSidebar.cpp:206
 msgid "wxMaxima"
 msgstr ""
 

--- a/src/Configuration.cpp
+++ b/src/Configuration.cpp
@@ -28,6 +28,7 @@
 
 #include "BuildConfig.h"
 #include "Configuration.h"
+#include "ai/AiProvider.h"
 
 #include "cells/Cell.h"
 #include "cells/TextStyle.h"
@@ -323,10 +324,15 @@ void Configuration::ResetAllToDefaults() {
   m_mcpServerEnabled = false;
   m_mcpServerPort = 8765;
   m_aiChatProvider = 0; // AiProviderKind::None
-  m_aiModelAnthropic = wxS("claude-3-5-sonnet-20241022");
-  m_aiModelOpenAI = wxS("gpt-4o-mini");
-  m_aiModelGoogle = wxS("gemini-1.5-flash");
-  m_aiModelQwen = wxS("qwen-plus");
+  // A single source of truth for these, via AiProviderDefaultModel(), not a
+  // second hardcoded copy here: found live while updating Anthropic's own
+  // default to its rolling "-latest" alias -- this file's own copy was the
+  // one Options actually displayed, and it was untouched by that edit,
+  // exactly the kind of silent drift a duplicated constant invites.
+  m_aiModelAnthropic = AiProviderDefaultModel(AiProviderKind::Anthropic);
+  m_aiModelOpenAI = AiProviderDefaultModel(AiProviderKind::OpenAI);
+  m_aiModelGoogle = AiProviderDefaultModel(AiProviderKind::Google);
+  m_aiModelQwen = AiProviderDefaultModel(AiProviderKind::Qwen);
   m_fixReorderedIndices = true;
   m_rightToLeftDocument = false;
   m_showBrackets = true;

--- a/src/ai/AiProvider.cpp
+++ b/src/ai/AiProvider.cpp
@@ -188,6 +188,16 @@ wxString AiProviderDefaultModel(AiProviderKind kind) {
   }
 }
 
+wxString AiProviderApiKeyUrl(AiProviderKind kind) {
+  switch (kind) {
+  case AiProviderKind::Anthropic: return wxS("https://console.anthropic.com/settings/keys");
+  case AiProviderKind::OpenAI: return wxS("https://platform.openai.com/api-keys");
+  case AiProviderKind::Google: return wxS("https://aistudio.google.com/apikey");
+  case AiProviderKind::Qwen: return wxS("https://dashscope.console.aliyun.com/apiKey");
+  default: return wxEmptyString;
+  }
+}
+
 std::shared_ptr<AiProvider> MakeAiProvider(AiProviderKind kind, const wxString &apiKey,
                                            const wxString &model) {
   switch (kind) {

--- a/src/ai/AiProvider.cpp
+++ b/src/ai/AiProvider.cpp
@@ -179,8 +179,19 @@ wxString AiProviderKindName(AiProviderKind kind) {
 }
 
 wxString AiProviderDefaultModel(AiProviderKind kind) {
+  // Each of these is that provider's own "rolling" alias -- it always
+  // resolves to the current snapshot of that model line, rather than a
+  // pinned dated snapshot (e.g. Anthropic's own "claude-3-5-sonnet-
+  // 20241022", which this used to be) that provider eventually retires on
+  // its own schedule regardless of what this code does. This only pushes
+  // the staleness problem up one level, from "this specific snapshot got
+  // retired" to "this whole model line got superseded" -- a real, slower-
+  // moving case a plain string constant genuinely cannot track by itself
+  // (see AiProviderModelListUrl() -- the actual fix for that is a link to
+  // the provider's own current list, not a fancier detection mechanism
+  // trying to chase a moving target with another moving target).
   switch (kind) {
-  case AiProviderKind::Anthropic: return wxS("claude-3-5-sonnet-20241022");
+  case AiProviderKind::Anthropic: return wxS("claude-3-5-sonnet-latest");
   case AiProviderKind::OpenAI: return wxS("gpt-4o-mini");
   case AiProviderKind::Google: return wxS("gemini-1.5-flash");
   case AiProviderKind::Qwen: return wxS("qwen-plus");
@@ -194,6 +205,17 @@ wxString AiProviderApiKeyUrl(AiProviderKind kind) {
   case AiProviderKind::OpenAI: return wxS("https://platform.openai.com/api-keys");
   case AiProviderKind::Google: return wxS("https://aistudio.google.com/apikey");
   case AiProviderKind::Qwen: return wxS("https://dashscope.console.aliyun.com/apiKey");
+  default: return wxEmptyString;
+  }
+}
+
+wxString AiProviderModelListUrl(AiProviderKind kind) {
+  switch (kind) {
+  case AiProviderKind::Anthropic:
+    return wxS("https://docs.anthropic.com/en/docs/about-claude/models");
+  case AiProviderKind::OpenAI: return wxS("https://platform.openai.com/docs/models");
+  case AiProviderKind::Google: return wxS("https://ai.google.dev/gemini-api/docs/models");
+  case AiProviderKind::Qwen: return wxS("https://www.alibabacloud.com/help/en/model-studio/models");
   default: return wxEmptyString;
   }
 }

--- a/src/ai/AiProvider.h
+++ b/src/ai/AiProvider.h
@@ -61,6 +61,15 @@ wxString AiProviderKindName(AiProviderKind kind);
 //! model catalogs change far more often than this code does.
 wxString AiProviderDefaultModel(AiProviderKind kind);
 
+//! Where to go to create/find an API key for this provider -- shown as a
+//! link next to that provider's key field in Options, since there is no
+//! "log in" button that could get one automatically: none of these four
+//! providers offer a legitimate third-party OAuth flow a desktop app could
+//! use, so pasting a key from the provider's own site is the only option.
+//! Best-effort: a provider's console is free to move its own pages, same
+//! caveat as AiProviderDefaultModel()'s model ids going stale over time.
+wxString AiProviderApiKeyUrl(AiProviderKind kind);
+
 /*! Talks to one external AI provider's chat completion HTTP API.
 
   Deliberately split into a stateless, directly-testable half (BuildRequestBody()/

--- a/src/ai/AiProvider.h
+++ b/src/ai/AiProvider.h
@@ -70,6 +70,17 @@ wxString AiProviderDefaultModel(AiProviderKind kind);
 //! caveat as AiProviderDefaultModel()'s model ids going stale over time.
 wxString AiProviderApiKeyUrl(AiProviderKind kind);
 
+//! Where to see this provider's current list of available model ids --
+//! shown as a link next to Options' model field. AiProviderDefaultModel()
+//! uses each provider's own "rolling" alias where one exists, but a model
+//! *line* still eventually gets superseded by a new one, something a
+//! plain string constant in this codebase cannot track by itself; a link
+//! to the provider's own list is the durable fix, not a fancier
+//! auto-detection mechanism that would itself need to keep up with each
+//! provider's API just to answer the same question this link answers
+//! directly. Same best-effort/link-rot caveat as AiProviderApiKeyUrl().
+wxString AiProviderModelListUrl(AiProviderKind kind);
+
 /*! Talks to one external AI provider's chat completion HTTP API.
 
   Deliberately split into a stateless, directly-testable half (BuildRequestBody()/

--- a/src/dialogs/ConfigDialogue.cpp
+++ b/src/dialogs/ConfigDialogue.cpp
@@ -2013,6 +2013,21 @@ wxWindow *ConfigDialogue::CreateAiChatPanel() {
         keyUrl);
       box->Add(link, wxSizerFlags().Border(wxALL, 5 * GetContentScaleFactor()));
     }
+    // The default Model: value above is that provider's own "rolling"
+    // alias where one exists (AiProviderDefaultModel()'s own comment), but
+    // model lines still get superseded over time -- a link to the
+    // provider's current list is the durable fix for that, not a fancier
+    // auto-detection mechanism that would itself need to keep chasing each
+    // provider's API just to answer the same question this link answers
+    // directly.
+    wxString modelListUrl = AiProviderModelListUrl(kind);
+    if (!modelListUrl.IsEmpty()) {
+      wxHyperlinkCtrl *modelLink = new wxHyperlinkCtrl(
+        box->GetStaticBox(), wxID_ANY,
+        wxString::Format(_("See current models for %s..."), AiProviderKindName(kind)),
+        modelListUrl);
+      box->Add(modelLink, wxSizerFlags().Border(wxALL, 5 * GetContentScaleFactor()));
+    }
     vbox->Add(box, wxSizerFlags().Expand().Border(wxALL, 5 * GetContentScaleFactor()));
   };
   addProviderBox(AiProviderKind::Anthropic, m_aiKeyAnthropic, m_aiModelAnthropicCtrl);

--- a/src/dialogs/ConfigDialogue.cpp
+++ b/src/dialogs/ConfigDialogue.cpp
@@ -30,6 +30,7 @@
 
 #include "ConfigDialogue.h"
 #include "ai/AiProvider.h"
+#include <wx/hyperlink.h>
 #include "WXMformat.h"
 #include "BTextCtrl.h"
 #include "cells/Cell.h"
@@ -1975,9 +1976,10 @@ wxWindow *ConfigDialogue::CreateAiChatPanel() {
   // One box per provider, always shown (not just the active one): this way
   // switching providers never loses a key/model you already entered for
   // another one.
-  auto addProviderBox = [&](const wxString &title, wxTextCtrl *&keyCtrl,
+  auto addProviderBox = [&](AiProviderKind kind, wxTextCtrl *&keyCtrl,
                             wxTextCtrl *&modelCtrl) {
-    wxStaticBoxSizer *box = new wxStaticBoxSizer(wxVERTICAL, panel, title);
+    wxStaticBoxSizer *box =
+      new wxStaticBoxSizer(wxVERTICAL, panel, AiProviderKindName(kind));
     wxFlexGridSizer *grid = new wxFlexGridSizer(2, 2, 5, 5);
     grid->AddGrowableCol(1);
     grid->Add(new wxStaticText(box->GetStaticBox(), wxID_ANY, _("API key:")),
@@ -1994,16 +1996,29 @@ wxWindow *ConfigDialogue::CreateAiChatPanel() {
                                wxSize(300 * GetContentScaleFactor(), -1));
     grid->Add(modelCtrl, wxSizerFlags().Expand());
     box->Add(grid, wxSizerFlags().Expand().Border(wxALL, 5 * GetContentScaleFactor()));
+    // No "log in" button is possible here (see AiProviderApiKeyUrl()'s own
+    // comment: none of these providers offer a legitimate third-party OAuth
+    // flow a desktop app could use) -- a direct link to where to actually
+    // get a key is the closest equivalent.
+    wxString keyUrl = AiProviderApiKeyUrl(kind);
+    if (!keyUrl.IsEmpty()) {
+      wxHyperlinkCtrl *link = new wxHyperlinkCtrl(
+        box->GetStaticBox(), wxID_ANY,
+        // "Get an API key for %s..." rather than "Get a/an %s API key...":
+        // sidesteps the a/an article agreement entirely, which the four
+        // provider names don't share (an Anthropic/OpenAI key, but a
+        // Google/Qwen key) -- confirmed live this was wrong before ("Get
+        // an Google...") with the naive uniform format string.
+        wxString::Format(_("Get an API key for %s..."), AiProviderKindName(kind)),
+        keyUrl);
+      box->Add(link, wxSizerFlags().Border(wxALL, 5 * GetContentScaleFactor()));
+    }
     vbox->Add(box, wxSizerFlags().Expand().Border(wxALL, 5 * GetContentScaleFactor()));
   };
-  addProviderBox(AiProviderKindName(AiProviderKind::Anthropic), m_aiKeyAnthropic,
-                m_aiModelAnthropicCtrl);
-  addProviderBox(AiProviderKindName(AiProviderKind::OpenAI), m_aiKeyOpenAI,
-                m_aiModelOpenAICtrl);
-  addProviderBox(AiProviderKindName(AiProviderKind::Google), m_aiKeyGoogle,
-                m_aiModelGoogleCtrl);
-  addProviderBox(AiProviderKindName(AiProviderKind::Qwen), m_aiKeyQwen,
-                m_aiModelQwenCtrl);
+  addProviderBox(AiProviderKind::Anthropic, m_aiKeyAnthropic, m_aiModelAnthropicCtrl);
+  addProviderBox(AiProviderKind::OpenAI, m_aiKeyOpenAI, m_aiModelOpenAICtrl);
+  addProviderBox(AiProviderKind::Google, m_aiKeyGoogle, m_aiModelGoogleCtrl);
+  addProviderBox(AiProviderKind::Qwen, m_aiKeyQwen, m_aiModelQwenCtrl);
 
   panel->SetSizer(vbox);
   panel->FitInside();

--- a/src/mcp/McpTools.cpp
+++ b/src/mcp/McpTools.cpp
@@ -78,6 +78,14 @@ wxString McpTools::CapLength(wxString text) {
   return text;
 }
 
+wxString McpTools::TruncateText(const wxString &text, std::size_t maxLen,
+                                bool fromEnd, bool &wasTruncated) {
+  wasTruncated = text.Length() > maxLen;
+  if (!wasTruncated)
+    return text;
+  return fromEnd ? text.Right(maxLen) : text.Left(maxLen);
+}
+
 wxString McpTools::RequireString(const json &arguments, const char *name) {
   auto it = arguments.find(name);
   if (it == arguments.end() || !it->is_string())
@@ -100,7 +108,7 @@ GroupCell *McpTools::FindGroupByUUID(const wxString &uuid) const {
   return nullptr;
 }
 
-json McpTools::CellSummary(GroupCell &cell, int index) {
+json McpTools::CellSummary(GroupCell &cell, int index) const {
   if (cell.GetUUID().IsEmpty())
     cell.GenerateUUID();
   wxString input = InputText(cell);
@@ -114,7 +122,27 @@ json McpTools::CellSummary(GroupCell &cell, int index) {
   entry["group_type"] = U8(GroupTypeName(cell.GetGroupType()));
   entry["input_preview"] = U8(preview);
   entry["has_output"] = cell.GetOutput() != nullptr;
+  entry["is_current"] = (&cell == CurrentCell());
+  entry["has_error"] = HasError(cell);
   return entry;
+}
+
+GroupCell *McpTools::CurrentCell() const {
+  return m_worksheet ? m_worksheet->GetHCaret() : nullptr;
+}
+
+bool McpTools::HasError(GroupCell &cell) const {
+  return m_worksheet && m_worksheet->GetErrorList().Contains(&cell);
+}
+
+bool McpTools::MaximaIsBusy() const {
+  if (!m_worksheet)
+    return false;
+  // GetWorkingGroup(false) (no fallback) is null exactly when nothing is
+  // currently being evaluated; a non-empty queue means there is more work
+  // waiting behind whatever (if anything) is running right now.
+  return (m_worksheet->GetWorkingGroup(false) != nullptr) ||
+    !m_worksheet->GetEvaluationQueue().Empty();
 }
 
 json McpTools::ListTools() const {
@@ -144,19 +172,48 @@ json McpTools::ListTools() const {
                     "List every cell in the worksheet, in document order: "
                     "its UUID (use with read_cell/read_section), its type "
                     "(code/text/title/section/.../image), a short preview of "
-                    "its input, and whether it has output."},
+                    "its input, whether it has output, is_current (the "
+                    "user's cursor is at or just after this cell -- what "
+                    "\"the current cell\" or \"the cell above the cursor\" "
+                    "means), and has_error (Maxima reported an error here)."},
                    {"inputSchema", noArgs}});
+  json readCellSchema;
+  readCellSchema["type"] = "object";
+  readCellSchema["properties"]["uuid"] = {{"type", "string"},
+                                          {"description", "The cell's UUID"}};
+  readCellSchema["properties"]["output_length"] = {
+    {"type", "integer"},
+    {"description",
+     "Max characters of this cell's output to return (default: no real "
+     "limit, up to a 200000-character hard cap). Ask for a small value "
+     "for a quick preview of a cell whose output might be huge (a large "
+     "matrix, a long list, ...) instead of the whole thing."}};
+  readCellSchema["properties"]["output_from_end"] = {
+    {"type", "boolean"},
+    {"description",
+     "If true, return the LAST output_length characters instead of the "
+     "first -- e.g. to check whether a long computation converged, or "
+     "what its final answer was, without the potentially huge middle."}};
+  readCellSchema["required"] = json::array({"uuid"});
   tools.push_back({{"name", "read_cell"},
                    {"description",
-                    "Read one cell's full input and output text by UUID "
-                    "(from list_cells/read_toc)."},
-                   {"inputSchema", stringArg("The cell's UUID")}});
+                    "Read one cell's full input and its output (optionally "
+                    "capped/from-the-end via output_length/output_from_end), "
+                    "plus is_current/has_error (see list_cells) and "
+                    "output_truncated, by UUID (from list_cells/read_toc)."},
+                   {"inputSchema", readCellSchema}});
   tools.push_back(
     {{"name", "read_worksheet"},
      {"description",
-      "Read the whole worksheet's input and output as plain text. For a "
+      "Read the whole worksheet's input and output as plain text. The cell "
+      "the user's cursor is at or just after is marked \"(CURRENT CELL)\", "
+      "and any cell Maxima reported an error in is marked \"(THIS CELL HAS "
+      "AN ERROR)\", directly in the text. Each cell's own output is capped "
+      "to a short preview here (marked \"[truncated -- use read_cell ...]\" "
+      "when it was) so one cell with a huge output can't crowd out every "
+      "other cell -- use read_cell for that one cell's full output. For a "
       "large worksheet, prefer read_toc + read_section to avoid a huge "
-      "response."},
+      "response in the first place."},
      {"inputSchema", noArgs}});
   tools.push_back(
     {{"name", "read_toc"},
@@ -171,22 +228,32 @@ json McpTools::ListTools() const {
      {"description",
       "Read one whole section's text (a heading cell and every cell under "
       "it, up to but excluding the next heading of the same or higher "
-      "level), by the heading cell's UUID (from read_toc)."},
+      "level), by the heading cell's UUID (from read_toc). Same per-cell "
+      "output preview capping as read_worksheet -- use read_cell for one "
+      "cell's full output."},
      {"inputSchema", stringArg("The heading cell's UUID, from read_toc")}});
   tools.push_back(
     {{"name", "read_variables"},
      {"description",
       "Read the name/value pairs currently shown in the Variables sidebar's "
       "watchlist. A variable not on the watchlist isn't returned -- add it "
-      "with watch_variable first."},
+      "with watch_variable first. Also reports maxima_busy: while true, "
+      "Maxima is still evaluating something (or has queued work), so a "
+      "variable's value may not have updated to reflect a query yet -- an "
+      "empty value in that case likely means \"not answered yet,\" not "
+      "\"undefined.\" If maxima_busy is true right after watch_variable, "
+      "wait and call read_variables again rather than concluding the "
+      "variable has no value."},
      {"inputSchema", noArgs}});
   tools.push_back(
     {{"name", "watch_variable"},
      {"description",
       "Add a Maxima variable name to the Variables sidebar's watchlist, the "
       "same as typing it into that sidebar by hand. Its value becomes "
-      "available (once Maxima has answered) via read_variables. Does not "
-      "touch worksheet content or evaluate anything."},
+      "available via read_variables only once Maxima actually answers the "
+      "query this triggers -- not immediately, and not at all while Maxima "
+      "is busy (see read_variables' maxima_busy). Does not touch worksheet "
+      "content or evaluate anything."},
      {"inputSchema", nameArg("The Maxima variable name, e.g. \"x\" or \"%o3\"")}});
   tools.push_back(
     {{"name", "unwatch_variable"},
@@ -246,27 +313,85 @@ json McpTools::ReadCell(const json &arguments) const {
   GroupCell *cell = FindGroupByUUID(uuid);
   if (!cell)
     throw McpToolError("No cell with that UUID");
+
+  // Defaults to the full MAX_TEXT_LENGTH (in practice, no real limit for
+  // any normal cell) since the caller already named this one specific
+  // cell -- but a pathologically huge single output (a large matrix, a
+  // long list, ...) still can't exceed the same hard cap every other tool
+  // respects. output_length/output_from_end let an AI that only needs a
+  // preview -- or specifically the tail, e.g. "did this converge" -- ask
+  // for just that instead of the whole thing.
+  std::size_t maxLen = MAX_TEXT_LENGTH;
+  // is_number_integer() (not is_number_unsigned()) on purpose: nlohmann
+  // only classifies a value as "unsigned" if it came from something
+  // already typed unsigned (e.g. text-parsed JSON with no minus sign);
+  // the identical value built from a plain C++ int literal -- as any
+  // hand-constructed json object, tests included, would -- is classified
+  // "integer" (signed) instead despite being positive. is_number_integer()
+  // covers both representations; a negative value is simply ignored below.
+  if (arguments.contains("output_length") &&
+      arguments["output_length"].is_number_integer()) {
+    long long requested = arguments["output_length"].get<long long>();
+    if (requested > 0)
+      maxLen = std::min<std::size_t>(static_cast<std::size_t>(requested),
+                                     MAX_TEXT_LENGTH);
+  }
+  bool fromEnd = arguments.contains("output_from_end") &&
+    arguments["output_from_end"].is_boolean() &&
+    arguments["output_from_end"].get<bool>();
+  bool truncated = false;
+  wxString output = TruncateText(OutputText(*cell), maxLen, fromEnd, truncated);
+
   json result;
   result["uuid"] = U8(cell->GetUUID());
   result["group_type"] = U8(GroupTypeName(cell->GetGroupType()));
   result["input"] = U8(InputText(*cell));
-  result["output"] = U8(OutputText(*cell));
+  result["output"] = U8(output);
+  result["output_truncated"] = truncated;
+  result["is_current"] = (cell == CurrentCell());
+  result["has_error"] = HasError(*cell);
   return result;
+}
+
+wxString McpTools::CellText(GroupCell &cell) const {
+  wxString text = wxS("--- ") + GroupTypeName(cell.GetGroupType());
+  // Flagged inline, not just in the JSON-returning tools, so the same
+  // information reaches an AI reading only this plain-text dump -- e.g.
+  // the in-app AI chat sidebar, which sends this text as its entire
+  // worksheet context and has no separate way to ask "where is the
+  // user's cursor" or "which cell errored."
+  if (&cell == CurrentCell())
+    text += wxS(" (CURRENT CELL -- the user's cursor is here)");
+  if (HasError(cell))
+    text += wxS(" (THIS CELL HAS AN ERROR)");
+  text += wxS(" ---\n");
+  wxString input = InputText(cell);
+  if (!input.IsEmpty())
+    text += input + wxS("\n");
+  // Capped per cell (unlike read_cell, which the caller uses precisely
+  // because they want one specific cell's full output): a single cell
+  // with a huge output must not crowd out every other cell sharing this
+  // same response. read_cell(uuid, output_length, output_from_end) is the
+  // way to actually read a capped-here cell's output in full, or its tail.
+  bool truncated = false;
+  wxString output =
+    TruncateText(OutputText(cell), OUTPUT_PREVIEW_LENGTH, false, truncated);
+  if (!output.IsEmpty()) {
+    text += wxS("Output: ") + output;
+    if (truncated)
+      text += wxS(" ... [truncated -- use read_cell with this cell's UUID "
+                  "for the full output]");
+    text += wxS("\n");
+  }
+  text += wxS("\n");
+  return text;
 }
 
 json McpTools::ReadWorksheet() const {
   wxString text;
   if (m_worksheet && m_worksheet->GetTree()) {
-    for (GroupCell &cell : OnList(m_worksheet->GetTree())) {
-      text += wxS("--- ") + GroupTypeName(cell.GetGroupType()) + wxS(" ---\n");
-      wxString input = InputText(cell);
-      if (!input.IsEmpty())
-        text += input + wxS("\n");
-      wxString output = OutputText(cell);
-      if (!output.IsEmpty())
-        text += wxS("Output: ") + output + wxS("\n");
-      text += wxS("\n");
-    }
+    for (GroupCell &cell : OnList(m_worksheet->GetTree()))
+      text += CellText(cell);
   }
   json result;
   result["text"] = U8(CapLength(text));
@@ -301,19 +426,7 @@ json McpTools::ReadSection(const json &arguments) const {
   if (!heading->IsHeading())
     throw McpToolError("That cell is not a heading (title/section/.../heading6)");
 
-  wxString text;
-  auto appendCell = [&text](GroupCell &cell) {
-    text += wxS("--- ") + GroupTypeName(cell.GetGroupType()) + wxS(" ---\n");
-    wxString input = InputText(cell);
-    if (!input.IsEmpty())
-      text += input + wxS("\n");
-    wxString output = OutputText(cell);
-    if (!output.IsEmpty())
-      text += wxS("Output: ") + output + wxS("\n");
-    text += wxS("\n");
-  };
-
-  appendCell(*heading);
+  wxString text = CellText(*heading);
   // Same "how far does this section extend" walk GroupCell::Fold() uses:
   // everything up to (excluding) the next cell whose type is the same as, or
   // a higher heading level than, the section's own heading.
@@ -321,7 +434,7 @@ json McpTools::ReadSection(const json &arguments) const {
     if ((cell->GetGroupType() == heading->GetGroupType()) ||
         heading->IsLesserGCType(cell->GetGroupType()))
       break;
-    appendCell(*cell);
+    text += CellText(*cell);
   }
 
   json result;
@@ -342,6 +455,11 @@ json McpTools::ReadVariables() const {
   }
   json result;
   result["variables"] = variables;
+  // A variable's value only updates once Maxima actually answers the query
+  // watching it triggers -- while Maxima is busy, an empty or stale-looking
+  // value here can just mean "no answer yet," not "undefined." Surfaced
+  // explicitly so a tool-calling AI doesn't misread the difference.
+  result["maxima_busy"] = MaximaIsBusy();
   return result;
 }
 

--- a/src/mcp/McpTools.h
+++ b/src/mcp/McpTools.h
@@ -90,6 +90,13 @@ public:
   //! A cap on how much text a single response ever carries (read_worksheet/
   //! read_section), so a huge worksheet can't produce an unbounded reply.
   static constexpr std::size_t MAX_TEXT_LENGTH = 200000;
+  //! The cap applied to each individual cell's own output when it's one of
+  //! many being concatenated (ReadWorksheet/ReadSection) -- keeps one cell
+  //! with a huge output (a large matrix, a long list, ...) from crowding
+  //! out every other cell's info in the same response. read_cell, which
+  //! targets exactly one cell the caller already chose, is not limited to
+  //! this -- see its output_length/output_from_end arguments.
+  static constexpr std::size_t OUTPUT_PREVIEW_LENGTH = 2000;
 
 private:
   Worksheet *m_worksheet;
@@ -104,9 +111,37 @@ private:
   //! This cell's output, as plain text (empty if it has none/isn't evaluated).
   static wxString OutputText(GroupCell &cell);
   //! {uuid, group_type, index} plus a short input preview -- used by ListCells().
-  static nlohmann::json CellSummary(GroupCell &cell, int index);
+  nlohmann::json CellSummary(GroupCell &cell, int index) const;
+  //! One cell's "--- type (markers) ---\ninput\nOutput: ...\n\n" block, with
+  //! the is_current/has_error markers and OUTPUT_PREVIEW_LENGTH capping on
+  //! its own output -- shared by ReadWorksheet() and ReadSection() so a
+  //! marker or the capping can't accidentally end up in only one of them.
+  wxString CellText(GroupCell &cell) const;
+  //! The cell the user's cursor/h-caret is currently at or after (the same
+  //! cell Worksheet itself treats as the insertion point) -- or nullptr if
+  //! there is no worksheet at all. Falls back to the last cell in the
+  //! worksheet if nothing more specific is active, same as
+  //! Worksheet::GetHCaret() itself does for its own callers.
+  GroupCell *CurrentCell() const;
+  //! Is this cell the one Maxima has reported an error in? (DocumentCellPointers::
+  //! ErrorList, populated live by MaximaEvaluator/MaximaResponseReader --
+  //! the same mechanism Worksheet::ScrollToError() already relies on.)
+  bool HasError(GroupCell &cell) const;
+  //! Is Maxima currently evaluating something, or does it still have queued
+  //! work? A newly-watched (or already-watched) variable's value in
+  //! ReadVariables() only updates once Maxima actually answers the query
+  //! read_variables/watch_variable causes -- while this is true, an empty
+  //! or unchanged value there may just mean "not answered yet," not "this
+  //! variable is undefined."
+  bool MaximaIsBusy() const;
   //! Truncates to MAX_TEXT_LENGTH, appending a note if it had to.
   static wxString CapLength(wxString text);
+  //! Truncates text to at most maxLen characters -- the end if fromEnd,
+  //! otherwise the start -- and reports via wasTruncated whether it had to.
+  //! Shared by read_cell's output_length/output_from_end arguments and the
+  //! per-cell OUTPUT_PREVIEW_LENGTH capping in ReadWorksheet()/ReadSection().
+  static wxString TruncateText(const wxString &text, std::size_t maxLen,
+                               bool fromEnd, bool &wasTruncated);
   //! Extracts a required string argument, or throws McpToolError.
   static wxString RequireString(const nlohmann::json &arguments,
                                 const char *name);

--- a/src/sidebars/AiChatSidebar.cpp
+++ b/src/sidebars/AiChatSidebar.cpp
@@ -155,14 +155,35 @@ wxString AiChatSidebar::BuildContextSnapshot() const {
   json worksheet = m_tools.ReadWorksheet();
   wxString text = wxString::FromUTF8(worksheet.value("text", std::string()).c_str());
   if (text.Length() > MAX_CONTEXT_LENGTH) {
-    text = text.Left(MAX_CONTEXT_LENGTH);
+    // A plain Left() truncation would silently cut off the "(CURRENT
+    // CELL ...)" marker below for any worksheet long enough to need
+    // truncating in the first place -- exactly the case where a user is
+    // most likely to ask about "the current cell" or "the cell above the
+    // cursor," since a short worksheet never needs truncating at all.
+    // Center the kept window on that marker instead, when there is one.
+    int markerPos = text.Find(wxS("(CURRENT CELL"));
+    size_t start = 0;
+    if (markerPos != wxNOT_FOUND) {
+      size_t pos = static_cast<size_t>(markerPos);
+      start = (pos > MAX_CONTEXT_LENGTH / 2) ? pos - MAX_CONTEXT_LENGTH / 2 : 0;
+      if (start + MAX_CONTEXT_LENGTH > text.Length())
+        start = text.Length() - MAX_CONTEXT_LENGTH;
+    }
+    text = text.Mid(start, MAX_CONTEXT_LENGTH);
+    if (start > 0)
+      text = wxS("[... earlier worksheet content omitted ...]\n") + text;
     text += wxS("\n... [truncated for the chat context]");
   }
   return _("You are an assistant embedded in wxMaxima, a GUI front-end for "
           "the Maxima computer algebra system. Below is a read-only "
           "snapshot of the user's current worksheet -- you cannot edit, "
           "evaluate or otherwise change it; only the user can do that "
-          "through the wxMaxima UI. Use it only as context.\n\n"
+          "through the wxMaxima UI. A cell marked \"(CURRENT CELL -- the "
+          "user's cursor is here)\" is where the user's cursor currently "
+          "is -- that is what they mean by \"this cell,\" \"the current "
+          "cell,\" or \"the cell above/here.\" A cell marked \"(THIS CELL "
+          "HAS AN ERROR)\" is one Maxima reported an error in. Use the "
+          "snapshot only as context.\n\n"
           "--- Worksheet snapshot ---\n") +
     text;
 }

--- a/src/sidebars/AiChatSidebar.cpp
+++ b/src/sidebars/AiChatSidebar.cpp
@@ -35,6 +35,15 @@ AiChatSidebar::AiChatSidebar(wxWindow *parent, Configuration *configuration,
   vbox->Add(m_statusText,
            wxSizerFlags().Expand().Border(wxALL, 5 * GetContentScaleFactor()));
 
+  // Only shown while no provider is configured (see ReloadProviderFromConfig())
+  // -- there is no "log in" button that could get an API key automatically
+  // (AiProviderApiKeyUrl()'s own comment explains why), so this is the
+  // closest equivalent: one click to the exact place that both explains the
+  // options and links to where to actually get a key.
+  m_openOptionsButton = new wxButton(this, wxID_ANY, _("Open Options..."));
+  vbox->Add(m_openOptionsButton,
+           wxSizerFlags().Expand().Border(wxALL, 5 * GetContentScaleFactor()));
+
   m_historyCtrl =
     new wxTextCtrl(this, wxID_ANY, wxEmptyString, wxDefaultPosition,
                    wxDefaultSize,
@@ -75,6 +84,7 @@ AiChatSidebar::AiChatSidebar(wxWindow *parent, Configuration *configuration,
   m_sendButton->Bind(wxEVT_BUTTON, &AiChatSidebar::OnSend, this);
   m_clearButton->Bind(wxEVT_BUTTON,
                       [this](wxCommandEvent &) { ClearConversation(); });
+  m_openOptionsButton->Bind(wxEVT_BUTTON, &AiChatSidebar::OnOpenOptions, this);
   m_inputCtrl->Bind(wxEVT_KEY_DOWN, &AiChatSidebar::OnInputKeyDown, this);
 
   ReloadProviderFromConfig();
@@ -106,6 +116,13 @@ void AiChatSidebar::ReloadProviderFromConfig() {
   m_provider = (apiKey.IsEmpty()) ? nullptr : MakeAiProvider(kind, apiKey, model);
   UpdateStatusText();
   m_sendButton->Enable(!m_requestInFlight && (m_provider != nullptr));
+  m_openOptionsButton->Show(m_provider == nullptr);
+  Layout();
+}
+
+void AiChatSidebar::OnOpenOptions(wxCommandEvent &WXUNUSED(event)) {
+  wxCommandEvent openPreferences(wxEVT_MENU, wxID_PREFERENCES);
+  GetParent()->GetEventHandler()->AddPendingEvent(openPreferences);
 }
 
 void AiChatSidebar::ClearConversation() {

--- a/src/sidebars/AiChatSidebar.h
+++ b/src/sidebars/AiChatSidebar.h
@@ -74,6 +74,15 @@ public:
 private:
   void OnSend(wxCommandEvent &event);
   void OnInputKeyDown(wxKeyEvent &event);
+  //! Opens the Options dialog's AI Chat tab -- shown only while no provider
+  //! is configured, since there is no "log in" button that could get an API
+  //! key automatically (see AiProviderApiKeyUrl()'s own comment). Re-posts
+  //! wxID_PREFERENCES to the top-level window rather than constructing
+  //! ConfigDialogue itself, so this reuses the exact same handling
+  //! (MaximaCommandMenus.cpp) the Edit -> Configure menu item already does
+  //! (re-reading the config file first, applying settings afterwards, ...)
+  //! instead of duplicating any of it.
+  void OnOpenOptions(wxCommandEvent &event);
   void AppendToHistory(const wxString &speaker, const wxString &text);
   void SetBusy(bool busy);
   //! A compact, size-capped plain-text snapshot of the worksheet (table of
@@ -93,6 +102,7 @@ private:
   wxButton *m_sendButton;
   wxButton *m_clearButton;
   wxStaticText *m_statusText;
+  wxButton *m_openOptionsButton;
 
   //! A cap on the worksheet snapshot's size distinct from (and much
   //! smaller than) McpTools::MAX_TEXT_LENGTH: that limit exists to bound a

--- a/test/unit_tests/test_McpTools.cpp
+++ b/test/unit_tests/test_McpTools.cpp
@@ -144,6 +144,138 @@ SCENARIO("McpTools::ListCells() and ReadCell() reflect the real worksheet") {
   }
 }
 
+SCENARIO("McpTools caps a cell's output so one huge cell can't crowd out "
+        "everything else, while still letting an AI read it in full or "
+        "just its tail via read_cell") {
+  g_ws->ClearDocument();
+  g_vars->Clear();
+
+  GIVEN("A cell whose output is longer than the per-cell preview cap") {
+    wxString hugeOutput;
+    for (int i = 0; i < 500; ++i)
+      hugeOutput += wxString::Format(wxS("line %d "), i); // well over 2000 chars
+    REQUIRE(hugeOutput.Length() > McpTools::OUTPUT_PREVIEW_LENGTH);
+    GroupCell *small = AppendCodeGroup(wxS("1+1;"), nullptr, wxS("2"));
+    GroupCell *huge = AppendCodeGroup(wxS("big();"), small, hugeOutput);
+
+    McpTools tools(g_ws, g_vars);
+
+    WHEN("ReadCell() is called on it with no output_length") {
+      huge->GenerateUUID();
+      nlohmann::json result = tools.ReadCell(Args("uuid", huge->GetUUID().ToStdString()));
+      THEN("it returns the full output, uncapped, since the caller named "
+          "this one cell specifically") {
+        CHECK(result["output"] == hugeOutput.ToStdString());
+        CHECK(result["output_truncated"] == false);
+      }
+    }
+
+    WHEN("ReadCell() is called with a small output_length") {
+      huge->GenerateUUID();
+      nlohmann::json args = {{"uuid", huge->GetUUID().ToStdString()},
+                             {"output_length", 50}};
+      nlohmann::json result = tools.ReadCell(args);
+      THEN("it returns only the first 50 characters and reports truncation") {
+        std::string output = result["output"].get<std::string>();
+        CHECK(output.size() == 50);
+        CHECK(output == hugeOutput.Left(50).ToStdString());
+        CHECK(result["output_truncated"] == true);
+      }
+    }
+
+    WHEN("ReadCell() is called with a small output_length and output_from_end") {
+      huge->GenerateUUID();
+      nlohmann::json args = {{"uuid", huge->GetUUID().ToStdString()},
+                             {"output_length", 50},
+                             {"output_from_end", true}};
+      nlohmann::json result = tools.ReadCell(args);
+      THEN("it returns the LAST 50 characters instead of the first") {
+        std::string output = result["output"].get<std::string>();
+        CHECK(output.size() == 50);
+        CHECK(output == hugeOutput.Right(50).ToStdString());
+        CHECK(result["output_truncated"] == true);
+      }
+    }
+
+    WHEN("ReadWorksheet() is called") {
+      wxString text = wxString::FromUTF8(
+        tools.ReadWorksheet()["text"].get<std::string>().c_str());
+      THEN("the huge cell's own output is capped to the preview length, but "
+          "the small cell right after it is still fully present -- proving "
+          "the huge cell didn't crowd it out") {
+        CHECK(text.Contains(wxS("[truncated -- use read_cell")));
+        CHECK(text.Contains(wxS("1+1;")));
+        CHECK(text.Contains(wxS("Output: 2")));
+      }
+    }
+  }
+}
+
+SCENARIO("McpTools flags the current cell and any cell with an error, so an "
+        "AI reading the worksheet can answer \"what's wrong with the "
+        "current cell\" / \"the cell above the cursor\"") {
+  g_ws->ClearDocument();
+  g_vars->Clear();
+
+  GIVEN("Three code cells, the cursor at the second, and an error flagged "
+       "on the third") {
+    GroupCell *first = AppendCodeGroup(wxS("1+1;"), nullptr, wxS("2"));
+    GroupCell *second = AppendCodeGroup(wxS("2+2;"), first, wxS("4"));
+    GroupCell *third = AppendCodeGroup(wxS("1/0;"), second, wxS("Error"));
+    g_ws->SetHCaret(second);
+    g_ws->GetErrorList().Add(third);
+
+    McpTools tools(g_ws, g_vars);
+
+    WHEN("ListCells() is called") {
+      nlohmann::json result = tools.ListCells();
+      THEN("only the cursor's cell is_current, and only the erroring cell "
+          "has_error") {
+        REQUIRE(result["cells"].size() == 3);
+        CHECK(result["cells"][0]["is_current"] == false);
+        CHECK(result["cells"][0]["has_error"] == false);
+        CHECK(result["cells"][1]["is_current"] == true);
+        CHECK(result["cells"][1]["has_error"] == false);
+        CHECK(result["cells"][2]["is_current"] == false);
+        CHECK(result["cells"][2]["has_error"] == true);
+      }
+    }
+
+    WHEN("ReadCell() is called on the current cell and on the erroring cell") {
+      // GetUUID() is lazy -- empty until something first asks for it (see
+      // McpTools::FindGroupByUUID()'s own on-demand generation) -- so
+      // generate it explicitly here rather than capturing an empty string.
+      second->GenerateUUID();
+      third->GenerateUUID();
+      nlohmann::json current = tools.ReadCell(Args("uuid", second->GetUUID().ToStdString()));
+      nlohmann::json errored = tools.ReadCell(Args("uuid", third->GetUUID().ToStdString()));
+      THEN("each reports its own flags correctly") {
+        CHECK(current["is_current"] == true);
+        CHECK(current["has_error"] == false);
+        CHECK(errored["is_current"] == false);
+        CHECK(errored["has_error"] == true);
+      }
+    }
+
+    WHEN("ReadWorksheet() is called") {
+      wxString text = wxString::FromUTF8(
+        tools.ReadWorksheet()["text"].get<std::string>().c_str());
+      THEN("the plain-text dump marks both inline, since that is the only "
+          "context the AI chat sidebar actually sends") {
+        CHECK(text.Contains(wxS("(CURRENT CELL -- the user's cursor is here)")));
+        CHECK(text.Contains(wxS("(THIS CELL HAS AN ERROR)")));
+        // The marked-current cell's own input is "2+2;" -- confirm the
+        // marker landed on the right cell's line, not just anywhere.
+        int currentMarkerPos = text.Find(wxS("(CURRENT CELL"));
+        int secondInputPos = text.Find(wxS("2+2;"));
+        REQUIRE(currentMarkerPos != wxNOT_FOUND);
+        REQUIRE(secondInputPos != wxNOT_FOUND);
+        CHECK(currentMarkerPos < secondInputPos);
+      }
+    }
+  }
+}
+
 SCENARIO("McpTools::ReadToc() and ReadSection() follow the same section "
         "boundaries GroupCell::Fold() does") {
   g_ws->ClearDocument();
@@ -210,9 +342,22 @@ SCENARIO("McpTools' variable watchlist tools only ever touch the sidebar, "
 
   GIVEN("An empty watchlist") {
     WHEN("ReadVariables() is called") {
-      THEN("it reports no variables") {
-        CHECK(tools.ReadVariables()["variables"].empty());
+      THEN("it reports no variables, and maxima_busy is false (nothing is "
+          "queued or being evaluated)") {
+        nlohmann::json result = tools.ReadVariables();
+        CHECK(result["variables"].empty());
+        CHECK(result["maxima_busy"] == false);
       }
+    }
+
+    WHEN("Maxima is set as currently working on a cell") {
+      GroupCell *working = AppendCodeGroup(wxS("1+1;"), nullptr);
+      g_ws->SetWorkingGroup(working);
+      THEN("ReadVariables() reports maxima_busy true, so a tool-calling AI "
+          "knows an empty/stale value might just not have arrived yet") {
+        CHECK(tools.ReadVariables()["maxima_busy"] == true);
+      }
+      g_ws->SetWorkingGroup(nullptr); // don't leak state into later SCENARIOs
     }
 
     WHEN("WatchVariable() adds a valid variable name") {


### PR DESCRIPTION
## Summary

Three related gaps in the MCP server / AI chat sidebar's worksheet context (#2290, #2291), each raised directly during review of that work:

- **No notion of "the current cell" or "the cell above the cursor that errored."** An AI had no way to answer either question. Added `is_current`/`has_error` to `list_cells`/`read_cell`, and matching inline markers (`"(CURRENT CELL...)"`/`"(THIS CELL HAS AN ERROR)"`) in the plain-text worksheet dump the AI chat sidebar sends — it has no tool-calling yet, so JSON fields alone wouldn't reach it.
  - Found and fixed a related bug in the same pass: `AiChatSidebar::BuildContextSnapshot()`'s truncation for its 8000-character context limit truncated from the *start*, which would silently strip the new `(CURRENT CELL...)` marker out of any worksheet long enough to need truncating in the first place — exactly the worksheets where a user is most likely to ask about their current cell. Fixed by centering the kept window on the marker. Verified live with a real ~15KB synthetic worksheet: confirmed via temporary logging that the truncated ~8KB snapshot still contained both the marker and the last cell's distinctive content.
- **`read_variables` gave no way to tell "Maxima hasn't answered this query yet" apart from "this variable is undefined."** Both look identical (an empty value). Added a `maxima_busy` flag (derived from `Worksheet::GetWorkingGroup()`/`GetEvaluationQueue()`).
- **`read_cell` had no cap on a single cell's output at all**, and `read_worksheet`/`read_section` only capped the *aggregate* text, not each cell's own contribution — one huge cell's output (a large matrix, a long list, ...) could dominate or even crowd out other cells' content in the response (worse: since that aggregate cap also truncates from the start, a huge cell early in the document could crowd out the current-cell/error markers above too). Added `output_length`/`output_from_end` arguments to `read_cell` so an AI can ask for a preview or specifically the tail (e.g. "did this converge"), plus a smaller per-cell preview cap in the worksheet/section dumps with an inline pointer back to `read_cell` for the full text.

Full root-cause writeups for all three, including the live verification methodology, are in `AGENTS.md`.

## Test plan

- [x] `test_McpTools` — 68 assertions across 5 test cases (up from 53/4), covering `is_current`/`has_error` on `list_cells`/`read_cell`/`read_worksheet`, `maxima_busy`, and the `output_length`/`output_from_end`/`output_truncated` capping behavior
- [x] Full clean rebuild, zero new warnings
- [x] `check-pot-coverage` passes; the one changed translatable string (the AI chat sidebar's system prompt, now explaining the markers) is reflected in `wxMaxima.pot`
- [x] Live end-to-end verification in a real Xvfb session: a synthetic long worksheet, cursor moved to the last cell, confirmed the sent context snapshot correctly retained the current-cell marker despite truncation
- [ ] Full broad `ctest` regression suite was still running at push time; will report back if it turns up anything unrelated

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011iszcZR49S3QXrTKUQjiu6)_