### PR TITLE
Add runtime-gated diagnostic tracing for the wxmaxima_version_string CI flake

### DIFF
--- a/.github/workflows/compile_windows.yml
+++ b/.github/workflows/compile_windows.yml
@@ -271,12 +271,33 @@ jobs:
         # unzip tests, which cannot run on Windows) are excluded; timeout-minutes
         # is a hard ceiling.
         timeout-minutes: 20
+        # WXM_STDIO_DEBUG_LOG: diagnostic tracing for the still-unexplained
+        # wxmaxima_version_string flake (see AGENTS.md's long investigation --
+        # this env var is the only thing that turns it on; main.cpp's tracing is
+        # a no-op without it, in every other build and every other CI job).
+        # Scoped to just this step, not job-wide, so the log stays small and
+        # only covers the one ctest invocation that actually reproduces the bug.
+        env:
+          WXM_STDIO_DEBUG_LOG: ${{ github.workspace }}\wxm_stdio_debug.log
         run: |
             cd wxMaxima
             cd build
             ctest -LE "unittest|needs_posix" -E "multithreadtest" --repeat after-timeout:2 -j 2 --output-on-failure
             cd ..
             cd ..
+      - name: Upload stdio debug log
+        # Only produced/useful when the step above actually failed -- see the
+        # WXM_STDIO_DEBUG_LOG env var on that step. if: always() (not
+        # if: failure()) because upload-artifact itself already no-ops cleanly
+        # when the file doesn't exist, and this keeps the step's own log
+        # readable ("no files were found" is more informative on a green run
+        # than never seeing this step at all).
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: wxm-stdio-debug-log
+          path: wxm_stdio_debug.log
+          if-no-files-found: ignore
       - name: Upload the unsigned installer for SignPath
         # SignPath does NOT accept an uploaded file directly: its GitHub
         # connector downloads the GitHub Actions artifact itself and checks the

--- a/.github/workflows/compile_windows.yml
+++ b/.github/workflows/compile_windows.yml
@@ -285,6 +285,22 @@ jobs:
             ctest -LE "unittest|needs_posix" -E "multithreadtest" --repeat after-timeout:2 -j 2 --output-on-failure
             cd ..
             cd ..
+      - name: Print stdio debug log
+        # Echoes the trace straight into this job's own console output, in
+        # addition to the artifact upload below -- a downloading agent (e.g.
+        # an AI coding assistant investigating this from a sandboxed session)
+        # may have no route to actions-results.blob.core.windows.net (the
+        # artifact's actual storage backend) even though it can read job logs
+        # via the GitHub API; this step makes the trace reachable either way.
+        if: always()
+        run: |
+            if (Test-Path wxm_stdio_debug.log) {
+              Write-Output "----- wxm_stdio_debug.log -----"
+              Get-Content wxm_stdio_debug.log
+              Write-Output "----- end wxm_stdio_debug.log -----"
+            } else {
+              Write-Output "wxm_stdio_debug.log was not produced."
+            }
       - name: Upload stdio debug log
         # Only produced/useful when the step above actually failed -- see the
         # WXM_STDIO_DEBUG_LOG env var on that step. if: always() (not

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1604,13 +1604,27 @@ a local TCP socket.
     harmless either way -- this test is fast and gains nothing from
     parallelism -- and the finding itself is worth keeping visible on the
     test), but stop describing it as an open experiment still gathering
-    data; it has its answer. The next real lead, if this is picked up
-    again, is real Windows hardware with `rr` (this sandbox's Wine
-    environment cannot simulate whatever the actual trigger is, per the
-    "essentially unreproducible everywhere except the actual CI runner"
-    conclusion above) or bisecting the GH #2274 startup-reordering commit
-    (`3f5e895`) directly on real Windows -- not another synthetic Wine
-    repro of ctest-level contention specifically.
+    data; it has its answer. **Correction to this entry's own earlier
+    wording**: "real Windows hardware with `rr`" was never a coherent next
+    step and should not have been written here -- `rr` (Mozilla's
+    record-replay debugger) is Linux-only and has no Windows port at all;
+    that line was carried over by mistake from this file's unrelated
+    `tutorial_10Minutes` entry, which is a genuinely different, Linux-side
+    Maxima flake where `rr` really is the right tool. Separately, "real
+    Windows hardware" was also the wrong framing of the actual blocker:
+    GitHub Actions' `windows-latest` runner already *is* real Windows --
+    the actual limitation this investigation has run into is that runner's
+    non-interactivity (no way to attach a live debugger to the exact
+    process instance that reproduces the bug), not a lack of a genuine
+    Windows target to test against. The next real lead, if this is picked
+    up again, is either (a) a live interactive session on the actual runner
+    via `mxschmitt/action-tmate` (or equivalent), or (b) targeted
+    diagnostic tracing shipped in the binary itself and captured
+    automatically as a CI artifact -- see the follow-up entry immediately
+    below, which does (b) -- or bisecting the GH #2274 startup-reordering
+    commit (`3f5e895`) directly on the real runner. Not another synthetic
+    Wine repro of ctest-level contention specifically -- that lead is now
+    closed.
   - **Follow-up (2026-09-07): "does this only fail on PRs?" -- checked
     directly, and no.** A fair question to ask given how much of this
     investigation happened on PR branches -- but `compile_windows.yml`
@@ -1634,6 +1648,99 @@ a local TCP socket.
     easier to not notice -- a visibility/sampling effect, not a real
     behavioral difference between the two trigger paths. Don't re-open
     "PR-specific" as a lead without new evidence.
+  - **Follow-up (2026-09-07): shipped real diagnostic tracing in the binary
+    itself, gated behind an env var, to capture actual runner-side evidence
+    on the next CI run instead of another Wine simulation.** Prompted by
+    the user's own correct pushback on "go get real Windows hardware" (see
+    the correction two entries above) -- the runner is already real
+    Windows, and every debugging tool that needs live interactivity (a
+    real debugger, `rr`, hardware watchpoints) is unavailable here anyway,
+    so the only way to learn something new without an interactive session
+    is to have the actual failing process record its own evidence and hand
+    it back as a CI artifact. Two previously-unexamined facts motivated
+    what got instrumented, specifically: (1) every prior Wine repro across
+    multiple sessions tested a bare `fprintf(stdout, ...)` -- never the
+    *actual* code path `--version` uses, which is
+    `wxMessageOutput::Get()->Printf(...)` through a `wxMessageOutputStderr`
+    object (`wxMessageOutput::Set(new wxMessageOutputStderr(stdout))`,
+    `main.cpp`, called once early in `OnInit()`); (2) `cmdLineParser.Parse()`
+    (`wxCmdLineParser`, a real library call) runs between that `Set()` call
+    and the `-v` branch, and has never been traced through either. Added a
+    small, self-contained diagnostic block to `main.cpp` (Windows-only,
+    anonymous namespace, immediately before `BindStdStreamToParent()`):
+    `StdioDebugLog(msg)` appends a timestamp-free but PID-prefixed line to
+    whatever file `WXM_STDIO_DEBUG_LOG` names (read once, cached, via
+    `wxGetEnv()`) -- entirely inert (single cheap env-var check, cached
+    after the first call) unless that variable is set, which only the CI
+    workflow does, scoped to just the one ctest step that reproduces this;
+    a normal build or a normal user's run never sets it and pays only that
+    one cached check. Deliberately written via raw `CreateFileW`/`WriteFile`,
+    never CRT stdio -- tracing a stdio bug through the very subsystem
+    suspected of being broken would be self-defeating. Opened with
+    `FILE_APPEND_DATA` alone (no `GENERIC_WRITE`), which per MSDN makes
+    Windows itself position each `WriteFile` atomically at end-of-file --
+    load-bearing, since this ctest step runs `-j 2` and many independent
+    `wxmaxima` processes share this one log path; a separate
+    `SetFilePointer(..., FILE_END)` call would reintroduce exactly the
+    seek-then-write race this flag exists to avoid, so don't add one back.
+    Each line is prefixed with `GetCurrentProcessId()` so interleaved
+    processes' lines can be told apart afterward.
+    `DescribeStdHandle(stdHandleId)` (raw `GetStdHandle`/`GetFileType` --
+    "none"/"handle=%p type=pipe|disk|char|unknown") and
+    `DescribeStream(FILE*)` (`_fileno()` + `_get_osfhandle()` -- "fd=%d
+    osHandle=%p") are the two probes; checkpoints call one or the other at:
+    the very start and end of `BindStdStreamToParent()` (per stream, so
+    stdout/stderr/stdin each get their own before/after pair), the end of
+    `RedirectStdioToParent()`, right after the `SetHandleInformation(...,
+    HANDLE_FLAG_INHERIT, 0)` block, immediately before and after
+    `wxMessageOutput::Set(...)`, immediately before and after
+    `cmdLineParser.Parse()`, and right as the `-v` branch is entered plus
+    right after its `Printf()` call (before `exit(0)`). The specific
+    question this is built to answer: does `_fileno(stdout)`'s resolved
+    `osHandle` (or the raw `GetStdHandle(STD_OUTPUT_HANDLE)` value) ever
+    silently change, or does `GetFileType` ever stop reporting `pipe`,
+    somewhere across that chain -- something no prior Wine repro could
+    observe since none of them ever ran the real chain end to end.
+    **A `const wxChar*` gotcha caught during review, not live**:
+    `DescribeStdHandle()`'s type-name strings are built from `wxS(...)`
+    literals, not plain `"pipe"`/`"disk"`/... `char*` ones -- passing a
+    narrow `char*` for a `%s` conversion in `wxString::Format` on a
+    Unicode build is exactly the class of mismatch this file's own
+    `wxLogMessage`/`%zu`-from-a-worker-thread note (under "Communication
+    with Maxima") already flags as capable of asserting rather than just
+    printing; fixed before ever running by matching every `%s` argument's
+    width to the build's native `wxChar`, not found by tripping it live.
+    **Deliberately did NOT add an `fflush(stdout)` before `exit(0)`**: an
+    earlier draft of this instrumentation added one gated only by
+    `#ifdef __WXMSW__` (i.e. unconditionally on every Windows build, not
+    behind the env var) on the theory "can't hurt, might even help
+    flush a stuck buffer" -- caught in self-review before committing: that
+    would have been a real, non-diagnostic behavior change riding along
+    with what's supposed to be a strictly inert change, and worse, if it
+    happened to paper over the actual bug, the next CI run would report
+    "fixed" while teaching nothing about the real mechanism. Removed
+    outright rather than gating it behind the env var too, since gating a
+    behavior change behind a flag that's only set on the one CI run
+    collecting evidence would make that evidence describe a different code
+    path than every other build ships.
+    Wired into `.github/workflows/compile_windows.yml`: `WXM_STDIO_DEBUG_LOG`
+    is set (to `${{ github.workspace }}\wxm_stdio_debug.log`) only as an
+    `env:` on the existing "Run integration tests" step, and a new "Upload
+    stdio debug log" step immediately follows it,
+    `actions/upload-artifact@v7` with `if-no-files-found: ignore` and
+    `if: always()` (not `if: failure()`) -- `upload-artifact` already
+    no-ops cleanly when the path doesn't exist, and `always()` means a
+    green run's log (which should show nothing anomalous, itself a useful
+    negative data point) gets uploaded too, not just a red run's.
+    **Not yet verified against a real CI run as of this writing** -- this
+    entry documents the instrumentation's design and the reasoning behind
+    each choice; the actual captured evidence (or absence of anything
+    anomalous, which would itself be informative) belongs in a follow-up
+    entry once the next push's `compile_windows` run completes and the
+    artifact can be pulled and read. This diagnostic block should be
+    removed (or at least re-gated more strictly) once this investigation
+    either finds its answer or is shelved again -- it's instrumentation for
+    an open question, not a permanent feature.
 
 - **System tray icon (`src/TrayIcon.{h,cpp}`, GH #2286) -- mirrors the busy
   status, gated entirely by `wxUSE_TASKBARICON`.** The maintainer's own

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1777,6 +1777,124 @@ a local TCP socket.
     (the real payoff of this whole diagnostic effort) is still unread as of
     this entry. That comes in the next follow-up once the console-print
     step lands and a fresh run reproduces the failure again.
+  - **Follow-up (2026-09-07, same day): the console-print fallback worked,
+    the trace was read end to end for the failing `wxmaxima_version_string`
+    invocation itself, and it shows a completely clean, anomaly-free
+    sequence all the way through -- which redirects the investigation
+    rather than closing it.** Commit `0dfb7ba`'s `compile_windows` run
+    (job `101648978179`, run `34092563005`) failed the same way again
+    ("Compile using minGW" red; the earlier commit's run on this same PR
+    had the identical `wxmaxima_version_string` signature and nothing else
+    in this diff touches non-Windows code, so this is the same failure,
+    not a new one). `mcp__github__get_job_logs` returned the trace directly
+    in the job's own console output exactly as designed -- the
+    Azure-Blob-Storage egress gap from the previous entry is now fully
+    worked around for good.
+    The trace for the one process that reached the `-v` branch (pid 3420,
+    identified unambiguously: `wxmaxima_version_string` is the only test in
+    the whole suite that both passes `--version` and checks the captured
+    text, so it's the only process that could ever log an "entering -v
+    branch" line) is, verbatim:
+    ```
+    [pid 3420] BindStdStreamToParent(4294967285) start: handle=0000000000000450 type=char
+    [pid 3420] BindStdStreamToParent(4294967285) done: fd=1 osHandle=0000000000000240
+    [pid 3420] BindStdStreamToParent(4294967284) start: handle=0000000000000454 type=char
+    [pid 3420] BindStdStreamToParent(4294967284) done: fd=2 osHandle=000000000000042c
+    [pid 3420] BindStdStreamToParent(4294967286) start: handle=00000000000000b4 type=char
+    [pid 3420] BindStdStreamToParent(4294967286) done: fd=0 osHandle=0000000000000454
+    [pid 3420] RedirectStdioToParent() done: stdout fd=1 osHandle=0000000000000240, stderr fd=2 osHandle=000000000000042c
+    [pid 3420] after SetHandleInformation: stdout fd=1 osHandle=0000000000000240, stderr fd=2 osHandle=000000000000042c
+    [pid 3420] after wxMessageOutput::Set: stdout fd=1 osHandle=0000000000000240
+    [pid 3420] before cmdLineParser.Parse(): stdout fd=1 osHandle=0000000000000240
+    [pid 3420] after cmdLineParser.Parse() (result=0): stdout fd=1 osHandle=0000000000000240
+    [pid 3420] entering -v branch: stdout fd=1 osHandle=0000000000000240, wxMessageOutput::Get()=00000217191f0790
+    [pid 3420] after Printf, before exit(0)
+    ```
+    **Every single checkpoint is exactly what a correctly-working process
+    should show**: the initial handle is valid (never null/invalid, so the
+    `AttachConsole` fallback branch never fires), `_dup2()` succeeds and
+    produces a stable `osHandle` (`0x240`) that *never changes* across
+    `SetHandleInformation`, `wxMessageOutput::Set()`, or
+    `cmdLineParser.Parse()`, `wxMessageOutput::Get()` returns a valid
+    non-null pointer right before the real `Printf()` call, and the trace
+    reaches "after Printf, before exit(0)" -- meaning the `Printf()` call
+    itself returned normally, no exception, no crash, nothing to indicate
+    the write failed at the C++ level. **This rules out every mechanism
+    this instrumentation was built to catch**: the fd/handle chain does not
+    silently change, drop, or point somewhere unexpected anywhere between
+    `RedirectStdioToParent()` and the actual write call. Whatever is wrong
+    is downstream of a call that, from inside the process, looks completely
+    successful.
+    **A genuinely new, unexpected, load-bearing fact surfaced as a side
+    effect of tracing this**: `GetFileType()` on the very first
+    `GetStdHandle(STD_OUTPUT_HANDLE)` -- before any of this code's own
+    logic runs -- reports `FILE_TYPE_CHAR`, not `FILE_TYPE_PIPE`, and this
+    is true for *every* wxmaxima subprocess this ctest step spawns, not
+    just the failing one (confirmed by grepping the same trace for every
+    other pid's `BindStdStreamToParent(...) start` line -- all say
+    `type=char`). ctest's `--output-on-failure`/regex-matching machinery
+    has to capture each test's stdout+stderr somehow to check
+    `PASS_REGULAR_EXPRESSION`-style assertions against it, and the
+    textbook assumption (an anonymous pipe, which would show up as
+    `FILE_TYPE_PIPE` to the child) does not match what's actually
+    happening here -- every child inherits a real console-type handle
+    instead. This was previously completely unknown and changes the shape
+    of the problem: it is not "something about wxMaxima's own code breaks
+    a working pipe redirection" (the redirection, whatever it targets, is
+    demonstrably rock-solid across this entire trace) -- it is "does a
+    write through a `FILE_TYPE_CHAR` handle via this specific
+    `wxMessageOutputStderr::Printf()` code path actually reach wherever
+    ctest is reading captured test output from, on this toolchain, for a
+    WIN32-subsystem (GUI) child process specifically."
+    **Why there is no working comparison case to rule this in or out**:
+    `wxMessageOutput`/`wxMessageOutputStderr` is used for exactly two
+    things in this codebase -- the `--version` text and `wxCmdLineParser`'s
+    own `--help` usage text -- and `wxmaxima_help_returncode` (the sibling
+    test for `--help`) only checks the exit code, never the captured text.
+    So `wxmaxima_version_string` is the *only* test in the entire suite
+    that both (a) goes through this specific WIN32-subsystem console-output
+    code path and (b) actually asserts on the captured content -- every
+    other content-checked batch test's expected text comes from Maxima's
+    own separate output-writing mechanism over the TCP socket, which never
+    touches `BindStdStreamToParent()`/`wxMessageOutput` at all. There is no
+    other "this exact mechanism, but it happens to pass" test to compare
+    against; the FILE_TYPE_CHAR fact, while true for every process, cannot
+    be dismissed as "clearly fine, everything else uses it too" the way it
+    might look at first glance, because nothing else's *pass/fail result*
+    actually depends on it.
+    **Not yet investigated, and the concrete next steps if this is picked
+    up again**: (1) instrument (still diagnostic-only, still gated behind
+    `WXM_STDIO_DEBUG_LOG`) whether the underlying write call inside
+    `wxMessageOutputStderr::Printf()` -- which per wxWidgets' own source is
+    a plain `fputs(psz, m_fp)` against the `FILE*` passed to its
+    constructor (`stdout`) -- actually succeeds, e.g. by checking `errno`/
+    `ferror(stdout)` right after the call, since the trace above cannot
+    currently distinguish "the write genuinely succeeded but the bytes
+    went somewhere ctest doesn't read" from "some later, still-unlogged
+    step silently swallows or discards them"; (2) as a genuinely separate,
+    clearly-labeled *experiment* (not a fix riding along with a diagnostic
+    change) -- add an explicit `fflush(stdout)` right after the `Printf()`
+    call in the `-v` branch, gated behind the same env var so it only runs
+    on the one CI invocation collecting evidence, and see whether that
+    changes the outcome; if it does, that's real evidence toward a
+    buffering-related mechanism despite `setvbuf(..., _IONBF, 0)` already
+    having been set on this stream earlier -- worth double-checking that
+    the unbuffered mode actually survived being set on a `FILE_TYPE_CHAR`-
+    backed stream specifically, since Windows' CRT console-handle plumbing
+    is not guaranteed to behave identically to its pipe/file plumbing here;
+    (3) look directly at how CMake/CTest's own child-process execution
+    (`cmsysProcess`/kwsys on Windows) sets up stdio redirection for a
+    `WIN32`-subsystem child specifically -- the `FILE_TYPE_CHAR` finding
+    suggests it may not be using `STARTF_USESTDHANDLES` + anonymous pipes
+    the way it would for an ordinary console-subsystem test executable,
+    and if so, understanding *that* mechanism (not wxMaxima's own code) is
+    probably the real key to this bug. This is the first concrete lead in
+    this entire investigation that isn't "one more mechanism ruled out" --
+    it's a real, previously-unknown fact about how this specific CI
+    environment captures a WIN32-subsystem child's output, and the next
+    session picking this up should start here rather than re-tracing the
+    fd/handle chain again, which is now about as thoroughly instrumented
+    as it usefully can be.
 
 - **System tray icon (`src/TrayIcon.{h,cpp}`, GH #2286) -- mirrors the busy
   status, gated entirely by `wxUSE_TASKBARICON`.** The maintainer's own

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1741,6 +1741,42 @@ a local TCP socket.
     removed (or at least re-gated more strictly) once this investigation
     either finds its answer or is shelved again -- it's instrumentation for
     an open question, not a permanent feature.
+  - **Follow-up (2026-09-07, same day): the very first real CI run reproduced
+    the failure exactly as expected, but the uploaded artifact ZIP itself
+    turned out to be unreachable from this sandbox.** PR #2295's
+    `compile_windows` run failed `wxmaxima_version_string` right on cue
+    ("Required regular expression not found", 133/134 -- identical signature
+    to every prior occurrence) and `actions/upload-artifact@v7` uploaded a
+    real 5525-byte `wxm-stdio-debug-log` artifact. But both `curl` (via this
+    sandbox's egress proxy) and the `WebFetch` tool failed identically on the
+    artifact's actual storage backend
+    (`productionresultssa12.blob.core.windows.net`, an Azure Blob Storage
+    host, not `github.com` itself) with `EGRESS_BLOCKED` -- this sandbox's
+    network policy allowlists GitHub's own API/web domains but not the
+    separate blob-storage domain artifact downloads are redirected to.
+    `mcp__github__actions_get`'s `download_workflow_run_artifact` method
+    happily returns a valid, correctly-signed short-lived SAS URL for the
+    artifact -- the GitHub API call itself works fine -- but actually
+    fetching that URL's bytes is what fails, and no available MCP tool
+    proxies that fetch through an allowlisted path. **Fixed by not depending
+    on artifact download at all**: added a new "Print stdio debug log" step
+    (`.github/workflows/compile_windows.yml`, right before "Upload stdio
+    debug log", also `if: always()`) that `Get-Content`s the log file
+    straight into the job's own console output when it exists. Job step logs
+    are fetched through `mcp__github__get_job_logs`, a plain GitHub API call
+    against `github.com` itself -- confirmed working earlier in this exact
+    investigation (that's how the `wxmaxima_version_string` failure text
+    above was read) -- so this sidesteps the blob-storage egress gap
+    entirely instead of trying to work around it. The artifact upload step
+    is left in place too (harmless, and useful for anyone reading this from
+    an environment that *can* reach Azure Blob Storage), but the console
+    print is now the primary, verified-reachable way to retrieve this
+    trace. **Not yet re-verified**: this fix hasn't had a CI run of its own
+    yet -- the analysis above is from the run that used only the
+    artifact-upload step, so the actual `StdioDebugLog()` trace content
+    (the real payoff of this whole diagnostic effort) is still unread as of
+    this entry. That comes in the next follow-up once the console-print
+    step lands and a fresh run reproduces the failure again.
 
 - **System tray icon (`src/TrayIcon.{h,cpp}`, GH #2286) -- mirrors the busy
   status, gated entirely by `wxUSE_TASKBARICON`.** The maintainer's own

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -57,10 +57,11 @@
 #include <vector>
 #ifdef __WXMSW__
 #include <windows.h>
-#include <io.h>      // _open_osfhandle()
+#include <io.h>      // _open_osfhandle(), _get_osfhandle()
 #include <fcntl.h>   // _O_TEXT
 #include <cstdio>    // freopen(), _fdopen(), stdout/stderr/stdin
 #include <cstdint>   // intptr_t
+#include <string>    // std::string, used by the diagnostic StdioDebugLog() only
 #endif
 
 #include "dialogs/ConfigDialogue.h"
@@ -238,6 +239,101 @@ int WINAPI WinMain(_In_ HINSTANCE hI, _In_opt_ HINSTANCE hPrevI, _In_ LPSTR lpCm
 
 
 #ifdef __WXMSW__
+namespace {
+// Diagnostic tracing for the still-unexplained wxmaxima_version_string CI
+// flake (see AGENTS.md's long investigation -- struct-copy-vs-_dup2(),
+// several Wine-simulated mechanisms, and ctest-level self-concurrency via
+// RUN_SERIAL have all been individually ruled out, but the real trigger was
+// never actually observed on the one environment that reproduces it). Every
+// Wine repro built so far wrote via a bare fprintf(stdout, ...); the real
+// --version path instead goes through wxMessageOutputStderr (see its
+// wxMessageOutput::Set() call below), a code path none of those repros ever
+// exercised -- this traces the real path itself instead of a stand-in for it.
+//
+// Entirely inert unless WXM_STDIO_DEBUG_LOG names a real, writable file path
+// (set by the CI workflow only around the one ctest step that reproduces
+// this; never set in a normal build or a normal user's run). Deliberately
+// written via the raw Win32 API (CreateFileW/WriteFile), never the CRT
+// stdio, so tracing the exact stdio-redirection bug this investigates can
+// never itself be perturbed by that same bug -- if the CRT's own stdout is
+// somehow broken, this logging path must not depend on it being intact.
+wxString StdioDebugLogPath() {
+  static wxString path;
+  static bool checked = false;
+  if (!checked) {
+    checked = true;
+    wxGetEnv(wxS("WXM_STDIO_DEBUG_LOG"), &path);
+  }
+  return path;
+}
+
+void StdioDebugLog(const wxString &msg) {
+  wxString path = StdioDebugLogPath();
+  if (path.IsEmpty())
+    return;
+  // Opened with FILE_APPEND_DATA and nothing else (no GENERIC_WRITE) -- per
+  // MSDN this makes Windows position each WriteFile atomically at the
+  // then-current end of file itself, which is what actually keeps concurrent
+  // writers (this ctest step runs with -j 2, and every spawned wxmaxima
+  // process opens/writes/closes this same path independently) from
+  // clobbering each other's lines. Do NOT add an explicit SetFilePointer(...,
+  // FILE_END) call here -- that would reintroduce exactly the race (seek,
+  // then write, as two separate non-atomic steps) this flag exists to avoid.
+  HANDLE file = CreateFileW(path.wc_str(), FILE_APPEND_DATA,
+                            FILE_SHARE_READ | FILE_SHARE_WRITE, nullptr,
+                            OPEN_ALWAYS, FILE_ATTRIBUTE_NORMAL, nullptr);
+  if (file == INVALID_HANDLE_VALUE)
+    return;
+  // Every wxmaxima process this ctest step spawns (there are many, run with
+  // -j 2) shares this one log file -- prefix the PID so lines from different,
+  // interleaved processes can be told apart after the fact; without it the
+  // log would be an unattributable shuffle once more than one process is
+  // alive at a time.
+  wxString prefixed = wxString::Format(wxS("[pid %lu] %s"),
+                                       GetCurrentProcessId(), msg);
+  std::string line = std::string(prefixed.ToUTF8().data()) + "\r\n";
+  DWORD written;
+  WriteFile(file, line.data(), static_cast<DWORD>(line.size()), &written, nullptr);
+  CloseHandle(file);
+}
+
+// Describes a std handle's current identity: whether it exists at all, its
+// raw value (to check whether it ever silently changes across the checkpoints
+// below), and what kind of object it actually is (pipe/disk/char/unknown) --
+// ctest's own redirection should always show "pipe" here.
+wxString DescribeStdHandle(DWORD stdHandleId) {
+  HANDLE h = GetStdHandle(stdHandleId);
+  if ((h == nullptr) || (h == INVALID_HANDLE_VALUE))
+    return wxS("none");
+  // Built from wxS() literals rather than plain char* ones deliberately --
+  // wxString::Format's %s is type-checked against the build's native wxChar
+  // width (see AGENTS.md's note on wxLogMessage/%zu asserting from a mismatched
+  // narrow argument), so a raw "pipe"/"disk"/... here could assert instead of
+  // just printing on a Unicode build.
+  const wxChar *typeName = wxS("unknown");
+  switch (GetFileType(h)) {
+  case FILE_TYPE_PIPE: typeName = wxS("pipe"); break;
+  case FILE_TYPE_DISK: typeName = wxS("disk"); break;
+  case FILE_TYPE_CHAR: typeName = wxS("char"); break;
+  default: break;
+  }
+  return wxString::Format(wxS("handle=%p type=%s"), h, typeName);
+}
+
+// Describes a CRT stream's current fd and the raw OS handle that fd actually
+// resolves to right now -- the key question this whole investigation still
+// has no direct answer for: does this handle value ever change, unexpectedly,
+// between RedirectStdioToParent() succeeding and the --version Printf() call?
+wxString DescribeStream(FILE *stream) {
+  int fd = _fileno(stream);
+  if (fd < 0)
+    return wxS("fd=<invalid>");
+  intptr_t osHandle = _get_osfhandle(fd);
+  return wxString::Format(wxS("fd=%d osHandle=%p"), fd,
+                          reinterpret_cast<void *>(osHandle));
+}
+} // namespace
+
 // wxMaxima is built as a GUI-subsystem binary (add_executable(wxmaxima WIN32 ...)),
 // so Windows does not wire up stdin/stdout/stderr for it. Anything that would
 // normally go to a console -- the --version / --help text, and the
@@ -255,6 +351,8 @@ int WINAPI WinMain(_In_ HINSTANCE hI, _In_opt_ HINSTANCE hPrevI, _In_ LPSTR lpCm
 // This is Windows-only by construction; macOS and Linux never compile it.
 static void BindStdStreamToParent(DWORD stdHandleId, FILE *stream,
                                   bool &consoleAttached) {
+  StdioDebugLog(wxString::Format(wxS("BindStdStreamToParent(%lu) start: %s"),
+                                 stdHandleId, DescribeStdHandle(stdHandleId)));
   HANDLE handle = GetStdHandle(stdHandleId);
   if ((handle == nullptr) || (handle == INVALID_HANDLE_VALUE)) {
     // No inherited handle -- hook up to the launching console, at most once.
@@ -288,6 +386,8 @@ static void BindStdStreamToParent(DWORD stdHandleId, FILE *stream,
   }
   _close(fd); // _dup2 duplicated the descriptor; the original is no longer needed.
   setvbuf(stream, nullptr, _IONBF, 0);
+  StdioDebugLog(wxString::Format(wxS("BindStdStreamToParent(%lu) done: %s"),
+                                 stdHandleId, DescribeStream(stream)));
 }
 
 static void RedirectStdioToParent() {
@@ -295,6 +395,9 @@ static void RedirectStdioToParent() {
   BindStdStreamToParent(STD_OUTPUT_HANDLE, stdout, consoleAttached);
   BindStdStreamToParent(STD_ERROR_HANDLE, stderr, consoleAttached);
   BindStdStreamToParent(STD_INPUT_HANDLE, stdin, consoleAttached);
+  StdioDebugLog(wxString::Format(
+      wxS("RedirectStdioToParent() done: stdout %s, stderr %s"),
+      DescribeStream(stdout), DescribeStream(stderr)));
 }
 
 // True once we have a usable stderr handle (inherited pipe/file or an attached
@@ -382,6 +485,9 @@ bool MyApp::OnInit() {
     if ((errHandle != nullptr) && (errHandle != INVALID_HANDLE_VALUE))
       SetHandleInformation(errHandle, HANDLE_FLAG_INHERIT, 0);
   }
+  StdioDebugLog(wxString::Format(
+      wxS("after SetHandleInformation: stdout %s, stderr %s"),
+      DescribeStream(stdout), DescribeStream(stderr)));
   // For a GUI-subsystem binary the default wxMessageOutput is a *modal* message
   // box. That is what hangs every head-less wxmaxima launch (--version, --help /
   // wxCmdLineParser::Usage(), and early diagnostics all go through it). Now that
@@ -390,6 +496,8 @@ bool MyApp::OnInit() {
   // macOS/Linux never compile this, so the macOS message-output behaviour that
   // is sensitive around menu setup is left exactly as it was.
   wxMessageOutput::Set(new wxMessageOutputStderr(stdout));
+  StdioDebugLog(wxString::Format(
+      wxS("after wxMessageOutput::Set: stdout %s"), DescribeStream(stdout)));
 #endif
   // Needed for making wxSocket work for multiple threads. We currently don't
   // use this feature. But it doesn't harm to be prepared
@@ -580,7 +688,16 @@ bool MyApp::OnInit() {
   }
 
 
+#ifdef __WXMSW__
+  StdioDebugLog(wxString::Format(wxS("before cmdLineParser.Parse(): stdout %s"),
+                                 DescribeStream(stdout)));
+#endif
   int cmdLineError = cmdLineParser.Parse();
+#ifdef __WXMSW__
+  StdioDebugLog(wxString::Format(
+      wxS("after cmdLineParser.Parse() (result=%d): stdout %s"), cmdLineError,
+      DescribeStream(stdout)));
+#endif
 
   if (cmdLineParser.Found(wxS("single_process")))
     m_allWindowsInOneProcess = true;
@@ -748,10 +865,18 @@ bool MyApp::OnInit() {
 #endif
 
   if (cmdLineParser.Found(wxS("v"))) {
+#ifdef __WXMSW__
+    StdioDebugLog(wxString::Format(
+        wxS("entering -v branch: stdout %s, wxMessageOutput::Get()=%p"),
+        DescribeStream(stdout), static_cast<void *>(wxMessageOutput::Get())));
+#endif
     if (WxMaximaGitShortHash())
       wxMessageOutput::Get()->Printf("wxMaxima %s (Git version: %s)\n", WXMAXIMA_VERSION, WxMaximaGitShortHash());
     else
       wxMessageOutput::Get()->Printf("wxMaxima %s\n", WXMAXIMA_VERSION);
+#ifdef __WXMSW__
+    StdioDebugLog(wxS("after Printf, before exit(0)"));
+#endif
     exit(0);
   }
 


### PR DESCRIPTION
## Summary

This is a diagnostic-only change, not a fix — `wxmaxima_version_string`'s intermittent failure on the minGW Windows CI runner (documented at length in `AGENTS.md`) is still unsolved after several Wine-based investigations that each disconfirmed one concrete mechanism (struct-copy vs. `_dup2()`, a shared-handle-after-close theory, ctest-level `-j 2` self-concurrency via `RUN_SERIAL`, and — checked directly this session — the theory that this only fails on PRs, which it doesn't).

Every prior Wine repro tested a bare `fprintf(stdout, ...)` write, never the *actual* code path `--version` uses: `wxMessageOutput::Get()->Printf(...)` through a `wxMessageOutputStderr` object, with a real `cmdLineParser.Parse()` call (`wxCmdLineParser`) running in between. Since GitHub Actions' `windows-latest` runner already is real Windows — the actual gap is its non-interactivity, not a lack of a genuine target — this has the binary record its own evidence instead of running yet another simulation.

**What's added**, all in `src/main.cpp` (Windows-only):
- `StdioDebugLog()`/`DescribeStdHandle()`/`DescribeStream()`: small helpers using raw Win32 I/O (`CreateFileW`/`WriteFile`), never CRT stdio, so tracing a stdio bug can't itself be perturbed by that same bug. Entirely inert unless `WXM_STDIO_DEBUG_LOG` names a log file — a single cached env-var check otherwise, in every normal build and every other CI job.
- Checkpoints bracketing the full chain: `BindStdStreamToParent()` (start/end, per stream), `RedirectStdioToParent()`, right after `SetHandleInformation(..., HANDLE_FLAG_INHERIT, 0)`, around `wxMessageOutput::Set(...)`, around `cmdLineParser.Parse()`, and entering the `-v` branch plus right after its `Printf()` call.

**CI wiring**, in `.github/workflows/compile_windows.yml`:
- `WXM_STDIO_DEBUG_LOG` is set only as an `env:` on the "Run integration tests" step (not job-wide), so the log only covers the one ctest invocation that reproduces this.
- A new "Upload stdio debug log" step follows it, uploading the resulting file as a build artifact (`if: always()`, `if-no-files-found: ignore` — a green run's log, showing nothing anomalous, is itself a useful data point).

No behavior change for macOS, Linux, or any Windows build/run that doesn't set `WXM_STDIO_DEBUG_LOG`.

## Test plan
- [x] Reviewed the full diff by hand for syntax/type correctness (no MinGW+wxWidgets cross-build available in this sandbox to fully compile-check) — in particular fixed a `wxString::Format` `%s`/`char*` width mismatch that could otherwise assert on a Unicode build, and removed an unconditional `fflush(stdout)` from an earlier draft since it would have been a real (non-diagnostic) behavior change riding along with what must stay strictly inert.
- [x] Confirmed the artifact-upload step's relative path resolves correctly against `${{ github.workspace }}`, matching where the traced process's `cd wxMaxima && cd build ... cd .. && cd ..` sequence leaves it.
- [ ] Not verifiable here: the actual captured trace content — that needs a real run on the Windows CI runner, which reproduces this failure on essentially every push.

See `AGENTS.md`'s `wxmaxima_version_string` entry for the full investigation history and the reasoning behind each design choice in this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011iszcZR49S3QXrTKUQjiu6

---
_Generated by [Claude Code](https://claude.ai/code/session_011iszcZR49S3QXrTKUQjiu6)_