### PR TITLE
Add GitHub Models as a built-in AI Chat provider

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1033,6 +1033,73 @@ a local TCP socket.
     (`wxUSE_SECRETSTORE` is off here, so the whole AI Chat tab stays hidden
     per its own gating) -- verified by code reading plus the unit test
     above, not a live screenshot.
+  - **Follow-up (2026-09-11): "can you implement a GitHub Copilot
+    connector?" -- researched directly with the user rather than just
+    coding it, since "GitHub Copilot" turned out to mean two genuinely
+    different things with very different risk profiles.** GitHub Copilot
+    Chat (the assistant bundled with a Copilot subscription) has **no
+    official third-party API at all**. The way every community tool that
+    reaches it (copilot.vim-style plugins, "copilot-api" proxies) actually
+    works: perform the GitHub OAuth device flow using *another product's*
+    client id (typically an approved editor's, e.g. VS Code's -- GitHub
+    only allowlists Copilot-token exchange for client ids it has
+    specifically approved, so a freshly-registered wxMaxima OAuth app would
+    authenticate fine via the device flow but be rejected at the next
+    step), then exchange the resulting token at an undocumented internal
+    endpoint (`api.github.com/copilot_internal/v2/token`) for a short-lived
+    Copilot token, then call another undocumented endpoint
+    (`api.githubcopilot.com/chat/completions`) while sending headers that
+    make the request look like it came from that editor. That is not "no
+    legitimate OAuth flow for a desktop app" (the situation already
+    documented for Anthropic/OpenAI/Google/Qwen/GitHub Models, all of
+    which still have a real pasted-API-key path) -- it is impersonating an
+    authorized client's identity to reach an API GitHub has not opened to
+    third parties, which risks the account being flagged or suspended
+    under GitHub's Copilot terms. Presented to the user as an explicit
+    choice with this risk spelled out; the user's first answer was "both,"
+    but on seeing the mechanism restated even more concretely (a borrowed
+    client id, not wxMaxima's own) they reconsidered mid-implementation
+    ("If that feature risks getting our users banned perhaps we should
+    only support the personal chat...") and the Copilot Chat half was
+    dropped entirely -- no OAuth device-flow code, no borrowed client id,
+    no new Custom-provider auth scheme for it exists anywhere in this
+    codebase. Don't re-add it without a new, explicit request; if one comes
+    in, this reasoning (and the specific "GitHub gates the token-exchange
+    endpoint to an allowlist, not just any authenticated OAuth app" fact)
+    is the thing to re-derive from, not guess at again.
+    **What *was* added: GitHub Models**, a genuinely different, official
+    GitHub product -- an OpenAI-compatible chat-completions endpoint
+    (`https://models.github.ai/inference/chat/completions`) authenticated
+    with a plain GitHub personal access token via a standard
+    `Authorization: Bearer` header, publicly documented at
+    <https://docs.github.com/en/github-models>, not a workaround of
+    anything. This is the sixth `AiProviderKind` (`GitHubModels = 6`,
+    `src/ai/AiProvider.h`) and needed **zero new provider logic**: its
+    request/response shape and auth header are byte-for-byte what
+    `OpenAiCompatibleProvider` already implements for OpenAI/Qwen, so
+    `MakeAiProvider(AiProviderKind::GitHubModels, ...)` just constructs one
+    pointed at GitHub's own URL (`AiProvider.cpp`) -- the same "OpenAI-
+    compatible shape, different base URL/auth secret" pattern Qwen already
+    established. Wired through the same places every built-in kind needs:
+    `Configuration::AiApiKeyGitHubModels()`/`AiModelGitHubModels()` (new
+    accessors, same secret-store-backed pattern as the other four),
+    `ConfigDialogue.cpp`'s `fixedKinds[]` array and both of its per-kind
+    switch statements (populate-on-open, apply-on-OK), and
+    `AiChatSidebar::ReloadProviderFromConfig()`'s switch -- all three of
+    these switches are the actual places that need a new `case` per
+    built-in kind; `RebuildAiProviderChoice()`/`LoadAiProviderRecordIntoUi()`
+    and the rest of the Options UI are already fully generic over
+    `m_aiProviderRecords`, so nothing there needed touching, and it's worth
+    checking that dynamism holds before assuming a new provider needs UI
+    changes beyond the three switches. `AiProviderDefaultModel()` uses
+    `"openai/gpt-4o-mini"` -- GitHub Models' catalog names entries
+    `<publisher>/<model>`, and that specific one is on the free tier, unlike
+    some of the catalog's larger models which need a paid Models plan.
+    Verified with a new `test_AiProvider.cpp` SCENARIO mirroring the
+    existing OpenAI/Qwen one (request URL, Bearer header, OpenAI-compatible
+    body/reply shape) -- not verified live (no real GitHub PAT in this
+    sandbox), same caveat this file's other AI-provider entries already
+    carry for OpenAI/Google/Qwen.
   - **Follow-up (2026-09-09): a new `evaluation_status` MCP tool -- "if
     Maxima is evaluating, what cell it works on, what command within that
     cell and for how long this command already is being evaluated,"

--- a/NEWS.md
+++ b/NEWS.md
@@ -25,6 +25,11 @@
   maxima_connected, so an AI can tell "Maxima isn't running at all" apart
   from "Maxima is running and genuinely idle" -- previously both cases
   looked identical (maxima_busy/evaluating both false).
+- Added GitHub Models as a fifth built-in AI Chat provider -- GitHub's own
+  official, OpenAI-compatible model-hosting API, authenticated with a plain
+  GitHub personal access token. (This is a deliberately different thing
+  from "GitHub Copilot Chat", which has no sanctioned third-party API and
+  was not added.)
 - The MCP server and AI Chat sidebar's worksheet context now tell an AI
   where the user's cursor is and which cell (if any) has an error, so it
   can actually answer "what's wrong with my current cell" or "the cell

--- a/src/Configuration.cpp
+++ b/src/Configuration.cpp
@@ -129,6 +129,7 @@ Configuration::Configuration(const Configuration &o) :
   m_aiModelOpenAI(o.m_aiModelOpenAI),
   m_aiModelGoogle(o.m_aiModelGoogle),
   m_aiModelQwen(o.m_aiModelQwen),
+  m_aiModelGitHubModels(o.m_aiModelGitHubModels),
   m_aiCustomProvidersJson(o.m_aiCustomProvidersJson),
   m_aiActiveCustomProviderId(o.m_aiActiveCustomProviderId),
   m_displayedDigits(o.m_displayedDigits),
@@ -334,6 +335,7 @@ void Configuration::ResetAllToDefaults() {
   m_aiModelOpenAI = AiProviderDefaultModel(AiProviderKind::OpenAI);
   m_aiModelGoogle = AiProviderDefaultModel(AiProviderKind::Google);
   m_aiModelQwen = AiProviderDefaultModel(AiProviderKind::Qwen);
+  m_aiModelGitHubModels = AiProviderDefaultModel(AiProviderKind::GitHubModels);
 #endif
   m_fixReorderedIndices = true;
   m_rightToLeftDocument = false;
@@ -922,6 +924,14 @@ wxString Configuration::AiApiKeyQwen() const {
 void Configuration::AiApiKeyQwen(const wxString &key) {
   AiProvider::SaveApiKey(AiProvider::BuiltinProviderSecretService(AiProviderKind::Qwen), key);
 }
+wxString Configuration::AiApiKeyGitHubModels() const {
+  return AiProvider::LoadApiKey(
+    AiProvider::BuiltinProviderSecretService(AiProviderKind::GitHubModels));
+}
+void Configuration::AiApiKeyGitHubModels(const wxString &key) {
+  AiProvider::SaveApiKey(
+    AiProvider::BuiltinProviderSecretService(AiProviderKind::GitHubModels), key);
+}
 #endif
 
 //TODO: Don't underline the section number of titles
@@ -1375,6 +1385,7 @@ Configuration::ScalarConfigSettings() {
     {wxS("aiModelOpenAI"), &Configuration::m_aiModelOpenAI},
     {wxS("aiModelGoogle"), &Configuration::m_aiModelGoogle},
     {wxS("aiModelQwen"), &Configuration::m_aiModelQwen},
+    {wxS("aiModelGitHubModels"), &Configuration::m_aiModelGitHubModels},
     {wxS("aiCustomProviders"), &Configuration::m_aiCustomProvidersJson},
     {wxS("aiActiveCustomProvider"), &Configuration::m_aiActiveCustomProviderId},
     {wxS("numpadEnterEvaluates"), &Configuration::m_numpadEnterEvaluates},

--- a/src/Configuration.h
+++ b/src/Configuration.h
@@ -772,6 +772,11 @@ public:
   void AiApiKeyGoogle(const wxString &key);
   wxString AiApiKeyQwen() const;
   void AiApiKeyQwen(const wxString &key);
+  //! A GitHub personal access token (fine-grained, "Models: read"
+  //! permission) -- see AiProviderKind::GitHubModels's own doc comment for
+  //! why this is GitHub's official Models API, not Copilot Chat.
+  wxString AiApiKeyGitHubModels() const;
+  void AiApiKeyGitHubModels(const wxString &key);
 
   //! The model id to request from each provider; defaults to
   //! AiProviderDefaultModel() but the user can override it in Options,
@@ -784,6 +789,8 @@ public:
   void AiModelGoogle(const wxString &model) { m_aiModelGoogle = model; }
   wxString AiModelQwen() const { return m_aiModelQwen; }
   void AiModelQwen(const wxString &model) { m_aiModelQwen = model; }
+  wxString AiModelGitHubModels() const { return m_aiModelGitHubModels; }
+  void AiModelGitHubModels(const wxString &model) { m_aiModelGitHubModels = model; }
 
   //! User-added custom providers (beyond the four built-in ones), as a
   //! JSON array -- see AiCustomProviderConfig/ParseAiCustomProviders() in
@@ -1485,6 +1492,7 @@ private:
   wxString m_aiModelOpenAI;
   wxString m_aiModelGoogle;
   wxString m_aiModelQwen;
+  wxString m_aiModelGitHubModels;
   //! User-added custom providers. See AiCustomProvidersJson().
   wxString m_aiCustomProvidersJson;
   //! See AiActiveCustomProviderId().

--- a/src/ai/AiProvider.cpp
+++ b/src/ai/AiProvider.cpp
@@ -187,6 +187,7 @@ wxString AiProviderKindName(AiProviderKind kind) {
   case AiProviderKind::OpenAI: return wxS("OpenAI");
   case AiProviderKind::Google: return wxS("Google (Gemini)");
   case AiProviderKind::Qwen: return wxS("Qwen (Alibaba)");
+  case AiProviderKind::GitHubModels: return wxS("GitHub Models");
   // A Custom provider's own display name is carried on the AiProvider
   // instance itself (AiProvider::SetDisplayName()/Name()), not derivable
   // from the kind alone -- this generic fallback is only ever seen if
@@ -223,6 +224,10 @@ wxString AiProviderDefaultModel(AiProviderKind kind) {
   case AiProviderKind::OpenAI: return wxS("gpt-4o-mini");
   case AiProviderKind::Google: return wxS("gemini-1.5-flash");
   case AiProviderKind::Qwen: return wxS("qwen-plus");
+  // GitHub Models' catalog names models "<publisher>/<model>"; this one is
+  // consistently free-tier-available, unlike some of the larger catalog
+  // entries which need a paid Models plan.
+  case AiProviderKind::GitHubModels: return wxS("openai/gpt-4o-mini");
   default: return wxEmptyString;
   }
 }
@@ -233,6 +238,13 @@ wxString AiProviderApiKeyUrl(AiProviderKind kind) {
   case AiProviderKind::OpenAI: return wxS("https://platform.openai.com/api-keys");
   case AiProviderKind::Google: return wxS("https://aistudio.google.com/apikey");
   case AiProviderKind::Qwen: return wxS("https://dashscope.console.aliyun.com/apiKey");
+  // A fine-grained personal access token with "Models" (read-only)
+  // permission -- GitHub Models is the one built-in provider here whose
+  // "API key" is a real GitHub credential, not a service-specific one; see
+  // AiProviderKind's own doc comment for why this is GitHub Models, not
+  // GitHub Copilot Chat.
+  case AiProviderKind::GitHubModels:
+    return wxS("https://github.com/settings/personal-access-tokens/new");
   default: return wxEmptyString;
   }
 }
@@ -244,6 +256,7 @@ wxString AiProviderModelListUrl(AiProviderKind kind) {
   case AiProviderKind::OpenAI: return wxS("https://platform.openai.com/docs/models");
   case AiProviderKind::Google: return wxS("https://ai.google.dev/gemini-api/docs/models");
   case AiProviderKind::Qwen: return wxS("https://www.alibabacloud.com/help/en/model-studio/models");
+  case AiProviderKind::GitHubModels: return wxS("https://github.com/marketplace/models");
   default: return wxEmptyString;
   }
 }
@@ -256,6 +269,8 @@ wxString AiProviderBaseUrl(AiProviderKind kind) {
     return wxS("https://dashscope.aliyuncs.com/compatible-mode/v1/chat/completions");
   case AiProviderKind::Google:
     return wxS("https://generativelanguage.googleapis.com/v1beta/models/");
+  case AiProviderKind::GitHubModels:
+    return wxS("https://models.github.ai/inference/chat/completions");
   default: return wxEmptyString;
   }
 }
@@ -276,6 +291,15 @@ std::shared_ptr<AiProvider> MakeAiProvider(AiProviderKind kind, const wxString &
       apiKey, model);
   case AiProviderKind::Google:
     return std::make_shared<GoogleProvider>(apiKey, model);
+  case AiProviderKind::GitHubModels:
+    // Officially documented, OpenAI-compatible-shaped endpoint
+    // (https://docs.github.com/en/github-models), authenticated with a
+    // plain GitHub personal access token via "Authorization: Bearer" --
+    // exactly what OpenAiCompatibleProvider already sends, so no new
+    // provider class is needed.
+    return std::make_shared<OpenAiCompatibleProvider>(
+      AiProviderKind::GitHubModels,
+      wxS("https://models.github.ai/inference/chat/completions"), apiKey, model);
   default:
     return nullptr;
   }

--- a/src/ai/AiProvider.h
+++ b/src/ai/AiProvider.h
@@ -55,7 +55,18 @@ struct AiChatMessage {
 //! reports from AiProvider::Kind() -- Configuration::AiActiveCustomProviderId()
 //! says which one, since a plain kind alone can't distinguish two custom
 //! entries from each other.
-enum class AiProviderKind { None = 0, Anthropic = 1, OpenAI = 2, Google = 3, Qwen = 4, Custom = 5 };
+//! GitHubModels is GitHub's own official, OpenAI-compatible model-hosting
+//! API (https://github.com/marketplace/models), authenticated with a plain
+//! GitHub personal access token -- deliberately NOT "GitHub Copilot Chat":
+//! that assistant has no sanctioned third-party API at all (the community
+//! tools that reach it do so by reusing an approved editor's OAuth client
+//! id and calling an undocumented internal endpoint, which risks the
+//! account being flagged under GitHub's Copilot terms), so it was not
+//! implemented here -- see the "GitHub Models" follow-up in AGENTS.md's AI
+//! chat sidebar entry for the full reasoning.
+enum class AiProviderKind {
+  None = 0, Anthropic = 1, OpenAI = 2, Google = 3, Qwen = 4, Custom = 5, GitHubModels = 6
+};
 
 //! Which request/response wire format a provider uses. The four built-in
 //! AiProviderKinds each hardcode one of these; a user-added custom provider
@@ -139,7 +150,7 @@ wxString AiProviderDefaultModel(AiProviderKind kind);
 
 //! Where to go to create/find an API key for this provider -- shown as a
 //! link next to that provider's key field in Options, since there is no
-//! "log in" button that could get one automatically: none of these four
+//! "log in" button that could get one automatically: none of these five
 //! providers offer a legitimate third-party OAuth flow a desktop app could
 //! use, so pasting a key from the provider's own site is the only option.
 //! Best-effort: a provider's console is free to move its own pages, same

--- a/src/dialogs/ConfigDialogue.cpp
+++ b/src/dialogs/ConfigDialogue.cpp
@@ -633,7 +633,8 @@ void ConfigDialogue::SetCheckboxValues() {
   if (AiProvider::SecretStoreAvailable()) {
     m_aiProviderRecords.clear();
     AiProviderKind fixedKinds[] = {AiProviderKind::Anthropic, AiProviderKind::OpenAI,
-                                   AiProviderKind::Google, AiProviderKind::Qwen};
+                                   AiProviderKind::Google, AiProviderKind::Qwen,
+                                   AiProviderKind::GitHubModels};
     for (AiProviderKind kind : fixedKinds) {
       AiProviderUiRecord rec;
       rec.kind = kind;
@@ -654,6 +655,10 @@ void ConfigDialogue::SetCheckboxValues() {
       case AiProviderKind::Qwen:
         rec.apiKey = configuration->AiApiKeyQwen();
         rec.model = configuration->AiModelQwen();
+        break;
+      case AiProviderKind::GitHubModels:
+        rec.apiKey = configuration->AiApiKeyGitHubModels();
+        rec.model = configuration->AiModelGitHubModels();
         break;
       default:
         break;
@@ -2840,6 +2845,10 @@ void ConfigDialogue::WriteSettings() {
       case AiProviderKind::Qwen:
         configuration->AiApiKeyQwen(rec.apiKey);
         configuration->AiModelQwen(rec.model);
+        break;
+      case AiProviderKind::GitHubModels:
+        configuration->AiApiKeyGitHubModels(rec.apiKey);
+        configuration->AiModelGitHubModels(rec.model);
         break;
       default:
         break;

--- a/src/sidebars/AiChatSidebar.cpp
+++ b/src/sidebars/AiChatSidebar.cpp
@@ -127,6 +127,10 @@ void AiChatSidebar::ReloadProviderFromConfig() {
       apiKey = m_configuration->AiApiKeyQwen();
       model = m_configuration->AiModelQwen();
       break;
+    case AiProviderKind::GitHubModels:
+      apiKey = m_configuration->AiApiKeyGitHubModels();
+      model = m_configuration->AiModelGitHubModels();
+      break;
     default:
       break;
     }

--- a/test/unit_tests/test_AiProvider.cpp
+++ b/test/unit_tests/test_AiProvider.cpp
@@ -158,6 +158,41 @@ SCENARIO("OpenAI's (and Qwen's identical) chat/completions shape") {
   }
 }
 
+SCENARIO("GitHub Models -- GitHub's own official, OpenAI-compatible model API") {
+  auto provider = MakeAiProvider(AiProviderKind::GitHubModels, wxS("github_pat_test"),
+                                 wxS("openai/gpt-4o-mini"));
+  REQUIRE(provider);
+
+  GIVEN("its request URL") {
+    THEN("it points at GitHub's own Models inference endpoint, not Copilot's") {
+      CHECK(provider->RequestUrl() ==
+           wxS("https://models.github.ai/inference/chat/completions"));
+    }
+  }
+
+  GIVEN("the Bearer auth header") {
+    THEN("it carries the personal access token, the same way OpenAI's does") {
+      auto headers = provider->AuthHeaders();
+      REQUIRE(headers.size() == 1);
+      CHECK(headers[0].first == wxS("Authorization"));
+      CHECK(headers[0].second == wxS("Bearer github_pat_test"));
+    }
+  }
+
+  GIVEN("a system context and one user message") {
+    wxString body = provider->BuildRequestBody(wxS("worksheet context"),
+                                               OneUserTurn(wxS("Hello")));
+    json parsed = json::parse(std::string(body.ToUTF8()));
+    THEN("its request/response shape is identical to OpenAI's own") {
+      CHECK(parsed.at("model") == "openai/gpt-4o-mini");
+      REQUIRE(parsed.at("messages").size() == 2);
+      CHECK(parsed.at("messages")[0].at("role") == "system");
+      CHECK(provider->ParseReply(
+              wxS(R"({"choices":[{"message":{"content":"ok"}}]})")) == wxS("ok"));
+    }
+  }
+}
+
 SCENARIO("Google Gemini's generateContent shape") {
   auto provider = MakeAiProvider(AiProviderKind::Google, wxS("goog-key"),
                                  wxS("gemini-1.5-flash"));


### PR DESCRIPTION
## Summary

- Adds **GitHub Models** as a sixth built-in AI Chat provider (`AiProviderKind::GitHubModels`). It's GitHub's own official, OpenAI-compatible model-hosting API (`https://models.github.ai/inference/chat/completions`), authenticated with a plain GitHub personal access token via a standard `Authorization: Bearer` header — publicly documented at <https://docs.github.com/en/github-models>.
- Needed **zero new provider logic**: its request/response shape and auth header are byte-for-byte what `OpenAiCompatibleProvider` already implements for OpenAI/Qwen, so this is the same "OpenAI-compatible shape, different base URL/auth secret" pattern Qwen already established.
- Wired through every place a built-in kind needs: `Configuration` (new `AiApiKeyGitHubModels()`/`AiModelGitHubModels()` accessors, persistence, `ResetAllToDefaults()`), `ConfigDialogue.cpp`'s provider list and both of its per-kind switch statements (populate-on-open, apply-on-OK), and `AiChatSidebar::ReloadProviderFromConfig()`.

**Deliberately not implemented: real "GitHub Copilot Chat".** That assistant has no sanctioned third-party API at all — every community tool that reaches it does so by reusing an *approved editor's* OAuth client id (GitHub only allowlists Copilot's token-exchange endpoint for client ids it has specifically approved) and calling undocumented internal endpoints while impersonating that editor. That's a materially different (and riskier) thing than "no OAuth flow for a desktop app" — it risks the account being flagged/suspended under GitHub's Copilot terms — so it was intentionally left out. GitHub Models is the genuinely official, ToS-clean alternative that actually satisfies "talk to a GitHub-hosted model from wxMaxima."

## Test plan

- [x] Full clean rebuild (`ninja`), zero new warnings
- [x] `test_AiProvider` — new SCENARIO covering GitHub Models' request URL, Bearer auth header, and OpenAI-compatible request/reply shape (127 assertions / 9 test cases total, up from 116/8)
- [x] `test_ConfigRoundtrip` — unaffected, still passing (95 assertions)
- [x] Full non-batch/non-live-Maxima `ctest` suite under Xvfb — 145/145 passed, no regressions
- [ ] Not verified live against a real GitHub PAT (no network credentials in the build sandbox) — same caveat this codebase's other built-in AI providers (OpenAI/Google/Qwen) already carry

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011iszcZR49S3QXrTKUQjiu6

---
_Generated by [Claude Code](https://claude.ai/code/session_011iszcZR49S3QXrTKUQjiu6)_