### PR TITLE
Fix grid-sizer overflow, hyperlink assert, and dropdown width in AI Chat tab

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1033,6 +1033,84 @@ a local TCP socket.
     (`wxUSE_SECRETSTORE` is off here, so the whole AI Chat tab stays hidden
     per its own gating) -- verified by code reading plus the unit test
     above, not a live screenshot.
+  - **Follow-up (2026-09-08): three real layout/API-misuse bugs in the
+    redesigned Options -> AI Chat tab, all invisible in this sandbox and
+    only caught because the maintainer ran a real build with a stricter
+    wxWidgets (their own experimental GTK4 port) that actually asserts on
+    them.** The maintainer asked directly "is that us or my experimental
+    wxWidgets version?" -- worth restating the answer here since it's the
+    reusable lesson: **all three were wxMaxima's own bugs**, not anything
+    specific to that fork. wxWidgets' assertions exist precisely to catch
+    API misuse that an unasserted (or `NDEBUG`) build silently tolerates --
+    this sandbox's prebuilt `libwxgtk3.2-dev` apparently doesn't hit either
+    assert at all (or has assertions compiled out), which is exactly why
+    the earlier follow-ups in this section could only claim "verified by
+    code reading," never a live screenshot of this tab. A stricter build
+    surfacing a real bug the moment the tab is actually opened is the
+    system working as intended, not a fork-specific false positive.
+    1. `wxFlexGridSizer(2, 2, 5, 5)` -- interpreted as the (rows, cols,
+       vgap, hgap) overload, so *rows* was hardcoded to 2 -- appeared twice
+       (the shared provider-detail box in `CreateAiChatPanel()`, and
+       `AddCustomAiProviderDialog()`), each adding 4-5 rows x 2 columns of
+       items. Every other `wxFlexGridSizer(N, 2, 5, 5)` call already in
+       this file (search it -- `10, 2, 5, 5`, `9, 2, 5, 5`, `20, 2, 5, 5`,
+       ...) correctly passes the real row count as the first argument;
+       these two didn't, presumably copy-pasted before the actual row
+       count was known and never updated as rows were added. Since a
+       `wxFlexGridSizer` with *both* rows and cols fixed caps its total
+       item count at `rows*cols` (`wxGridSizer::DoInsert()`'s own
+       contract), the 5th item added (the second row's label) tripped
+       `assert "Assert failure" failed in DoInsert(): too many items
+       (5 > 2*2) in grid sizer` -- deterministically, on every single open
+       of that tab, not a race or a GTK4-specific quirk. Fixed by setting
+       each grid's row count to its actual number of rows (4 and 5
+       respectively), matching the established convention.
+    2. `m_aiApiKeyLink`/`m_aiModelListLink` were each constructed as
+       `new wxHyperlinkCtrl(parent, id, wxEmptyString, wxEmptyString)` --
+       both label and URL empty, since the real values aren't known until
+       `LoadAiProviderRecordIntoUi()` runs moments later and the control
+       has to exist before that to be added to the sizer. wxWidgets'
+       `wxHyperlinkCtrlBase::CheckParams()` asserts `!url.empty() ||
+       !label.empty()` -- constructing with both empty is invalid
+       regardless of platform; this sandbox's wx build simply doesn't
+       enforce it. Fixed by giving each a throwaway single-space
+       placeholder label (satisfies the assert; never actually seen) and
+       calling `Show(false)` immediately at construction, matching what
+       `LoadAiProviderRecordIntoUi()` already does once a real URL is
+       known (`m_aiApiKeyLink->Show(!keyUrl.IsEmpty())` etc.) -- the
+       control was already meant to start hidden, it just wasn't
+       constructed in a way that survived a strict build long enough to
+       reach that point.
+    3. The "Active provider" `wxChoice` (`m_aiChatProviderChoice`) rendered
+       as a near-invisible sliver instead of spanning the tab's width --
+       reported directly by the maintainer from the same live run. Root
+       cause: the choice is constructed empty (`RebuildAiProviderChoice()`
+       populates it a moment later, once the four built-ins plus any
+       custom entries are known), and neither its own sizer item nor the
+       horizontal `providerBox` row it sits in carried an `Expand()`/
+       stretch factor -- so both defaulted to their natural size, which for
+       a not-yet-populated `wxChoice` is essentially zero. This is the
+       same "one control crowds/shrinks to an invisible sliver" shape the
+       AI chat *sidebar*'s own layout entry earlier in this section
+       already warns about, just in a different dialog. Fixed by adding
+       `wxSizerFlags(1).Expand()` to the choice's own `Add()` call and
+       `wxSizerFlags().Expand()` to `providerBox`'s -- both are required
+       together (a proportion-1 item in an unexpanded row still only gets
+       that row's own natural width; an expanded row with no stretch
+       factor on its child still leaves the child at its natural size
+       inside the extra space).
+    None of these three could be verified live in this sandbox for the
+    same `wxUSE_SECRETSTORE=0` reason the rest of this feature couldn't
+    (the tab never appears at all here) -- fixed by reading the exact
+    wxWidgets contracts each violated (`wxGridSizer::DoInsert()`'s
+    `rows*cols` cap, `wxHyperlinkCtrlBase::CheckParams()`'s assert, plain
+    sizer-proportion semantics) rather than by reproducing them, and
+    rebuilt clean with the existing unit tests (`test_AiProvider`,
+    `test_ConfigRoundtrip`, `test_StyleConfigRoundtrip`) still passing
+    unchanged -- none of them touch this tab's actual widget construction.
+    Confirming the fix's actual on-screen effect (grid opens without
+    asserting, both links stay hidden until populated, the dropdown spans
+    the tab) needs the maintainer's own build to re-check.
   - **Not implemented, and shouldn't be without a separate decision: a
     write/evaluate-capable MCP tool.** Raised and discussed directly with
     the user (2026-09-06): unlike `watch_variable`/`unwatch_variable` (see

--- a/src/dialogs/ConfigDialogue.cpp
+++ b/src/dialogs/ConfigDialogue.cpp
@@ -2047,9 +2047,16 @@ wxWindow *ConfigDialogue::CreateAiChatPanel() {
   // this constructor call only needs to create the control itself.
   m_aiChatProviderChoice =
     new wxChoice(panel, wxID_ANY, wxDefaultPosition, wxDefaultSize);
+  // Proportion(1).Expand() on the choice, plus Expand() on the row itself
+  // just below -- without both, a wxChoice's natural width is based on
+  // whatever it's populated with, and since RebuildAiProviderChoice() only
+  // fills it in a moment later, it started out sized for an empty list
+  // (rendering as a barely-there sliver, confirmed live) instead of
+  // stretching to the tab's actual width the way every other wide control
+  // on this tab does.
   providerBox->Add(m_aiChatProviderChoice,
-                   wxSizerFlags().Border(wxALL, 5 * GetContentScaleFactor()));
-  vbox->Add(providerBox);
+                   wxSizerFlags(1).Expand().Border(wxALL, 5 * GetContentScaleFactor()));
+  vbox->Add(providerBox, wxSizerFlags().Expand());
 
   // A single reusable box for whichever provider is currently selected,
   // instead of all of them stacked at once -- LoadAiProviderRecordIntoUi()
@@ -2060,7 +2067,7 @@ wxWindow *ConfigDialogue::CreateAiChatPanel() {
   // StashAiProviderUiIntoRecord()).
   m_aiProviderDetailBox = new wxStaticBoxSizer(wxVERTICAL, panel, wxEmptyString);
   wxWindow *detailBoxWin = m_aiProviderDetailBox->GetStaticBox();
-  wxFlexGridSizer *grid = new wxFlexGridSizer(2, 2, 5, 5);
+  wxFlexGridSizer *grid = new wxFlexGridSizer(4, 2, 5, 5);
   grid->AddGrowableCol(1);
 
   m_aiShapeLabel = new wxStaticText(detailBoxWin, wxID_ANY, _("API style:"));
@@ -2100,9 +2107,17 @@ wxWindow *ConfigDialogue::CreateAiChatPanel() {
   // link to where to actually get a key is the closest equivalent. Hidden
   // for a Custom entry, since there's no generic "get a key" URL for an
   // arbitrary user-supplied endpoint.
-  m_aiApiKeyLink = new wxHyperlinkCtrl(detailBoxWin, wxID_ANY, wxEmptyString, wxEmptyString);
+  // Both start with a placeholder label and no URL -- wxHyperlinkCtrl
+  // asserts if label and URL are *both* empty at construction time (a
+  // newer/stricter wxWidgets build catches this; an older one may not),
+  // and the real label/URL aren't known until LoadAiProviderRecordIntoUi()
+  // runs just below, so a throwaway non-empty label stands in until then.
+  // Hidden immediately for the same reason: nothing meaningful to show yet.
+  m_aiApiKeyLink = new wxHyperlinkCtrl(detailBoxWin, wxID_ANY, wxS(" "), wxEmptyString);
+  m_aiApiKeyLink->Show(false);
   m_aiProviderDetailBox->Add(m_aiApiKeyLink, wxSizerFlags().Border(wxALL, 5 * GetContentScaleFactor()));
-  m_aiModelListLink = new wxHyperlinkCtrl(detailBoxWin, wxID_ANY, wxEmptyString, wxEmptyString);
+  m_aiModelListLink = new wxHyperlinkCtrl(detailBoxWin, wxID_ANY, wxS(" "), wxEmptyString);
+  m_aiModelListLink->Show(false);
   m_aiProviderDetailBox->Add(m_aiModelListLink, wxSizerFlags().Border(wxALL, 5 * GetContentScaleFactor()));
 
   m_aiRemoveCustomProviderButton =
@@ -2240,7 +2255,7 @@ bool ConfigDialogue::AddCustomAiProviderDialog() {
   wxDialog dlg(this, wxID_ANY, _("Add Custom AI Provider"), wxDefaultPosition,
               wxDefaultSize, wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER);
   wxBoxSizer *dlgVbox = new wxBoxSizer(wxVERTICAL);
-  wxFlexGridSizer *grid = new wxFlexGridSizer(2, 2, 5, 5);
+  wxFlexGridSizer *grid = new wxFlexGridSizer(5, 2, 5, 5);
   grid->AddGrowableCol(1);
 
   // A quick-fill shortcut for a handful of well-known *local* AI servers


### PR DESCRIPTION
## Summary
Three real bugs in Options -> AI Chat's redesigned UI, surfaced by a stricter wxWidgets build (the maintainer's own experimental GTK4 port) asserting where this sandbox's own build silently didn't:

- Both `wxFlexGridSizer(2, 2, 5, 5)` grids hardcoded `rows=2` despite needing 4-5 rows, tripping `wxGridSizer`'s `rows*cols` item cap (`DoInsert()` asserts once more than 4 items are added).
- The API-key/model-list `wxHyperlinkCtrl`s were constructed with both label and URL empty, violating `wxHyperlinkCtrlBase::CheckParams()`'s own contract (`!url.empty() || !label.empty()`).
- The "Active provider" `wxChoice` and its row had no stretch/`Expand()`, so the empty-at-construction choice rendered as a near-invisible sliver instead of spanning the tab.

All three were wxMaxima's own bugs, not anything specific to that fork — this sandbox's prebuilt `libwxgtk3.2-dev` just doesn't hit either assert (or has assertions compiled out), which is why they went unnoticed until a stricter build actually opened the tab.

## Test plan
- [x] `test_AiProvider`, `test_ConfigRoundtrip`, `test_StyleConfigRoundtrip` all still pass unchanged (none touch this tab's widget construction)
- [x] Full clean rebuild succeeds
- [ ] Actual on-screen effect (grid opens without asserting, links stay hidden until populated, dropdown spans the tab) needs a build with `wxUSE_SECRETSTORE` enabled to re-check — this sandbox's wx build has it off, so the whole AI Chat tab is hidden here regardless

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011iszcZR49S3QXrTKUQjiu6

---
_Generated by [Claude Code](https://claude.ai/code/session_011iszcZR49S3QXrTKUQjiu6)_