### PR TITLE
MCP: report maxima_connected, and add an evaluation_status tool

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1128,6 +1128,36 @@ a local TCP socket.
       convincing, which wasn't attempted this pass); the full existing
       ctest suite's non-batch/non-live-Maxima tests were re-run and a
       clean full rebuild was confirmed to produce zero new warnings.
+  - **Follow-up (2026-09-09): `watch_variable` gave no hint that Maxima was
+    busy, forcing an extra round trip just to learn that -- raised
+    directly by the maintainer: "if the AI tries to query a variable and
+    Maxima is busy which prevents it from receiving a result, is the AI
+    informed about the reason?"** Answer at the time: only partially, and
+    not from the tool an AI would call first. `WatchVariable()`'s own
+    response was just `{"ok": true, "name": "..."}` -- the busy state only
+    surfaced if the AI *separately* called `read_variables` afterward
+    (which already reports `maxima_busy`), a round trip the tool's own
+    description already told it to make ("If maxima_busy is true right
+    after watch_variable, wait and call read_variables again") but that a
+    tool-calling AI could easily skip, reading back an empty value and
+    concluding the variable is undefined instead of "not answered yet."
+    Fixed by adding `maxima_busy` (via the existing `MaximaIsBusy()`)
+    directly to `WatchVariable()`'s own result -- the same information,
+    just available one call earlier, no new mechanism needed since
+    nothing about *whether* Maxima is busy depends on the watch request
+    itself. Also cross-referenced the brand-new `evaluation_status` tool
+    (added earlier this same session) from both `read_variables`' and
+    `watch_variable`'s `ListTools()` descriptions, since `maxima_busy`
+    alone only ever answered "is something blocking this," never the
+    *reason* the maintainer's question was actually asking about (which
+    cell, which command, how long) -- `evaluation_status` is precisely
+    the tool built to answer that, but until this fix nothing pointed an
+    AI at it from here. `test_McpTools.cpp` gained a new WHEN case pinning
+    the true branch (`SetWorkingGroup()` set before calling
+    `WatchVariable()`, checking its response reports `maxima_busy: true`
+    directly) alongside the existing idle-case WHEN, which was extended to
+    also check `maxima_busy == false` -- 104 assertions in 7 test cases
+    now, all passing; full 47-test ctest suite re-run clean.
   - **Not implemented, and shouldn't be without a separate decision: a
     write/evaluate-capable MCP tool.** Raised and discussed directly with
     the user (2026-09-06): unlike `watch_variable`/`unwatch_variable` (see

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1033,6 +1033,101 @@ a local TCP socket.
     (`wxUSE_SECRETSTORE` is off here, so the whole AI Chat tab stays hidden
     per its own gating) -- verified by code reading plus the unit test
     above, not a live screenshot.
+  - **Follow-up (2026-09-09): a new `evaluation_status` MCP tool -- "if
+    Maxima is evaluating, what cell it works on, what command within that
+    cell and for how long this command already is being evaluated,"
+    raised directly by the maintainer.** Two of the three pieces already
+    existed and just needed exposing; the third (elapsed time) needed new
+    state, since nothing in this codebase timed a single in-flight command
+    before this. Researched via a dedicated Explore agent across
+    `Worksheet`, `EvaluationQueue`, `MaximaEvaluator`, `StatusBar` and
+    `GroupCell` before writing anything, specifically to avoid re-deriving
+    "does timing already exist somewhere" from scratch:
+    - **"Is Maxima evaluating" / "which cell"**: `Worksheet::
+      GetWorkingGroup(false)` (no fallback) already returns exactly the
+      cell being worked on right now, `nullptr` the instant nothing is in
+      flight -- the same distinction `McpTools::MaximaIsBusy()` already
+      relies on. No new state needed.
+    - **"Which command within that cell"**: `EvaluationQueue` already
+      tracks this at the single-statement level, not just per-cell --
+      commands are tokenized lazily, one at a time (`m_commands` holds 0
+      or 1 entries, see its own doc comment: this is deliberate, since a
+      cell's lisp/maxima mode split can only be known once the previous
+      command's prompt arrives). `EvaluationQueue::GetCommand()` returns
+      the exact statement text currently in flight;
+      `EvaluationQueue::GetIndex()` its character offset within the
+      cell's input. Both already existed, unused by anything outside
+      `MaximaEvaluator::TriggerEvaluation()` itself.
+    - **"For how long"**: genuinely new. Added `wxStopWatch
+      m_commandStopwatch` + `bool m_commandTimerRunning` to
+      `EvaluationQueue` (`src/EvaluationQueue.h`), with
+      `MarkCommandSent()` (starts/restarts it) and
+      `GetCommandElapsedMilliseconds()` (returns -1 when nothing is
+      currently timed). **Deliberately started at the moment the command
+      is actually written to the socket, not when it's tokenized**:
+      `EvaluationQueue::AddTokens()`/`ProduceNextCommand()` can produce a
+      command that then sits briefly unsent (`MaximaEvaluator::
+      TriggerEvaluation()` still has to validate its parenthesis balance
+      in the *current* lisp/maxima mode before deciding to send it at
+      all -- see that function's own comment on why this check has to
+      happen per-command, not per-cell) -- timing from tokenization would
+      report time Maxima was never actually working. `MarkCommandSent()`
+      is called from `TriggerEvaluation()` immediately after the real
+      `SendMaxima(text, true)` call that dispatches it
+      (`MaximaEvaluator.cpp`, right where `m_wxMaxima.m_maximaBusy = true`
+      is also set a line later). The timer is stopped again (`
+      m_commandTimerRunning = false`) at the top of `RemoveFirst()`,
+      before that command is erased -- and in `Clear()`, for the abort/
+      restart paths. Confirmed by tracing every call site that can end a
+      command's lifetime (`RemoveFirst()`'s own erase, `Clear()`) that
+      none can leave a stale "still timing" flag set once the command it
+      was timing is gone.
+    - **New tool**: `McpTools::EvaluationStatus()` (`src/mcp/McpTools.{h,
+      cpp}`) returns `{"evaluating": bool}` alone when idle, or adds
+      `cell_uuid`/`is_current`/`has_error` (same fields `CellSummary()`
+      already surfaces elsewhere, built inline here rather than through
+      `CellSummary()` itself since that needs a document-order `index`
+      this tool has no reason to compute), `command` (the exact in-flight
+      statement text), `command_index_in_cell`, `elapsed_ms` (omitted
+      rather than reported as a bogus value in the -- believed impossible
+      -- case `GetCommandElapsedMilliseconds()` returns -1 while
+      `evaluating` is true), `commands_left_in_cell` (existing
+      `EvaluationQueue::CommandsLeftInCell()`, already a "best-effort
+      hint" per its own doc comment, since lazy tokenization means the
+      exact count isn't knowable ahead of time) and `queue_length`
+      (`EvaluationQueue::Size()`, counting the currently-evaluating cell
+      too -- "how much work is left," not "how much is waiting behind the
+      current one"). **Queued-but-not-yet-sent is deliberately reported as
+      `evaluating: false`**: a cell freshly handed to `AddToQueue()` gets
+      tokenized (`m_commands` non-empty) before `TriggerEvaluation()` ever
+      calls `MarkCommandSent()` on it, and calling `GetWorkingGroup(false)`
+      at that point still correctly returns `nullptr` -- so "a command
+      exists in the queue" and "a command has actually been dispatched"
+      stay distinguishable, matching the tool's own framing (deliberately
+      *not* reusing `MaximaIsBusy()`'s broader "busy OR queued" definition
+      here, since the maintainer's own wording asked specifically about
+      *evaluating*).
+    - **Verification**: `test_McpTools.cpp` gained a new SCENARIO with
+      three GIVENs -- nothing queued (evaluating=false, no per-command
+      fields present at all, checked with `CHECK_FALSE(status.contains(...))`
+      rather than assuming a default), a cell actually
+      dispatched via the real `AddToQueue()` + `MarkCommandSent()` +
+      `SetWorkingGroup()` sequence (evaluating=true, correct uuid/command
+      text/non-negative elapsed_ms), and a cell merely queued via
+      `AddToQueue()` with neither `MarkCommandSent()` nor
+      `SetWorkingGroup()` called (evaluating stays false despite
+      `queue_length` being 1) -- this last case is exactly the "tokenized
+      but not dispatched" distinction above, pinned as its own scenario so
+      a future change can't collapse it back into "queued counts as
+      evaluating" without a test failing. 101 assertions in 7 test cases
+      now, all passing. Not verified live (no live Maxima connection in
+      this sandbox for this specific tool -- unlike `search_cells`'s own
+      live-`curl` verification, actually timing a real multi-second Maxima
+      computation and reading `elapsed_ms` back through a live MCP
+      `tools/call` would need a genuinely slow real computation to be
+      convincing, which wasn't attempted this pass); the full existing
+      ctest suite's non-batch/non-live-Maxima tests were re-run and a
+      clean full rebuild was confirmed to produce zero new warnings.
   - **Not implemented, and shouldn't be without a separate decision: a
     write/evaluate-capable MCP tool.** Raised and discussed directly with
     the user (2026-09-06): unlike `watch_variable`/`unwatch_variable` (see

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1158,6 +1158,87 @@ a local TCP socket.
     directly) alongside the existing idle-case WHEN, which was extended to
     also check `maxima_busy == false` -- 104 assertions in 7 test cases
     now, all passing; full 47-test ctest suite re-run clean.
+  - **Follow-up (2026-09-09): a new `maxima_connected` field on
+    `read_variables`/`watch_variable`/`evaluation_status` -- raised
+    directly by the maintainer as a follow-up to the `maxima_busy` fix
+    above: "if Maxima isn't running at all and that causes the variable
+    query to fail, is the AI informed about that?"** Researched via a
+    dedicated Explore agent before answering (across `Worksheet`,
+    `Variablespane`, `MaximaProcessManager`, `Maxima` and `StatusBar`)
+    rather than guessing: the answer was **no**. `MaximaIsBusy()` (and
+    `EvaluationStatus()`'s `evaluating`) only ever read `Worksheet::
+    GetWorkingGroup()`/`GetEvaluationQueue()` -- both describe *evaluation-
+    queue content*, not process/socket state -- so when Maxima was never
+    started, crashed, or was killed, they report exactly the same "false"/
+    "nothing queued" as a genuinely idle, fully-answered Maxima. The real
+    connection state (`Maxima::IsConnected()`, `m_socket->IsConnected()`)
+    lives on `wxMaxima::m_client`, completely unreachable from a bare
+    `Worksheet*`/`Variablespane*` -- the only two things `McpTools` ever
+    holds (confirmed: no connection concept exists anywhere on `Worksheet`/
+    `Variablespane` themselves).
+    **Plumbing chosen**: a `std::function<bool()>` callback, not a new
+    constructor parameter or a raw `MaximaProcessManager*`/`wxMaxima*`
+    pointer threaded down -- a raw pointer would force every existing
+    `test_McpTools.cpp` fixture (none of which build a live Maxima
+    connection, or even a full `wxMaxima` app object) to either construct
+    one or special-case a null check, where a callback left unset simply
+    defaults to "assume connected" (the correct default: nothing indicates
+    trouble, so don't report false alarm). `McpTools::SetConnectionCheck()`
+    stores it; `IsMaximaConnected()` is `!m_isMaximaConnected ||
+    m_isMaximaConnected()`. `McpServer::SetConnectionCheck()` forwards to
+    it. Wired up once, in `wxMaxima`'s own constructor (`wxMaxima.cpp`,
+    right after `StatusMaximaBusy(StatusBar::MaximaStatus::disconnected)`):
+    `m_mcpServer->SetConnectionCheck([this] { return m_client &&
+    m_client->IsConnected(); });` -- safe to register this early even
+    though `m_client` is still null at that exact point in the constructor,
+    since the lambda captures `this` and re-reads `m_client` fresh on every
+    future call, not at bind time; `m_mcpServer` itself (constructed inside
+    `wxMaximaFrame`'s constructor, a base-class step that runs *before*
+    `wxMaxima`'s own body) is reachable here because it's declared
+    `protected`, not `private`, on `wxMaximaFrame` -- no virtual-dispatch
+    trick or deferred-`this`-cast needed, unlike what would have been
+    required had it been private.
+    **A real, self-inflicted compile break caught immediately, not shipped**:
+    the first draft's new Doxygen comment on `McpTools::SetConnectionCheck()`
+    literally wrote out "a Worksheet*/Variablespane* pointer" -- the `*/`
+    inside that phrase closed the `/*! ... */` block comment early, so
+    every subsequent line (the setter itself, `IsMaximaConnected()`, the
+    private member) silently fell *outside* the comment and became raw,
+    malformed declarations, breaking every translation unit that includes
+    `McpTools.h` (i.e. nearly the whole `wxMaximaFrame.h` include chain)
+    with a wall of "missing terminating '" / "does not name a type" errors
+    that look nothing like their real cause at first glance. Fixed by
+    rewording to avoid embedding a literal `*/` inside a block comment at
+    all ("a Worksheet/Variablespane pointer") -- worth remembering
+    generally: any doc comment mentioning two pointer types back to back
+    with a slash between them (`Foo*/Bar*`) is one keystroke away from
+    silently truncating the comment it's written inside.
+    **Deliberately reported from all three tools, not just
+    `read_variables`**: `watch_variable` gets it for the same reason it
+    already got `maxima_busy` in the follow-up just above (save the AI a
+    round trip it might not think to make); `evaluation_status` gets it
+    too since `evaluating: false` has exactly the same "idle vs. not
+    running" ambiguity `maxima_busy` does, and the whole point of that
+    tool is to answer detailed "why" questions this ambiguity would
+    otherwise leave unanswered. All three `ListTools()` descriptions were
+    updated to explain the distinction explicitly, not just add the field
+    silently.
+    **Verification**: a new dedicated SCENARIO in `test_McpTools.cpp`
+    calls `tools.SetConnectionCheck([] { return false; })` once and checks
+    all three tools (`EvaluationStatus()`, `ReadVariables()`,
+    `WatchVariable()`) report `maxima_connected: false` alongside their
+    existing busy/evaluating fields staying `false` too -- pinning that
+    the two are independent signals, not one implying the other. The
+    pre-existing "nothing queued" `EvaluationStatus()` scenario also now
+    checks `maxima_connected == true` (the un-configured default) so a
+    future regression that silently flips that default would be caught.
+    112 assertions in 8 test cases now, all passing; full 47-test ctest
+    suite and a full clean rebuild (zero new warnings) re-confirmed
+    afterward. Not verified live end-to-end (no real Maxima
+    connect/disconnect cycle driven through a live MCP `tools/call` in
+    this pass) -- the callback wiring itself was checked by reading the
+    exact construction-order/`protected`-visibility facts above, not by
+    running the real app with Maxima killed mid-session.
   - **Not implemented, and shouldn't be without a separate decision: a
     write/evaluate-capable MCP tool.** Raised and discussed directly with
     the user (2026-09-06): unlike `watch_variable`/`unwatch_variable` (see
@@ -3429,6 +3510,28 @@ has already been broken.
 Items the maintainer has flagged as worth doing but hasn't asked for yet -- don't
 start on these without checking in first, but pick them up if asked for "what's
 next" style work.
+
+- **New MCP tools: let an AI query which sidebars are currently visible, and
+  show/hide them.** Explicitly requested by the maintainer (2026-09-09) as
+  "for the next branch and PR" -- i.e. scoped as a deliberately separate PR
+  from the `evaluation_status`/`maxima_connected` work above, not something
+  to fold into it. Not yet started. Likely shape, based on this session's
+  own conventions: a `list_sidebars` (or fold into an existing tool) read
+  query over `wxMaximaFrame`'s existing `m_sidebarNames`/pane-visibility
+  bookkeeping (`ShowPane()`/`IsPaneDisplayed()`, the same generic mechanism
+  the "Dockable Find and Replace" entry above already documents using for
+  every `EventIDs::menu_pane_*` sidebar), plus a `show_sidebar`/`hide_sidebar`
+  pair calling `ShowPane()` directly. Two things worth checking before
+  writing any code: (1) `McpTools` currently only holds a `Worksheet*`/
+  `Variablespane*` -- reaching `wxMaximaFrame`'s pane-visibility API needs
+  the same kind of new plumbing the `maxima_connected` follow-up just added
+  (a callback/pointer threaded in from wherever `McpServer` is actually
+  constructed), not something already reachable; (2) whether toggling a
+  sidebar's visibility is safe to classify alongside `watch_variable`/
+  `unwatch_variable` as a "changes only what's displayed, never worksheet
+  content" write (this section's own "why 'read-only except two things' and
+  not stricter" reasoning) needs confirming with the maintainer the same way
+  those two were, rather than assumed by analogy.
 
 - **Real tab handling in `EditorCell`:** tabs are currently just replaced by
   spaces on input instead of being handled as their own character/column-stop

--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,11 @@
   output contains a given plain-text or regular-expression pattern, so an
   AI can jump straight to the relevant cell(s) of a large worksheet instead
   of reading it all.
+- Added an MCP evaluation_status tool that reports whether Maxima is
+  actively evaluating a command right now, which cell, the exact statement
+  within that cell currently running (a cell can hold several $/;-separated
+  statements), and how many milliseconds that specific statement has been
+  running.
 - The MCP server and AI Chat sidebar's worksheet context now tell an AI
   where the user's cursor is and which cell (if any) has an error, so it
   can actually answer "what's wrong with my current cell" or "the cell

--- a/NEWS.md
+++ b/NEWS.md
@@ -21,6 +21,10 @@
 - MCP's watch_variable now reports maxima_busy in its own response, so an
   AI adding a watch no longer needs a separate read_variables call just to
   learn that Maxima is still busy and the value isn't available yet.
+- MCP's read_variables, watch_variable and evaluation_status now report
+  maxima_connected, so an AI can tell "Maxima isn't running at all" apart
+  from "Maxima is running and genuinely idle" -- previously both cases
+  looked identical (maxima_busy/evaluating both false).
 - The MCP server and AI Chat sidebar's worksheet context now tell an AI
   where the user's cursor is and which cell (if any) has an error, so it
   can actually answer "what's wrong with my current cell" or "the cell

--- a/NEWS.md
+++ b/NEWS.md
@@ -18,6 +18,9 @@
   within that cell currently running (a cell can hold several $/;-separated
   statements), and how many milliseconds that specific statement has been
   running.
+- MCP's watch_variable now reports maxima_busy in its own response, so an
+  AI adding a watch no longer needs a separate read_variables call just to
+  learn that Maxima is still busy and the value isn't available yet.
 - The MCP server and AI Chat sidebar's worksheet context now tell an AI
   where the user's cursor is and which cell (if any) has an error, so it
   can actually answer "what's wrong with my current cell" or "the cell

--- a/src/EvaluationQueue.cpp
+++ b/src/EvaluationQueue.cpp
@@ -51,6 +51,7 @@ void EvaluationQueue::Clear() {
   m_integrityFailure = false;
   m_integrityFailureEnqueuedText.Clear();
   m_integrityFailureCurrentText.Clear();
+  m_commandTimerRunning = false;
 }
 
 bool EvaluationQueue::IsInQueue(GroupCell *gr) const {
@@ -113,6 +114,10 @@ void EvaluationQueue::AddHiddenTreeToQueue(const GroupCell *gr) {
 void EvaluationQueue::RemoveFirst() {
   if (!m_commands.empty()) {
     m_workingGroupChanged = false;
+    // The command whose elapsed time was being timed just finished (its
+    // result/prompt arrived) -- MarkCommandSent() will start a fresh timer
+    // once (if) the next command is actually sent.
+    m_commandTimerRunning = false;
     m_commands.erase(m_commands.begin());
     // The prompt for the command we just finished may have switched lisp mode on
     // or off, so tokenize the next command of THIS cell in the mode current now.

--- a/src/EvaluationQueue.h
+++ b/src/EvaluationQueue.h
@@ -35,6 +35,7 @@
 #include "precomp.h"
 #include "cells/GroupCell.h"
 #include <wx/arrstr.h>
+#include <wx/stopwatch.h>
 #include <vector>
 #include <utility>
 
@@ -95,6 +96,20 @@ private:
   std::size_t m_size;
   //! The label the user has assigned to the current command.
   wxString m_userLabel;
+
+  //! Runs from the moment the current command's text is actually handed to
+  //! Maxima::Write() (MarkCommandSent(), called from
+  //! MaximaEvaluator::TriggerEvaluation() right where it sends it) until
+  //! RemoveFirst() erases that command once its result/prompt arrives.
+  //! Deliberately NOT started any earlier (e.g. when the command is first
+  //! tokenized by ProduceNextCommand()): a command can sit tokenized-but-
+  //! unsent for a moment (e.g. while its parenthesis balance is validated),
+  //! and "how long has Maxima actually been working on this" should only
+  //! count time Maxima itself could plausibly have been evaluating it.
+  wxStopWatch m_commandStopwatch;
+  //! Whether m_commandStopwatch is currently timing a real, sent command --
+  //! wxStopWatch itself has no "not running" state to query once started.
+  bool m_commandTimerRunning = false;
 
   //! A cell in the queue, together with the text it had when it was queued
   //! (see m_integrityFailure below).
@@ -215,6 +230,23 @@ public:
   //! mode, only known once each prior command's prompt arrives) this is a
   //! best-effort progress hint, not an exact count.
   int CommandsLeftInCell() const;
+
+  //! Call exactly once, right after the current command's text is actually
+  //! written to Maxima's socket -- starts (or restarts) the "how long has
+  //! this command been running" clock GetCommandElapsedMilliseconds() reads.
+  void MarkCommandSent()
+    {
+      m_commandStopwatch.Start();
+      m_commandTimerRunning = true;
+    }
+
+  //! Milliseconds since MarkCommandSent() was last called for the command
+  //! currently in flight, or -1 if no command has been sent since the last
+  //! RemoveFirst()/Clear() (nothing to report an elapsed time for).
+  long GetCommandElapsedMilliseconds() const
+    {
+      return m_commandTimerRunning ? m_commandStopwatch.Time() : -1;
+    }
 };
 
 

--- a/src/MaximaEvaluator.cpp
+++ b/src/MaximaEvaluator.cpp
@@ -481,6 +481,13 @@ void MaximaEvaluator::TriggerEvaluation() {
       if (!MaximaProtocol::CommandIsBlank(m_wxMaxima.m_configCommands))
         SendMaxima(m_wxMaxima.m_configCommands);
       SendMaxima(text, true);
+      // Starts the "how long has Maxima been working on this specific
+      // command" clock the MCP evaluation_status tool reports -- right here,
+      // not any earlier, since this is the moment the command actually
+      // leaves for Maxima (see EvaluationQueue::MarkCommandSent()'s own
+      // comment for why it isn't started when the command is merely
+      // tokenized).
+      m_wxMaxima.GetWorksheet()->GetEvaluationQueue().MarkCommandSent();
       m_wxMaxima.m_maximaBusy = true;
       // Now that we have sent a command we need to query all variable values
       // anew

--- a/src/mcp/McpServer.h
+++ b/src/mcp/McpServer.h
@@ -25,6 +25,7 @@
 #include "precomp.h"
 #include "McpTools.h"
 #include <wx/socket.h>
+#include <functional>
 #include <memory>
 #include <string>
 #include <unordered_map>
@@ -86,6 +87,17 @@ public:
   //! once after construction and again whenever the option or port could
   //! have changed (the Options dialog closing).
   void ReconcileWithConfig(const Configuration &config);
+
+  //! Plugs in a live "is Maxima actually connected right now" query --
+  //! see McpTools::SetConnectionCheck() for why this can't be answered
+  //! from a Worksheet/Variablespane alone and has to be threaded in from
+  //! outside. Call once, from wherever this McpServer is constructed
+  //! (wxMaximaFrame doesn't itself know this; wxMaxima, which owns the
+  //! actual Maxima process/socket, does).
+  void SetConnectionCheck(std::function<bool()> isConnected)
+    {
+      m_tools.SetConnectionCheck(std::move(isConnected));
+    }
 
 private:
   //! One accepted-but-not-yet-fully-handled HTTP connection.

--- a/src/mcp/McpTools.cpp
+++ b/src/mcp/McpTools.cpp
@@ -284,6 +284,22 @@ json McpTools::ListTools() const {
       "watchlist, the same as removing it from that sidebar by hand."},
      {"inputSchema", nameArg("The Maxima variable name to stop watching")}});
 
+  tools.push_back(
+    {{"name", "evaluation_status"},
+     {"description",
+      "Report whether Maxima is actively evaluating a command right now: "
+      "\"evaluating\" (false if it's idle -- everything else below is only "
+      "present when true), the cell's uuid/is_current/has_error (see "
+      "list_cells), the exact text of the specific statement currently in "
+      "flight (a code cell can hold several $/;-separated statements; only "
+      "one is ever sent to Maxima at a time) plus its character offset "
+      "within the cell's input, how many milliseconds that one statement "
+      "has been running (elapsed_ms), roughly how many more statements are "
+      "left in this same cell (commands_left_in_cell), and how many cells "
+      "in total still have work queued up (queue_length, which counts the "
+      "cell currently evaluating too)."},
+     {"inputSchema", noArgs}});
+
   json searchSchema;
   searchSchema["type"] = "object";
   searchSchema["properties"]["pattern"] = {
@@ -341,6 +357,8 @@ json McpTools::CallTool(const wxString &name, const json &arguments) const {
     return TextResult(ReadSection(arguments));
   if (name == wxS("read_variables"))
     return TextResult(ReadVariables());
+  if (name == wxS("evaluation_status"))
+    return TextResult(EvaluationStatus());
   if (name == wxS("watch_variable"))
     return TextResult(WatchVariable(arguments));
   if (name == wxS("unwatch_variable"))
@@ -514,6 +532,41 @@ json McpTools::ReadVariables() const {
   // value here can just mean "no answer yet," not "undefined." Surfaced
   // explicitly so a tool-calling AI doesn't misread the difference.
   result["maxima_busy"] = MaximaIsBusy();
+  return result;
+}
+
+json McpTools::EvaluationStatus() const {
+  json result;
+  if (!m_worksheet) {
+    result["evaluating"] = false;
+    result["queue_length"] = 0;
+    return result;
+  }
+  EvaluationQueue &queue = m_worksheet->GetEvaluationQueue();
+  // GetWorkingGroup(false) (no fallback) is the cell Maxima is actually
+  // waiting on an answer for right now -- null the instant nothing is
+  // in flight, even if the queue still has more cells waiting behind it
+  // (same distinction MaximaIsBusy() already relies on).
+  GroupCell *working = m_worksheet->GetWorkingGroup(false);
+  result["evaluating"] = (working != nullptr);
+  result["queue_length"] = queue.Size();
+  if (working) {
+    if (working->GetUUID().IsEmpty())
+      working->GenerateUUID();
+    result["cell_uuid"] = U8(working->GetUUID());
+    result["is_current"] = (working == CurrentCell());
+    result["has_error"] = HasError(*working);
+    result["command"] = U8(queue.GetCommand());
+    result["command_index_in_cell"] = queue.GetIndex();
+    // -1 means "no command has actually been sent since the queue last
+    // advanced" -- shouldn't normally happen while working != nullptr, but
+    // omitting the field entirely rather than reporting a bogus 0 keeps
+    // that (hopefully impossible) case honest.
+    long elapsedMs = queue.GetCommandElapsedMilliseconds();
+    if (elapsedMs >= 0)
+      result["elapsed_ms"] = elapsedMs;
+    result["commands_left_in_cell"] = queue.CommandsLeftInCell();
+  }
   return result;
 }
 

--- a/src/mcp/McpTools.cpp
+++ b/src/mcp/McpTools.cpp
@@ -266,7 +266,11 @@ json McpTools::ListTools() const {
       "\"undefined.\" If maxima_busy is true right after watch_variable, "
       "wait and call read_variables again rather than concluding the "
       "variable has no value; call evaluation_status for the specific "
-      "reason (which cell/command, and for how long)."},
+      "reason (which cell/command, and for how long). Also reports "
+      "maxima_connected: if false, Maxima isn't running at all (crashed, "
+      "was killed, or was never started) -- maxima_busy will show false "
+      "too in that case, but no amount of waiting or re-querying will ever "
+      "produce a value, since nothing is running to answer the query."},
      {"inputSchema", noArgs}});
   tools.push_back(
     {{"name", "watch_variable"},
@@ -274,12 +278,13 @@ json McpTools::ListTools() const {
       "Add a Maxima variable name to the Variables sidebar's watchlist, the "
       "same as typing it into that sidebar by hand. Its value becomes "
       "available via read_variables only once Maxima actually answers the "
-      "query this triggers -- not immediately, and not at all while Maxima "
-      "is busy. This call's own maxima_busy field already reports whether "
-      "that's the case right now, without a separate read_variables round "
-      "trip; call evaluation_status for the specific reason (which cell/ "
-      "command, and for how long) if it is. Does not touch worksheet "
-      "content or evaluate anything."},
+      "query this triggers -- not immediately, not while Maxima is busy, "
+      "and not at all if Maxima isn't running. This call's own maxima_busy "
+      "and maxima_connected fields already report both of those right now, "
+      "without a separate read_variables round trip -- see read_variables' "
+      "own description for what each one means; call evaluation_status for "
+      "the specific reason (which cell/command, and for how long) if busy. "
+      "Does not touch worksheet content or evaluate anything."},
      {"inputSchema", nameArg("The Maxima variable name, e.g. \"x\" or \"%o3\"")}});
   tools.push_back(
     {{"name", "unwatch_variable"},
@@ -301,7 +306,10 @@ json McpTools::ListTools() const {
       "has been running (elapsed_ms), roughly how many more statements are "
       "left in this same cell (commands_left_in_cell), and how many cells "
       "in total still have work queued up (queue_length, which counts the "
-      "cell currently evaluating too)."},
+      "cell currently evaluating too). Also reports maxima_connected "
+      "(always present, even when evaluating is false): if false, Maxima "
+      "isn't running at all -- \"evaluating: false\" alone can't tell a "
+      "genuinely idle Maxima apart from no Maxima process to begin with."},
      {"inputSchema", noArgs}});
 
   json searchSchema;
@@ -536,6 +544,12 @@ json McpTools::ReadVariables() const {
   // value here can just mean "no answer yet," not "undefined." Surfaced
   // explicitly so a tool-calling AI doesn't misread the difference.
   result["maxima_busy"] = MaximaIsBusy();
+  // maxima_busy alone can't tell "genuinely idle, fully answered" apart
+  // from "there is no Maxima process to answer at all" -- both report
+  // false. This does: false here means a variable's value (or lack of one)
+  // isn't going to change no matter how long you wait, since nothing is
+  // running to ever answer the query watching it triggered.
+  result["maxima_connected"] = IsMaximaConnected();
   return result;
 }
 
@@ -554,6 +568,10 @@ json McpTools::EvaluationStatus() const {
   GroupCell *working = m_worksheet->GetWorkingGroup(false);
   result["evaluating"] = (working != nullptr);
   result["queue_length"] = queue.Size();
+  // Same reasoning as ReadVariables()'s own maxima_connected: "evaluating:
+  // false" alone doesn't distinguish a genuinely idle Maxima from no
+  // Maxima process at all.
+  result["maxima_connected"] = IsMaximaConnected();
   if (working) {
     if (working->GetUUID().IsEmpty())
       working->GenerateUUID();
@@ -589,6 +607,11 @@ json McpTools::WatchVariable(const json &arguments) const {
   // has no way to tell "not answered yet" apart from "genuinely
   // undefined" without a second round trip it might not think to make.
   result["maxima_busy"] = MaximaIsBusy();
+  // Same reasoning again: maxima_busy alone reports false whether Maxima is
+  // genuinely idle or isn't running at all -- this tells the two apart, so
+  // an AI doesn't wait forever for a value from a query nothing will ever
+  // answer.
+  result["maxima_connected"] = IsMaximaConnected();
   return result;
 }
 

--- a/src/mcp/McpTools.cpp
+++ b/src/mcp/McpTools.cpp
@@ -265,7 +265,8 @@ json McpTools::ListTools() const {
       "empty value in that case likely means \"not answered yet,\" not "
       "\"undefined.\" If maxima_busy is true right after watch_variable, "
       "wait and call read_variables again rather than concluding the "
-      "variable has no value."},
+      "variable has no value; call evaluation_status for the specific "
+      "reason (which cell/command, and for how long)."},
      {"inputSchema", noArgs}});
   tools.push_back(
     {{"name", "watch_variable"},
@@ -274,7 +275,10 @@ json McpTools::ListTools() const {
       "same as typing it into that sidebar by hand. Its value becomes "
       "available via read_variables only once Maxima actually answers the "
       "query this triggers -- not immediately, and not at all while Maxima "
-      "is busy (see read_variables' maxima_busy). Does not touch worksheet "
+      "is busy. This call's own maxima_busy field already reports whether "
+      "that's the case right now, without a separate read_variables round "
+      "trip; call evaluation_status for the specific reason (which cell/ "
+      "command, and for how long) if it is. Does not touch worksheet "
       "content or evaluate anything."},
      {"inputSchema", nameArg("The Maxima variable name, e.g. \"x\" or \"%o3\"")}});
   tools.push_back(
@@ -580,6 +584,11 @@ json McpTools::WatchVariable(const json &arguments) const {
   json result;
   result["ok"] = true;
   result["name"] = U8(name);
+  // Reported here too, not just from read_variables: without it, an AI
+  // that calls watch_variable then immediately reads back an empty value
+  // has no way to tell "not answered yet" apart from "genuinely
+  // undefined" without a second round trip it might not think to make.
+  result["maxima_busy"] = MaximaIsBusy();
   return result;
 }
 

--- a/src/mcp/McpTools.h
+++ b/src/mcp/McpTools.h
@@ -24,6 +24,7 @@
 
 #include <nlohmann/json.hpp>
 #include <wx/string.h>
+#include <functional>
 #include <stdexcept>
 #include <string>
 
@@ -70,6 +71,21 @@ public:
 class McpTools {
 public:
   McpTools(Worksheet *worksheet, Variablespane *variablesPane);
+
+  /*! Lets the owner (McpServer, wired up from wxMaxima -- see
+    McpServer::SetConnectionCheck()) plug in a live "is the Maxima process
+    actually connected right now" query. McpTools has no way to know this on
+    its own: that state lives on Maxima/MaximaProcessManager, owned by
+    wxMaxima, which a Worksheet/Variablespane pointer alone can't reach --
+    see IsMaximaConnected()'s own comment for why this matters. Left unset
+    (as every existing test in test_McpTools.cpp does, with no live Maxima
+    to ask about) means "assume connected"; only production wiring should
+    ever pass a real check.
+  */
+  void SetConnectionCheck(std::function<bool()> isConnected)
+    {
+      m_isMaximaConnected = std::move(isConnected);
+    }
 
   //! The tools/list result: name/description/inputSchema for every tool below.
   nlohmann::json ListTools() const;
@@ -118,6 +134,8 @@ public:
 private:
   Worksheet *m_worksheet;
   Variablespane *m_variablesPane;
+  //! See SetConnectionCheck(). Empty (never set) means "assume connected."
+  std::function<bool()> m_isMaximaConnected;
 
   //! Finds the (still tree-attached) GroupCell with this UUID, or nullptr.
   GroupCell *FindGroupByUUID(const wxString &uuid) const;
@@ -151,6 +169,19 @@ private:
   //! or unchanged value there may just mean "not answered yet," not "this
   //! variable is undefined."
   bool MaximaIsBusy() const;
+  //! Is the Maxima process actually running and connected right now? A user
+  //! asked directly: "if Maxima isn't running at all and that causes a
+  //! variable query to fail, is the AI informed about that?" -- it wasn't:
+  //! MaximaIsBusy() (and, before this, EvaluationStatus()'s "evaluating")
+  //! reads Worksheet::GetWorkingGroup()/GetEvaluationQueue(), which are both
+  //! about evaluation-QUEUE content, not process/socket state -- when
+  //! Maxima was never started, crashed, or was killed, they report exactly
+  //! the same "false"/"nothing queued" as a genuinely idle, fully-answered
+  //! Maxima, with no way to tell the two apart. See SetConnectionCheck().
+  bool IsMaximaConnected() const
+    {
+      return !m_isMaximaConnected || m_isMaximaConnected();
+    }
   //! Truncates to MAX_TEXT_LENGTH, appending a note if it had to.
   static wxString CapLength(wxString text);
   //! Truncates text to at most maxLen characters -- the end if fromEnd,

--- a/src/mcp/McpTools.h
+++ b/src/mcp/McpTools.h
@@ -84,6 +84,13 @@ public:
   nlohmann::json ReadToc() const;
   nlohmann::json ReadSection(const nlohmann::json &arguments) const;
   nlohmann::json ReadVariables() const;
+  //! Is Maxima actively evaluating a command right now, and if so: which
+  //! cell, which exact statement within that (possibly multi-statement)
+  //! cell, and how long has that specific statement been running? Raised by
+  //! the maintainer directly: "A way to query if Maxima is evaluating, what
+  //! cell it works on, what command within that cell and for how long this
+  //! command already is being evaluated."
+  nlohmann::json EvaluationStatus() const;
   nlohmann::json WatchVariable(const nlohmann::json &arguments) const;
   nlohmann::json UnwatchVariable(const nlohmann::json &arguments) const;
   //! Finds every cell whose input and/or output contains `pattern` (a plain

--- a/src/wxMaxima.cpp
+++ b/src/wxMaxima.cpp
@@ -396,6 +396,19 @@ wxMaxima::wxMaxima(wxWindow *parent, int id,
 
   StatusMaximaBusy(StatusBar::MaximaStatus::disconnected);
 
+  // Lets the MCP server's evaluation_status/read_variables/watch_variable
+  // tools tell "Maxima isn't running at all" apart from "genuinely idle" --
+  // see McpTools::SetConnectionCheck()'s own comment for why McpTools can't
+  // answer this on its own (m_client lives here, on wxMaxima, not on
+  // Worksheet/Variablespane, which are all McpTools/McpServer ever hold).
+  // Safe to wire up now even though m_client is still null at this point in
+  // the constructor: the lambda captures `this` and reads m_client fresh on
+  // every call, not at bind time -- it will report whatever m_client
+  // actually is whenever an MCP request later asks.
+  if (m_mcpServer)
+    m_mcpServer->SetConnectionCheck(
+      [this] { return m_client && m_client->IsConnected(); });
+
   m_statusBar->GetNetworkStatusElement()->Bind(wxEVT_LEFT_DCLICK, &wxMaxima::NetworkDClick, this);
   m_statusBar->GetMaximaStatusElement()->Bind(wxEVT_LEFT_DCLICK, &wxMaxima::MaximaDClick, this);
 

--- a/test/unit_tests/test_McpTools.cpp
+++ b/test/unit_tests/test_McpTools.cpp
@@ -362,8 +362,11 @@ SCENARIO("McpTools' variable watchlist tools only ever touch the sidebar, "
 
     WHEN("WatchVariable() adds a valid variable name") {
       nlohmann::json result = tools.WatchVariable(Args("name", "myvar"));
-      THEN("it reports success and the sidebar now tracks it") {
+      THEN("it reports success, the sidebar now tracks it, and it reports "
+          "maxima_busy itself (no separate read_variables round trip "
+          "needed just to learn that)") {
         CHECK(result["ok"] == true);
+        CHECK(result["maxima_busy"] == false);
         std::vector<wxString> names = g_vars->GetVarnames();
         CHECK(std::find(names.begin(), names.end(), wxS("myvar")) !=
              names.end());
@@ -385,6 +388,19 @@ SCENARIO("McpTools' variable watchlist tools only ever touch the sidebar, "
         CHECK_THROWS_AS(tools.WatchVariable(Args("name", "1bad:name")),
                         McpToolError);
       }
+    }
+
+    WHEN("WatchVariable() is called while Maxima is busy") {
+      GroupCell *working = AppendCodeGroup(wxS("1+1;"), nullptr);
+      g_ws->SetWorkingGroup(working);
+      nlohmann::json result = tools.WatchVariable(Args("name", "myvar"));
+      THEN("its own response already reports maxima_busy -- an AI doesn't "
+          "have to call read_variables separately just to learn its new "
+          "watch won't have a value yet") {
+        CHECK(result["ok"] == true);
+        CHECK(result["maxima_busy"] == true);
+      }
+      g_ws->SetWorkingGroup(nullptr); // don't leak state into later SCENARIOs
     }
   }
 }

--- a/test/unit_tests/test_McpTools.cpp
+++ b/test/unit_tests/test_McpTools.cpp
@@ -389,6 +389,63 @@ SCENARIO("McpTools' variable watchlist tools only ever touch the sidebar, "
   }
 }
 
+SCENARIO("McpTools::EvaluationStatus() reports whether Maxima is actually "
+        "evaluating, and which cell/command/elapsed-time if so") {
+  g_ws->ClearDocument();
+  g_vars->Clear();
+  McpTools tools(g_ws, g_vars);
+
+  GIVEN("Nothing is queued or being evaluated") {
+    THEN("it reports evaluating=false and none of the per-command fields") {
+      nlohmann::json status = tools.EvaluationStatus();
+      CHECK(status["evaluating"] == false);
+      CHECK(status["queue_length"] == 0);
+      CHECK_FALSE(status.contains("cell_uuid"));
+      CHECK_FALSE(status.contains("command"));
+      CHECK_FALSE(status.contains("elapsed_ms"));
+    }
+  }
+
+  GIVEN("A code cell whose command has actually been sent to Maxima") {
+    GroupCell *working = AppendCodeGroup(wxS("1+1;"), nullptr);
+    g_ws->GetEvaluationQueue().AddToQueue(working);
+    g_ws->GetEvaluationQueue().MarkCommandSent();
+    g_ws->SetWorkingGroup(working);
+
+    THEN("EvaluationStatus() reports evaluating=true with that cell's uuid, "
+        "the exact command text, and a non-negative elapsed time") {
+      nlohmann::json status = tools.EvaluationStatus();
+      CHECK(status["evaluating"] == true);
+      CHECK(status["cell_uuid"] == working->GetUUID().ToStdString());
+      CHECK(status["is_current"] == false);
+      CHECK(status["has_error"] == false);
+      CHECK(status["command"] == "1+1;");
+      REQUIRE(status.contains("elapsed_ms"));
+      CHECK(status["elapsed_ms"].get<long>() >= 0);
+      CHECK(status["queue_length"] == 1);
+    }
+
+    g_ws->GetEvaluationQueue().Clear(); // don't leak state into later SCENARIOs
+    g_ws->SetWorkingGroup(nullptr);
+  }
+
+  GIVEN("A cell is queued but Maxima hasn't actually sent its command yet") {
+    GroupCell *queued = AppendCodeGroup(wxS("2+2;"), nullptr);
+    g_ws->GetEvaluationQueue().AddToQueue(queued);
+    // Deliberately no MarkCommandSent()/SetWorkingGroup() call: this is the
+    // "tokenized but not yet dispatched" state EvaluationQueue.h's own
+    // m_commandStopwatch comment distinguishes from "actually sent."
+
+    THEN("evaluating is still false -- queuing alone isn't evaluating") {
+      nlohmann::json status = tools.EvaluationStatus();
+      CHECK(status["evaluating"] == false);
+      CHECK(status["queue_length"] == 1);
+    }
+
+    g_ws->GetEvaluationQueue().Clear();
+  }
+}
+
 SCENARIO("McpTools::SearchCells() finds cells by plain substring or regex, "
         "in input and/or output, so an AI can jump straight to a match "
         "instead of reading every cell") {

--- a/test/unit_tests/test_McpTools.cpp
+++ b/test/unit_tests/test_McpTools.cpp
@@ -412,9 +412,12 @@ SCENARIO("McpTools::EvaluationStatus() reports whether Maxima is actually "
   McpTools tools(g_ws, g_vars);
 
   GIVEN("Nothing is queued or being evaluated") {
-    THEN("it reports evaluating=false and none of the per-command fields") {
+    THEN("it reports evaluating=false, maxima_connected=true (the default "
+        "with no SetConnectionCheck() wired up), and none of the "
+        "per-command fields") {
       nlohmann::json status = tools.EvaluationStatus();
       CHECK(status["evaluating"] == false);
+      CHECK(status["maxima_connected"] == true);
       CHECK(status["queue_length"] == 0);
       CHECK_FALSE(status.contains("cell_uuid"));
       CHECK_FALSE(status.contains("command"));
@@ -459,6 +462,41 @@ SCENARIO("McpTools::EvaluationStatus() reports whether Maxima is actually "
     }
 
     g_ws->GetEvaluationQueue().Clear();
+  }
+}
+
+SCENARIO("McpTools reports maxima_connected=false when Maxima isn't running "
+        "at all, not just maxima_busy/evaluating=false -- raised directly "
+        "by the maintainer: \"if Maxima isn't running at all and that "
+        "causes a variable query to fail, is the AI informed about that?\"") {
+  g_ws->ClearDocument();
+  g_vars->Clear();
+  McpTools tools(g_ws, g_vars);
+  tools.SetConnectionCheck([] { return false; });
+
+  GIVEN("Maxima is reported as not connected, and genuinely idle (nothing "
+        "queued or evaluating)") {
+    THEN("EvaluationStatus() reports evaluating=false AND "
+        "maxima_connected=false -- the two are independent, so an AI can "
+        "tell \"nothing to report\" apart from \"nothing ever will "
+        "answer\"") {
+      nlohmann::json status = tools.EvaluationStatus();
+      CHECK(status["evaluating"] == false);
+      CHECK(status["maxima_connected"] == false);
+    }
+    AND_THEN("ReadVariables() reports maxima_busy=false and "
+            "maxima_connected=false at the same time") {
+      nlohmann::json vars = tools.ReadVariables();
+      CHECK(vars["maxima_busy"] == false);
+      CHECK(vars["maxima_connected"] == false);
+    }
+    AND_THEN("WatchVariable() reports maxima_connected=false in its own "
+            "response too, not only via a separate ReadVariables() call") {
+      nlohmann::json result = tools.WatchVariable(Args("name", "myvar"));
+      CHECK(result["ok"] == true);
+      CHECK(result["maxima_busy"] == false);
+      CHECK(result["maxima_connected"] == false);
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- Add a new `evaluation_status` MCP tool: reports whether Maxima is actively evaluating a command right now, which cell, the exact statement within that (possibly multi-statement) cell currently in flight, and how long that statement has been running. Elapsed time is genuinely new state (`EvaluationQueue` gained a `wxStopWatch`, started when a command is actually written to the socket, not merely tokenized).
- `watch_variable` now reports `maxima_busy` directly in its own response, so an AI doesn't need a separate `read_variables` round trip just to learn a fresh watch has no value yet because Maxima is busy.
- All three tools (`read_variables`, `watch_variable`, `evaluation_status`) now also report `maxima_connected`, so an AI can tell "Maxima isn't running at all" (never started, crashed, or killed) apart from "Maxima is running and genuinely idle" — previously both cases looked identical (`maxima_busy`/`evaluating` both `false`). Plumbed via a `std::function<bool()>` callback (`McpTools::SetConnectionCheck()` → `McpServer::SetConnectionCheck()`) wired up once from `wxMaxima`'s own constructor, since the real connection state lives on `wxMaxima::m_client`, unreachable from `McpTools`'s `Worksheet*`/`Variablespane*` alone.

## Test plan
- [x] `test_McpTools`: 112 assertions in 8 test cases, all passing (headless, no live Maxima needed)
- [x] Full clean rebuild produces zero new warnings
- [x] `AGENTS.md`/`NEWS.md` updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011iszcZR49S3QXrTKUQjiu6

---
_Generated by [Claude Code](https://claude.ai/code/session_011iszcZR49S3QXrTKUQjiu6)_