### PR TITLE
Add an MCP search_cells tool to find cells by text or regex

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -739,6 +739,66 @@ a local TCP socket.
     having `ResetAllToDefaults()` call `AiProviderDefaultModel()` for all
     four, removing the second copy entirely; re-verified live in Xvfb
     that Options now genuinely shows `claude-3-5-sonnet-latest`.
+  - **Follow-up (2026-09-06): a new `search_cells` MCP tool, so an AI can
+    find a cell instead of reading the whole worksheet.** Raised by the
+    user directly ("would the AI profit from some regex search for input/
+    output?") -- a fair gap, since `list_cells`/`read_worksheet` were the
+    only way to find "which cell mentions X" and both mean reading every
+    cell yourself, exactly the friction the current-cell/error markers
+    above already exist to reduce. Added `McpTools::SearchCells()`: a
+    `pattern` argument, a plain case-insensitive substring by default, or
+    a POSIX extended regular expression with `"regex": true` (`wxRegEx`,
+    the same engine `RegexSearch`/`FindReplacePane` already use elsewhere
+    in this codebase -- reused directly rather than adding a second regex
+    dependency); optional `case_sensitive` and `scope` ("input"/"output"/
+    "both", default "both") to narrow a search. Returns each matching
+    cell's usual summary (uuid/is_current/has_error, via the existing
+    `CellSummary()`) plus `matched_in` and a short `match_snippet` (40
+    characters of context on each side of the match, with "..." markers
+    where it was cut) -- enough to judge relevance without dumping a
+    potentially huge cell's entire text for every hit. Capped to
+    `MAX_SEARCH_MATCHES` (50) with a `truncated` flag, the same shape as
+    every other capped response in this file, so a pathological pattern
+    matching most of a huge worksheet can't turn into an unbounded reply.
+    An invalid regex (checked via `wxRegEx::IsValid()` right after
+    construction) throws `McpToolError` rather than matching nothing
+    silently or crashing. The whole search runs under a `wxLogNull` guard
+    -- a bad pattern or a match attempt could otherwise trigger a
+    `wxLogXXX` call that, per this file's own "not reliably visible"
+    entry, could in the worst case surface as an unwanted modal `wxLogGui`
+    popup from what is, from the caller's perspective, an ordinary
+    JSON-RPC error response. Verified both ways: `test_McpTools.cpp` gained
+    a new SCENARIO (substring/regex/case-sensitivity/scope/invalid-pattern/
+    the 50-match cap, 18 new assertions, 86 total in the file) against a
+    real headless `Worksheet`, and the transport itself was re-checked live
+    in Xvfb via `curl` against a real running MCP server (`tools/list`
+    includes it; a plain-substring call, a case-insensitive call, and an
+    invalid-regex call all matched expectations) -- catching, in the
+    process, an unrelated test-harness mistake of my own (a `.wxm` file
+    written for the live check without the required `/* [wxMaxima batch
+    file version 1] ... */` header line fails to load with a completely
+    silent-to-the-MCP-caller empty worksheet, `Format::ParseWXMFile()`'s
+    own recognized-header check rejecting it before a single cell is
+    parsed -- not a McpTools bug, just a reminder that a `.wxm` fixture
+    needs that exact header, see the existing fixtures under
+    `test/automatic_test_files/` for the correct shape).
+  - **Not implemented, and shouldn't be without a separate decision: a
+    write/evaluate-capable MCP tool.** Raised and discussed directly with
+    the user (2026-09-06): unlike `watch_variable`/`unwatch_variable` (see
+    this section's own "why 'read-only except two things' and not
+    stricter" note above), an `evaluate_cell`-style tool is not a bounded
+    side effect -- Maxima has no sandbox at all around it (it can `system()`
+    out to the shell, read/write arbitrary files the user can access, ...),
+    so letting an AI evaluate a cell is, in effect, letting it run arbitrary
+    code on the user's machine. Per-call user consent does not bound that
+    blast radius the way it does for a sidebar-display change. If this is
+    picked up later: a consent-gated `insert_cell` that only inserts text
+    *without* auto-evaluating it (the user still has to press Enter/
+    Shift-Enter themselves) is a meaningfully safer middle ground than a
+    tool that evaluates anything -- treat a real `evaluate_cell` as a
+    separate, much bigger decision that needs either genuine sandboxing
+    around the Maxima process or explicit human-in-the-loop confirmation
+    on every single call, not a one-time "make this permanent" toggle.
 - **wxAuiManager:** The application uses `wxAuiManager` for its complex layout (sidebars, toolbars, worksheet).
   - **Linux/GTK Timing:** On Linux (especially KDE Plasma with Global Menus), calling `m_manager.Update()` can disrupt the menu bar if it's already attached. This is a known environmental issue in the interaction between wxWidgets, GTK3, and the KDE Global Menu proxy.
     - **Automated Fix:** On systems with wxWidgets <= 3.2 running on KDE, Unity, or with `appmenu-gtk-module` enabled, wxMaxima automatically sets `UBUNTU_MENUPROXY=0` at startup in `main.cpp` to force menus to remain within the window and prevent disappearance.

--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,10 @@
   in the worksheet -- every tool only reads, except adding/removing a
   variable from the watchlist, which only changes what that sidebar
   displays, the same as typing a name into it by hand.
+- Added an MCP search_cells tool that finds every cell whose input and/or
+  output contains a given plain-text or regular-expression pattern, so an
+  AI can jump straight to the relevant cell(s) of a large worksheet instead
+  of reading it all.
 - The MCP server and AI Chat sidebar's worksheet context now tell an AI
   where the user's cursor is and which cell (if any) has an error, so it
   can actually answer "what's wrong with my current cell" or "the cell

--- a/src/mcp/McpTools.cpp
+++ b/src/mcp/McpTools.cpp
@@ -24,6 +24,10 @@
 #include "cells/EditorCell.h"
 #include "sidebars/VariablesPane.h"
 #include "worksheet/Worksheet.h"
+#include <wx/log.h>
+#include <wx/regex.h>
+#include <algorithm>
+#include <memory>
 
 using json = nlohmann::json;
 
@@ -32,6 +36,24 @@ namespace {
 std::string U8(const wxString &s) { return s.ToUTF8().data(); }
 wxString FromU8(const std::string &s) {
   return wxString::FromUTF8(s.c_str());
+}
+
+//! A short excerpt of `text` around [matchStart, matchStart+matchLen), with
+//! "..." markers where the excerpt was cut -- lets search_cells's result show
+//! *where* a match sits without dumping the cell's entire (possibly huge)
+//! input/output for every hit.
+wxString SearchSnippet(const wxString &text, std::size_t matchStart,
+                       std::size_t matchLen) {
+  const std::size_t context = 40;
+  std::size_t start = (matchStart > context) ? matchStart - context : 0;
+  std::size_t afterMatch = matchStart + matchLen;
+  std::size_t end = std::min(text.Length(), afterMatch + context);
+  wxString snippet = text.Mid(start, end - start);
+  if (start > 0)
+    snippet = wxS("...") + snippet;
+  if (end < text.Length())
+    snippet += wxS("...");
+  return snippet;
 }
 } // namespace
 
@@ -262,6 +284,36 @@ json McpTools::ListTools() const {
       "watchlist, the same as removing it from that sidebar by hand."},
      {"inputSchema", nameArg("The Maxima variable name to stop watching")}});
 
+  json searchSchema;
+  searchSchema["type"] = "object";
+  searchSchema["properties"]["pattern"] = {
+    {"type", "string"},
+    {"description", "The text to search for (a plain substring by default; "
+     "an extended-regular-expression pattern if regex is true)."}};
+  searchSchema["properties"]["regex"] = {
+    {"type", "boolean"},
+    {"description", "Treat pattern as a POSIX extended regular expression "
+     "instead of a plain substring. Default: false."}};
+  searchSchema["properties"]["case_sensitive"] = {
+    {"type", "boolean"},
+    {"description", "Default: false (case-insensitive)."}};
+  searchSchema["properties"]["scope"] = {
+    {"type", "string"},
+    {"description", "\"input\", \"output\", or \"both\" (default) -- which "
+     "part of each cell to search."}};
+  searchSchema["required"] = json::array({"pattern"});
+  tools.push_back(
+    {{"name", "search_cells"},
+     {"description",
+      "Find every cell whose input and/or output contains a given text or "
+      "regular expression, so you can jump straight to the relevant cell(s) "
+      "of a large worksheet instead of reading it all via read_worksheet/ "
+      "list_cells. Returns each matching cell's UUID (use with read_cell/"
+      "read_section), is_current/has_error (see list_cells), which part it "
+      "matched in, and a short snippet of context around the match. Capped "
+      "to 50 matches; \"truncated\" reports if there would have been more."},
+     {"inputSchema", searchSchema}});
+
   json result;
   result["tools"] = tools;
   return result;
@@ -293,6 +345,8 @@ json McpTools::CallTool(const wxString &name, const json &arguments) const {
     return TextResult(WatchVariable(arguments));
   if (name == wxS("unwatch_variable"))
     return TextResult(UnwatchVariable(arguments));
+  if (name == wxS("search_cells"))
+    return TextResult(SearchCells(arguments));
   throw McpToolError("Unknown tool: " + std::string(name.ToUTF8()));
 }
 
@@ -484,5 +538,85 @@ json McpTools::UnwatchVariable(const json &arguments) const {
   json result;
   result["ok"] = true;
   result["name"] = U8(name);
+  return result;
+}
+
+json McpTools::SearchCells(const json &arguments) const {
+  wxString pattern = RequireString(arguments, "pattern");
+  bool useRegex = arguments.contains("regex") && arguments["regex"].is_boolean() &&
+    arguments["regex"].get<bool>();
+  bool caseSensitive = arguments.contains("case_sensitive") &&
+    arguments["case_sensitive"].is_boolean() && arguments["case_sensitive"].get<bool>();
+  wxString scope = wxS("both");
+  if (arguments.contains("scope") && arguments["scope"].is_string())
+    scope = FromU8(arguments["scope"].get<std::string>());
+  bool searchInput = scope != wxS("output");
+  bool searchOutput = scope != wxS("input");
+
+  // Suppresses any wxLogXXX a bad pattern or a match attempt might trigger --
+  // an unhandled one could otherwise surface as a modal wxLogGui popup (see
+  // AGENTS.md's "wxLogMessage/wxLogWarning/wxLogError are NOT reliably
+  // visible" entry) from what is, from the caller's perspective, an ordinary
+  // JSON-RPC error response, not something that should ever touch the GUI.
+  wxLogNull suppressLogging;
+  std::unique_ptr<wxRegEx> regex;
+  if (useRegex) {
+    regex = std::make_unique<wxRegEx>(pattern, caseSensitive ? wxRE_DEFAULT : wxRE_ICASE);
+    if (!regex->IsValid())
+      throw McpToolError("Invalid regular expression");
+  }
+  wxString patternLower = pattern.Lower();
+
+  // Returns true and fills `snippet` if `text` contains a match; false
+  // (leaving `snippet` untouched) otherwise.
+  auto matchesText = [&](const wxString &text, wxString &snippet) -> bool {
+    if (text.IsEmpty())
+      return false;
+    if (useRegex) {
+      if (!regex->Matches(text))
+        return false;
+      std::size_t start = 0;
+      std::size_t len = 0;
+      regex->GetMatch(&start, &len, 0);
+      snippet = SearchSnippet(text, start, len);
+      return true;
+    }
+    const wxString &haystack = caseSensitive ? text : text.Lower();
+    const wxString &needle = caseSensitive ? pattern : patternLower;
+    int pos = haystack.Find(needle);
+    if (pos == wxNOT_FOUND)
+      return false;
+    snippet = SearchSnippet(text, static_cast<std::size_t>(pos), needle.Length());
+    return true;
+  };
+
+  json matches = json::array();
+  bool truncated = false;
+  if (m_worksheet && m_worksheet->GetTree()) {
+    int index = 0;
+    for (GroupCell &cell : OnList(m_worksheet->GetTree())) {
+      int idx = index++;
+      wxString snippet;
+      wxString matchedIn;
+      if (searchInput && matchesText(InputText(cell), snippet))
+        matchedIn = wxS("input");
+      else if (searchOutput && matchesText(OutputText(cell), snippet))
+        matchedIn = wxS("output");
+      else
+        continue;
+      if (matches.size() >= MAX_SEARCH_MATCHES) {
+        truncated = true;
+        break;
+      }
+      json entry = CellSummary(cell, idx);
+      entry["matched_in"] = U8(matchedIn);
+      entry["match_snippet"] = U8(snippet);
+      matches.push_back(entry);
+    }
+  }
+
+  json result;
+  result["matches"] = matches;
+  result["truncated"] = truncated;
   return result;
 }

--- a/src/mcp/McpTools.h
+++ b/src/mcp/McpTools.h
@@ -86,10 +86,20 @@ public:
   nlohmann::json ReadVariables() const;
   nlohmann::json WatchVariable(const nlohmann::json &arguments) const;
   nlohmann::json UnwatchVariable(const nlohmann::json &arguments) const;
+  //! Finds every cell whose input and/or output contains `pattern` (a plain
+  //! substring by default, or a regular expression with "regex":true), so an
+  //! AI can jump straight to the relevant cell(s) of a large worksheet
+  //! instead of reading everything via read_worksheet/list_cells. Read-only,
+  //! same as every other tool here -- it never touches worksheet content.
+  nlohmann::json SearchCells(const nlohmann::json &arguments) const;
 
   //! A cap on how much text a single response ever carries (read_worksheet/
   //! read_section), so a huge worksheet can't produce an unbounded reply.
   static constexpr std::size_t MAX_TEXT_LENGTH = 200000;
+  //! search_cells stops collecting further matches once it hits this many,
+  //! reporting "truncated" instead -- a pathological pattern matching most
+  //! of a huge worksheet must not turn into an unbounded response either.
+  static constexpr std::size_t MAX_SEARCH_MATCHES = 50;
   //! The cap applied to each individual cell's own output when it's one of
   //! many being concatenated (ReadWorksheet/ReadSection) -- keeps one cell
   //! with a huge output (a large matrix, a long list, ...) from crowding

--- a/test/unit_tests/test_McpTools.cpp
+++ b/test/unit_tests/test_McpTools.cpp
@@ -389,6 +389,112 @@ SCENARIO("McpTools' variable watchlist tools only ever touch the sidebar, "
   }
 }
 
+SCENARIO("McpTools::SearchCells() finds cells by plain substring or regex, "
+        "in input and/or output, so an AI can jump straight to a match "
+        "instead of reading every cell") {
+  g_ws->ClearDocument();
+  g_vars->Clear();
+
+  GIVEN("Three code cells, only one of which mentions \"integrate\"") {
+    GroupCell *first = AppendCodeGroup(wxS("x: 1+1;"), nullptr, wxS("2"));
+    GroupCell *second =
+      AppendCodeGroup(wxS("integrate(sin(x), x);"), first, wxS("-cos(x)"));
+    AppendCodeGroup(wxS("y: 3;"), second, wxS("3"));
+
+    McpTools tools(g_ws, g_vars);
+
+    WHEN("SearchCells() is called with a plain substring in the input") {
+      nlohmann::json result = tools.SearchCells(Args("pattern", "integrate"));
+      THEN("it finds only that cell, and reports where it matched") {
+        REQUIRE(result["matches"].size() == 1);
+        CHECK(result["matches"][0]["matched_in"] == "input");
+        CHECK(result["matches"][0]["group_type"] == "code");
+        CHECK(result["truncated"] == false);
+        std::string snippet = result["matches"][0]["match_snippet"].get<std::string>();
+        CHECK(snippet.find("integrate") != std::string::npos);
+      }
+    }
+
+    WHEN("SearchCells() is called with a substring only present in output") {
+      nlohmann::json result = tools.SearchCells(Args("pattern", "-cos"));
+      THEN("it still finds the cell, flagged as matched in output") {
+        REQUIRE(result["matches"].size() == 1);
+        CHECK(result["matches"][0]["matched_in"] == "output");
+      }
+    }
+
+    WHEN("SearchCells() is called with different case than the text") {
+      nlohmann::json result = tools.SearchCells(Args("pattern", "INTEGRATE"));
+      THEN("it still matches, since case_sensitive defaults to false") {
+        REQUIRE(result["matches"].size() == 1);
+      }
+    }
+
+    WHEN("SearchCells() is called with case_sensitive true and wrong case") {
+      nlohmann::json args = {{"pattern", "INTEGRATE"}, {"case_sensitive", true}};
+      nlohmann::json result = tools.SearchCells(args);
+      THEN("it finds nothing") {
+        CHECK(result["matches"].empty());
+      }
+    }
+
+    WHEN("SearchCells() is called with scope=\"output\" for a pattern only "
+        "in that cell's input") {
+      nlohmann::json args = {{"pattern", "integrate"}, {"scope", "output"}};
+      nlohmann::json result = tools.SearchCells(args);
+      THEN("it finds nothing, since the match was excluded by scope") {
+        CHECK(result["matches"].empty());
+      }
+    }
+
+    WHEN("SearchCells() is called with a regular expression") {
+      nlohmann::json args = {{"pattern", "y: [0-9]+"}, {"regex", true}};
+      nlohmann::json result = tools.SearchCells(args);
+      THEN("it matches using regex semantics, not literal substring") {
+        REQUIRE(result["matches"].size() == 1);
+        CHECK(result["matches"][0]["matched_in"] == "input");
+      }
+    }
+
+    WHEN("SearchCells() is given an invalid regular expression") {
+      nlohmann::json args = {{"pattern", "("}, {"regex", true}};
+      THEN("it throws McpToolError instead of crashing") {
+        CHECK_THROWS_AS(tools.SearchCells(args), McpToolError);
+      }
+    }
+
+    WHEN("SearchCells() finds no matches at all") {
+      nlohmann::json result = tools.SearchCells(Args("pattern", "nonexistent_xyz"));
+      THEN("it returns an empty, non-truncated match list") {
+        CHECK(result["matches"].empty());
+        CHECK(result["truncated"] == false);
+      }
+    }
+
+    WHEN("SearchCells() is called with a missing pattern argument") {
+      THEN("it throws McpToolError") {
+        CHECK_THROWS_AS(tools.SearchCells(nlohmann::json::object()), McpToolError);
+      }
+    }
+  }
+
+  GIVEN("More cells than MAX_SEARCH_MATCHES that all match") {
+    GroupCell *last = nullptr;
+    for (std::size_t i = 0; i < McpTools::MAX_SEARCH_MATCHES + 5; ++i)
+      last = AppendCodeGroup(wxS("needle: 1;"), last);
+
+    McpTools tools(g_ws, g_vars);
+
+    WHEN("SearchCells() is called") {
+      nlohmann::json result = tools.SearchCells(Args("pattern", "needle"));
+      THEN("it caps the result and reports truncation") {
+        CHECK(result["matches"].size() == McpTools::MAX_SEARCH_MATCHES);
+        CHECK(result["truncated"] == true);
+      }
+    }
+  }
+}
+
 class TestApp : public wxApp {
 public:
   bool OnInit() override { return true; }


### PR DESCRIPTION
## Summary
- Adds `search_cells`, a new read-only MCP tool that finds every cell whose input and/or output contains a given plain-text substring (default, case-insensitive) or a POSIX extended regular expression (`"regex": true`), so an AI can jump straight to the relevant cell(s) of a large worksheet instead of reading everything via `list_cells`/`read_worksheet`.
- Reuses `wxRegEx`, the same regex engine `RegexSearch`/`FindReplacePane` already use elsewhere in this codebase, rather than adding a second dependency.
- Optional `case_sensitive` and `scope` (`"input"`/`"output"`/`"both"`) arguments narrow a search; results are capped to 50 matches (`truncated` flag) so a pathological pattern can't produce an unbounded reply.
- An invalid regex throws a proper `McpToolError` instead of matching nothing silently.

## Test plan
- [x] `test_McpTools` gained a new SCENARIO covering substring/regex/case-sensitivity/scope/invalid-pattern/the match cap (18 new assertions, 86 total in the file) — all passing.
- [x] Live-verified the transport end-to-end in Xvfb: started wxMaxima with the MCP server enabled, confirmed `search_cells` appears in `tools/list`, and exercised plain-substring, case-insensitive, and invalid-regex calls via `curl` against the real running server.
- [x] Full clean rebuild with zero new warnings; full `ctest` suite re-run with no regressions (one apparent failure, `testbench_simple.wxmx`, was confirmed to be an artifact of running that one test outside `xvfb-run` in isolation, not a real regression — it passes cleanly under `xvfb-run`).
- [x] Regenerated the POT and confirmed it is byte-identical in content (only the timestamp differs) — this tool's descriptions are AI-facing strings, not `_()`-wrapped user-facing UI text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011iszcZR49S3QXrTKUQjiu6

---
_Generated by [Claude Code](https://claude.ai/code/session_011iszcZR49S3QXrTKUQjiu6)_