### PR TITLE
Regenerate wxMaxima.pot to fix the POT-coverage CI check

### DIFF
--- a/locales/wxMaxima/wxMaxima.pot
+++ b/locales/wxMaxima/wxMaxima.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-09-06 18:32+0000\n"
+"POT-Creation-Date: 2026-09-11 18:01+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -51,117 +51,117 @@ msgid ""
 "Now reads: "
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2011
+#: ../../src/wxMaxima.cpp:2026
 msgid ""
 "\n"
 "Use the menu \"View->Toggle log window\" to show/hide a log window with all debug messages."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1624
+#: ../../src/dialogs/ConfigDialogue.cpp:1696
 msgid "      -X \"--control-stack-size <int>\""
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1623
+#: ../../src/dialogs/ConfigDialogue.cpp:1695
 msgid "      -X \"--dynamic-space-size <int>\""
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1627
+#: ../../src/dialogs/ConfigDialogue.cpp:1699
 msgid "      -X '--control-stack-size <int>'"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1626
+#: ../../src/dialogs/ConfigDialogue.cpp:1698
 msgid "      -X '--dynamic-space-size <int>'"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1606
+#: ../../src/dialogs/ConfigDialogue.cpp:1678
 msgid "      -l <name>"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1612
+#: ../../src/dialogs/ConfigDialogue.cpp:1684
 msgid "      -u <versionnumber>"
 msgstr ""
 
-#: ../../src/Configuration.cpp:1435
+#: ../../src/Configuration.cpp:1506
 #, c-format
 msgid "  Cells converted to 2D: %ld"
 msgstr ""
 
-#: ../../src/Configuration.cpp:1434
+#: ../../src/Configuration.cpp:1505
 #, c-format
 msgid "  Cells converted to linear: %ld"
 msgstr ""
 
-#: ../../src/Configuration.cpp:1436
+#: ../../src/Configuration.cpp:1507
 #, c-format
 msgid "  Cells drawn at the wrong font size: %ld"
 msgstr ""
 
-#: ../../src/Configuration.cpp:1426
+#: ../../src/Configuration.cpp:1497
 #, c-format
 msgid "  Font cache hits: %ld"
 msgstr ""
 
-#: ../../src/Configuration.cpp:1427
+#: ../../src/Configuration.cpp:1498
 #, c-format
 msgid "  Font cache misses: %ld"
 msgstr ""
 
-#: ../../src/Configuration.cpp:1438
+#: ../../src/Configuration.cpp:1509
 #, c-format
 msgid "  Full-window worksheet repaints: %ld"
 msgstr ""
 
-#: ../../src/Configuration.cpp:1422
+#: ../../src/Configuration.cpp:1493
 #, c-format
 msgid "  Manual anchors from built-in: %ld"
 msgstr ""
 
-#: ../../src/Configuration.cpp:1423
+#: ../../src/Configuration.cpp:1494
 #, c-format
 msgid "  Manual anchors from cache: %ld"
 msgstr ""
 
-#: ../../src/Configuration.cpp:1424
+#: ../../src/Configuration.cpp:1495
 #, c-format
 msgid "  Manual anchors self-compiled: %ld"
 msgstr ""
 
-#: ../../src/Configuration.cpp:1425
+#: ../../src/Configuration.cpp:1496
 #, c-format
 msgid "  Maxima processes spawned: %ld"
 msgstr ""
 
-#: ../../src/Configuration.cpp:1432
+#: ../../src/Configuration.cpp:1503
 #, c-format
 msgid "  Recalculation needed - Cells appended: %ld"
 msgstr ""
 
-#: ../../src/Configuration.cpp:1431
+#: ../../src/Configuration.cpp:1502
 #, c-format
 msgid "  Recalculation needed - Config changed: %ld"
 msgstr ""
 
-#: ../../src/Configuration.cpp:1433
+#: ../../src/Configuration.cpp:1504
 #, c-format
 msgid "  Recalculation needed - Editor dirty: %ld"
 msgstr ""
 
-#: ../../src/Configuration.cpp:1428
+#: ../../src/Configuration.cpp:1499
 #, c-format
 msgid "  Recalculation needed - Font invalid: %ld"
 msgstr ""
 
-#: ../../src/Configuration.cpp:1430
+#: ../../src/Configuration.cpp:1501
 #, c-format
 msgid "  Recalculation needed - Font mismatch: %ld"
 msgstr ""
 
-#: ../../src/Configuration.cpp:1429
+#: ../../src/Configuration.cpp:1500
 #, c-format
 msgid "  Recalculation needed - Size invalid: %ld"
 msgstr ""
 
-#: ../../src/Configuration.cpp:1437
+#: ../../src/Configuration.cpp:1508
 #, c-format
 msgid "  Worksheet repaints: %ld"
 msgstr ""
@@ -193,7 +193,7 @@ msgstr ""
 msgid " Returns the unique elements of the list"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1673
+#: ../../src/wxMaximaFrame.cpp:1691
 msgid " Wrong, if a is complex"
 msgstr ""
 
@@ -220,19 +220,23 @@ msgstr ""
 msgid "\"..\" means \"one directory up\"."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1226
+#: ../../src/dialogs/ConfigDialogue.cpp:1298
 msgid "\"Copy LaTeX\" adds equation markers"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:450
+#: ../../src/dialogs/ConfigDialogue.cpp:466
 msgid ""
 "\"MathML (rendered by the browser)\" is the recommended choice: every current browser renders MathML natively and instantly, and the exported page needs no JavaScript and makes no requests to any external server.\n"
 "\"MathML + MathJaX fall-back for old browsers\" behaves the same on current browsers, but additionally downloads MathJaX from an external server (a CDN) as a fall-back on browsers too old to support MathML. Only choose this if you need to support such browsers and accept the external dependency.\n"
 "Bitmaps tend to need more band width than the other options. They lack support for advanced features like drag-and-drop or accessibility. Also they have problems aligning and scaling with the rest of the text and might use fonts that don't match the rest of the document."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:948
+#: ../../src/dialogs/ConfigDialogue.cpp:1020
 msgid "\"Numpad Enter\" always evaluates cells"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:2330
+msgid "\"OpenAI-compatible\" covers most third-party and self-hosted APIs (OpenRouter, Groq, a local Ollama server, ...) -- pick Anthropic's or Google's own style only for an endpoint that actually speaks that provider's specific request/response format (e.g. a proxy in front of one of them)."
 msgstr ""
 
 #: ../../src/sidebars/SymbolsSidebar.cpp:90
@@ -244,7 +248,7 @@ msgstr ""
 msgid "%d differences"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:1862
+#: ../../src/wxMaxima.cpp:1877
 #, c-format
 msgid "%i cells in evaluation queue"
 msgstr ""
@@ -259,12 +263,12 @@ msgstr ""
 msgid "%s image, %li×%li, %li ppi"
 msgstr ""
 
-#: ../../src/ai/AiProvider.cpp:347
+#: ../../src/ai/AiProvider.cpp:582
 #, c-format
 msgid "%s rejected the API key (HTTP 401): %s"
 msgstr ""
 
-#: ../../src/ai/AiProvider.cpp:318
+#: ../../src/ai/AiProvider.cpp:553
 #, c-format
 msgid "%s returned HTTP %d: %s"
 msgstr ""
@@ -274,62 +278,62 @@ msgstr ""
 msgid "%s: Can't interpret line: %s"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2955
+#: ../../src/wxMaxima.cpp:2970
 #, c-format
 msgid ""
 "%sCould not write the setting for:%s\n"
 "(Is the client installed?)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1769
+#: ../../src/wxMaximaFrame.cpp:1787
 msgid "&Algebraic Mode"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1998
+#: ../../src/wxMaximaFrame.cpp:2016
 msgid "&Apropos..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:720
+#: ../../src/wxMaximaFrame.cpp:732
 msgid "&Batch File...\tCtrl+B"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1389
+#: ../../src/wxMaximaFrame.cpp:1407
 msgid "&Boundary Value Problem..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:2064
+#: ../../src/wxMaximaFrame.cpp:2082
 msgid "&Bug Report"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1619
+#: ../../src/wxMaximaFrame.cpp:1637
 msgid "&Calculus"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1715
+#: ../../src/wxMaximaFrame.cpp:1733
 msgid "&Canonical Form"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1469
+#: ../../src/wxMaximaFrame.cpp:1487
 msgid "&Characteristic Polynomial..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1101
+#: ../../src/wxMaximaFrame.cpp:1119
 msgid "&Clear Memory"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1697
+#: ../../src/wxMaximaFrame.cpp:1715
 msgid "&Combine Factorials"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1742
+#: ../../src/wxMaximaFrame.cpp:1760
 msgid "&Complex Simplification"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1616
+#: ../../src/wxMaximaFrame.cpp:1634
 msgid "&Continued Fraction"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:749
+#: ../../src/wxMaximaFrame.cpp:761
 msgid "&Copy\tCtrl+C"
 msgstr ""
 
@@ -337,115 +341,115 @@ msgstr ""
 msgid "&Definite integration"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1735
+#: ../../src/wxMaximaFrame.cpp:1753
 msgid "&Demoivre"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1473
+#: ../../src/wxMaximaFrame.cpp:1491
 msgid "&Determinant"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1580
+#: ../../src/wxMaximaFrame.cpp:1598
 msgid "&Differentiate..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:800
+#: ../../src/wxMaximaFrame.cpp:812
 msgid "&Edit"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1357
+#: ../../src/wxMaximaFrame.cpp:1375
 msgid "&Eliminate Variable..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1429
+#: ../../src/wxMaximaFrame.cpp:1447
 msgid "&Enter Matrix..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1997
+#: ../../src/wxMaximaFrame.cpp:2015
 msgid "&Example..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1638
+#: ../../src/wxMaximaFrame.cpp:1656
 msgid "&Expand Expression"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1711
+#: ../../src/wxMaximaFrame.cpp:1729
 msgid "&Expand Trigonometric"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1740
+#: ../../src/wxMaximaFrame.cpp:1758
 msgid "&Exponentialize"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:725
+#: ../../src/wxMaximaFrame.cpp:737
 msgid "&Export..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1630
+#: ../../src/wxMaximaFrame.cpp:1648
 msgid "&Factor Expression"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:737
+#: ../../src/wxMaximaFrame.cpp:749
 msgid "&File"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1130
+#: ../../src/wxMaximaFrame.cpp:1148
 msgid "&Functions"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1604
+#: ../../src/wxMaximaFrame.cpp:1622
 msgid "&Greatest Common Divisor..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:2098
+#: ../../src/wxMaximaFrame.cpp:2116
 msgid "&Help"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1567
+#: ../../src/wxMaximaFrame.cpp:1585
 msgid "&Integrate..."
 msgstr ""
 
-#: ../../src/TrayIcon.cpp:111 ../../src/wxMaximaFrame.cpp:1075
+#: ../../src/TrayIcon.cpp:111 ../../src/wxMaximaFrame.cpp:1093
 msgid "&Interrupt\tCtrl+G"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1466
+#: ../../src/wxMaximaFrame.cpp:1484
 msgid "&Invert Matrix"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:2072
+#: ../../src/wxMaximaFrame.cpp:2090
 msgid "&License"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1877
+#: ../../src/wxMaximaFrame.cpp:1895
 msgid "&List"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:715
+#: ../../src/wxMaximaFrame.cpp:727
 msgid "&Load Package...\tCtrl+L"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1343
+#: ../../src/wxMaximaFrame.cpp:1361
 msgid "&Maxima"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1996
+#: ../../src/wxMaximaFrame.cpp:2014
 msgid "&Maxima help"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1774
+#: ../../src/wxMaximaFrame.cpp:1792
 msgid "&Modulus Computation..."
 msgstr ""
 
-#: ../../src/main.cpp:737
+#: ../../src/main.cpp:854
 msgid "&New\tCtrl+N"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1984
+#: ../../src/wxMaximaFrame.cpp:2002
 msgid "&Numeric"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1899
+#: ../../src/wxMaximaFrame.cpp:1917
 msgid "&Numeric Output"
 msgstr ""
 
@@ -457,15 +461,15 @@ msgstr ""
 msgid "&Nusum"
 msgstr ""
 
-#: ../../src/main.cpp:738
+#: ../../src/main.cpp:855
 msgid "&Open\tCtrl+O"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:703
+#: ../../src/wxMaximaFrame.cpp:715
 msgid "&Open...\tCtrl+O"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1894
+#: ../../src/wxMaximaFrame.cpp:1912
 msgid "&Plot"
 msgstr ""
 
@@ -473,7 +477,7 @@ msgstr ""
 msgid "&Power series"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:729
+#: ../../src/wxMaximaFrame.cpp:741
 msgid "&Print...\tCtrl+P"
 msgstr ""
 
@@ -481,15 +485,15 @@ msgstr ""
 msgid "&Rational"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1708
+#: ../../src/wxMaximaFrame.cpp:1726
 msgid "&Reduce Trigonometric"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1085
+#: ../../src/wxMaximaFrame.cpp:1103
 msgid "&Restart Maxima\tCtrl+Alt+R"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:713
+#: ../../src/wxMaximaFrame.cpp:725
 msgid "&Save\tCtrl+S"
 msgstr ""
 
@@ -497,19 +501,19 @@ msgstr ""
 msgid "&Show wxMaxima"
 msgstr ""
 
-#: ../../src/wizards/SumWiz.cpp:43 ../../src/wxMaximaFrame.cpp:1776
+#: ../../src/wizards/SumWiz.cpp:43 ../../src/wxMaximaFrame.cpp:1794
 msgid "&Simplify"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1695
+#: ../../src/wxMaximaFrame.cpp:1713
 msgid "&Simplify Factorials"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1705
+#: ../../src/wxMaximaFrame.cpp:1723
 msgid "&Simplify Trigonometric"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1349
+#: ../../src/wxMaximaFrame.cpp:1367
 msgid "&Solve..."
 msgstr ""
 
@@ -521,19 +525,19 @@ msgstr ""
 msgid "&Taylor series"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1146
+#: ../../src/wxMaximaFrame.cpp:1164
 msgid "&Time Display"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1486
+#: ../../src/wxMaximaFrame.cpp:1504
 msgid "&Transpose Matrix"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1719
+#: ../../src/wxMaximaFrame.cpp:1737
 msgid "&Trigonometric Simplification"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1132
+#: ../../src/wxMaximaFrame.cpp:1150
 msgid "&Variables"
 msgstr ""
 
@@ -547,6 +551,10 @@ msgstr ""
 
 #: ../../src/MaximaProcessManager.cpp:789
 msgid "(Config tells to suppress the output of long cells)"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:2284
+msgid "(Custom)"
 msgstr ""
 
 #: ../../src/cells/ImgCell.cpp:284
@@ -573,7 +581,7 @@ msgstr ""
 msgid "(Not a valid variable name)"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:185
+#: ../../src/dialogs/ConfigDialogue.cpp:189
 msgid "(Use default language)"
 msgstr ""
 
@@ -589,19 +597,19 @@ msgstr ""
 msgid "(f(x),x,a,b), (semi-) infinite interval"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1955
+#: ../../src/wxMaximaFrame.cpp:1973
 msgid "(f(x),x,a,b), Epsilon algorithm"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1957
+#: ../../src/wxMaximaFrame.cpp:1975
 msgid "(f(x),x,a,b), infinite interval"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1953
+#: ../../src/wxMaximaFrame.cpp:1971
 msgid "(f(x),x,a,b), strategy of Aind"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:596 ../../src/wxMaximaFrame.cpp:1981
+#: ../../src/MaximaCommandMenus.cpp:596 ../../src/wxMaximaFrame.cpp:1999
 msgid "(f(x),x,y) with singularities+discontinuities"
 msgstr ""
 
@@ -639,23 +647,23 @@ msgstr ""
 msgid "2D"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1423
+#: ../../src/wxMaximaFrame.cpp:1441
 msgid "2D Array to Matrix..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:857
+#: ../../src/wxMaximaFrame.cpp:875
 msgid "2D equations using ASCII Art"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:860
+#: ../../src/wxMaximaFrame.cpp:878
 msgid "2D equations using ASCII Art with unicode characters, if available"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:804
+#: ../../src/dialogs/ConfigDialogue.cpp:876
 msgid "2D if it fits on the page width"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:803
+#: ../../src/dialogs/ConfigDialogue.cpp:875
 msgid "2D, whenever possible"
 msgstr ""
 
@@ -663,12 +671,12 @@ msgstr ""
 msgid "3D"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:1866
+#: ../../src/wxMaxima.cpp:1881
 #, c-format
 msgid "; %i commands left in the current cell"
 msgstr ""
 
-#: ../../src/MaximaEvaluator.cpp:500
+#: ../../src/MaximaEvaluator.cpp:507
 msgid "A \":lisp\" as the first command might fail to send a \"finished\" signal."
 msgstr ""
 
@@ -694,7 +702,7 @@ msgid ""
 "Most probable cause: A missing comma between two list items."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2738
+#: ../../src/wxMaxima.cpp:2753
 #, c-format
 msgid "A find event, %s"
 msgstr ""
@@ -755,11 +763,11 @@ msgstr ""
 msgid "A right-associative function"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:440
+#: ../../src/dialogs/ConfigDialogue.cpp:456
 msgid "A scale factor for the printout. Helpful for printing big equations on small pdf pages."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1748
+#: ../../src/wxMaximaFrame.cpp:1766
 msgid "A search-and-replace for equations"
 msgstr ""
 
@@ -787,7 +795,7 @@ msgstr ""
 msgid "A subsection heading"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1750
+#: ../../src/wxMaximaFrame.cpp:1768
 msgid "A subst with basic maths knowledge"
 msgstr ""
 
@@ -817,28 +825,33 @@ msgstr ""
 msgid "A worksheet cell"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1556
+#: ../../src/wxMaximaFrame.cpp:1574
 msgid "A&pply function to each Matrix element..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1402
+#: ../../src/wxMaximaFrame.cpp:1420
 msgid "A&t Value..."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:291 ../../src/wxMaximaFrame.cpp:317
-#: ../../src/wxMaximaFrame.cpp:832
+#: ../../src/dialogs/ConfigDialogue.cpp:305 ../../src/wxMaximaFrame.cpp:327
+#: ../../src/wxMaximaFrame.cpp:849
 msgid "AI Chat"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1985
+#: ../../src/dialogs/ConfigDialogue.cpp:2103
 msgid "API key:"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:2086
+#: ../../src/dialogs/ConfigDialogue.cpp:2302
+msgid "API style:"
 msgstr ""
 
 #: ../../src/Styles.cpp:169
 msgid "ASCII maths"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1673
+#: ../../src/dialogs/ConfigDialogue.cpp:1745
 msgid "Abort evaluation on error"
 msgstr ""
 
@@ -847,11 +860,11 @@ msgstr ""
 msgid "Aborting due to --exit-on-error (exit code %d). Cell: %s"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:2093
+#: ../../src/wxMaximaFrame.cpp:2111
 msgid "About"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:2093 ../../src/wxMaximaFrame.cpp:2095
+#: ../../src/wxMaximaFrame.cpp:2111 ../../src/wxMaximaFrame.cpp:2113
 msgid "About wxMaxima"
 msgstr ""
 
@@ -867,7 +880,7 @@ msgstr ""
 msgid "Accepts one variable or a list in the format [var1,var2,...]"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:296
+#: ../../src/dialogs/ConfigDialogue.cpp:312
 msgid "Accessibility"
 msgstr ""
 
@@ -875,23 +888,27 @@ msgstr ""
 msgid "Accuracy"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1961
+#: ../../src/dialogs/ConfigDialogue.cpp:2055
 msgid "Active provider:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1482
+#: ../../src/wxMaximaFrame.cpp:1500
 msgid "Ad&joint Matrix"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1771
+#: ../../src/wxMaximaFrame.cpp:1789
 msgid "Add Algebraic E&quality..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1126
+#: ../../src/dialogs/ConfigDialogue.cpp:2268
+msgid "Add Custom AI Provider"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:1144
 msgid "Add a directory to search path"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1866
+#: ../../src/wxMaximaFrame.cpp:1884
 msgid "Add a new item to the beginning of the list. Useful for creating stacks."
 msgstr ""
 
@@ -907,11 +924,15 @@ msgstr ""
 msgid "Add an element to the start of a list"
 msgstr ""
 
+#: ../../src/dialogs/ConfigDialogue.cpp:2156
+msgid "Add custom provider..."
+msgstr ""
+
 #: ../../src/MaximaCommandMenus.cpp:4527
 msgid "Add dir to path:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1772
+#: ../../src/wxMaximaFrame.cpp:1790
 msgid "Add equality to the rational simplifier"
 msgstr ""
 
@@ -919,11 +940,11 @@ msgstr ""
 msgid "Add more symbols"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1280
+#: ../../src/dialogs/ConfigDialogue.cpp:1352
 msgid "Add the .wxmx file to the HTML export"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1126
+#: ../../src/wxMaximaFrame.cpp:1144
 msgid "Add to &Path..."
 msgstr ""
 
@@ -942,35 +963,35 @@ msgstr ""
 msgid "Added much text (%li chars) to the XML inspector."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2053
+#: ../../src/dialogs/ConfigDialogue.cpp:2393
 msgid "Additional clipboard formats to put on the clipboard on ordinary copy"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:397
+#: ../../src/dialogs/ConfigDialogue.cpp:413
 msgid "Additional commands to be added to the preamble of LaTeX output for pdftex."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1205
+#: ../../src/dialogs/ConfigDialogue.cpp:1277
 msgid "Additional lines for the TeX preamble:"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:393
+#: ../../src/dialogs/ConfigDialogue.cpp:409
 msgid "Additional parameters for Maxima (e.g. -l clisp)."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1598
+#: ../../src/dialogs/ConfigDialogue.cpp:1670
 msgid "Additional parameters for Maxima (restart Maxima after changes)"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1336
+#: ../../src/dialogs/ConfigDialogue.cpp:1408
 msgid "Additional symbols for the \"symbols\" sidebar:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1676
+#: ../../src/wxMaximaFrame.cpp:1694
 msgid "Additionally: log(a*b)=log(a)+log(b)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1680
+#: ../../src/wxMaximaFrame.cpp:1698
 msgid "Additionally: log(a/b)=log(a)-log(b), a and b positive integers"
 msgstr ""
 
@@ -978,19 +999,19 @@ msgstr ""
 msgid "Additive function: f(a+b)=f(a)+f(b)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:2025
+#: ../../src/wxMaximaFrame.cpp:2043
 msgid "Advanced 2d plotting"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1923
+#: ../../src/wxMaximaFrame.cpp:1941
 msgid "Advanced guess (PSLQ algorithm)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:2034
+#: ../../src/wxMaximaFrame.cpp:2052
 msgid "Advanced variable names"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:186
+#: ../../src/dialogs/ConfigDialogue.cpp:190
 msgid "Afrikaans"
 msgstr ""
 
@@ -998,11 +1019,11 @@ msgstr ""
 msgid "After clicking on animations created with with_slider_draw() or similar, this slider allows changing the current frame."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:187
+#: ../../src/dialogs/ConfigDialogue.cpp:191
 msgid "Albanian"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1139
+#: ../../src/wxMaximaFrame.cpp:1157
 msgid "Aliases"
 msgstr ""
 
@@ -1010,23 +1031,23 @@ msgstr ""
 msgid "All Levels"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1828
+#: ../../src/wxMaximaFrame.cpp:1846
 msgid "All but the 1st n elements"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1830
+#: ../../src/wxMaximaFrame.cpp:1848
 msgid "All but the last n elements"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:2198 ../../src/main.cpp:946
+#: ../../src/MaximaCommandMenus.cpp:2198 ../../src/main.cpp:1071
 msgid "All openable types (*.wxm, *.wxmx, *.mac, *.out, *.xml)|*.wxm;*.wxmx;*.mac;*.out;*.xml|wxMaxima document (*.wxm, *.wxmx)|*.wxm;*.wxmx|Maxima session (*.mac)|*.mac|Xmaxima session (*.out)|*.out|xml from broken .wxmx (*.xml)|*.xml"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:768
+#: ../../src/dialogs/ConfigDialogue.cpp:840
 msgid "All variable names"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:847
+#: ../../src/wxMaximaFrame.cpp:865
 msgid "All visible sidebars"
 msgstr ""
 
@@ -1034,7 +1055,7 @@ msgstr ""
 msgid "Allow access to an online manual?"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1764
+#: ../../src/wxMaximaFrame.cpp:1782
 msgid "Allow substituting operators"
 msgstr ""
 
@@ -1054,15 +1075,15 @@ msgstr ""
 msgid "All|*"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:877
+#: ../../src/wxMaximaFrame.cpp:895
 msgid "Always after underscores"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:878
+#: ../../src/wxMaximaFrame.cpp:896
 msgid "Always autosubscript after an underscore"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:888
+#: ../../src/wxMaximaFrame.cpp:906
 msgid "Always display this variable with subscript"
 msgstr ""
 
@@ -1090,7 +1111,7 @@ msgstr ""
 msgid "Anchors file has no top node."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:905
+#: ../../src/wxMaximaFrame.cpp:923
 msgid "Angles"
 msgstr ""
 
@@ -1099,39 +1120,43 @@ msgstr ""
 msgid "Animated Diagram"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1889
+#: ../../src/wxMaximaFrame.cpp:1907
 msgid "Animation autoplay"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1892
+#: ../../src/wxMaximaFrame.cpp:1910
 msgid "Animation framerate..."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1926
+#: ../../src/dialogs/ConfigDialogue.cpp:1998
 msgid "Announce Maxima's output as MathML"
 msgstr ""
 
-#: ../../src/worksheet/Worksheet.cpp:5507 ../../src/wxMaximaFrame.cpp:2066
+#: ../../src/worksheet/Worksheet.cpp:5507 ../../src/wxMaximaFrame.cpp:2084
 msgid "Anonymize Code for Bug Report"
+msgstr ""
+
+#: ../../src/ai/AiProvider.cpp:203
+msgid "Anthropic (Messages API)"
 msgstr ""
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:778
 msgid "Antisymmetric function: f(x)=-f(-x)"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2221
+#: ../../src/dialogs/ConfigDialogue.cpp:2561
 msgid "Appearance:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1853
+#: ../../src/wxMaximaFrame.cpp:1871
 msgid "Append"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1849
+#: ../../src/wxMaximaFrame.cpp:1867
 msgid "Append a list"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1850
+#: ../../src/wxMaximaFrame.cpp:1868
 msgid "Append a list to an existing list"
 msgstr ""
 
@@ -1139,15 +1164,15 @@ msgstr ""
 msgid "Append a list to another list"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1843
+#: ../../src/wxMaximaFrame.cpp:1861
 msgid "Append an element"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1848
+#: ../../src/wxMaximaFrame.cpp:1866
 msgid "Append an element to the beginning an existing list"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1844
+#: ../../src/wxMaximaFrame.cpp:1862
 msgid "Append an element to the end of an existing list"
 msgstr ""
 
@@ -1155,12 +1180,12 @@ msgstr ""
 msgid "Apply a function to each list element"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1924
+#: ../../src/wxMaximaFrame.cpp:1942
 #, c-format
 msgid "Approximate by a fraction using log(), sqrt() and %pi, when needed. Only available in maxima > 5.46.0"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1920
+#: ../../src/wxMaximaFrame.cpp:1938
 msgid "Approximate by nice fraction"
 msgstr ""
 
@@ -1178,7 +1203,7 @@ msgstr ""
 msgid "Apropos"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:188
+#: ../../src/dialogs/ConfigDialogue.cpp:192
 msgid "Arabic"
 msgstr ""
 
@@ -1206,7 +1231,7 @@ msgstr ""
 msgid "Array"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1134
+#: ../../src/wxMaximaFrame.cpp:1152
 msgid "Arrays"
 msgstr ""
 
@@ -1225,11 +1250,11 @@ msgstr ""
 msgid "Ascii code to char"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1249
+#: ../../src/wxMaximaFrame.cpp:1267
 msgid "Ascii code to char..."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1415
+#: ../../src/dialogs/ConfigDialogue.cpp:1487
 msgid "Ask to save untitled documents"
 msgstr ""
 
@@ -1253,21 +1278,21 @@ msgstr ""
 msgid "Attention: Extracting a random list element isn't efficient for long lists.Iterating over lists using makelist() or for loops is way faster."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:915
+#: ../../src/dialogs/ConfigDialogue.cpp:987
 msgid "Auto-indent new lines"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:911
+#: ../../src/dialogs/ConfigDialogue.cpp:983
 msgid "Auto-insert closing parenthesis"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1496
-#: ../../src/dialogs/ConfigDialogue.cpp:1527
+#: ../../src/dialogs/ConfigDialogue.cpp:1568
+#: ../../src/dialogs/ConfigDialogue.cpp:1599
 #: ../../src/dialogs/MaximaNotStartingDialog.cpp:43
 msgid "Autodetect"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1254
+#: ../../src/dialogs/ConfigDialogue.cpp:1326
 msgid "Automatic"
 msgstr ""
 
@@ -1275,20 +1300,20 @@ msgstr ""
 msgid "Automatic labels"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:787
+#: ../../src/dialogs/ConfigDialogue.cpp:859
 #, c-format
 msgid "Automatic labels (%i1, %o1,...)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1063
+#: ../../src/wxMaximaFrame.cpp:1081
 msgid "Automatically answer questions"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1064
+#: ../../src/wxMaximaFrame.cpp:1082
 msgid "Automatically fill in answers known from the last run"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:464
+#: ../../src/dialogs/ConfigDialogue.cpp:480
 msgid "Automatically insert a closing parenthesis the moment the user enters an opening one."
 msgstr ""
 
@@ -1307,15 +1332,15 @@ msgstr ""
 msgid "Autosaving the .wxmx file as %s"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:895
+#: ../../src/wxMaximaFrame.cpp:913
 msgid "Autosubscript"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:896
+#: ../../src/wxMaximaFrame.cpp:914
 msgid "Autosubscript chars after an underscore"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:881
+#: ../../src/wxMaximaFrame.cpp:899
 msgid "Autosubscript numbers and text following single letters"
 msgstr ""
 
@@ -1323,7 +1348,7 @@ msgstr ""
 msgid "Autosubscript this variable"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:752
+#: ../../src/dialogs/ConfigDialogue.cpp:824
 msgid "Autowrap long lines:"
 msgstr ""
 
@@ -1343,11 +1368,11 @@ msgstr ""
 msgid "Barsplot..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1461
+#: ../../src/wxMaximaFrame.cpp:1479
 msgid "Basic matrix operations"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:189
+#: ../../src/dialogs/ConfigDialogue.cpp:193
 msgid "Basque"
 msgstr ""
 
@@ -1359,12 +1384,12 @@ msgstr ""
 msgid "Batch File"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2109
+#: ../../src/wxMaxima.cpp:2124
 #, c-format
 msgid "Batch mode: %d image(s) could not be loaded at all (exit code %d)."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2115
+#: ../../src/wxMaxima.cpp:2130
 #, c-format
 msgid "Batch mode: %d image(s) failed to decode/render (--debug, exit code %d)."
 msgstr ""
@@ -1386,27 +1411,27 @@ msgstr ""
 msgid "Beta"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2055
+#: ../../src/dialogs/ConfigDialogue.cpp:2395
 msgid "Bitmap"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1291
+#: ../../src/dialogs/ConfigDialogue.cpp:1363
 msgid "Bitmap scale for export:"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1241
+#: ../../src/dialogs/ConfigDialogue.cpp:1313
 msgid "Bitmaps"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2266
+#: ../../src/dialogs/ConfigDialogue.cpp:2606
 msgid "Bold"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2293
+#: ../../src/wxMaxima.cpp:2308
 msgid "Both horizontal and vertical cursor active at the same time"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2156
+#: ../../src/dialogs/ConfigDialogue.cpp:2496
 msgid "Bottom"
 msgstr ""
 
@@ -1481,7 +1506,7 @@ msgstr ""
 msgid "Bug: Math Cell that claims to have no group Cell it belongs to"
 msgstr ""
 
-#: ../../src/Configuration.h:794
+#: ../../src/Configuration.h:818
 msgid "Bug: Maximum number of digits that is to be displayed is too low!"
 msgstr ""
 
@@ -1561,7 +1586,7 @@ msgstr ""
 msgid "Bug: y position of cell is unknown!"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:2062
+#: ../../src/wxMaximaFrame.cpp:2080
 msgid "Build &Info"
 msgstr ""
 
@@ -1570,7 +1595,7 @@ msgstr ""
 msgid "Build from Git version: %s\n"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1436
+#: ../../src/dialogs/ConfigDialogue.cpp:1508
 msgid "By default \"Find and Replace\" (Ctrl+F) opens as a floating window. Enable this to make it a sidebar you can dock, like the other sidebars, instead."
 msgstr ""
 
@@ -1582,11 +1607,11 @@ msgstr ""
 msgid "Byte:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1572
+#: ../../src/wxMaximaFrame.cpp:1590
 msgid "C&hange Variable in Integrate..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:798
+#: ../../src/wxMaximaFrame.cpp:810
 msgid "C&onfigure"
 msgstr ""
 
@@ -1603,7 +1628,7 @@ msgstr ""
 msgid "Caching font variant: %s"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1596
+#: ../../src/wxMaximaFrame.cpp:1614
 msgid "Calculate &Product..."
 msgstr ""
 
@@ -1615,15 +1640,15 @@ msgstr ""
 msgid "Calculate Singular Value Decomposition, left and right singular vectors numerically"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1594
+#: ../../src/wxMaximaFrame.cpp:1612
 msgid "Calculate Su&m..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1909
+#: ../../src/wxMaximaFrame.cpp:1927
 msgid "Calculate bigfloat value of the last result"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1906
+#: ../../src/wxMaximaFrame.cpp:1924
 msgid "Calculate float value of the last result"
 msgstr ""
 
@@ -1639,11 +1664,11 @@ msgstr ""
 msgid "Calculate modulus:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1912
+#: ../../src/wxMaximaFrame.cpp:1930
 msgid "Calculate numeric value of the last result"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1597
+#: ../../src/wxMaximaFrame.cpp:1615
 msgid "Calculate products"
 msgstr ""
 
@@ -1651,7 +1676,7 @@ msgstr ""
 msgid "Calculate standard deviation"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1594
+#: ../../src/wxMaximaFrame.cpp:1612
 msgid "Calculate sums"
 msgstr ""
 
@@ -1683,16 +1708,16 @@ msgstr ""
 msgid "Can be specified as flag in ev(exp, flag)"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3534
+#: ../../src/wxMaxima.cpp:3549
 msgid "Can not connect to the web server."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3480 ../../src/wxMaxima.cpp:3516
-#: ../../src/wxMaxima.cpp:3568
+#: ../../src/wxMaxima.cpp:3495 ../../src/wxMaxima.cpp:3531
+#: ../../src/wxMaxima.cpp:3583
 msgid "Can not download version info."
 msgstr ""
 
-#: ../../src/MaximaProcessManager.cpp:595 ../../src/wxMaxima.cpp:1612
+#: ../../src/MaximaProcessManager.cpp:595 ../../src/wxMaxima.cpp:1627
 msgid "Can not start Maxima. The most probable cause is that Maxima isn't installed (it can be downloaded from https://maxima.sourceforge.io) or in wxMaxima's config dialogue the setting for Maxima's location is wrong."
 msgstr ""
 
@@ -1730,7 +1755,7 @@ msgstr ""
 #: ../../src/wizards/SeriesWiz.cpp:52 ../../src/wizards/SubstituteWiz.cpp:42
 #: ../../src/wizards/SubstituteWiz.cpp:44 ../../src/wizards/SumWiz.cpp:48
 #: ../../src/wizards/SumWiz.cpp:50 ../../src/wizards/SystemWiz.cpp:39
-#: ../../src/wizards/SystemWiz.cpp:41 ../../src/wxMaxima.cpp:3605
+#: ../../src/wizards/SystemWiz.cpp:41 ../../src/wxMaxima.cpp:3620
 msgid "Cancel"
 msgstr ""
 
@@ -1738,7 +1763,7 @@ msgstr ""
 msgid "Cannot authenticate Maxima!"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:1300
+#: ../../src/wxMaxima.cpp:1315
 #, c-format
 msgid "Cannot cache the list of known symbols to %s"
 msgstr ""
@@ -1762,8 +1787,8 @@ msgstr ""
 msgid "Cannot interpret the numeric value of pid %s"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3443 ../../src/wxMaxima.cpp:3450
-#: ../../src/wxMaxima.cpp:3457
+#: ../../src/wxMaxima.cpp:3458 ../../src/wxMaxima.cpp:3465
+#: ../../src/wxMaxima.cpp:3472
 #, c-format
 msgid "Cannot interpret version number component %s"
 msgstr ""
@@ -1821,7 +1846,7 @@ msgstr ""
 msgid "Canonical (tr)"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:190
+#: ../../src/dialogs/ConfigDialogue.cpp:194
 msgid "Catalan"
 msgstr ""
 
@@ -1829,11 +1854,11 @@ msgstr ""
 msgid "Cauchy principal value of f(x)/(x-c), finite interval"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1959
+#: ../../src/wxMaximaFrame.cpp:1977
 msgid "Cauchy principal value, finite interval"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1066
+#: ../../src/wxMaximaFrame.cpp:1084
 msgid "Ce&ll"
 msgstr ""
 
@@ -1845,7 +1870,7 @@ msgstr ""
 msgid "Cell bracket fill, Inactive"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3178
+#: ../../src/wxMaxima.cpp:3193
 msgid "Cell ends in a backslash"
 msgstr ""
 
@@ -1854,7 +1879,7 @@ msgstr ""
 msgid "Cell with UUID %s not found!"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1149
+#: ../../src/wxMaximaFrame.cpp:1167
 msgid "Change &2d Display"
 msgstr ""
 
@@ -1866,7 +1891,7 @@ msgstr ""
 msgid "Change Image..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:2074
+#: ../../src/wxMaximaFrame.cpp:2092
 msgid "Change Log"
 msgstr ""
 
@@ -1874,19 +1899,19 @@ msgstr ""
 msgid "Change directory"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1313
+#: ../../src/wxMaximaFrame.cpp:1331
 msgid "Change directory..."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:877
+#: ../../src/dialogs/ConfigDialogue.cpp:949
 msgid "Change names of greek letters to greek letters"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1150
+#: ../../src/wxMaximaFrame.cpp:1168
 msgid "Change the 2d display algorithm used to display math output"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:493
+#: ../../src/dialogs/ConfigDialogue.cpp:509
 msgid "Change the text \"alpha\" and \"beta\" to the corresponding greek letter?"
 msgstr ""
 
@@ -1898,11 +1923,11 @@ msgstr ""
 msgid "Change variable and evaluate"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1573
+#: ../../src/wxMaximaFrame.cpp:1591
 msgid "Change variable in integral or sum"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1577
+#: ../../src/wxMaximaFrame.cpp:1595
 msgid "Change variable in integral or sum and evaluate the result"
 msgstr ""
 
@@ -1910,7 +1935,7 @@ msgstr ""
 msgid "ChangeLog"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1137
+#: ../../src/wxMaximaFrame.cpp:1155
 msgid "Changed option variables"
 msgstr ""
 
@@ -1931,7 +1956,7 @@ msgstr ""
 msgid "Char #2:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1251
+#: ../../src/wxMaximaFrame.cpp:1269
 msgid "Char to Unicode code point..."
 msgstr ""
 
@@ -1947,7 +1972,7 @@ msgstr ""
 msgid "Char:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1242
+#: ../../src/wxMaximaFrame.cpp:1260
 msgid "Character Tests"
 msgstr ""
 
@@ -1959,16 +1984,16 @@ msgstr ""
 msgid "Chars are strings that are one character long"
 msgstr ""
 
-#: ../../src/sidebars/AiChatSidebar.cpp:168
+#: ../../src/sidebars/AiChatSidebar.cpp:191
 #, c-format
 msgid "Chatting with %s"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:2077
+#: ../../src/wxMaximaFrame.cpp:2095
 msgid "Check for Updates"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:2078
+#: ../../src/wxMaximaFrame.cpp:2096
 msgid "Check if a newer version of wxMaxima is available."
 msgstr ""
 
@@ -1976,19 +2001,19 @@ msgstr ""
 msgid "Chi"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:191
+#: ../../src/dialogs/ConfigDialogue.cpp:195
 msgid "Chinese (Simplified)"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:192
+#: ../../src/dialogs/ConfigDialogue.cpp:196
 msgid "Chinese (traditional)"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1609
+#: ../../src/dialogs/ConfigDialogue.cpp:1681
 msgid "Choose a Lisp Maxima was compiled with"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1615
+#: ../../src/dialogs/ConfigDialogue.cpp:1687
 msgid "Choose between installed Maxima versions"
 msgstr ""
 
@@ -1996,11 +2021,11 @@ msgstr ""
 msgid "Choose between the following help topics:"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2257
+#: ../../src/dialogs/ConfigDialogue.cpp:2597
 msgid "Choose font"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:811
+#: ../../src/dialogs/ConfigDialogue.cpp:883
 msgid ""
 "Choose how mathematical output is formatted:\n"
 "\"2D, whenever possible\" keeps all expressions in two-dimensional form (fractions stacked, matrices drawn as boxes), even if they overflow the page width.\n"
@@ -2012,12 +2037,12 @@ msgstr ""
 msgid "Choose new plot format:"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2601
+#: ../../src/dialogs/ConfigDialogue.cpp:2983
 #, c-format
 msgid "Choose the %s Font"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:914
+#: ../../src/wxMaximaFrame.cpp:932
 msgid "Choose the parenthesis type for Matrices"
 msgstr ""
 
@@ -2025,7 +2050,7 @@ msgstr ""
 msgid "Classes:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1489
+#: ../../src/wxMaximaFrame.cpp:1507
 msgid "Classic matrix operations"
 msgstr ""
 
@@ -2033,23 +2058,23 @@ msgstr ""
 msgid "Clear"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1109
+#: ../../src/wxMaximaFrame.cpp:1127
 msgid "Clear all aliases"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1106
+#: ../../src/wxMaximaFrame.cpp:1124
 msgid "Clear all arrays"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1103
+#: ../../src/wxMaximaFrame.cpp:1121
 msgid "Clear all dependencies"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1105
+#: ../../src/wxMaximaFrame.cpp:1123
 msgid "Clear all functions"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1112
+#: ../../src/wxMaximaFrame.cpp:1130
 msgid "Clear all gradefs"
 msgstr ""
 
@@ -2057,31 +2082,31 @@ msgstr ""
 msgid "Clear all history"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1111
+#: ../../src/wxMaximaFrame.cpp:1129
 msgid "Clear all labels"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1115
+#: ../../src/wxMaximaFrame.cpp:1133
 msgid "Clear all let rule packages"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1114
+#: ../../src/wxMaximaFrame.cpp:1132
 msgid "Clear all macros"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1113
+#: ../../src/wxMaximaFrame.cpp:1131
 msgid "Clear all props"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1108
+#: ../../src/wxMaximaFrame.cpp:1126
 msgid "Clear all rules"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1110
+#: ../../src/wxMaximaFrame.cpp:1128
 msgid "Clear all structures"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1104
+#: ../../src/wxMaximaFrame.cpp:1122
 msgid "Clear all variables"
 msgstr ""
 
@@ -2094,11 +2119,11 @@ msgstr ""
 msgid "Cleared font cache for font %s"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2083
+#: ../../src/dialogs/ConfigDialogue.cpp:2423
 msgid "Clipboard format parameters"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:711
+#: ../../src/wxMaximaFrame.cpp:723
 msgid "Close\tCtrl+W"
 msgstr ""
 
@@ -2106,11 +2131,11 @@ msgstr ""
 msgid "Close Stream"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:711
+#: ../../src/wxMaximaFrame.cpp:723
 msgid "Close window"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1216
+#: ../../src/wxMaximaFrame.cpp:1234
 msgid "Close..."
 msgstr ""
 
@@ -2190,7 +2215,7 @@ msgstr ""
 msgid "Columns:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1698
+#: ../../src/wxMaximaFrame.cpp:1716
 msgid "Combine factorials in an expression"
 msgstr ""
 
@@ -2198,7 +2223,7 @@ msgstr ""
 msgid "Comma"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3237
+#: ../../src/wxMaxima.cpp:3252
 msgid "Comma directly followed by a closing parenthesis"
 msgstr ""
 
@@ -2292,7 +2317,7 @@ msgstr ""
 msgid "Command:"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1163
+#: ../../src/dialogs/ConfigDialogue.cpp:1235
 msgid "Commands that are executed at every start of maxima."
 msgstr ""
 
@@ -2304,11 +2329,11 @@ msgstr ""
 msgid "Comment Selection"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:792
+#: ../../src/wxMaximaFrame.cpp:804
 msgid "Comment out the currently selected text"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:791
+#: ../../src/wxMaximaFrame.cpp:803
 msgid "Comment selection\tCtrl+/"
 msgstr ""
 
@@ -2316,15 +2341,15 @@ msgstr ""
 msgid "Commutative function"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:723
+#: ../../src/wxMaximaFrame.cpp:735
 msgid "Compare files..."
 msgstr ""
 
-#: ../../src/main.cpp:786
+#: ../../src/main.cpp:911
 msgid "Comparing worksheets (the --diff option or the wxmxdiff command) needs 2 or 3 files to compare."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1507
+#: ../../src/wxMaximaFrame.cpp:1525
 msgid "Compile a QR decomposition using dgeqrf"
 msgstr ""
 
@@ -2332,27 +2357,27 @@ msgstr ""
 msgid "Compile a function"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1299
+#: ../../src/wxMaximaFrame.cpp:1317
 msgid "Compile a regular expression"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1496
+#: ../../src/wxMaximaFrame.cpp:1514
 msgid "Compile eigenvalues using dgeev"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1499
+#: ../../src/wxMaximaFrame.cpp:1517
 msgid "Compile eigenvalues using zgeev"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1502
+#: ../../src/wxMaximaFrame.cpp:1520
 msgid "Compile eigenvalues+eigenvectors using dgeev"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1505
+#: ../../src/wxMaximaFrame.cpp:1523
 msgid "Compile eigenvalues+eigenvectors using zgeev"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1187
+#: ../../src/wxMaximaFrame.cpp:1205
 msgid "Compile function..."
 msgstr ""
 
@@ -2373,11 +2398,11 @@ msgstr ""
 msgid "Compiling a function can generate a considerable speed boost if the types of the function parameters are made known to the function before it is compiled. Else the generated code has to be hideously generic."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1003
+#: ../../src/wxMaximaFrame.cpp:1021
 msgid "Complete Word\tCtrl+Space"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1004
+#: ../../src/wxMaximaFrame.cpp:1022
 msgid "Complete word"
 msgstr ""
 
@@ -2393,35 +2418,35 @@ msgstr ""
 msgid "Composing a list of the line starts we can use as page starts"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1617
+#: ../../src/wxMaximaFrame.cpp:1635
 msgid "Compute continued fraction of a value"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1483
+#: ../../src/wxMaximaFrame.cpp:1501
 msgid "Compute the adjoint matrix"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1470
+#: ../../src/wxMaximaFrame.cpp:1488
 msgid "Compute the characteristic polynomial of a matrix"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1474
+#: ../../src/wxMaximaFrame.cpp:1492
 msgid "Compute the determinant of a matrix"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1605
+#: ../../src/wxMaximaFrame.cpp:1623
 msgid "Compute the greatest common divisor"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1467
+#: ../../src/wxMaximaFrame.cpp:1485
 msgid "Compute the inverse of a matrix"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1608
+#: ../../src/wxMaximaFrame.cpp:1626
 msgid "Compute the least common multiple (do load(functs) before using)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1485
+#: ../../src/wxMaximaFrame.cpp:1503
 msgid "Compute the rank of a matrix"
 msgstr ""
 
@@ -2429,24 +2454,24 @@ msgstr ""
 msgid "Condition:"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2648
-#: ../../src/dialogs/ConfigDialogue.cpp:2658
-#: ../../src/dialogs/ConfigDialogue.cpp:2810
-#: ../../src/dialogs/ConfigDialogue.cpp:2816
+#: ../../src/dialogs/ConfigDialogue.cpp:3030
+#: ../../src/dialogs/ConfigDialogue.cpp:3040
+#: ../../src/dialogs/ConfigDialogue.cpp:3192
+#: ../../src/dialogs/ConfigDialogue.cpp:3198
 msgid "Config file (*.ini)|*.ini"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2708
+#: ../../src/dialogs/ConfigDialogue.cpp:3090
 #, c-format
 msgid "Config item \"%s\" was of an unknown type"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2776
+#: ../../src/dialogs/ConfigDialogue.cpp:3158
 msgid "Configuration warning"
 msgstr ""
 
 #: ../../src/ToolBar.cpp:367 ../../src/ToolBar.cpp:369
-#: ../../src/wxMaximaFrame.cpp:796 ../../src/wxMaximaFrame.cpp:798
+#: ../../src/wxMaximaFrame.cpp:808 ../../src/wxMaximaFrame.cpp:810
 msgid "Configure wxMaxima"
 msgstr ""
 
@@ -2472,7 +2497,7 @@ msgstr ""
 msgid "Construct a fraction"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1416
+#: ../../src/wxMaximaFrame.cpp:1434
 msgid "Construct fraction..."
 msgstr ""
 
@@ -2484,11 +2509,11 @@ msgstr ""
 msgid "Contents:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1991
+#: ../../src/wxMaximaFrame.cpp:2009
 msgid "Context-sensitive &Help\tCtrl+?"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1993
+#: ../../src/wxMaximaFrame.cpp:2011
 msgid "Context-sensitive &Help\tF1"
 msgstr ""
 
@@ -2516,55 +2541,55 @@ msgstr ""
 msgid "Contour lines settings for the following 3d plots"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1656
+#: ../../src/wxMaximaFrame.cpp:1674
 msgid "Contract Logarithms"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1272
+#: ../../src/wxMaximaFrame.cpp:1290
 msgid "Conversions"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1340
+#: ../../src/wxMaximaFrame.cpp:1358
 msgid "Convert"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1341
+#: ../../src/wxMaximaFrame.cpp:1359
 msgid "Convert + Write to file"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1548
+#: ../../src/wxMaximaFrame.cpp:1566
 msgid "Convert Column to list..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1544
+#: ../../src/wxMaximaFrame.cpp:1562
 msgid "Convert Row to list..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1155
+#: ../../src/wxMaximaFrame.cpp:1173
 msgid "Convert a command to maxima code"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1432
+#: ../../src/wxMaximaFrame.cpp:1450
 msgid "Convert a list of lists to a matrix"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1688
+#: ../../src/wxMaximaFrame.cpp:1706
 msgid "Convert binomials, beta and gamma function to factorials"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1692
+#: ../../src/wxMaximaFrame.cpp:1710
 msgid "Convert binomials, factorials and beta function to gamma function"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1727
+#: ../../src/wxMaximaFrame.cpp:1745
 msgid "Convert complex expression to polar form"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1724
+#: ../../src/wxMaximaFrame.cpp:1742
 msgid "Convert complex expression to rect form"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1736
+#: ../../src/wxMaximaFrame.cpp:1754
 msgid "Convert exponential function of imaginary argument to trigonometric form"
 msgstr ""
 
@@ -2576,23 +2601,23 @@ msgstr ""
 msgid "Convert string to matching regex"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1657
+#: ../../src/wxMaximaFrame.cpp:1675
 msgid "Convert sum of logarithms to logarithm of product"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1687
+#: ../../src/wxMaximaFrame.cpp:1705
 msgid "Convert to &Factorials"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1691
+#: ../../src/wxMaximaFrame.cpp:1709
 msgid "Convert to &Gamma"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1726
+#: ../../src/wxMaximaFrame.cpp:1744
 msgid "Convert to &Polarform"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1723
+#: ../../src/wxMaximaFrame.cpp:1741
 msgid "Convert to &Rectform"
 msgstr ""
 
@@ -2624,7 +2649,7 @@ msgstr ""
 msgid "Convert to Title"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1277
+#: ../../src/wxMaximaFrame.cpp:1295
 msgid "Convert to downcase..."
 msgstr ""
 
@@ -2636,11 +2661,11 @@ msgstr ""
 msgid "Convert to programming language file"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1716
+#: ../../src/wxMaximaFrame.cpp:1734
 msgid "Convert trigonometric expression to canonical quasilinear form"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1741
+#: ../../src/wxMaximaFrame.cpp:1759
 msgid "Convert trigonometric functions to exponential form"
 msgstr ""
 
@@ -2652,16 +2677,16 @@ msgstr ""
 msgid "Converted to linear:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1876
+#: ../../src/wxMaximaFrame.cpp:1894
 msgid "Converts a matrix to a list of lists"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1874
+#: ../../src/wxMaximaFrame.cpp:1892
 msgid "Converts a nested list like [[1,2],[3,4]] to a matrix"
 msgstr ""
 
 #: ../../src/ToolBar.cpp:380 ../../src/ToolBar.cpp:384
-#: ../../src/dialogs/ConfigDialogue.cpp:287
+#: ../../src/dialogs/ConfigDialogue.cpp:297
 #: ../../src/worksheet/WorksheetContextMenu.cpp:48
 #: ../../src/worksheet/WorksheetContextMenu.cpp:122
 #: ../../src/worksheet/WorksheetContextMenu.cpp:271
@@ -2675,11 +2700,11 @@ msgstr ""
 msgid "Copy Animation"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:998
+#: ../../src/wxMaximaFrame.cpp:1016
 msgid "Copy Previous Input\tCtrl+I"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1001
+#: ../../src/wxMaximaFrame.cpp:1019
 msgid "Copy Previous Output\tCtrl+U"
 msgstr ""
 
@@ -2689,7 +2714,7 @@ msgstr ""
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:145
 #: ../../src/worksheet/WorksheetContextMenu.cpp:294
-#: ../../src/wxMaximaFrame.cpp:774
+#: ../../src/wxMaximaFrame.cpp:786
 msgid "Copy as EMF"
 msgstr ""
 
@@ -2700,17 +2725,17 @@ msgstr ""
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:135
 #: ../../src/worksheet/WorksheetContextMenu.cpp:284
-#: ../../src/wxMaximaFrame.cpp:763
+#: ../../src/wxMaximaFrame.cpp:775
 msgid "Copy as Image"
 msgstr ""
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:126
 #: ../../src/worksheet/WorksheetContextMenu.cpp:275
-#: ../../src/wxMaximaFrame.cpp:756
+#: ../../src/wxMaximaFrame.cpp:768
 msgid "Copy as LaTeX"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:759
+#: ../../src/wxMaximaFrame.cpp:771
 msgid "Copy as MathML"
 msgstr ""
 
@@ -2721,17 +2746,17 @@ msgstr ""
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:148
 #: ../../src/worksheet/WorksheetContextMenu.cpp:297
-#: ../../src/wxMaximaFrame.cpp:769
+#: ../../src/wxMaximaFrame.cpp:781
 msgid "Copy as RTF"
 msgstr ""
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:142
 #: ../../src/worksheet/WorksheetContextMenu.cpp:291
-#: ../../src/wxMaximaFrame.cpp:766
+#: ../../src/wxMaximaFrame.cpp:778
 msgid "Copy as SVG"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:751
+#: ../../src/wxMaximaFrame.cpp:763
 msgid "Copy as Text\tCtrl+Shift+C"
 msgstr ""
 
@@ -2744,13 +2769,13 @@ msgstr ""
 msgid "Copy file"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1325
+#: ../../src/wxMaximaFrame.cpp:1343
 msgid "Copy file..."
 msgstr ""
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:124
 #: ../../src/worksheet/WorksheetContextMenu.cpp:273
-#: ../../src/wxMaximaFrame.cpp:754
+#: ../../src/wxMaximaFrame.cpp:766
 msgid "Copy for Octave/Matlab"
 msgstr ""
 
@@ -2762,39 +2787,39 @@ msgid "Copy position (UUID)"
 msgstr ""
 
 #: ../../src/ToolBar.cpp:380 ../../src/ToolBar.cpp:384
-#: ../../src/wxMaximaFrame.cpp:749
+#: ../../src/wxMaximaFrame.cpp:761
 msgid "Copy selection"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:775
+#: ../../src/wxMaximaFrame.cpp:787
 msgid "Copy selection from document as an Enhanced Metafile"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:767
+#: ../../src/wxMaximaFrame.cpp:779
 msgid "Copy selection from document as an SVG image"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:764
+#: ../../src/wxMaximaFrame.cpp:776
 msgid "Copy selection from document as an image"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:770
+#: ../../src/wxMaximaFrame.cpp:782
 msgid "Copy selection from document as rtf that a word processor might understand"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:752
+#: ../../src/wxMaximaFrame.cpp:764
 msgid "Copy selection from document as text"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:757
+#: ../../src/wxMaximaFrame.cpp:769
 msgid "Copy selection from document in LaTeX format"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:755
+#: ../../src/wxMaximaFrame.cpp:767
 msgid "Copy selection from document in Matlab format"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:760
+#: ../../src/wxMaximaFrame.cpp:772
 msgid "Copy selection from document in a MathML format many word processors can display as 2d equation"
 msgstr ""
 
@@ -2802,7 +2827,7 @@ msgstr ""
 msgid "Copy string"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1276
+#: ../../src/wxMaximaFrame.cpp:1294
 msgid "Copy string..."
 msgstr ""
 
@@ -2810,31 +2835,31 @@ msgstr ""
 msgid "Copy, Cut and Paste button"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2692
+#: ../../src/dialogs/ConfigDialogue.cpp:3074
 #, c-format
 msgid "Copying config bool \"%s\""
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2702
+#: ../../src/dialogs/ConfigDialogue.cpp:3084
 #, c-format
 msgid "Copying config float \"%s\""
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2697
+#: ../../src/dialogs/ConfigDialogue.cpp:3079
 #, c-format
 msgid "Copying config int \"%s\""
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2687
+#: ../../src/dialogs/ConfigDialogue.cpp:3069
 #, c-format
 msgid "Copying config string \"%s\""
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:193
+#: ../../src/dialogs/ConfigDialogue.cpp:197
 msgid "Corsican"
 msgstr ""
 
-#: ../../src/ai/AiProvider.cpp:275
+#: ../../src/ai/AiProvider.cpp:510
 msgid "Could not create the HTTP request."
 msgstr ""
 
@@ -2854,7 +2879,7 @@ msgstr ""
 msgid "Could not parse the SVG image data."
 msgstr ""
 
-#: ../../src/ai/AiProvider.cpp:359
+#: ../../src/ai/AiProvider.cpp:594
 #, c-format
 msgid "Could not reach %s (network error)."
 msgstr ""
@@ -2868,11 +2893,11 @@ msgstr ""
 msgid "Could not write the file's contents during saving => aborting."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1436
+#: ../../src/wxMaximaFrame.cpp:1454
 msgid "Create Matrix"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1802
+#: ../../src/wxMaximaFrame.cpp:1820
 msgid "Create a list"
 msgstr ""
 
@@ -2888,19 +2913,19 @@ msgstr ""
 msgid "Create a list from a rule"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1784
+#: ../../src/wxMaximaFrame.cpp:1802
 msgid "Create a list from comma-separated elements"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:999
+#: ../../src/wxMaximaFrame.cpp:1017
 msgid "Create a new cell with previous input"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1002
+#: ../../src/wxMaximaFrame.cpp:1020
 msgid "Create a new cell with previous output"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1459
+#: ../../src/wxMaximaFrame.cpp:1477
 msgid "Create copy, not clone..."
 msgstr ""
 
@@ -2908,7 +2933,7 @@ msgstr ""
 msgid "Create directory"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1314
+#: ../../src/wxMaximaFrame.cpp:1332
 msgid "Create directory..."
 msgstr ""
 
@@ -2916,11 +2941,11 @@ msgstr ""
 msgid "Create empty string"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1279
+#: ../../src/wxMaximaFrame.cpp:1297
 msgid "Create empty string..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1801
+#: ../../src/wxMaximaFrame.cpp:1819
 msgid "Create list"
 msgstr ""
 
@@ -2928,11 +2953,11 @@ msgstr ""
 msgid "Create list from comma-separated elements"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1407
+#: ../../src/dialogs/ConfigDialogue.cpp:1479
 msgid "Create scalable plots."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1193
+#: ../../src/wxMaximaFrame.cpp:1211
 msgid "Create struct..."
 msgstr ""
 
@@ -2940,11 +2965,11 @@ msgstr ""
 msgid "Created a .zip archive (the .wxmx file technically is a .zip file)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1460
+#: ../../src/wxMaximaFrame.cpp:1478
 msgid "Creates an independent matrix with the same contents"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:194
+#: ../../src/dialogs/ConfigDialogue.cpp:198
 msgid "Croatian"
 msgstr ""
 
@@ -2965,24 +2990,24 @@ msgstr ""
 msgid "Cut"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:747
+#: ../../src/wxMaximaFrame.cpp:759
 msgid "Cut\tCtrl+X"
 msgstr ""
 
 #: ../../src/ToolBar.cpp:379 ../../src/ToolBar.cpp:383
-#: ../../src/wxMaximaFrame.cpp:747
+#: ../../src/wxMaximaFrame.cpp:759
 msgid "Cut selection"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:195
+#: ../../src/dialogs/ConfigDialogue.cpp:199
 msgid "Czech"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:196
+#: ../../src/dialogs/ConfigDialogue.cpp:200
 msgid "Danish"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2226
+#: ../../src/dialogs/ConfigDialogue.cpp:2566
 msgid "Dark"
 msgstr ""
 
@@ -3007,11 +3032,11 @@ msgstr ""
 msgid "Data:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1168
+#: ../../src/wxMaximaFrame.cpp:1186
 msgid "Debugger trigger"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:893
+#: ../../src/wxMaximaFrame.cpp:911
 msgid "Declare Text to always be displayed as subscript"
 msgstr ""
 
@@ -3040,7 +3065,7 @@ msgstr ""
 msgid "Declare these chars as ordinary letters"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1614 ../../src/wxMaximaFrame.cpp:1650
+#: ../../src/wxMaximaFrame.cpp:1632 ../../src/wxMaximaFrame.cpp:1668
 msgid "Decompose rational function to partial fractions"
 msgstr ""
 
@@ -3048,15 +3073,15 @@ msgstr ""
 msgid "Decreasing function f(x)<x"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1354
+#: ../../src/dialogs/ConfigDialogue.cpp:1426
 msgid "Default animation framerate:"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:735
+#: ../../src/dialogs/ConfigDialogue.cpp:807
 msgid "Default plot size for new maxima sessions:"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1589
+#: ../../src/dialogs/ConfigDialogue.cpp:1661
 msgid "Default port for communication with wxMaxima:"
 msgstr ""
 
@@ -3080,31 +3105,31 @@ msgstr ""
 msgid "Define a variable"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1183
+#: ../../src/wxMaximaFrame.cpp:1201
 msgid "Define function..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1190
+#: ../../src/wxMaximaFrame.cpp:1208
 msgid "Define macro..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1188
+#: ../../src/wxMaximaFrame.cpp:1206
 msgid "Define parameter type..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1192
+#: ../../src/wxMaximaFrame.cpp:1210
 msgid "Define struct..."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:408
+#: ../../src/dialogs/ConfigDialogue.cpp:424
 msgid "Define the default speed (in frames per second) animations are played back with."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1191
+#: ../../src/wxMaximaFrame.cpp:1209
 msgid "Define variable..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1890
+#: ../../src/wxMaximaFrame.cpp:1908
 msgid "Defines if an animation is automatically started or only by clicking on it."
 msgstr ""
 
@@ -3112,7 +3137,7 @@ msgstr ""
 msgid "Degree:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1096
+#: ../../src/wxMaximaFrame.cpp:1114
 msgid "Delete F&unction..."
 msgstr ""
 
@@ -3121,23 +3146,23 @@ msgstr ""
 msgid "Delete Selection"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1098
+#: ../../src/wxMaximaFrame.cpp:1116
 msgid "Delete V&ariable..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1097
+#: ../../src/wxMaximaFrame.cpp:1115
 msgid "Delete a function"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1099
+#: ../../src/wxMaximaFrame.cpp:1117
 msgid "Delete a variable"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1093
+#: ../../src/wxMaximaFrame.cpp:1111
 msgid "Delete all objects with a given name"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1102
+#: ../../src/wxMaximaFrame.cpp:1120
 msgid "Delete all values from memory"
 msgstr ""
 
@@ -3145,7 +3170,7 @@ msgstr ""
 msgid "Delete file"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1327
+#: ../../src/wxMaximaFrame.cpp:1345
 msgid "Delete file..."
 msgstr ""
 
@@ -3157,7 +3182,7 @@ msgstr ""
 msgid "Delete named object(s)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1092
+#: ../../src/wxMaximaFrame.cpp:1110
 msgid "Delete named object..."
 msgstr ""
 
@@ -3179,7 +3204,7 @@ msgstr ""
 msgid "Demo for \"%s\""
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:2044
+#: ../../src/wxMaximaFrame.cpp:2062
 msgid "Demos"
 msgstr ""
 
@@ -3191,7 +3216,7 @@ msgstr ""
 msgid "Denominator:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1141
+#: ../../src/wxMaximaFrame.cpp:1159
 msgid "Dependencies"
 msgstr ""
 
@@ -3234,7 +3259,7 @@ msgstr ""
 msgid "Deviation..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1611
+#: ../../src/wxMaximaFrame.cpp:1629
 msgid "Di&vide Polynomials..."
 msgstr ""
 
@@ -3254,7 +3279,7 @@ msgstr ""
 msgid "Didn't find the maxima HTML manual."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:1716
+#: ../../src/wxMaxima.cpp:1731
 msgid "Didn't get a help browser launch program command line, but can request the system's default help browser."
 msgstr ""
 
@@ -3275,7 +3300,7 @@ msgstr ""
 msgid "Differentiate"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1581
+#: ../../src/wxMaximaFrame.cpp:1599
 msgid "Differentiate expression"
 msgstr ""
 
@@ -3295,11 +3320,11 @@ msgstr ""
 msgid "Direction:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1323
+#: ../../src/wxMaximaFrame.cpp:1341
 msgid "Directory operations"
 msgstr ""
 
-#: ../../src/main.cpp:331
+#: ../../src/main.cpp:434
 msgid "Disabled the console's QuickEdit mode for this batch run so a click into the console cannot suspend wxMaxima."
 msgstr ""
 
@@ -3307,11 +3332,11 @@ msgstr ""
 msgid "Discrete plot"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:717
+#: ../../src/dialogs/ConfigDialogue.cpp:789
 msgid "Display"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1152
+#: ../../src/wxMaximaFrame.cpp:1170
 msgid "Display Te&X Form"
 msgstr ""
 
@@ -3319,23 +3344,23 @@ msgstr ""
 msgid "Display algorithm"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:845
+#: ../../src/dialogs/ConfigDialogue.cpp:917
 msgid "Display all and allow linebreaks in long numbers"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:838
+#: ../../src/dialogs/ConfigDialogue.cpp:910
 msgid "Display all digits"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:865
+#: ../../src/wxMaximaFrame.cpp:883
 msgid "Display an expression as maxima's internal lisp representation"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:868
+#: ../../src/wxMaximaFrame.cpp:886
 msgid "Display an expression as wxMaxima's internal XML representation"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:872
+#: ../../src/wxMaximaFrame.cpp:890
 msgid "Display equations"
 msgstr ""
 
@@ -3347,11 +3372,11 @@ msgstr ""
 msgid "Display expression in wxMaxima's internal representation"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1153
+#: ../../src/wxMaximaFrame.cpp:1171
 msgid "Display last result in TeX form"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:822
+#: ../../src/dialogs/ConfigDialogue.cpp:894
 msgid "Display of long numbers"
 msgstr ""
 
@@ -3360,11 +3385,11 @@ msgstr ""
 msgid "Display resolution according to wxWidgets: %li x %li ppi"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:916
+#: ../../src/wxMaximaFrame.cpp:934
 msgid "Display string quotation marks"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1147
+#: ../../src/wxMaximaFrame.cpp:1165
 msgid "Display time used for evaluation"
 msgstr ""
 
@@ -3372,32 +3397,32 @@ msgstr ""
 msgid "Displayed Precision"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:2027
+#: ../../src/wxMaximaFrame.cpp:2045
 msgid "Displaying 3d curves"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1576
+#: ../../src/wxMaximaFrame.cpp:1594
 msgid "Dito, and evaluate the result..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1559
+#: ../../src/wxMaximaFrame.cpp:1577
 msgid "Dito, but affect all clones of the Matrix..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1366
+#: ../../src/wxMaximaFrame.cpp:1384
 msgid "Dito, but as fraction (real only)..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1646
+#: ../../src/wxMaximaFrame.cpp:1664
 msgid "Dito, including denominator"
 msgstr ""
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:492
-#: ../../src/wxMaximaFrame.cpp:1055
+#: ../../src/wxMaximaFrame.cpp:1073
 msgid "Divide Cell"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1612
+#: ../../src/wxMaximaFrame.cpp:1630
 msgid "Divide numbers or polynomials"
 msgstr ""
 
@@ -3409,12 +3434,12 @@ msgstr ""
 msgid "Do for each list element"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3599
+#: ../../src/wxMaxima.cpp:3614
 #, c-format
 msgid "Do you want to save the changes you made in the document \"%s\"?"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:838
+#: ../../src/wxMaximaFrame.cpp:856
 msgid "Dock all Sidebars"
 msgstr ""
 
@@ -3430,19 +3455,19 @@ msgstr ""
 msgid "Document was saved using a newer version of wxMaxima. Please update your wxMaxima."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1188
+#: ../../src/dialogs/ConfigDialogue.cpp:1260
 msgid "Documentclass for TeX export:"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1196
+#: ../../src/dialogs/ConfigDialogue.cpp:1268
 msgid "Documentclass options:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:884
+#: ../../src/wxMaximaFrame.cpp:902
 msgid "Don't autosubscript after an underscore"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1197
+#: ../../src/wxMaximaFrame.cpp:1215
 msgid "Don't evaluate Expression..."
 msgstr ""
 
@@ -3464,7 +3489,7 @@ msgstr ""
 msgid "Don't mark this message text in yellow"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3605
+#: ../../src/wxMaxima.cpp:3620
 msgid "Don't save"
 msgstr ""
 
@@ -3476,7 +3501,7 @@ msgstr ""
 msgid "Don't use if unassigned"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:911
+#: ../../src/wxMaximaFrame.cpp:929
 msgid "Don't use parenthesis for matrices"
 msgstr ""
 
@@ -3504,39 +3529,39 @@ msgstr ""
 msgid "Drop the last n list elements"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:197
+#: ../../src/dialogs/ConfigDialogue.cpp:201
 msgid "Dutch"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1417
+#: ../../src/wxMaximaFrame.cpp:1435
 msgid "E&quations"
 msgstr ""
 
-#: ../../src/TrayIcon.cpp:114 ../../src/wxMaximaFrame.cpp:732
+#: ../../src/TrayIcon.cpp:114 ../../src/wxMaximaFrame.cpp:744
 msgid "E&xit\tCtrl+Q"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1479
+#: ../../src/wxMaximaFrame.cpp:1497
 msgid "Eige&nvectors"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1476
+#: ../../src/wxMaximaFrame.cpp:1494
 msgid "Eigen&values"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1498
+#: ../../src/wxMaximaFrame.cpp:1516
 msgid "Eigenvalues (complex)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1495
+#: ../../src/wxMaximaFrame.cpp:1513
 msgid "Eigenvalues (real)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1504
+#: ../../src/wxMaximaFrame.cpp:1522
 msgid "Eigenvalues, left+right eigenvectors (complex)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1501
+#: ../../src/wxMaximaFrame.cpp:1519
 msgid "Eigenvalues, left+right eigenvectors (real)"
 msgstr ""
 
@@ -3578,7 +3603,7 @@ msgstr ""
 msgid "Element-by-element exponentiation of two matrices"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1453
+#: ../../src/wxMaximaFrame.cpp:1471
 msgid "Element-by-element multiplication"
 msgstr ""
 
@@ -3594,11 +3619,11 @@ msgstr ""
 msgid "Eliminate a variable"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1358
+#: ../../src/wxMaximaFrame.cpp:1376
 msgid "Eliminate a variable from a system of equations"
 msgstr ""
 
-#: ../../src/MaximaEvaluator.cpp:536
+#: ../../src/MaximaEvaluator.cpp:543
 msgid "Empty command => re-triggering evaluation"
 msgstr ""
 
@@ -3644,11 +3669,11 @@ msgstr ""
 msgid "Ended lisp mode after receiving a maxima prompt!"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1942
+#: ../../src/wxMaximaFrame.cpp:1960
 msgid "Engineering format (12.1e6 etc.)"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:198
+#: ../../src/dialogs/ConfigDialogue.cpp:202
 msgid "English"
 msgstr ""
 
@@ -3656,7 +3681,7 @@ msgstr ""
 msgid "Enhanced 3D settings:"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2076
+#: ../../src/dialogs/ConfigDialogue.cpp:2416
 msgid "Enhanced meta file (emf)"
 msgstr ""
 
@@ -3668,11 +3693,11 @@ msgstr ""
 msgid "Enter UUID to jump to:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1430
+#: ../../src/wxMaximaFrame.cpp:1448
 msgid "Enter a matrix"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:943
+#: ../../src/dialogs/ConfigDialogue.cpp:1015
 msgid "Enter adds newlines, Ctrl+Enter evaluates cells"
 msgstr ""
 
@@ -3684,7 +3709,7 @@ msgstr ""
 msgid "Enter comma separated list of variables."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:939
+#: ../../src/dialogs/ConfigDialogue.cpp:1011
 msgid "Enter evaluates cells, Ctrl+Enter adds newlines"
 msgstr ""
 
@@ -3704,7 +3729,7 @@ msgstr ""
 msgid "Enter sends; Shift+Enter inserts a newline."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:392
+#: ../../src/dialogs/ConfigDialogue.cpp:408
 msgid "Enter the path to the Maxima executable."
 msgstr ""
 
@@ -3712,11 +3737,11 @@ msgstr ""
 msgid "Enumerator:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1331
+#: ../../src/wxMaximaFrame.cpp:1349
 msgid "Environment variables"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1660
+#: ../../src/dialogs/ConfigDialogue.cpp:1732
 msgid "Environment variables for maxima"
 msgstr ""
 
@@ -3728,11 +3753,11 @@ msgstr ""
 msgid "Epsilon:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1235 ../../src/wxMaximaFrame.cpp:1246
+#: ../../src/wxMaximaFrame.cpp:1253 ../../src/wxMaximaFrame.cpp:1264
 msgid "Equal, ignoring case?..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1244
+#: ../../src/wxMaximaFrame.cpp:1262
 msgid "Equal?..."
 msgstr ""
 
@@ -3771,9 +3796,9 @@ msgstr ""
 #: ../../src/WXMXformat.cpp:290 ../../src/WXMXformat.cpp:298
 #: ../../src/WXMXformat.cpp:313 ../../src/WXMXformat.cpp:334
 #: ../../src/WXMXformat.cpp:364 ../../src/dialogs/BinaryNameCtrl.cpp:78
-#: ../../src/main.cpp:788 ../../src/sidebars/AiChatSidebar.cpp:243
-#: ../../src/wxMaxima.cpp:3480 ../../src/wxMaxima.cpp:3516
-#: ../../src/wxMaxima.cpp:3534 ../../src/wxMaxima.cpp:3568
+#: ../../src/main.cpp:913 ../../src/sidebars/AiChatSidebar.cpp:266
+#: ../../src/wxMaxima.cpp:3495 ../../src/wxMaxima.cpp:3531
+#: ../../src/wxMaxima.cpp:3549 ../../src/wxMaxima.cpp:3583
 msgid "Error"
 msgstr ""
 
@@ -3823,15 +3848,15 @@ msgstr ""
 msgid "Evaluate"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1766
+#: ../../src/wxMaximaFrame.cpp:1784
 msgid "Evaluate &Noun Forms..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:967
+#: ../../src/wxMaximaFrame.cpp:985
 msgid "Evaluate All Cells\tCtrl+Shift+R"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:962
+#: ../../src/wxMaximaFrame.cpp:980
 msgid "Evaluate All Visible Cells\tCtrl+R"
 msgstr ""
 
@@ -3840,7 +3865,7 @@ msgid "Evaluate Cell"
 msgstr ""
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:171
-#: ../../src/wxMaximaFrame.cpp:955
+#: ../../src/wxMaximaFrame.cpp:973
 msgid "Evaluate Cell(s)"
 msgstr ""
 
@@ -3849,13 +3874,13 @@ msgstr ""
 msgid "Evaluate Cells Above"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:977
+#: ../../src/wxMaximaFrame.cpp:995
 msgid "Evaluate Cells Above\tCtrl+Shift+P"
 msgstr ""
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:175
 #: ../../src/worksheet/WorksheetContextMenu.cpp:453
-#: ../../src/wxMaximaFrame.cpp:987
+#: ../../src/wxMaximaFrame.cpp:1005
 msgid "Evaluate Cells Below"
 msgstr ""
 
@@ -3897,7 +3922,7 @@ msgstr ""
 msgid "Evaluate Subsection\tShift+Ctrl+Enter"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:956
+#: ../../src/wxMaximaFrame.cpp:974
 msgid "Evaluate active or selected cell(s)"
 msgstr ""
 
@@ -3905,15 +3930,15 @@ msgstr ""
 msgid "Evaluate all"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:968
+#: ../../src/wxMaximaFrame.cpp:986
 msgid "Evaluate all cells in the document"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1767
+#: ../../src/wxMaximaFrame.cpp:1785
 msgid "Evaluate all noun forms in expression"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:963
+#: ../../src/wxMaximaFrame.cpp:981
 msgid "Evaluate all visible cells in the document"
 msgstr ""
 
@@ -3925,7 +3950,7 @@ msgstr ""
 msgid "Evaluate string"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1262
+#: ../../src/wxMaximaFrame.cpp:1280
 msgid "Evaluate string..."
 msgstr ""
 
@@ -3953,19 +3978,19 @@ msgstr ""
 msgid "Even number"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2828
+#: ../../src/dialogs/ConfigDialogue.cpp:3210
 msgid "Example text"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1602
+#: ../../src/dialogs/ConfigDialogue.cpp:1674
 msgid "Examples:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1817
+#: ../../src/wxMaximaFrame.cpp:1835
 msgid "Execute a command for each element of the list"
 msgstr ""
 
-#: ../../src/main.cpp:740
+#: ../../src/main.cpp:857
 msgid "Exit"
 msgstr ""
 
@@ -3981,11 +4006,11 @@ msgstr ""
 msgid "Expand Expression"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1639
+#: ../../src/wxMaximaFrame.cpp:1657
 msgid "Expand an expression"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1645
+#: ../../src/wxMaximaFrame.cpp:1663
 msgid "Expand for given variables"
 msgstr ""
 
@@ -3997,24 +4022,24 @@ msgstr ""
 msgid "Expand for variable(s):"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1659
+#: ../../src/wxMaximaFrame.cpp:1677
 msgid "Expand log in previous expression"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1712
+#: ../../src/wxMaximaFrame.cpp:1730
 msgid "Expand trigonometric expression"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1902
+#: ../../src/wxMaximaFrame.cpp:1920
 msgid "Expect numbers harder to be complex"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1903
+#: ../../src/wxMaximaFrame.cpp:1921
 msgid "Expect variables to contain complex numbers"
 msgstr ""
 
 #: ../../src/MaximaCommandMenus.cpp:2277
-#: ../../src/dialogs/ConfigDialogue.cpp:285
+#: ../../src/dialogs/ConfigDialogue.cpp:295
 msgid "Export"
 msgstr ""
 
@@ -4022,15 +4047,15 @@ msgstr ""
 msgid "Export As"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1819
+#: ../../src/wxMaximaFrame.cpp:1837
 msgid "Export List to csv file..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1820
+#: ../../src/wxMaximaFrame.cpp:1838
 msgid "Export a list to a csv file"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1443
+#: ../../src/wxMaximaFrame.cpp:1461
 msgid "Export a matrix to a csv file"
 msgstr ""
 
@@ -4038,7 +4063,7 @@ msgstr ""
 msgid "Export all history to a .mac file"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1034
+#: ../../src/dialogs/ConfigDialogue.cpp:1106
 msgid "Export all settings"
 msgstr ""
 
@@ -4046,15 +4071,15 @@ msgstr ""
 msgid "Export commands from the current maxima session to a .mac file"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:726
+#: ../../src/wxMaximaFrame.cpp:738
 msgid "Export document to a HTML or LaTeX file"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1236
+#: ../../src/dialogs/ConfigDialogue.cpp:1308
 msgid "Export equations to HTML as:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:663
+#: ../../src/wxMaximaFrame.cpp:675
 msgid "Export failed."
 msgstr ""
 
@@ -4070,7 +4095,7 @@ msgstr ""
 msgid "Export selected commands to a .mac file"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:651
+#: ../../src/wxMaximaFrame.cpp:663
 msgid "Export successful."
 msgstr ""
 
@@ -4078,7 +4103,7 @@ msgstr ""
 msgid "Export the selected output(s) to this folder"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1040
+#: ../../src/dialogs/ConfigDialogue.cpp:1112
 msgid "Export the style settings"
 msgstr ""
 
@@ -4091,7 +4116,7 @@ msgstr ""
 msgid "Exported %d output image(s) to %s"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2232 ../../src/wxMaxima.cpp:2274
+#: ../../src/wxMaxima.cpp:2247 ../../src/wxMaxima.cpp:2289
 #, c-format
 msgid "Exported the worksheet to %s"
 msgstr ""
@@ -4112,7 +4137,7 @@ msgstr ""
 msgid "Exporting to maxima batch file failed!"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:645
+#: ../../src/wxMaximaFrame.cpp:657
 msgid "Exporting..."
 msgstr ""
 
@@ -4148,7 +4173,7 @@ msgstr ""
 msgid "Expression to plot"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1199
+#: ../../src/wxMaximaFrame.cpp:1217
 msgid "Expression to string..."
 msgstr ""
 
@@ -4171,23 +4196,23 @@ msgstr ""
 msgid "Expression:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1534
+#: ../../src/wxMaximaFrame.cpp:1552
 msgid "Extract Column..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1840
+#: ../../src/wxMaximaFrame.cpp:1858
 msgid "Extract Elements"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1532
+#: ../../src/wxMaximaFrame.cpp:1550
 msgid "Extract Row..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1535
+#: ../../src/wxMaximaFrame.cpp:1553
 msgid "Extract a column from the matrix"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1549
+#: ../../src/wxMaximaFrame.cpp:1567
 msgid "Extract a column from the matrix and convert it to a list"
 msgstr ""
 
@@ -4199,7 +4224,7 @@ msgstr ""
 msgid "Extract a matrix column as a list"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1424
+#: ../../src/wxMaximaFrame.cpp:1442
 msgid "Extract a matrix from a 2-dimensional array"
 msgstr ""
 
@@ -4211,11 +4236,11 @@ msgstr ""
 msgid "Extract a matrix row as a list"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1533
+#: ../../src/wxMaximaFrame.cpp:1551
 msgid "Extract a row from the matrix"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1545
+#: ../../src/wxMaximaFrame.cpp:1563
 msgid "Extract a row from the matrix and convert it to a list"
 msgstr ""
 
@@ -4223,15 +4248,15 @@ msgstr ""
 msgid "Extract a variable's value from a list of variable values"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1837
+#: ../../src/wxMaximaFrame.cpp:1855
 msgid "Extract an actual value for a variable"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1274
+#: ../../src/wxMaximaFrame.cpp:1292
 msgid "Extract char..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1318
+#: ../../src/wxMaximaFrame.cpp:1336
 msgid "Extract dir from path..."
 msgstr ""
 
@@ -4243,7 +4268,7 @@ msgstr ""
 msgid "Extract file type extension"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1320
+#: ../../src/wxMaximaFrame.cpp:1338
 msgid "Extract filename from path..."
 msgstr ""
 
@@ -4251,7 +4276,7 @@ msgstr ""
 msgid "Extract filename part"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1322
+#: ../../src/wxMaximaFrame.cpp:1340
 msgid "Extract filetype from path..."
 msgstr ""
 
@@ -4259,7 +4284,7 @@ msgstr ""
 msgid "Extract function arguments"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1841
+#: ../../src/wxMaximaFrame.cpp:1859
 msgid "Extract list Elements"
 msgstr ""
 
@@ -4267,7 +4292,7 @@ msgstr ""
 msgid "Extract matrix from 2D array"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1800
+#: ../../src/wxMaximaFrame.cpp:1818
 msgid "Extract the argument list from a function call"
 msgstr ""
 
@@ -4287,11 +4312,11 @@ msgstr ""
 msgid "Extract the nth list elements"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1838
+#: ../../src/wxMaximaFrame.cpp:1856
 msgid "Extract the value for one variable assigned in a list"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1553
+#: ../../src/wxMaximaFrame.cpp:1571
 msgid "Extract, append or delete rows or columns"
 msgstr ""
 
@@ -4303,7 +4328,7 @@ msgstr ""
 msgid "Factor"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1635
+#: ../../src/wxMaximaFrame.cpp:1653
 msgid "Factor Complex"
 msgstr ""
 
@@ -4311,19 +4336,19 @@ msgstr ""
 msgid "Factor Expression"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1633
+#: ../../src/wxMaximaFrame.cpp:1651
 msgid "Factor Expression including subexpressions"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1631 ../../src/wxMaximaFrame.cpp:1634
+#: ../../src/wxMaximaFrame.cpp:1649 ../../src/wxMaximaFrame.cpp:1652
 msgid "Factor an expression"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1636
+#: ../../src/wxMaximaFrame.cpp:1654
 msgid "Factor an expression in Gaussian numbers"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1701
+#: ../../src/wxMaximaFrame.cpp:1719
 msgid "Factorials and &Gamma"
 msgstr ""
 
@@ -4345,11 +4370,11 @@ msgstr ""
 msgid "Failed to write to Maxima's stdin (LDB)."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1529
+#: ../../src/wxMaximaFrame.cpp:1547
 msgid "Fast fortran routines that perform numerical tasks"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:2036
+#: ../../src/wxMaximaFrame.cpp:2054
 msgid "Fast list access"
 msgstr ""
 
@@ -4378,11 +4403,11 @@ msgstr ""
 msgid "Figure %d:"
 msgstr ""
 
-#: ../../src/main.cpp:741
+#: ../../src/main.cpp:858
 msgid "File"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1444
+#: ../../src/wxMaximaFrame.cpp:1462
 msgid "File I/O"
 msgstr ""
 
@@ -4398,7 +4423,7 @@ msgstr ""
 msgid "File name:"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3091 ../../src/wxMaxima.cpp:3134
+#: ../../src/wxMaxima.cpp:3106 ../../src/wxMaxima.cpp:3149
 msgid "File not found"
 msgstr ""
 
@@ -4406,15 +4431,15 @@ msgstr ""
 msgid "File opened"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1328
+#: ../../src/wxMaximaFrame.cpp:1346
 msgid "File operations"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3090 ../../src/wxMaxima.cpp:3133
+#: ../../src/wxMaxima.cpp:3105 ../../src/wxMaxima.cpp:3148
 msgid "File you tried to open does not exist."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1332
+#: ../../src/wxMaximaFrame.cpp:1350
 msgid "File/directory functions"
 msgstr ""
 
@@ -4434,15 +4459,15 @@ msgstr ""
 msgid "Find"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:781
+#: ../../src/wxMaximaFrame.cpp:793
 msgid "Find\tCtrl+F"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1582
+#: ../../src/wxMaximaFrame.cpp:1600
 msgid "Find &Limit..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1584
+#: ../../src/wxMaximaFrame.cpp:1602
 msgid "Find Minimum..."
 msgstr ""
 
@@ -4450,48 +4475,48 @@ msgstr ""
 msgid "Find Root..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1585
+#: ../../src/wxMaximaFrame.cpp:1603
 msgid "Find a (unconstrained) minimum of an expression"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1918
+#: ../../src/wxMaximaFrame.cpp:1936
 msgid "Find a fraction that represents this float exactly"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1583
+#: ../../src/wxMaximaFrame.cpp:1601
 msgid "Find a limit of an expression"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1921
+#: ../../src/wxMaximaFrame.cpp:1939
 msgid "Find a nice fraction that is similar to this float"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1394
+#: ../../src/wxMaximaFrame.cpp:1412
 msgid "Find a numerical solution for a first degree ODE"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1363
+#: ../../src/wxMaximaFrame.cpp:1381
 msgid "Find a root of an equation on an interval"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1370
+#: ../../src/wxMaximaFrame.cpp:1388
 msgid "Find all roots of a polynomial"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1373
+#: ../../src/wxMaximaFrame.cpp:1391
 msgid "Find all roots of a polynomial (bfloat)"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:3129 ../../src/wxMaximaFrame.cpp:377
+#: ../../src/MaximaCommandMenus.cpp:3129 ../../src/wxMaximaFrame.cpp:389
 msgid "Find and Replace"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:825
+#: ../../src/wxMaximaFrame.cpp:837
 msgid "Find and Replace (if set to dockable)"
 msgstr ""
 
 #: ../../src/ToolBar.cpp:401 ../../src/ToolBar.cpp:403
-#: ../../src/wxMaximaFrame.cpp:781
+#: ../../src/wxMaximaFrame.cpp:793
 msgid "Find and replace"
 msgstr ""
 
@@ -4499,19 +4524,19 @@ msgstr ""
 msgid "Find char in string"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1283
+#: ../../src/wxMaximaFrame.cpp:1301
 msgid "Find char in string..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1648
+#: ../../src/wxMaximaFrame.cpp:1666
 msgid "Find common denominator"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1477
+#: ../../src/wxMaximaFrame.cpp:1495
 msgid "Find eigenvalues of a matrix"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1480
+#: ../../src/wxMaximaFrame.cpp:1498
 msgid "Find eigenvectors of a matrix"
 msgstr ""
 
@@ -4519,11 +4544,11 @@ msgstr ""
 msgid "Find first difference"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1281
+#: ../../src/wxMaximaFrame.cpp:1299
 msgid "Find first difference..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1367
+#: ../../src/wxMaximaFrame.cpp:1385
 msgid "Find fractions that real roots of a polynomial and "
 msgstr ""
 
@@ -4531,7 +4556,7 @@ msgstr ""
 msgid "Find minimum"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1362
+#: ../../src/wxMaximaFrame.cpp:1380
 msgid "Find numerical solution..."
 msgstr ""
 
@@ -4555,28 +4580,28 @@ msgstr ""
 msgid "Find:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1946
+#: ../../src/wxMaximaFrame.cpp:1964
 msgid "Fine-tune the display of engineering-format numbers"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:199
+#: ../../src/dialogs/ConfigDialogue.cpp:203
 msgid "Finnish"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1826
+#: ../../src/wxMaximaFrame.cpp:1844
 msgid "First"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:2032
+#: ../../src/wxMaximaFrame.cpp:2050
 msgid "Fitting curves to measurement data"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1422
+#: ../../src/dialogs/ConfigDialogue.cpp:1494
 #, c-format
 msgid "Fix reordered reference indices (of %i, %o) before saving"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:891
+#: ../../src/dialogs/ConfigDialogue.cpp:963
 msgid "Fixed font in text controls"
 msgstr ""
 
@@ -4584,15 +4609,15 @@ msgstr ""
 msgid "Flush stream"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1214
+#: ../../src/wxMaximaFrame.cpp:1232
 msgid "Flush..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1033
+#: ../../src/wxMaximaFrame.cpp:1051
 msgid "Fold All\tCtrl+Alt+["
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1034
+#: ../../src/wxMaximaFrame.cpp:1052
 msgid "Fold all sections"
 msgstr ""
 
@@ -4600,7 +4625,7 @@ msgstr ""
 msgid "Follow"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2227
+#: ../../src/dialogs/ConfigDialogue.cpp:2567
 msgid "Follow system"
 msgstr ""
 
@@ -4620,11 +4645,11 @@ msgstr ""
 msgid "Font cache misses:"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2204
+#: ../../src/dialogs/ConfigDialogue.cpp:2544
 msgid "Fonts"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:446
+#: ../../src/dialogs/ConfigDialogue.cpp:462
 msgid "For each Text-, Sectioning or code cell wxMaxima can display a bracket showing the extend of the cell and allowing to fold it. This setting now tells if this bracket is to be printed, as well."
 msgstr ""
 
@@ -4646,7 +4671,7 @@ msgstr ""
 msgid "For loop"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1173
+#: ../../src/wxMaximaFrame.cpp:1191
 msgid "For loop..."
 msgstr ""
 
@@ -4654,11 +4679,11 @@ msgstr ""
 msgid "Format:"
 msgstr ""
 
-#: ../../src/worksheet/Worksheet.cpp:306 ../../src/wxMaxima.cpp:3619
+#: ../../src/worksheet/Worksheet.cpp:306 ../../src/wxMaxima.cpp:3634
 msgid "Forwarding the keyboard focus to a text control"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3622
+#: ../../src/wxMaxima.cpp:3637
 msgid "Forwarding the keyboard focus to the worksheet"
 msgstr ""
 
@@ -4686,7 +4711,7 @@ msgstr ""
 msgid "Fourier coefficients"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1590
+#: ../../src/wxMaximaFrame.cpp:1608
 msgid "Fourier coefficients..."
 msgstr ""
 
@@ -4711,19 +4736,19 @@ msgstr ""
 msgid "Frame rate"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1116 ../../src/wxMaximaFrame.cpp:1120
+#: ../../src/wxMaximaFrame.cpp:1134 ../../src/wxMaximaFrame.cpp:1138
 msgid "Free all unused items now"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:200
+#: ../../src/dialogs/ConfigDialogue.cpp:204
 msgid "French"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1524
+#: ../../src/wxMaximaFrame.cpp:1542
 msgid "Frobenius Norm sqrt(sum((A(i,j))^2)) (complex)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1522
+#: ../../src/wxMaximaFrame.cpp:1540
 msgid "Frobenius Norm sqrt(sum((A(i,j))^2)) (real)"
 msgstr ""
 
@@ -4734,11 +4759,11 @@ msgstr ""
 msgid "From:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:941
+#: ../../src/wxMaximaFrame.cpp:959
 msgid "Full Screen\tAlt+Enter"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:938
+#: ../../src/wxMaximaFrame.cpp:956
 msgid "Full Screen\tF11"
 msgstr ""
 
@@ -4770,15 +4795,15 @@ msgstr ""
 msgid "Function:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1744
+#: ../../src/wxMaximaFrame.cpp:1762
 msgid "Functions for complex simplification"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1702
+#: ../../src/wxMaximaFrame.cpp:1720
 msgid "Functions for simplifying factorials and gamma function"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1720
+#: ../../src/wxMaximaFrame.cpp:1738
 msgid "Functions for simplifying trigonometric expressions"
 msgstr ""
 
@@ -4798,7 +4823,7 @@ msgstr ""
 msgid "GTK_IM_MODULE is set to \"xim\". Expect the program to hideously flicker and hotkeys to be broken, see for example https://github.com/wxWidgets/wxWidgets/issues/18462."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:201
+#: ../../src/dialogs/ConfigDialogue.cpp:205
 msgid "Galician"
 msgstr ""
 
@@ -4806,31 +4831,31 @@ msgstr ""
 msgid "Gamma"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:336
+#: ../../src/wxMaximaFrame.cpp:348
 msgid "General Math"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:808
+#: ../../src/wxMaximaFrame.cpp:820
 msgid "General Math\tAlt+Shift+M"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1427
+#: ../../src/wxMaximaFrame.cpp:1445
 msgid "Generate Matrix from Expression..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1428
+#: ../../src/wxMaximaFrame.cpp:1446
 msgid "Generate a matrix from a lambda expression"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1789
+#: ../../src/wxMaximaFrame.cpp:1807
 msgid "Generate a new list using a lists' elements"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1795
+#: ../../src/wxMaximaFrame.cpp:1813
 msgid "Generate a storage for variable values that can be introduced into equations at any time"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1786
+#: ../../src/wxMaximaFrame.cpp:1804
 msgid "Generate list elements using a rule"
 msgstr ""
 
@@ -4838,7 +4863,7 @@ msgstr ""
 msgid "Generate matrix from a rule"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1205
+#: ../../src/wxMaximaFrame.cpp:1223
 msgid "Generate unused symbol name"
 msgstr ""
 
@@ -4850,36 +4875,36 @@ msgstr ""
 msgid "Generates a matrix and fills each element with the result of the expression \"Rule\"."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:202
+#: ../../src/dialogs/ConfigDialogue.cpp:206
 msgid "Georgian"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:203
+#: ../../src/dialogs/ConfigDialogue.cpp:207
 msgid "German"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1733
+#: ../../src/wxMaximaFrame.cpp:1751
 msgid "Get &Imaginary Part"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1599
+#: ../../src/wxMaximaFrame.cpp:1617
 msgid "Get Laplace transformation of an expression"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1729
+#: ../../src/wxMaximaFrame.cpp:1747
 msgid "Get Real P&art"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2012
+#: ../../src/dialogs/ConfigDialogue.cpp:2219
 #, c-format
 msgid "Get an API key for %s..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1312
+#: ../../src/wxMaximaFrame.cpp:1330
 msgid "Get current directory"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1603
+#: ../../src/wxMaximaFrame.cpp:1621
 msgid "Get inverse Laplace transformation of an expression"
 msgstr ""
 
@@ -4887,15 +4912,15 @@ msgstr ""
 msgid "Get position in stream"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1213
+#: ../../src/wxMaximaFrame.cpp:1231
 msgid "Get position..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1734
+#: ../../src/wxMaximaFrame.cpp:1752
 msgid "Get the imaginary part of complex expression"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1730
+#: ../../src/wxMaximaFrame.cpp:1748
 msgid "Get the real part of complex expression"
 msgstr ""
 
@@ -4904,7 +4929,7 @@ msgstr ""
 msgid "Gnuplot (command line) found at: %s"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1684
+#: ../../src/dialogs/ConfigDialogue.cpp:1756
 msgid "Gnuplot flavour"
 msgstr ""
 
@@ -4930,8 +4955,12 @@ msgid ""
 "%s"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:2071 ../../src/wxMaximaFrame.cpp:2001
+#: ../../src/MaximaCommandMenus.cpp:2071 ../../src/wxMaximaFrame.cpp:2019
 msgid "Go to URL"
+msgstr ""
+
+#: ../../src/ai/AiProvider.cpp:204
+msgid "Google Gemini (generateContent)"
 msgstr ""
 
 #: ../../src/MaximaResponseReader.cpp:396
@@ -4942,7 +4971,7 @@ msgstr ""
 msgid "Got a request to undo an action that involves a delete which isn't possible at this moment."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1142
+#: ../../src/wxMaximaFrame.cpp:1160
 msgid "Gradefs"
 msgstr ""
 
@@ -4950,11 +4979,11 @@ msgstr ""
 msgid "Greater or less than a value"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1241
+#: ../../src/wxMaximaFrame.cpp:1259
 msgid "Greater, ignoring case?..."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:204
+#: ../../src/dialogs/ConfigDialogue.cpp:208
 msgid "Greek"
 msgstr ""
 
@@ -4962,7 +4991,7 @@ msgstr ""
 msgid "Greek Letters"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:812
+#: ../../src/wxMaximaFrame.cpp:824
 msgid "Greek Letters\tAlt+Shift+G"
 msgstr ""
 
@@ -4974,11 +5003,11 @@ msgstr ""
 msgid "Grid:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1929
+#: ../../src/wxMaximaFrame.cpp:1947
 msgid "Guess an exact number that could be meant by this float"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1233
+#: ../../src/dialogs/ConfigDialogue.cpp:1305
 msgid "HTML"
 msgstr ""
 
@@ -4986,7 +5015,7 @@ msgstr ""
 msgid "HTML file (*.html)|*.html|maxima batch file (*.mac)|*.mac|LaTeX file (*.tex)|*.tex"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1452
+#: ../../src/wxMaximaFrame.cpp:1470
 msgid "Hadamard (element-by-element) product..."
 msgstr ""
 
@@ -4998,7 +5027,7 @@ msgstr ""
 msgid "Hadamard exponent"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1456
+#: ../../src/wxMaximaFrame.cpp:1474
 msgid "Hadamard exponent..."
 msgstr ""
 
@@ -5017,16 +5046,16 @@ msgstr ""
 msgid "Heading 6"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:205
+#: ../../src/dialogs/ConfigDialogue.cpp:209
 msgid "Hebrew"
 msgstr ""
 
 #: ../../src/ToolBar.cpp:544 ../../src/ToolBar.cpp:546
-#: ../../src/wxMaximaFrame.cpp:390
+#: ../../src/wxMaximaFrame.cpp:402
 msgid "Help"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1516
+#: ../../src/dialogs/ConfigDialogue.cpp:1588
 msgid "Help browser:"
 msgstr ""
 
@@ -5053,7 +5082,7 @@ msgstr ""
 msgid "Hide Code"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:841
+#: ../../src/wxMaximaFrame.cpp:859
 msgid "Hide Code Cells\tAlt+Ctrl+H"
 msgstr ""
 
@@ -5081,15 +5110,15 @@ msgstr ""
 msgid "Hide Subsubsection"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:843
+#: ../../src/wxMaximaFrame.cpp:861
 msgid "Hide all Sidebars\tAlt+Shift+-"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:491
+#: ../../src/dialogs/ConfigDialogue.cpp:507
 msgid "Hide all multiplication signs that aren't really necessary for understanding the equation"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:844
+#: ../../src/wxMaximaFrame.cpp:862
 msgid "Hide all panes"
 msgstr ""
 
@@ -5105,7 +5134,7 @@ msgstr ""
 msgid "Hide multiplication dots"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:872
+#: ../../src/dialogs/ConfigDialogue.cpp:944
 msgid "Hide multiplication signs, if possible"
 msgstr ""
 
@@ -5113,7 +5142,7 @@ msgstr ""
 msgid "Hide objects behind the surface"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:506
+#: ../../src/dialogs/ConfigDialogue.cpp:522
 msgid "Hide the brackets that mark the extend of the worksheet cells at the worksheet's right side and that contain the \"hide\" button of the cell if the cells aren't active."
 msgstr ""
 
@@ -5131,15 +5160,15 @@ msgstr ""
 msgid "Highlight (box)"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:887
+#: ../../src/dialogs/ConfigDialogue.cpp:959
 msgid "Highlight the matching parenthesis"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:467
+#: ../../src/dialogs/ConfigDialogue.cpp:483
 msgid "Highlight the opening or closing parenthesis for the parenthesis the cursor is at."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:206
+#: ../../src/dialogs/ConfigDialogue.cpp:210
 msgid "Hindi"
 msgstr ""
 
@@ -5155,7 +5184,7 @@ msgstr ""
 msgid "History"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:818
+#: ../../src/wxMaximaFrame.cpp:830
 msgid "History\tAlt+Shift+I"
 msgstr ""
 
@@ -5163,11 +5192,11 @@ msgstr ""
 msgid "Horizontal cursor works like a normal cursor, but it operates on cells: press up or down arrow to move it, holding down Shift while moving will select cells, pressing backspace or delete twice will delete a cell next to it."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1640
+#: ../../src/wxMaximaFrame.cpp:1658
 msgid "Horner's rule"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:936
+#: ../../src/dialogs/ConfigDialogue.cpp:1008
 msgid "Hotkeys for sending commands to maxima"
 msgstr ""
 
@@ -5175,15 +5204,15 @@ msgstr ""
 msgid "How many digits to show:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:873
+#: ../../src/wxMaximaFrame.cpp:891
 msgid "How to display new equations"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:207
+#: ../../src/dialogs/ConfigDialogue.cpp:211
 msgid "Hungarian"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1224
+#: ../../src/wxMaximaFrame.cpp:1242
 msgid "I/O"
 msgstr ""
 
@@ -5195,43 +5224,43 @@ msgstr ""
 msgid "If a program doesn't need local variables, Maxima allows putting the commands between parentheses. The result of the last operation is the return value of the program."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:147
+#: ../../src/dialogs/ConfigDialogue.cpp:151
 msgid "If maxima versions compiled with different lisps are installed: The name of the lisp to use by default"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:176
+#: ../../src/dialogs/ConfigDialogue.cpp:180
 msgid "If maxima was compiled by GCL: Garbage Collect at minimum allocation past this heapsize"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:173
+#: ../../src/dialogs/ConfigDialogue.cpp:177
 msgid "If maxima was compiled by GCL: Minimum allocation fraction between Garbage Collects"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:170
+#: ../../src/dialogs/ConfigDialogue.cpp:174
 msgid "If maxima was compiled by GCL: Only garbage collect past this heapsize fraction of working mem"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:182
+#: ../../src/dialogs/ConfigDialogue.cpp:186
 msgid "If maxima was compiled by GCL: Share the allocated memory between gcl processes. Allows more than one gcl-compiled maxima to run at the same time, but might provoke crashes."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:179
+#: ../../src/dialogs/ConfigDialogue.cpp:183
 msgid "If maxima was compiled by GCL: The fraction of the total installed RAM to reserve for maxima"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:379
+#: ../../src/dialogs/ConfigDialogue.cpp:395
 msgid "If multiple cells are evaluated in one go: Abort evaluation if wxMaxima detects that maxima has encountered any error."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:745
+#: ../../src/dialogs/ConfigDialogue.cpp:817
 msgid "If not extremely long"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:744
+#: ../../src/dialogs/ConfigDialogue.cpp:816
 msgid "If not very long"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:422
+#: ../../src/dialogs/ConfigDialogue.cpp:438
 msgid "If numbers are getting longer than this number of digits they will be displayed abbreviated by an ellipsis."
 msgstr ""
 
@@ -5239,7 +5268,7 @@ msgstr ""
 msgid "If the \"Autosave\" functionality is enabled in the configuration dialogue wxMaxima acts like mobile apps that backup the file every few minutes and save it on closing."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:400
+#: ../../src/dialogs/ConfigDialogue.cpp:416
 msgid "If the font provides big parenthesis symbols: Use them when big parenthesis are needed for maths display."
 msgstr ""
 
@@ -5255,15 +5284,15 @@ msgid ""
 "array, boolean, integer, fixnum (machine-length integer), float (machine-size floating-point numbers), real or any (which is useful for declaring arrays of any)"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:403
+#: ../../src/dialogs/ConfigDialogue.cpp:419
 msgid "If this checkbox is checked wxMaxima automatically saves the file closing and every few minutes giving wxMaxima a more cellphone-app-like feel as the file is virtually always saved. If this checkbox is unchecked from time to time a backup is made in the temp folder instead."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:382
+#: ../../src/dialogs/ConfigDialogue.cpp:398
 msgid "If this checkbox is set a new code cell is opened as soon as maxima requests data. If it isn't set a new code cell is opened in this case as soon as the user starts typing in code."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:376
+#: ../../src/dialogs/ConfigDialogue.cpp:392
 msgid "If this checkbox isn't checked the current command is sent to maxima only on pressing Ctrl+Enter"
 msgstr ""
 
@@ -5271,18 +5300,18 @@ msgstr ""
 msgid "If this isn't a function returning a lambda() expression a multiplication sign (*) between closing and opening parenthesis is missing here."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:960
+#: ../../src/dialogs/ConfigDialogue.cpp:1032
 msgid ""
 "If this option is enabled, the filename and path of images inserted with \"Cell\" -> \"Insert Image...\" is stored in the worksheet file on save. This enables reloading of the image file via the context menu after re-opening the worksheet, but storing the filenames and paths may be an undesired data leak. If this option is disabled, reloading still works as long as the worksheet is not closed.\n"
 "\n"
 "Note: Storing the filenames for the reload functionality is independent of the automatically generated image captions."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:443
+#: ../../src/dialogs/ConfigDialogue.cpp:459
 msgid "If this option is set the .wxmx source of the current file is copied to a place a link to is put into the result of an export."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1928
+#: ../../src/dialogs/ConfigDialogue.cpp:2000
 msgid "If unset, Maxima's output is announced to the screen reader as maths in a linear text form. Set this option if your screen reader can speak MathML properly."
 msgstr ""
 
@@ -5328,11 +5357,11 @@ msgstr ""
 msgid "Implicit Plot"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1046
+#: ../../src/dialogs/ConfigDialogue.cpp:1118
 msgid "Import settings"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1031
+#: ../../src/dialogs/ConfigDialogue.cpp:1103
 msgid "Import+Export"
 msgstr ""
 
@@ -5373,7 +5402,7 @@ msgstr ""
 msgid "In text cells bullet lists can be created by beginning a line with \" * \". The number of spaces in front of the \"*\" determines the indentation level; Indentation can be continued in the next line by indenting the line using spaces."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:425
+#: ../../src/dialogs/ConfigDialogue.cpp:441
 msgid "In the LaTeX output: Put exponents after an eventual subscript instead of above it. Might increase readability for some fonts and short subscripts."
 msgstr ""
 
@@ -5385,15 +5414,15 @@ msgstr ""
 msgid "Increasing function f(x)>x"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:902
+#: ../../src/dialogs/ConfigDialogue.cpp:974
 msgid "Incremental Search"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:862
+#: ../../src/dialogs/ConfigDialogue.cpp:934
 msgid "Indent equations by the label width"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:516
+#: ../../src/dialogs/ConfigDialogue.cpp:532
 msgid "Indent maths so all lines are in par with the first line that starts after the label."
 msgstr ""
 
@@ -5417,7 +5446,7 @@ msgstr ""
 msgid "Index variable:"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:208
+#: ../../src/dialogs/ConfigDialogue.cpp:212
 msgid "Indonesian"
 msgstr ""
 
@@ -5438,7 +5467,7 @@ msgstr ""
 msgid "Infinity"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:2063
+#: ../../src/wxMaximaFrame.cpp:2081
 msgid "Info about Maxima build"
 msgstr ""
 
@@ -5454,11 +5483,11 @@ msgstr ""
 msgid "Initial Condition"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1381
+#: ../../src/wxMaximaFrame.cpp:1399
 msgid "Initial Value Problem (&1)..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1385
+#: ../../src/wxMaximaFrame.cpp:1403
 msgid "Initial Value Problem (&2)..."
 msgstr ""
 
@@ -5490,23 +5519,23 @@ msgid ""
 "Right-click for options!"
 msgstr ""
 
-#: ../../src/wizards/GenWizPanel.cpp:103 ../../src/wxMaximaFrame.cpp:355
+#: ../../src/wizards/GenWizPanel.cpp:103 ../../src/wxMaximaFrame.cpp:367
 msgid "Insert"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:907
+#: ../../src/dialogs/ConfigDialogue.cpp:979
 msgid "Insert % before an operator at the beginning of a cell"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1016
+#: ../../src/wxMaximaFrame.cpp:1034
 msgid "Insert &Section Cell\tCtrl+3"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1012
+#: ../../src/wxMaximaFrame.cpp:1030
 msgid "Insert &Text Cell\tCtrl+1"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:822
+#: ../../src/wxMaximaFrame.cpp:834
 msgid "Insert Cell\tAlt+Shift+C"
 msgstr ""
 
@@ -5522,23 +5551,23 @@ msgstr ""
 msgid "Insert Image"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1028
+#: ../../src/wxMaximaFrame.cpp:1046
 msgid "Insert Image..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1010
+#: ../../src/wxMaximaFrame.cpp:1028
 msgid "Insert Input &Cell\tCtrl+0"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1030
+#: ../../src/wxMaximaFrame.cpp:1048
 msgid "Insert Page Break"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1018
+#: ../../src/wxMaximaFrame.cpp:1036
 msgid "Insert S&ubsection Cell\tCtrl+4"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1021
+#: ../../src/wxMaximaFrame.cpp:1039
 msgid "Insert S&ubsubsection Cell\tCtrl+5"
 msgstr ""
 
@@ -5554,7 +5583,7 @@ msgstr ""
 msgid "Insert Subsubsection Cell"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1014
+#: ../../src/wxMaximaFrame.cpp:1032
 msgid "Insert T&itle Cell\tCtrl+2"
 msgstr ""
 
@@ -5566,39 +5595,39 @@ msgstr ""
 msgid "Insert Title Cell"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1024
+#: ../../src/wxMaximaFrame.cpp:1042
 msgid "Insert a new heading5 cell"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1026
+#: ../../src/wxMaximaFrame.cpp:1044
 msgid "Insert a new heading6 cell"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1011
+#: ../../src/wxMaximaFrame.cpp:1029
 msgid "Insert a new input cell"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1017
+#: ../../src/wxMaximaFrame.cpp:1035
 msgid "Insert a new section cell"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1019
+#: ../../src/wxMaximaFrame.cpp:1037
 msgid "Insert a new subsection cell"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1022
+#: ../../src/wxMaximaFrame.cpp:1040
 msgid "Insert a new subsubsection cell"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1013
+#: ../../src/wxMaximaFrame.cpp:1031
 msgid "Insert a new text cell"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1015
+#: ../../src/wxMaximaFrame.cpp:1033
 msgid "Insert a new title cell"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1031
+#: ../../src/wxMaximaFrame.cpp:1049
 msgid "Insert a page break"
 msgstr ""
 
@@ -5606,23 +5635,23 @@ msgstr ""
 msgid "Insert a string into another"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1275
+#: ../../src/wxMaximaFrame.cpp:1293
 msgid "Insert char..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1023
+#: ../../src/wxMaximaFrame.cpp:1041
 msgid "Insert heading5 Cell\tCtrl+6"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1025
+#: ../../src/wxMaximaFrame.cpp:1043
 msgid "Insert heading6 Cell\tCtrl+7"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1028
+#: ../../src/wxMaximaFrame.cpp:1046
 msgid "Insert image"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1027
+#: ../../src/wxMaximaFrame.cpp:1045
 msgid "Insert textbased cell"
 msgstr ""
 
@@ -5642,7 +5671,7 @@ msgstr ""
 msgid "Instructed to prefer wgnuplot over gnuplot"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:767
+#: ../../src/dialogs/ConfigDialogue.cpp:839
 msgid "Integers and single letters"
 msgstr ""
 
@@ -5663,15 +5692,15 @@ msgstr ""
 msgid "Integrate (risch)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1568
+#: ../../src/wxMaximaFrame.cpp:1586
 msgid "Integrate expression"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1570
+#: ../../src/wxMaximaFrame.cpp:1588
 msgid "Integrate expression with Risch algorithm"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1983
+#: ../../src/wxMaximaFrame.cpp:2001
 msgid "Integrate numerically (QUADPACK)"
 msgstr ""
 
@@ -5680,23 +5709,23 @@ msgstr ""
 msgid "Integrate..."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:852
+#: ../../src/dialogs/ConfigDialogue.cpp:924
 msgid "Intelligently hide cell brackets"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:899
+#: ../../src/dialogs/ConfigDialogue.cpp:971
 msgid "Interaction"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1367
+#: ../../src/dialogs/ConfigDialogue.cpp:1439
 msgid "Interactive popup memory limit [MB/plot]:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1851
+#: ../../src/wxMaximaFrame.cpp:1869
 msgid "Interleave"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1852
+#: ../../src/wxMaximaFrame.cpp:1870
 msgid "Interleave the values of two lists"
 msgstr ""
 
@@ -5704,11 +5733,11 @@ msgstr ""
 msgid "Interleave two lists"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1520
+#: ../../src/dialogs/ConfigDialogue.cpp:1592
 msgid "Internal"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1198
+#: ../../src/wxMaximaFrame.cpp:1216
 msgid "Interpret like input..."
 msgstr ""
 
@@ -5720,7 +5749,7 @@ msgstr ""
 msgid "Interpret string as maxima code"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1200
+#: ../../src/wxMaximaFrame.cpp:1218
 msgid "Interpret string..."
 msgstr ""
 
@@ -5728,7 +5757,7 @@ msgstr ""
 msgid "Interrupt"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1076
+#: ../../src/wxMaximaFrame.cpp:1094
 msgid "Interrupt current computation"
 msgstr ""
 
@@ -5745,7 +5774,7 @@ msgstr ""
 msgid "Introduce a list of actual values into an equation"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1811
+#: ../../src/wxMaximaFrame.cpp:1829
 msgid "Introduce the actual values for variables stored in the list"
 msgstr ""
 
@@ -5766,7 +5795,7 @@ msgstr ""
 msgid "Inverse Laplace"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1602
+#: ../../src/wxMaximaFrame.cpp:1620
 msgid "Inverse Laplace T&ransform..."
 msgstr ""
 
@@ -5794,7 +5823,7 @@ msgstr ""
 msgid "Is a char?"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1226
+#: ../../src/wxMaximaFrame.cpp:1244
 msgid "Is a char?..."
 msgstr ""
 
@@ -5806,7 +5835,7 @@ msgstr ""
 msgid "Is a digit?"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1229
+#: ../../src/wxMaximaFrame.cpp:1247
 msgid "Is a digit?..."
 msgstr ""
 
@@ -5826,11 +5855,11 @@ msgstr ""
 msgid "Is a uppercase char?"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1227
+#: ../../src/wxMaximaFrame.cpp:1245
 msgid "Is alphabetic?..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1228
+#: ../../src/wxMaximaFrame.cpp:1246
 msgid "Is alphanumeric?..."
 msgstr ""
 
@@ -5858,19 +5887,19 @@ msgstr ""
 msgid "Is an odd function"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1233
+#: ../../src/wxMaximaFrame.cpp:1251
 msgid "Is equal?..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1239
+#: ../../src/wxMaximaFrame.cpp:1257
 msgid "Is greater?..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1236
+#: ../../src/wxMaximaFrame.cpp:1254
 msgid "Is lower?..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1232
+#: ../../src/wxMaximaFrame.cpp:1250
 msgid "Is lowercase?..."
 msgstr ""
 
@@ -5878,15 +5907,15 @@ msgstr ""
 msgid "Is no integer variable"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1230
+#: ../../src/wxMaximaFrame.cpp:1248
 msgid "Is printable?..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1231
+#: ../../src/wxMaximaFrame.cpp:1249
 msgid "Is uppercase?..."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:502
+#: ../../src/dialogs/ConfigDialogue.cpp:518
 msgid "Issue a notification if maxima finishes calculating while the wxMaxima window isn't in focus."
 msgstr ""
 
@@ -5914,11 +5943,11 @@ msgstr ""
 msgid "It therefore makes sense to apply the known values for variables as late as possible."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:209
+#: ../../src/dialogs/ConfigDialogue.cpp:213
 msgid "Italian"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2268
+#: ../../src/dialogs/ConfigDialogue.cpp:2608
 msgid "Italic"
 msgstr ""
 
@@ -5930,7 +5959,7 @@ msgstr ""
 msgid "Iterator name:"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:210
+#: ../../src/dialogs/ConfigDialogue.cpp:214
 msgid "Japanese"
 msgstr ""
 
@@ -5938,11 +5967,11 @@ msgstr ""
 msgid "Jump to UUID"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:735
+#: ../../src/wxMaximaFrame.cpp:747
 msgid "Jump to UUID..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1159
+#: ../../src/wxMaximaFrame.cpp:1177
 msgid "Jump to last error"
 msgstr ""
 
@@ -5954,11 +5983,11 @@ msgstr ""
 msgid "Jump to previous difference"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1160
+#: ../../src/wxMaximaFrame.cpp:1178
 msgid "Jump to the last cell Maxima has reported an error in."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:212
+#: ../../src/dialogs/ConfigDialogue.cpp:216
 msgid "Kabyle"
 msgstr ""
 
@@ -5966,12 +5995,12 @@ msgstr ""
 msgid "Kappa"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:882
+#: ../../src/dialogs/ConfigDialogue.cpp:954
 #, c-format
 msgid "Keep percent sign with special symbols: %e, %i, etc."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:214
+#: ../../src/dialogs/ConfigDialogue.cpp:218
 msgid "Korean"
 msgstr ""
 
@@ -5979,39 +6008,39 @@ msgstr ""
 msgid "LCM"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1518
+#: ../../src/wxMaximaFrame.cpp:1536
 msgid "L[1] Norm (complex)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1517
+#: ../../src/wxMaximaFrame.cpp:1535
 msgid "L[1] Norm (real)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1520
+#: ../../src/wxMaximaFrame.cpp:1538
 msgid "L[inf] Norm (complex)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1519
+#: ../../src/wxMaximaFrame.cpp:1537
 msgid "L[inf] Norm (real)"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1184
+#: ../../src/dialogs/ConfigDialogue.cpp:1256
 msgid "LaTeX"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1217
+#: ../../src/dialogs/ConfigDialogue.cpp:1289
 msgid "LaTeX: Place exponents after, instead above subscripts"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1222
+#: ../../src/dialogs/ConfigDialogue.cpp:1294
 msgid "LaTeX: Use the \"partial derivative\" symbol to represent diff()"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:776
+#: ../../src/dialogs/ConfigDialogue.cpp:848
 msgid "Label width:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1136
+#: ../../src/wxMaximaFrame.cpp:1154
 msgid "Labels"
 msgstr ""
 
@@ -6027,11 +6056,11 @@ msgid ""
 "Also you can fill a variable with a lambda() construct, effectively generating a function pointer: A variable that can be used as a function, and filled with a different function, if needed."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:474
+#: ../../src/dialogs/ConfigDialogue.cpp:490
 msgid "Language used for wxMaxima GUI."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1329
+#: ../../src/dialogs/ConfigDialogue.cpp:1401
 msgid "Language:"
 msgstr ""
 
@@ -6039,11 +6068,11 @@ msgstr ""
 msgid "Laplace"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1598
+#: ../../src/wxMaximaFrame.cpp:1616
 msgid "Laplace &Transform..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1832
+#: ../../src/wxMaximaFrame.cpp:1850
 msgid "Last"
 msgstr ""
 
@@ -6057,24 +6086,24 @@ msgstr ""
 msgid "Last message from maxima's stdout: %s"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1834
+#: ../../src/wxMaximaFrame.cpp:1852
 msgid "Last n"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3183
+#: ../../src/wxMaxima.cpp:3198
 msgid "Last non-whitespace is a question mark"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:215
+#: ../../src/dialogs/ConfigDialogue.cpp:219
 msgid "Latvian"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:1706
+#: ../../src/wxMaxima.cpp:1721
 #, c-format
 msgid "Launching the system's default help browser as %s."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:1697 ../../src/wxMaxima.cpp:1718
+#: ../../src/wxMaxima.cpp:1712 ../../src/wxMaxima.cpp:1733
 msgid "Launching the system's default help browser failed."
 msgstr ""
 
@@ -6082,7 +6111,7 @@ msgstr ""
 msgid "Leads to"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1607
+#: ../../src/wxMaximaFrame.cpp:1625
 msgid "Least Common Multiple..."
 msgstr ""
 
@@ -6094,7 +6123,7 @@ msgstr ""
 msgid "Least Squares Fit..."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2164
+#: ../../src/dialogs/ConfigDialogue.cpp:2504
 msgid "Left"
 msgstr ""
 
@@ -6107,15 +6136,15 @@ msgstr ""
 msgid "Left end"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1408
+#: ../../src/wxMaximaFrame.cpp:1426
 msgid "Left side to the \"=\""
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1855
+#: ../../src/wxMaximaFrame.cpp:1873
 msgid "Length"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1215 ../../src/wxMaximaFrame.cpp:1278
+#: ../../src/wxMaximaFrame.cpp:1233 ../../src/wxMaximaFrame.cpp:1296
 msgid "Length..."
 msgstr ""
 
@@ -6123,11 +6152,11 @@ msgstr ""
 msgid "Length:"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1444
+#: ../../src/dialogs/ConfigDialogue.cpp:1516
 msgid "Let an AI tool read this worksheet (MCP server)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1143
+#: ../../src/wxMaximaFrame.cpp:1161
 msgid "Letrules"
 msgstr ""
 
@@ -6140,7 +6169,7 @@ msgstr ""
 msgid "License"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2225
+#: ../../src/dialogs/ConfigDialogue.cpp:2565
 msgid "Light"
 msgstr ""
 
@@ -6172,11 +6201,11 @@ msgstr ""
 msgid "Lisp format strings are more powerful than c++ format strings"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:1905
+#: ../../src/wxMaxima.cpp:1920
 msgid "Lisp mode."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1121 ../../src/wxMaximaFrame.cpp:1123
+#: ../../src/wxMaximaFrame.cpp:1139 ../../src/wxMaximaFrame.cpp:1141
 msgid "Lisp normally frees memory only when it has time or runs out of space"
 msgstr ""
 
@@ -6200,11 +6229,11 @@ msgstr ""
 msgid "List #2"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1311
+#: ../../src/wxMaximaFrame.cpp:1329
 msgid "List directory"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1316
+#: ../../src/wxMaximaFrame.cpp:1334
 msgid "List directory..."
 msgstr ""
 
@@ -6224,7 +6253,7 @@ msgstr ""
 msgid "List of char to String"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1261
+#: ../../src/wxMaximaFrame.cpp:1279
 msgid "List of chars to string..."
 msgstr ""
 
@@ -6289,11 +6318,11 @@ msgstr ""
 msgid "List:"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:216
+#: ../../src/dialogs/ConfigDialogue.cpp:220
 msgid "Lithuanian"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2319
+#: ../../src/dialogs/ConfigDialogue.cpp:2659
 msgid "Load"
 msgstr ""
 
@@ -6301,27 +6330,27 @@ msgstr ""
 msgid "Load Package"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:718
+#: ../../src/wxMaximaFrame.cpp:730
 msgid "Load Recent Package"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:721
+#: ../../src/wxMaximaFrame.cpp:733
 msgid "Load a Maxima file using the batch command"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:716
+#: ../../src/wxMaximaFrame.cpp:728
 msgid "Load a Maxima package file"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1435 ../../src/wxMaximaFrame.cpp:1441
+#: ../../src/wxMaximaFrame.cpp:1453 ../../src/wxMaximaFrame.cpp:1459
 msgid "Load a matrix from a csv file"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1792
+#: ../../src/wxMaximaFrame.cpp:1810
 msgid "Load a nested list from a csv file"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1492 ../../src/wxMaximaFrame.cpp:1493
+#: ../../src/wxMaximaFrame.cpp:1510 ../../src/wxMaximaFrame.cpp:1511
 msgid "Load lapack"
 msgstr ""
 
@@ -6329,23 +6358,23 @@ msgstr ""
 msgid "Load lisp code"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1203
+#: ../../src/wxMaximaFrame.cpp:1221
 msgid "Load lisp..."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2814
+#: ../../src/dialogs/ConfigDialogue.cpp:3196
 msgid "Load style from file"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1309
+#: ../../src/wxMaximaFrame.cpp:1327
 msgid "Load the file/dir operations (operatingsystem)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1298
+#: ../../src/wxMaximaFrame.cpp:1316
 msgid "Load the regular expression package (sregex)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1335
+#: ../../src/wxMaximaFrame.cpp:1353
 msgid "Load the translation generator (gentran)"
 msgstr ""
 
@@ -6361,11 +6390,11 @@ msgstr ""
 msgid "Lower bound:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1238
+#: ../../src/wxMaximaFrame.cpp:1256
 msgid "Lower, ignoring case?..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1562
+#: ../../src/wxMaximaFrame.cpp:1580
 msgid "M&atrix"
 msgstr ""
 
@@ -6373,7 +6402,7 @@ msgstr ""
 msgid "MAXIMA RESPONSE:"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1456
+#: ../../src/dialogs/ConfigDialogue.cpp:1528
 msgid "MCP server port:"
 msgstr ""
 
@@ -6395,11 +6424,11 @@ msgstr ""
 msgid "Macro name:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1135
+#: ../../src/wxMaximaFrame.cpp:1153
 msgid "Macros"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:946
+#: ../../src/wxMaximaFrame.cpp:964
 msgid "Main Toolbar\tShift+Alt+B"
 msgstr ""
 
@@ -6411,11 +6440,11 @@ msgstr ""
 msgid "Make an eventual ev() evaluate this"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1181
+#: ../../src/wxMaximaFrame.cpp:1199
 msgid "Make function local..."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:217
+#: ../../src/dialogs/ConfigDialogue.cpp:221
 msgid "Malay"
 msgstr ""
 
@@ -6439,11 +6468,11 @@ msgstr ""
 msgid "Map an expression"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1557
+#: ../../src/wxMaximaFrame.cpp:1575
 msgid "Map function to a matrix"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1560
+#: ../../src/wxMaximaFrame.cpp:1578
 msgid "Map function to a matrix, affecting all of its clones"
 msgstr ""
 
@@ -6455,7 +6484,7 @@ msgstr ""
 msgid "Math Default"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:807
+#: ../../src/dialogs/ConfigDialogue.cpp:879
 msgid "Math layout strategy"
 msgstr ""
 
@@ -6463,23 +6492,23 @@ msgstr ""
 msgid "Math output"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1239
+#: ../../src/dialogs/ConfigDialogue.cpp:1311
 msgid "MathML (rendered by the browser)"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1240
+#: ../../src/dialogs/ConfigDialogue.cpp:1312
 msgid "MathML + MathJaX fall-back for old browsers"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2063
+#: ../../src/dialogs/ConfigDialogue.cpp:2403
 msgid "MathML as HTML"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2059
+#: ../../src/dialogs/ConfigDialogue.cpp:2399
 msgid "MathML description"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:327
+#: ../../src/wxMaximaFrame.cpp:339
 msgid "Mathematical Symbols"
 msgstr ""
 
@@ -6503,15 +6532,15 @@ msgstr ""
 msgid "Matrix Exponent"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1450
+#: ../../src/wxMaximaFrame.cpp:1468
 msgid "Matrix exponent..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1440
+#: ../../src/wxMaximaFrame.cpp:1458
 msgid "Matrix from csv file"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1434
+#: ../../src/wxMaximaFrame.cpp:1452
 msgid "Matrix from csv file..."
 msgstr ""
 
@@ -6523,19 +6552,19 @@ msgstr ""
 msgid "Matrix name:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:912
+#: ../../src/wxMaximaFrame.cpp:930
 msgid "Matrix parenthesis"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1442
+#: ../../src/wxMaximaFrame.cpp:1460
 msgid "Matrix to csv file"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1445
+#: ../../src/wxMaximaFrame.cpp:1463
 msgid "Matrix to file or Matrix from file"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1875
+#: ../../src/wxMaximaFrame.cpp:1893
 msgid "Matrix to nested List"
 msgstr ""
 
@@ -6551,15 +6580,15 @@ msgstr ""
 msgid "Matrix:"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1388
+#: ../../src/dialogs/ConfigDialogue.cpp:1460
 msgid "Max. layout time [s] (0=no limit)"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:283
+#: ../../src/dialogs/ConfigDialogue.cpp:293
 msgid "Maxima"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1488
+#: ../../src/dialogs/ConfigDialogue.cpp:1560
 msgid "Maxima Location"
 msgstr ""
 
@@ -6584,7 +6613,7 @@ msgstr ""
 msgid "Maxima asks a question!"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:366
+#: ../../src/dialogs/ConfigDialogue.cpp:382
 #, c-format
 msgid "Maxima assigns each command/equation an automatic label (which looks like %i1 or %o1). If a command begins with a descriptive name followed by a : wxMaxima will call the descriptive name a \"user-defined label\" instead. This selection now allows telling wxMaxima whether to show only automatic labels, automatic labels if there aren't user-defined ones or no label at all until a user-defined label can be found by wxMaxima's heuristics. If automatic labels are suppressed extra vertical space is added between equations in order to ease discerning which line starts a new equation and which one only continues the one from the last line."
 msgstr ""
@@ -6599,15 +6628,15 @@ msgstr ""
 msgid "Maxima code"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1128
+#: ../../src/dialogs/ConfigDialogue.cpp:1200
 msgid "Maxima commands to be executed at every start of Maxima"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1081
+#: ../../src/dialogs/ConfigDialogue.cpp:1153
 msgid "Maxima commands to be executed every time wxMaxima starts Maxima"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1562
+#: ../../src/dialogs/ConfigDialogue.cpp:1634
 msgid "Maxima configuration"
 msgstr ""
 
@@ -6640,7 +6669,7 @@ msgstr ""
 msgid "Maxima has sent a new variable value."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2700
+#: ../../src/wxMaxima.cpp:2715
 #, c-format
 msgid ""
 "Maxima has started, but hasn't connected to wxMaxima within 5 seconds.\n"
@@ -6650,7 +6679,7 @@ msgid ""
 "Command: %s"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2674
+#: ../../src/wxMaxima.cpp:2689
 #, c-format
 msgid ""
 "Maxima has started, but hasn't connected to wxMaxima yet.\n"
@@ -6683,7 +6712,7 @@ msgstr ""
 msgid "Maxima help file not found!"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1154
+#: ../../src/wxMaximaFrame.cpp:1172
 msgid "Maxima input"
 msgstr ""
 
@@ -6691,11 +6720,11 @@ msgstr ""
 msgid "Maxima is calculating"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:1907
+#: ../../src/wxMaxima.cpp:1922
 msgid "Maxima is ready for input."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2696 ../../src/wxMaxima.cpp:2715
+#: ../../src/wxMaxima.cpp:2711 ../../src/wxMaxima.cpp:2730
 msgid "Maxima isn't connecting"
 msgstr ""
 
@@ -6716,11 +6745,11 @@ msgstr ""
 msgid "Maxima process terminated unexpectedly."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1492
+#: ../../src/dialogs/ConfigDialogue.cpp:1564
 msgid "Maxima program:"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:386
+#: ../../src/dialogs/ConfigDialogue.cpp:402
 msgid "Maxima provides no \"forget all\" command that flushes all settings a maxima session could make. wxMaxima therefore normally defaults to starting a fresh maxima process every time the worksheet is to be re-evaluated. As this needs a little bit of time this switch allows to disable this behavior."
 msgstr ""
 
@@ -6744,15 +6773,15 @@ msgstr ""
 msgid "Maxima session (*.mac)|*.mac"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1573 ../../src/wxMaximaFrame.cpp:2058
+#: ../../src/dialogs/ConfigDialogue.cpp:1645 ../../src/wxMaximaFrame.cpp:2076
 msgid "Maxima shows help in a browser"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1578 ../../src/wxMaximaFrame.cpp:2054
+#: ../../src/dialogs/ConfigDialogue.cpp:1650 ../../src/wxMaximaFrame.cpp:2072
 msgid "Maxima shows help in a sidebar"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1566 ../../src/wxMaximaFrame.cpp:2049
+#: ../../src/dialogs/ConfigDialogue.cpp:1638 ../../src/wxMaximaFrame.cpp:2067
 msgid "Maxima shows help in the console"
 msgstr ""
 
@@ -6772,7 +6801,7 @@ msgstr ""
 msgid "Maxima starts:"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1161
+#: ../../src/dialogs/ConfigDialogue.cpp:1233
 msgid "Maxima startup file location: "
 msgstr ""
 
@@ -6780,7 +6809,7 @@ msgstr ""
 msgid "Maxima supports three types of numbers: exact fractions (which can be generated for example by typing 1/10), IEEE floating-point numbers (0.2) and arbitrary precision big floats (1b-1). Note that, owing to their nature as binary (not decimal) numbers, there is for example no way to generate an IEEE floating-point number that exactly equals 0.1. If floating-point numbers are used instead of fractions, Maxima will therefore sometimes have to introduce a (very small) error and use things like 3602879701896397/36028797018963968 for 0.1."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1342
+#: ../../src/wxMaximaFrame.cpp:1360
 msgid "Maxima to other language"
 msgstr ""
 
@@ -6792,7 +6821,7 @@ msgstr ""
 msgid "Maxima tried to find out where between two points a curve crosses the zero line. Since the curve is on the same side of the zero line in both points its algorithms fails here. Set find_root_error to false if you want it to return false instead of an error."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1670
+#: ../../src/dialogs/ConfigDialogue.cpp:1742
 msgid "Maxima usage"
 msgstr ""
 
@@ -6835,7 +6864,7 @@ msgstr ""
 msgid "Maxima version: %s, Anchors cache version"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:2039
+#: ../../src/wxMaximaFrame.cpp:2057
 msgid "Maxima vs. Programming languages"
 msgstr ""
 
@@ -6896,7 +6925,7 @@ msgstr ""
 msgid "Maxima's power lies in symbolic operations."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2663
+#: ../../src/wxMaxima.cpp:2678
 msgid "Maxima's process is running, but hasn't connected back to wxMaxima within 5 seconds."
 msgstr ""
 
@@ -6946,7 +6975,7 @@ msgstr ""
 msgid "Maximum absolute value printed without exponent"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2088
+#: ../../src/dialogs/ConfigDialogue.cpp:2428
 msgid "Maximum bitmap size on clipboard [Mb]:"
 msgstr ""
 
@@ -6959,7 +6988,7 @@ msgstr ""
 msgid "Maximum number of digits to be displayed:"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:829
+#: ../../src/dialogs/ConfigDialogue.cpp:901
 msgid "Maximum number of displayed digits:"
 msgstr ""
 
@@ -6983,16 +7012,16 @@ msgstr ""
 msgid "Median..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:2038
+#: ../../src/wxMaximaFrame.cpp:2056
 msgid "Memoizing"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1124
+#: ../../src/wxMaximaFrame.cpp:1142
 msgid "Memory"
 msgstr ""
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:182
-#: ../../src/wxMaximaFrame.cpp:1046
+#: ../../src/wxMaximaFrame.cpp:1064
 msgid "Merge Cells"
 msgstr ""
 
@@ -7004,7 +7033,7 @@ msgstr ""
 msgid "Method:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1437
+#: ../../src/wxMaximaFrame.cpp:1455
 msgid "Methods of generating a matrix"
 msgstr ""
 
@@ -7027,15 +7056,15 @@ msgstr ""
 msgid "Minimum absolute value printed without exponent:"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1288
+#: ../../src/dialogs/ConfigDialogue.cpp:1360
 msgid "Misc"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2120
+#: ../../src/dialogs/ConfigDialogue.cpp:2460
 msgid "Misc settings"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3232 ../../src/wxMaxima.cpp:3234
+#: ../../src/wxMaxima.cpp:3247 ../../src/wxMaxima.cpp:3249
 msgid "Mismatched parenthesis"
 msgstr ""
 
@@ -7043,7 +7072,8 @@ msgstr ""
 msgid "Missing contents. Bug?"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1992
+#: ../../src/dialogs/ConfigDialogue.cpp:2110
+#: ../../src/dialogs/ConfigDialogue.cpp:2320
 msgid "Model:"
 msgstr ""
 
@@ -7077,7 +7107,7 @@ msgstr ""
 msgid "Mu"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1463
+#: ../../src/wxMaximaFrame.cpp:1481
 msgid "Multiplication, exponent and similar"
 msgstr ""
 
@@ -7085,7 +7115,7 @@ msgstr ""
 msgid "Multiplicative function: f(a*b)=f(a)*f(b)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1449
+#: ../../src/wxMaximaFrame.cpp:1467
 msgid "Multiply matrices..."
 msgstr ""
 
@@ -7105,15 +7135,15 @@ msgstr ""
 msgid "Name of x:"
 msgstr ""
 
-#: ../../src/wizards/MatWiz.cpp:163
+#: ../../src/dialogs/ConfigDialogue.cpp:2295 ../../src/wizards/MatWiz.cpp:163
 msgid "Name:"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:218
+#: ../../src/dialogs/ConfigDialogue.cpp:222
 msgid "Nepali"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1431 ../../src/wxMaximaFrame.cpp:1873
+#: ../../src/wxMaximaFrame.cpp:1449 ../../src/wxMaximaFrame.cpp:1891
 msgid "Nested list to Matrix"
 msgstr ""
 
@@ -7121,9 +7151,9 @@ msgstr ""
 msgid "Nested list to matrix"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:766
-#: ../../src/dialogs/ConfigDialogue.cpp:790 ../../src/wxMaximaFrame.cpp:883
-#: ../../src/wxMaximaFrame.cpp:1164
+#: ../../src/dialogs/ConfigDialogue.cpp:838
+#: ../../src/dialogs/ConfigDialogue.cpp:862 ../../src/wxMaximaFrame.cpp:901
+#: ../../src/wxMaximaFrame.cpp:1182
 msgid "Never"
 msgstr ""
 
@@ -7131,7 +7161,7 @@ msgstr ""
 msgid "Never autosubscript this variable"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:890
+#: ../../src/wxMaximaFrame.cpp:908
 msgid "Never display this variable with subscript"
 msgstr ""
 
@@ -7144,7 +7174,7 @@ msgstr ""
 msgid "New"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:702
+#: ../../src/wxMaximaFrame.cpp:714
 msgid "New\tCtrl+N"
 msgstr ""
 
@@ -7168,7 +7198,7 @@ msgstr ""
 msgid "New document"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:919
+#: ../../src/dialogs/ConfigDialogue.cpp:991
 msgid "New lines: Jump to text"
 msgstr ""
 
@@ -7190,7 +7220,7 @@ msgstr ""
 msgid "New variable:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1040
+#: ../../src/wxMaximaFrame.cpp:1058
 msgid "Next Command\tAlt+Down"
 msgstr ""
 
@@ -7198,20 +7228,20 @@ msgstr ""
 msgid "Next Difference"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:862
+#: ../../src/wxMaximaFrame.cpp:880
 msgid "Nice Graphical Equations"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:743
-#: ../../src/dialogs/ConfigDialogue.cpp:755 ../../src/wxMaximaFrame.cpp:1664
+#: ../../src/dialogs/ConfigDialogue.cpp:815
+#: ../../src/dialogs/ConfigDialogue.cpp:827 ../../src/wxMaximaFrame.cpp:1682
 msgid "No"
 msgstr ""
 
-#: ../../src/sidebars/AiChatSidebar.cpp:165
+#: ../../src/sidebars/AiChatSidebar.cpp:188
 msgid "No AI provider configured -- add an API key in Options."
 msgstr ""
 
-#: ../../src/sidebars/AiChatSidebar.cpp:218
+#: ../../src/sidebars/AiChatSidebar.cpp:241
 msgid "No AI provider is configured. Open Options to add an API key for one."
 msgstr ""
 
@@ -7235,7 +7265,7 @@ msgstr ""
 msgid "No differences"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3265
+#: ../../src/wxMaxima.cpp:3280
 msgid "No dollar ($) or semicolon (;) at the end of command"
 msgstr ""
 
@@ -7259,8 +7289,8 @@ msgstr ""
 msgid "No image to export"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2749 ../../src/wxMaxima.cpp:2757
-#: ../../src/wxMaxima.cpp:2778 ../../src/wxMaxima.cpp:2790
+#: ../../src/wxMaxima.cpp:2764 ../../src/wxMaxima.cpp:2772
+#: ../../src/wxMaxima.cpp:2793 ../../src/wxMaxima.cpp:2805
 msgid "No matches found!"
 msgstr ""
 
@@ -7288,11 +7318,11 @@ msgstr ""
 msgid "Non-builtin symbols"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:911
+#: ../../src/wxMaximaFrame.cpp:929
 msgid "None"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1965
+#: ../../src/dialogs/ConfigDialogue.cpp:2153
 msgid "None (disabled)"
 msgstr ""
 
@@ -7309,11 +7339,11 @@ msgid ""
 "The info that numbers have automatically been converted can be suppressed by setting ratprint to false."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:435
+#: ../../src/dialogs/ConfigDialogue.cpp:451
 msgid "Normally html expects images to be rather low-res but space saving. These images tend to look rather blurry when viewed on modern screens. Therefore this setting was introduces that selects the factor by which the HTML export increases the resolution in respect to the default value."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:219
+#: ../../src/dialogs/ConfigDialogue.cpp:223
 msgid "Norwegian"
 msgstr ""
 
@@ -7349,6 +7379,10 @@ msgstr ""
 msgid "Not triggering evaluation as there is no working maxima process"
 msgstr ""
 
+#: ../../src/dialogs/ConfigDialogue.cpp:2046
+msgid "Note: an API key is billed separately from a consumer chat subscription -- a Claude Pro/Max, ChatGPT Plus or Gemini Advanced plan does not include API usage, and a provider's site may ask you to add a small amount of prepaid credit before it lets you create a key."
+msgstr ""
+
 #: ../../src/sidebars/GreekSidebar.cpp:190
 msgid "Nu"
 msgstr ""
@@ -7369,11 +7403,11 @@ msgstr ""
 msgid "Number to octets"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1265
+#: ../../src/wxMaximaFrame.cpp:1283
 msgid "Number to octets..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:2020
+#: ../../src/wxMaximaFrame.cpp:2038
 msgid "Number types"
 msgstr ""
 
@@ -7381,7 +7415,7 @@ msgstr ""
 msgid "Number:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1900
+#: ../../src/wxMaximaFrame.cpp:1918
 msgid "Numeric output"
 msgstr ""
 
@@ -7389,7 +7423,7 @@ msgstr ""
 msgid "Numerical QR decomposition of a matrix"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1528
+#: ../../src/wxMaximaFrame.cpp:1546
 msgid "Numerical operations (lapack)"
 msgstr ""
 
@@ -7397,15 +7431,15 @@ msgstr ""
 msgid "Numerical solution for 1st degree ODE"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1393
+#: ../../src/wxMaximaFrame.cpp:1411
 msgid "Numerical solution..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1372
+#: ../../src/wxMaximaFrame.cpp:1390
 msgid "Numerical solutions of polynomial (bfloat)..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1369
+#: ../../src/wxMaximaFrame.cpp:1387
 msgid "Numerical solutions of polynomial..."
 msgstr ""
 
@@ -7476,11 +7510,11 @@ msgstr ""
 msgid "Octets to String"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1267
+#: ../../src/wxMaximaFrame.cpp:1285
 msgid "Octets to number..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1269
+#: ../../src/wxMaximaFrame.cpp:1287
 msgid "Octets to string..."
 msgstr ""
 
@@ -7492,7 +7526,7 @@ msgstr ""
 msgid "Odd number"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:928
+#: ../../src/dialogs/ConfigDialogue.cpp:1000
 msgid "Offer answers for questions known from previous runs"
 msgstr ""
 
@@ -7517,11 +7551,11 @@ msgstr ""
 msgid "Omicron"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1166
+#: ../../src/wxMaximaFrame.cpp:1184
 msgid "On all errors"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1165
+#: ../../src/wxMaximaFrame.cpp:1183
 msgid "On lisp errors"
 msgstr ""
 
@@ -7529,20 +7563,20 @@ msgstr ""
 msgid "One sample t-test"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:2041
+#: ../../src/wxMaximaFrame.cpp:2059
 msgid "Online tutorials"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:880
+#: ../../src/wxMaximaFrame.cpp:898
 msgid "Only Integers and single letters"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:789
+#: ../../src/dialogs/ConfigDialogue.cpp:861
 msgid "Only user-defined labels"
 msgstr ""
 
 #: ../../src/MaximaCommandMenus.cpp:2197 ../../src/ToolBar.cpp:330
-#: ../../src/ToolBar.cpp:333 ../../src/main.cpp:945
+#: ../../src/ToolBar.cpp:333 ../../src/main.cpp:1070
 msgid "Open"
 msgstr ""
 
@@ -7550,15 +7584,15 @@ msgstr ""
 msgid "Open Options..."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:923
+#: ../../src/dialogs/ConfigDialogue.cpp:995
 msgid "Open a cell when Maxima expects input"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:703
+#: ../../src/wxMaximaFrame.cpp:715
 msgid "Open a document"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:702
+#: ../../src/wxMaximaFrame.cpp:714
 msgid "Open a new window"
 msgstr ""
 
@@ -7574,7 +7608,7 @@ msgstr ""
 msgid "Open for appending"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1210
+#: ../../src/wxMaximaFrame.cpp:1228
 msgid "Open for appending..."
 msgstr ""
 
@@ -7582,7 +7616,7 @@ msgstr ""
 msgid "Open for reading"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1209
+#: ../../src/wxMaximaFrame.cpp:1227
 msgid "Open for reading..."
 msgstr ""
 
@@ -7590,7 +7624,7 @@ msgstr ""
 msgid "Open for writing"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1211
+#: ../../src/wxMaximaFrame.cpp:1229
 msgid "Open for writing..."
 msgstr ""
 
@@ -7598,8 +7632,12 @@ msgstr ""
 msgid "Open matrix"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:705
+#: ../../src/wxMaximaFrame.cpp:717
 msgid "Open recent"
+msgstr ""
+
+#: ../../src/ai/AiProvider.cpp:206
+msgid "OpenAI-compatible (most third-party/self-hosted APIs)"
 msgstr ""
 
 #: ../../src/MaximaFileIO.cpp:231
@@ -7611,16 +7649,16 @@ msgstr ""
 msgid "Opening file"
 msgstr ""
 
-#: ../../src/sidebars/HelpBrowser.cpp:175 ../../src/wxMaxima.cpp:1839
+#: ../../src/sidebars/HelpBrowser.cpp:175 ../../src/wxMaxima.cpp:1854
 #, c-format
 msgid "Opening help file %s"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1644
+#: ../../src/wxMaximaFrame.cpp:1662
 msgid "Optimize for CPU time"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1643
+#: ../../src/wxMaximaFrame.cpp:1661
 msgid "Optimize for memory"
 msgstr ""
 
@@ -7629,7 +7667,7 @@ msgid "Optional: A 2nd expression that defines a region to fill"
 msgstr ""
 
 #: ../../src/ToolBar.cpp:367 ../../src/ToolBar.cpp:369
-#: ../../src/dialogs/ConfigDialogue.cpp:286
+#: ../../src/dialogs/ConfigDialogue.cpp:296
 msgid "Options"
 msgstr ""
 
@@ -7641,15 +7679,15 @@ msgstr ""
 msgid "Output"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1336
+#: ../../src/wxMaximaFrame.cpp:1354
 msgid "Output C"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1337
+#: ../../src/wxMaximaFrame.cpp:1355
 msgid "Output Fortran"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1339
+#: ../../src/wxMaximaFrame.cpp:1357
 msgid "Output Rational Fortran"
 msgstr ""
 
@@ -7686,7 +7724,7 @@ msgstr ""
 msgid "Output: Variable names"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:857
+#: ../../src/dialogs/ConfigDialogue.cpp:929
 msgid "Overlay scrollbars (slow: repaints the worksheet while they fade)"
 msgstr ""
 
@@ -7694,7 +7732,7 @@ msgstr ""
 msgid "PNG image (*.png)|*.png|JPEG image (*.jpg)|*.jpg|Windows bitmap (*.bmp)|*.bmp|"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:462
+#: ../../src/dialogs/ConfigDialogue.cpp:478
 msgid "PNG images can be read by old wxMaxima versions - but aren't really scalable."
 msgstr ""
 
@@ -7702,7 +7740,7 @@ msgstr ""
 msgid "Pade approximation"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1592
+#: ../../src/wxMaximaFrame.cpp:1610
 msgid "Pade approximation of a Taylor series"
 msgstr ""
 
@@ -7710,7 +7748,7 @@ msgstr ""
 msgid "Pagebreak"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1751
+#: ../../src/wxMaximaFrame.cpp:1769
 msgid "Parallel Substitute..."
 msgstr ""
 
@@ -7742,7 +7780,7 @@ msgstr ""
 msgid "Parse string"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1263
+#: ../../src/wxMaximaFrame.cpp:1281
 msgid "Parse string only..."
 msgstr ""
 
@@ -7754,7 +7792,7 @@ msgstr ""
 msgid "Part:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1613 ../../src/wxMaximaFrame.cpp:1649
+#: ../../src/wxMaximaFrame.cpp:1631 ../../src/wxMaximaFrame.cpp:1667
 msgid "Partial &Fractions..."
 msgstr ""
 
@@ -7768,7 +7806,7 @@ msgstr ""
 msgid "Paste"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:778
+#: ../../src/wxMaximaFrame.cpp:790
 msgid "Paste\tCtrl+V"
 msgstr ""
 
@@ -7776,15 +7814,15 @@ msgstr ""
 msgid "Paste from clipboard"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:779
+#: ../../src/wxMaximaFrame.cpp:791
 msgid "Paste text from clipboard"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:278 ../../src/wxMaximaFrame.cpp:836
+#: ../../src/wxMaximaFrame.cpp:278 ../../src/wxMaximaFrame.cpp:854
 msgid "Performance Monitor"
 msgstr ""
 
-#: ../../src/Configuration.cpp:1421
+#: ../../src/Configuration.cpp:1492
 msgid "Performance Statistics:"
 msgstr ""
 
@@ -7792,7 +7830,7 @@ msgstr ""
 msgid "Perpendicular to"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:220
+#: ../../src/dialogs/ConfigDialogue.cpp:224
 msgid "Persian"
 msgstr ""
 
@@ -7808,11 +7846,11 @@ msgstr ""
 msgid "Piechart..."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:1618
+#: ../../src/wxMaxima.cpp:1633
 msgid "Please configure wxMaxima with 'Edit->Configure'."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2775
+#: ../../src/dialogs/ConfigDialogue.cpp:3157
 msgid "Please restart wxMaxima for changes to take effect!"
 msgstr ""
 
@@ -7820,15 +7858,15 @@ msgstr ""
 msgid "Please select exactly 2 or 3 files."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1882
+#: ../../src/wxMaximaFrame.cpp:1900
 msgid "Plot &2d..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1884
+#: ../../src/wxMaximaFrame.cpp:1902
 msgid "Plot &3d..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1886
+#: ../../src/wxMaximaFrame.cpp:1904
 msgid "Plot &Format..."
 msgstr ""
 
@@ -7878,11 +7916,11 @@ msgstr ""
 msgid "Plot format"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1882
+#: ../../src/wxMaximaFrame.cpp:1900
 msgid "Plot in 2 dimensions"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1884
+#: ../../src/wxMaximaFrame.cpp:1902
 msgid "Plot in 3 dimensions"
 msgstr ""
 
@@ -7894,7 +7932,7 @@ msgstr ""
 msgid "Plot to file:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:361 ../../src/wxMaximaFrame.cpp:823
+#: ../../src/wxMaximaFrame.cpp:373 ../../src/wxMaximaFrame.cpp:835
 msgid "Plot using Draw"
 msgstr ""
 
@@ -7924,7 +7962,7 @@ msgstr ""
 msgid "Points"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:221
+#: ../../src/dialogs/ConfigDialogue.cpp:225
 msgid "Polish"
 msgstr ""
 
@@ -7943,7 +7981,7 @@ msgstr ""
 msgid "Polynomial:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1868
+#: ../../src/wxMaximaFrame.cpp:1886
 msgid "Pop"
 msgstr ""
 
@@ -7956,15 +7994,15 @@ msgstr ""
 msgid "Portable anymap (*.pnm)|*.pnm|Tagged image file format (*.tif)|*.tif|X pixmap (*.xpm)|*.xpm"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:222
+#: ../../src/dialogs/ConfigDialogue.cpp:226
 msgid "Portuguese"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:223
+#: ../../src/dialogs/ConfigDialogue.cpp:227
 msgid "Portuguese (Brazilian)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1300
+#: ../../src/wxMaximaFrame.cpp:1318
 msgid "Position of a match"
 msgstr ""
 
@@ -7984,7 +8022,7 @@ msgstr ""
 msgid "Power series"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1589
+#: ../../src/wxMaximaFrame.cpp:1607
 msgid "Power series..."
 msgstr ""
 
@@ -7992,11 +8030,11 @@ msgstr ""
 msgid "Precision"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:805
+#: ../../src/dialogs/ConfigDialogue.cpp:877
 msgid "Prefer 1D"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1547
+#: ../../src/dialogs/ConfigDialogue.cpp:1619
 msgid "Prefer the all-in-one-file >1000 page manual"
 msgstr ""
 
@@ -8004,7 +8042,7 @@ msgstr ""
 msgid "Prefer user labels"
 msgstr ""
 
-#: ../../src/main.cpp:739
+#: ../../src/main.cpp:856
 msgid "Preferences"
 msgstr ""
 
@@ -8012,11 +8050,11 @@ msgstr ""
 msgid "Preferences button"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:796
+#: ../../src/wxMaximaFrame.cpp:808
 msgid "Preferences...\tCtrl+,"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1847
+#: ../../src/wxMaximaFrame.cpp:1865
 msgid "Prepend an element"
 msgstr ""
 
@@ -8028,7 +8066,7 @@ msgstr ""
 msgid "Pressing Ctrl+Space or Ctrl+Tab starts an autocomplete function that can not only complete all functions that are integrated into the Maxima core and their parameters: It also knows about parameters from currently loaded packages and from functions that are defined in the current file."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1038
+#: ../../src/wxMaximaFrame.cpp:1056
 msgid "Previous Command\tAlt+Up"
 msgstr ""
 
@@ -8040,7 +8078,7 @@ msgstr ""
 msgid "Print"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2145
+#: ../../src/dialogs/ConfigDialogue.cpp:2485
 msgid "Print Margins"
 msgstr ""
 
@@ -8053,23 +8091,23 @@ msgid "Print cell brackets"
 msgstr ""
 
 #: ../../src/ToolBar.cpp:343 ../../src/ToolBar.cpp:345
-#: ../../src/wxMaximaFrame.cpp:729
+#: ../../src/wxMaximaFrame.cpp:741
 msgid "Print document"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1943
+#: ../../src/wxMaximaFrame.cpp:1961
 msgid "Print floating-point numbers with exponents dividable by 3"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2125
+#: ../../src/dialogs/ConfigDialogue.cpp:2465
 msgid "Print scale:"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2138
+#: ../../src/dialogs/ConfigDialogue.cpp:2478
 msgid "Print the cell brackets [drawn to their left]"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:289
+#: ../../src/dialogs/ConfigDialogue.cpp:299
 msgid "Printout settings"
 msgstr ""
 
@@ -8115,7 +8153,7 @@ msgstr ""
 msgid "Printout: Setting the device origin to %lix%li"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:954
+#: ../../src/dialogs/ConfigDialogue.cpp:1026
 msgid "Privacy settings"
 msgstr ""
 
@@ -8133,7 +8171,7 @@ msgstr ""
 msgid "Product sign"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1206
+#: ../../src/wxMaximaFrame.cpp:1224
 msgid "Program"
 msgstr ""
 
@@ -8145,11 +8183,11 @@ msgstr ""
 msgid "Program block"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1177
+#: ../../src/wxMaximaFrame.cpp:1195
 msgid "Program block with local variables..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1179
+#: ../../src/wxMaximaFrame.cpp:1197
 msgid "Program block, no local variables..."
 msgstr ""
 
@@ -8157,7 +8195,7 @@ msgstr ""
 msgid "Psi"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1865
+#: ../../src/wxMaximaFrame.cpp:1883
 msgid "Push"
 msgstr ""
 
@@ -8165,7 +8203,7 @@ msgstr ""
 msgid "Push an element to a list"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1506
+#: ../../src/wxMaximaFrame.cpp:1524
 msgid "QR decomposition"
 msgstr ""
 
@@ -8173,11 +8211,15 @@ msgstr ""
 msgid "Querying gnuplot which graphics drivers it supports."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:732
+#: ../../src/dialogs/ConfigDialogue.cpp:2291
+msgid "Quick fill:"
+msgstr ""
+
+#: ../../src/wxMaximaFrame.cpp:744
 msgid "Quit wxMaxima"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2067
+#: ../../src/dialogs/ConfigDialogue.cpp:2407
 msgid "RTF with OMML maths"
 msgstr ""
 
@@ -8185,44 +8227,44 @@ msgstr ""
 msgid "Range radius:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1485
+#: ../../src/wxMaximaFrame.cpp:1503
 msgid "Rank"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:266 ../../src/wxMaximaFrame.cpp:834
+#: ../../src/wxMaximaFrame.cpp:266 ../../src/wxMaximaFrame.cpp:852
 msgid "Raw XML monitor"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:2268
+#: ../../src/wxMaximaFrame.cpp:2286
 #, c-format
 msgid "Re-Reading the config from %s."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:2265
+#: ../../src/wxMaximaFrame.cpp:2283
 msgid "Re-Reading the config from the default location."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:978
+#: ../../src/wxMaximaFrame.cpp:996
 msgid "Re-evaluate all cells above the one the cursor is in"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:988
+#: ../../src/wxMaximaFrame.cpp:1006
 msgid "Re-evaluate all cells below the one the cursor is in"
 msgstr ""
 
-#: ../../src/main.cpp:668
+#: ../../src/main.cpp:785
 msgid "Re-opening STDERR failed."
 msgstr ""
 
-#: ../../src/main.cpp:669
+#: ../../src/main.cpp:786
 msgid "Re-opening STDIN failed."
 msgstr ""
 
-#: ../../src/main.cpp:667
+#: ../../src/main.cpp:784
 msgid "Re-opening STDOUT failed."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2985
+#: ../../src/wxMaxima.cpp:3000
 #, c-format
 msgid "Re-pointed the .wxmx file association at %s"
 msgstr ""
@@ -8255,7 +8297,7 @@ msgstr ""
 msgid "Read char"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2657
+#: ../../src/dialogs/ConfigDialogue.cpp:3039
 msgid "Read config to file"
 msgstr ""
 
@@ -8263,7 +8305,7 @@ msgstr ""
 msgid "Read environment variable"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1330
+#: ../../src/wxMaximaFrame.cpp:1348
 msgid "Read environment variable..."
 msgstr ""
 
@@ -8271,7 +8313,7 @@ msgstr ""
 msgid "Read line"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1791
+#: ../../src/wxMaximaFrame.cpp:1809
 msgid "Read nested list from csv file..."
 msgstr ""
 
@@ -8350,11 +8392,11 @@ msgstr ""
 msgid "Recalculation hit the end of the worksheet => Updating its size (Visited %d cells, recalculated %d, in %ld ms)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1041
+#: ../../src/wxMaximaFrame.cpp:1059
 msgid "Recall next command from history"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1039
+#: ../../src/wxMaximaFrame.cpp:1057
 msgid "Recall previous command from history"
 msgstr ""
 
@@ -8368,11 +8410,11 @@ msgstr ""
 msgid "Received maxima's first prompt: %s"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1345
+#: ../../src/dialogs/ConfigDialogue.cpp:1417
 msgid "Recent files list length:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:708
+#: ../../src/wxMaximaFrame.cpp:720
 msgid "Recover unsaved"
 msgstr ""
 
@@ -8380,7 +8422,7 @@ msgstr ""
 msgid "Rectform"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1754
+#: ../../src/wxMaximaFrame.cpp:1772
 msgid "Recursive Substitute..."
 msgstr ""
 
@@ -8392,11 +8434,11 @@ msgstr ""
 msgid "Redo"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:744
+#: ../../src/wxMaximaFrame.cpp:756
 msgid "Redo\tCtrl+Y"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:744
+#: ../../src/wxMaximaFrame.cpp:756
 msgid "Redo last change"
 msgstr ""
 
@@ -8404,7 +8446,7 @@ msgstr ""
 msgid "Reduce (tr)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1709
+#: ../../src/wxMaximaFrame.cpp:1727
 msgid "Reduce trigonometric expression"
 msgstr ""
 
@@ -8414,7 +8456,7 @@ msgid ""
 "Queued as: "
 msgstr ""
 
-#: ../../src/MaximaEvaluator.cpp:123 ../../src/MaximaEvaluator.cpp:515
+#: ../../src/MaximaEvaluator.cpp:123 ../../src/MaximaEvaluator.cpp:522
 msgid "Refusing to send cell to maxima: "
 msgstr ""
 
@@ -8430,15 +8472,15 @@ msgstr ""
 msgid "Regex match position"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:2086
+#: ../../src/wxMaximaFrame.cpp:2104
 msgid "Register wxMaxima as the tool that compares .wxmx files in TortoiseSVN and TortoiseGit"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1306
+#: ../../src/wxMaximaFrame.cpp:1324
 msgid "Regular expression that matches a string"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1307
+#: ../../src/wxMaximaFrame.cpp:1325
 msgid "Regular expressions"
 msgstr ""
 
@@ -8451,11 +8493,11 @@ msgstr ""
 msgid "Reload Image \"%s\""
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1015
+#: ../../src/dialogs/ConfigDialogue.cpp:1087
 msgid "Reload all GUI settings from disc"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1022
+#: ../../src/dialogs/ConfigDialogue.cpp:1094
 msgid "Reload the style settings from disc"
 msgstr ""
 
@@ -8464,11 +8506,11 @@ msgstr ""
 msgid "Reloading image file %s."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2742
+#: ../../src/dialogs/ConfigDialogue.cpp:3124
 msgid "Reloading the configuration from disc"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2750
+#: ../../src/dialogs/ConfigDialogue.cpp:3132
 msgid "Reloading the styles from disc"
 msgstr ""
 
@@ -8476,15 +8518,15 @@ msgstr ""
 msgid "Remove"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:994
+#: ../../src/wxMaximaFrame.cpp:1012
 msgid "Remove All Output"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1540
+#: ../../src/wxMaximaFrame.cpp:1558
 msgid "Remove Columns..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1537
+#: ../../src/wxMaximaFrame.cpp:1555
 msgid "Remove Rows..."
 msgstr ""
 
@@ -8492,11 +8534,11 @@ msgstr ""
 msgid "Remove all"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1862
+#: ../../src/wxMaximaFrame.cpp:1880
 msgid "Remove all list elements that appear twice in a row. Normally used in conjunction with sort."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1285
+#: ../../src/wxMaximaFrame.cpp:1303
 msgid "Remove all occurrences of a word..."
 msgstr ""
 
@@ -8512,7 +8554,7 @@ msgstr ""
 msgid "Remove and return the first element of a list"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1541
+#: ../../src/wxMaximaFrame.cpp:1559
 msgid "Remove columns from a matrix"
 msgstr ""
 
@@ -8520,15 +8562,15 @@ msgstr ""
 msgid "Remove directory"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1315
+#: ../../src/wxMaximaFrame.cpp:1333
 msgid "Remove directory..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1861
+#: ../../src/wxMaximaFrame.cpp:1879
 msgid "Remove duplicates"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1287
+#: ../../src/wxMaximaFrame.cpp:1305
 msgid "Remove first occurrence of a word..."
 msgstr ""
 
@@ -8544,27 +8586,31 @@ msgstr ""
 msgid "Remove matrix rows"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:995
+#: ../../src/wxMaximaFrame.cpp:1013
 msgid "Remove output from input cells"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1538
+#: ../../src/wxMaximaFrame.cpp:1556
 msgid "Remove rows from the a matrix"
+msgstr ""
+
+#: ../../src/dialogs/ConfigDialogue.cpp:2137
+msgid "Remove this custom provider"
 msgstr ""
 
 #: ../../src/MaximaCommandMenus.cpp:4484
 msgid "Rename file"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1326
+#: ../../src/wxMaximaFrame.cpp:1344
 msgid "Rename file..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1641
+#: ../../src/wxMaximaFrame.cpp:1659
 msgid "Reorganize an expression using horner's rule"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1457
+#: ../../src/wxMaximaFrame.cpp:1475
 msgid "Repetitive element-by-element multiplication"
 msgstr ""
 
@@ -8580,7 +8626,7 @@ msgstr ""
 msgid "Replace first regex match"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:2067
+#: ../../src/wxMaximaFrame.cpp:2085
 msgid "Replace non-builtin variable and function names in the selected code cells (or the whole document) with random names, so a worksheet can be shared without revealing its original names"
 msgstr ""
 
@@ -8588,11 +8634,11 @@ msgstr ""
 msgid "Replace the first occurrence of Part"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1291
+#: ../../src/wxMaximaFrame.cpp:1309
 msgid "Replace..."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2816
+#: ../../src/wxMaxima.cpp:2831
 #, c-format
 msgid "Replaced %li occurrences."
 msgstr ""
@@ -8605,33 +8651,38 @@ msgstr ""
 msgid "Replaces the subexpression that part(expr, n_1, n_2, ...) would select by a new value. The part numbers form a path: n_1 selects a part of the expression, n_2 a part of that, and so on."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:2064
+#: ../../src/wxMaximaFrame.cpp:2082
 msgid "Report bug"
 msgstr ""
 
-#: ../../src/ai/AiProvider.cpp:364
+#: ../../src/dialogs/ConfigDialogue.cpp:2096
+#: ../../src/dialogs/ConfigDialogue.cpp:2313
+msgid "Request URL:"
+msgstr ""
+
+#: ../../src/ai/AiProvider.cpp:599
 msgid "Request cancelled."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1001
+#: ../../src/dialogs/ConfigDialogue.cpp:1073
 msgid "Reset all GUI settings"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1107
+#: ../../src/wxMaximaFrame.cpp:1125
 msgid "Reset option variables"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1008
+#: ../../src/dialogs/ConfigDialogue.cpp:1080
 msgid "Reset the Style settings"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2726
-#: ../../src/dialogs/ConfigDialogue.cpp:2734
+#: ../../src/dialogs/ConfigDialogue.cpp:3108
+#: ../../src/dialogs/ConfigDialogue.cpp:3116
 msgid "Resetting all configuration settings"
 msgstr ""
 
 #: ../../src/ToolBar.cpp:411 ../../src/ToolBar.cpp:417
-#: ../../src/wxMaximaFrame.cpp:1085
+#: ../../src/wxMaximaFrame.cpp:1103
 msgid "Restart Maxima"
 msgstr ""
 
@@ -8648,7 +8699,7 @@ msgstr ""
 msgid "Resulting Matrix name (may be empty):"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1301
+#: ../../src/wxMaximaFrame.cpp:1319
 msgid "Return a match"
 msgstr ""
 
@@ -8656,11 +8707,11 @@ msgstr ""
 msgid "Return from a block or loop"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1180
+#: ../../src/wxMaximaFrame.cpp:1198
 msgid "Return from current block/loop..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1869
+#: ../../src/wxMaximaFrame.cpp:1887
 msgid "Return the first item of the list and remove it from the list. Useful for creating stacks."
 msgstr ""
 
@@ -8676,7 +8727,7 @@ msgstr ""
 msgid "Return to the cell that is currently being evaluated"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1825
+#: ../../src/wxMaximaFrame.cpp:1843
 msgid "Returns an arbitrary list item"
 msgstr ""
 
@@ -8684,7 +8735,7 @@ msgstr ""
 msgid "Returns the first element of a list"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1827
+#: ../../src/wxMaximaFrame.cpp:1845
 msgid "Returns the first item of the list"
 msgstr ""
 
@@ -8692,23 +8743,23 @@ msgstr ""
 msgid "Returns the last element of a list"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1833
+#: ../../src/wxMaximaFrame.cpp:1851
 msgid "Returns the last item of the list"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1835
+#: ../../src/wxMaximaFrame.cpp:1853
 msgid "Returns the last n items of the list"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1856
+#: ../../src/wxMaximaFrame.cpp:1874
 msgid "Returns the length of the list"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1829
+#: ../../src/wxMaximaFrame.cpp:1847
 msgid "Returns the list without its first n elements"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1831
+#: ../../src/wxMaximaFrame.cpp:1849
 msgid "Returns the list without its last n elements"
 msgstr ""
 
@@ -8720,11 +8771,11 @@ msgstr ""
 msgid "Reuse last"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1857
+#: ../../src/wxMaximaFrame.cpp:1875
 msgid "Reverse"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1858
+#: ../../src/wxMaximaFrame.cpp:1876
 msgid "Reverse the order of the list items"
 msgstr ""
 
@@ -8732,11 +8783,11 @@ msgstr ""
 msgid "Reverses the order of the members of a list"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:299
+#: ../../src/dialogs/ConfigDialogue.cpp:315
 msgid "Revert all to defaults"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:998
+#: ../../src/dialogs/ConfigDialogue.cpp:1070
 msgid "Revert changes"
 msgstr ""
 
@@ -8744,7 +8795,7 @@ msgstr ""
 msgid "Rho"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2172
+#: ../../src/dialogs/ConfigDialogue.cpp:2512
 msgid "Right"
 msgstr ""
 
@@ -8761,23 +8812,23 @@ msgstr ""
 msgid "Right end"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1412
+#: ../../src/wxMaximaFrame.cpp:1430
 msgid "Right side to the \"=\""
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1569
+#: ../../src/wxMaximaFrame.cpp:1587
 msgid "Risch Integration..."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:224
+#: ../../src/dialogs/ConfigDialogue.cpp:228
 msgid "Romanian"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:899
+#: ../../src/wxMaximaFrame.cpp:917
 msgid "Rounded"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1551
+#: ../../src/wxMaximaFrame.cpp:1569
 msgid "Row and column operations"
 msgstr ""
 
@@ -8805,11 +8856,11 @@ msgstr ""
 msgid "Rule:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1138
+#: ../../src/wxMaximaFrame.cpp:1156
 msgid "Rules"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1807
+#: ../../src/wxMaximaFrame.cpp:1825
 msgid "Run each element through an expression"
 msgstr ""
 
@@ -8847,7 +8898,7 @@ msgstr ""
 msgid "Running on the universal wxWidgets port"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1446
+#: ../../src/dialogs/ConfigDialogue.cpp:1518
 msgid "Runs a local, read-only MCP (Model Context Protocol) server an AI tool can connect to for context on this worksheet's cells, table of contents and watched variables. It only answers questions -- it can never insert, edit or evaluate anything itself. Only accepts connections from this same machine (localhost)."
 msgstr ""
 
@@ -8859,23 +8910,23 @@ msgstr ""
 msgid "Runs each element of an object (list, matrix, equation,...) through an expression individually"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1805
+#: ../../src/wxMaximaFrame.cpp:1823
 msgid "Runs each element through a function"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1808
+#: ../../src/wxMaximaFrame.cpp:1826
 msgid "Runs each element through an expression"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:225
+#: ../../src/dialogs/ConfigDialogue.cpp:229
 msgid "Russian"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1633
+#: ../../src/dialogs/ConfigDialogue.cpp:1705
 msgid "SBCL: use <int>Mbytes of heap"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1640
+#: ../../src/dialogs/ConfigDialogue.cpp:1712
 msgid "SBCL: use <int>Mbytes of stack for function calls"
 msgstr ""
 
@@ -8883,7 +8934,7 @@ msgstr ""
 msgid "SENT TO MAXIMA:"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1242
+#: ../../src/dialogs/ConfigDialogue.cpp:1314
 msgid "SVG graphics"
 msgstr ""
 
@@ -8916,7 +8967,7 @@ msgid "Samples on a line:"
 msgstr ""
 
 #: ../../src/ToolBar.cpp:331 ../../src/ToolBar.cpp:334
-#: ../../src/dialogs/ConfigDialogue.cpp:2320 ../../src/wxMaxima.cpp:3605
+#: ../../src/dialogs/ConfigDialogue.cpp:2660 ../../src/wxMaxima.cpp:3620
 msgid "Save"
 msgstr ""
 
@@ -8928,7 +8979,7 @@ msgstr ""
 msgid "Save As"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:714
+#: ../../src/wxMaximaFrame.cpp:726
 msgid "Save As...\tShift+Ctrl+S"
 msgstr ""
 
@@ -8940,7 +8991,7 @@ msgstr ""
 msgid "Save Selection to Image"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:786
+#: ../../src/wxMaximaFrame.cpp:798
 msgid "Save Selection to Image..."
 msgstr ""
 
@@ -8952,20 +9003,20 @@ msgstr ""
 msgid "Save as lisp code"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1202
+#: ../../src/wxMaximaFrame.cpp:1220
 msgid "Save as lisp..."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2647
+#: ../../src/dialogs/ConfigDialogue.cpp:3029
 msgid "Save config to file"
 msgstr ""
 
 #: ../../src/ToolBar.cpp:331 ../../src/ToolBar.cpp:334
-#: ../../src/wxMaximaFrame.cpp:713
+#: ../../src/wxMaximaFrame.cpp:725
 msgid "Save document"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:714
+#: ../../src/wxMaximaFrame.cpp:726
 msgid "Save document as"
 msgstr ""
 
@@ -8973,7 +9024,7 @@ msgstr ""
 msgid "Save plot to file"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:787
+#: ../../src/wxMaximaFrame.cpp:799
 msgid "Save selection from document to an image file"
 msgstr ""
 
@@ -8981,11 +9032,11 @@ msgstr ""
 msgid "Save selection to file"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2809
+#: ../../src/dialogs/ConfigDialogue.cpp:3191
 msgid "Save style to file"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1402
+#: ../../src/dialogs/ConfigDialogue.cpp:1474
 msgid "Save the worksheet automatically"
 msgstr ""
 
@@ -8993,7 +9044,7 @@ msgstr ""
 msgid "Saving failed!"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:657
+#: ../../src/wxMaximaFrame.cpp:669
 msgid "Saving failed."
 msgstr ""
 
@@ -9001,7 +9052,7 @@ msgstr ""
 msgid "Saving succeeded, but the resulting files has disappeared ?!?."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2071
+#: ../../src/dialogs/ConfigDialogue.cpp:2411
 msgid "Scalable Vector Graphics (svg)"
 msgstr ""
 
@@ -9025,11 +9076,11 @@ msgstr ""
 msgid "Scheduling a background task that scans for autocompletable file names."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1922
+#: ../../src/dialogs/ConfigDialogue.cpp:1994
 msgid "Screen reader"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:736
+#: ../../src/wxMaximaFrame.cpp:748
 msgid "Scroll to a cell with a certain UUID"
 msgstr ""
 
@@ -9045,7 +9096,7 @@ msgstr ""
 msgid "Search input / UUID"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1289
+#: ../../src/wxMaximaFrame.cpp:1307
 msgid "Search..."
 msgstr ""
 
@@ -9065,7 +9116,7 @@ msgstr ""
 msgid "See also the speed <-> accuracy button."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2027
+#: ../../src/dialogs/ConfigDialogue.cpp:2225
 #, c-format
 msgid "See current models for %s..."
 msgstr ""
@@ -9095,7 +9146,7 @@ msgstr ""
 msgid "Select All"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:784
+#: ../../src/wxMaximaFrame.cpp:796
 msgid "Select All\tCtrl+A"
 msgstr ""
 
@@ -9114,7 +9165,7 @@ msgid "Select a constant"
 msgstr ""
 
 #: ../../src/ToolBar.cpp:390 ../../src/ToolBar.cpp:392
-#: ../../src/wxMaximaFrame.cpp:784
+#: ../../src/wxMaximaFrame.cpp:796
 msgid "Select all"
 msgstr ""
 
@@ -9170,19 +9221,19 @@ msgstr ""
 msgid "Sending an interrupt signal to Maxima."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:242
+#: ../../src/wxMaxima.cpp:244
 msgid "Sending configuration data to maxima."
 msgstr ""
 
-#: ../../src/MaximaEvaluator.cpp:558
+#: ../../src/MaximaEvaluator.cpp:565
 msgid "Sending maxima the info how to express 2d maths as XML"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1647
+#: ../../src/wxMaximaFrame.cpp:1665
 msgid "Sequential Comparative Simplification"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:226
+#: ../../src/dialogs/ConfigDialogue.cpp:230
 msgid "Serbian"
 msgstr ""
 
@@ -9190,7 +9241,7 @@ msgstr ""
 msgid "Series"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1593
+#: ../../src/wxMaximaFrame.cpp:1611
 msgid "Series approximation"
 msgstr ""
 
@@ -9198,31 +9249,31 @@ msgstr ""
 msgid "Server started"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1938
+#: ../../src/wxMaximaFrame.cpp:1956
 msgid "Set &displayed Precision..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1677
+#: ../../src/wxMaximaFrame.cpp:1695
 msgid "Set Maxima option variable logexpand:all"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1681
+#: ../../src/wxMaximaFrame.cpp:1699
 msgid "Set Maxima option variable logexpand:super"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1674
+#: ../../src/wxMaximaFrame.cpp:1692
 msgid "Set Maxima option variable logexpand:true"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:936
+#: ../../src/wxMaximaFrame.cpp:954
 msgid "Set Zoom"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1933
+#: ../../src/wxMaximaFrame.cpp:1951
 msgid "Set bigfloat &Precision..."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:483
+#: ../../src/dialogs/ConfigDialogue.cpp:499
 msgid "Set fixed font in text controls."
 msgstr ""
 
@@ -9235,7 +9286,7 @@ msgstr ""
 msgid "Set image resolution [in ppi]"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1624
+#: ../../src/wxMaximaFrame.cpp:1642
 msgid "Set main variable..."
 msgstr ""
 
@@ -9243,15 +9294,15 @@ msgstr ""
 msgid "Set maximum image size [in mm]"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1887
+#: ../../src/wxMaximaFrame.cpp:1905
 msgid "Set plot format"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1212
+#: ../../src/wxMaximaFrame.cpp:1230
 msgid "Set position..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1770
+#: ../../src/wxMaximaFrame.cpp:1788
 msgid "Set the \"algebraic\" flag"
 msgstr ""
 
@@ -9259,7 +9310,7 @@ msgstr ""
 msgid "Set the diagram title"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1893
+#: ../../src/wxMaximaFrame.cpp:1911
 msgid "Set the frame rate for animations."
 msgstr ""
 
@@ -9271,48 +9322,48 @@ msgstr ""
 msgid "Set the next plot's title. Empty = no title."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1934
+#: ../../src/wxMaximaFrame.cpp:1952
 msgid "Set the precision for numbers that are defined as bigfloat. Such numbers can be generated by entering 1.5b12 or as bfloat(1.234)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:925
+#: ../../src/wxMaximaFrame.cpp:943
 msgid "Set zoom to 100%"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:927
+#: ../../src/wxMaximaFrame.cpp:945
 msgid "Set zoom to 120%"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:929
+#: ../../src/wxMaximaFrame.cpp:947
 msgid "Set zoom to 150%"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:931
+#: ../../src/wxMaximaFrame.cpp:949
 msgid "Set zoom to 200%"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:933
+#: ../../src/wxMaximaFrame.cpp:951
 msgid "Set zoom to 300%"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:923
+#: ../../src/wxMaximaFrame.cpp:941
 msgid "Set zoom to 80%"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:165
+#: ../../src/dialogs/ConfigDialogue.cpp:169
 msgid "Sets the language, line ending type and charset encoding programs will use"
 msgstr ""
 
-#: ../../src/MaximaEvaluator.cpp:574
+#: ../../src/MaximaEvaluator.cpp:581
 #, c-format
 msgid "Setting gnuplot_binary to %s"
 msgstr ""
 
-#: ../../src/MaximaEvaluator.cpp:642
+#: ../../src/MaximaEvaluator.cpp:649
 msgid "Setting prompt and help format"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:167
+#: ../../src/dialogs/ConfigDialogue.cpp:171
 msgid "Setting this to \"cat\" causes gnuplot not to halt if there is much output"
 msgstr ""
 
@@ -9333,11 +9384,11 @@ msgstr ""
 msgid "Setup a 3D plot"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1403
+#: ../../src/wxMaximaFrame.cpp:1421
 msgid "Setup atvalues for solving ODE with Laplace transformation"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1775
+#: ../../src/wxMaximaFrame.cpp:1793
 msgid "Setup modulus computation"
 msgstr ""
 
@@ -9353,7 +9404,7 @@ msgstr ""
 msgid "Setup the engineering format"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1945
+#: ../../src/wxMaximaFrame.cpp:1963
 msgid "Setup the engineering format..."
 msgstr ""
 
@@ -9365,11 +9416,11 @@ msgstr ""
 msgid "Show \"%\" in special constants"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1434
+#: ../../src/dialogs/ConfigDialogue.cpp:1506
 msgid "Show \"Find and Replace\" as a dockable sidebar"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:2003
+#: ../../src/wxMaximaFrame.cpp:2021
 msgid "Show &Tips..."
 msgstr ""
 
@@ -9377,15 +9428,15 @@ msgstr ""
 msgid "Show * as multiplication dot"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1006
+#: ../../src/wxMaximaFrame.cpp:1024
 msgid "Show Template\tCtrl+Shift+Space"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:867
+#: ../../src/wxMaximaFrame.cpp:885
 msgid "Show XML representation"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:2003
+#: ../../src/wxMaximaFrame.cpp:2021
 msgid "Show a tip"
 msgstr ""
 
@@ -9405,7 +9456,7 @@ msgstr ""
 msgid "Show an example for the command:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1997
+#: ../../src/wxMaximaFrame.cpp:2015
 msgid "Show an example of usage"
 msgstr ""
 
@@ -9413,31 +9464,31 @@ msgstr ""
 msgid "Show commands from current session only"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1998
+#: ../../src/wxMaximaFrame.cpp:2016
 msgid "Show commands similar to"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1131
+#: ../../src/wxMaximaFrame.cpp:1149
 msgid "Show defined functions"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1133
+#: ../../src/wxMaximaFrame.cpp:1151
 msgid "Show defined variables"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1185
+#: ../../src/wxMaximaFrame.cpp:1203
 msgid "Show definition of a function"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:854
+#: ../../src/wxMaximaFrame.cpp:872
 msgid "Show equations in their linear form"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1184
+#: ../../src/wxMaximaFrame.cpp:1202
 msgid "Show function &Definition..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1007
+#: ../../src/wxMaximaFrame.cpp:1025
 msgid "Show function template"
 msgstr ""
 
@@ -9445,19 +9496,19 @@ msgstr ""
 msgid "Show input labels"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:784
+#: ../../src/dialogs/ConfigDialogue.cpp:856
 msgid "Show labels:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:864
+#: ../../src/wxMaximaFrame.cpp:882
 msgid "Show lisp representation"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:469
+#: ../../src/dialogs/ConfigDialogue.cpp:485
 msgid "Show long expressions in wxMaxima document."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:740
+#: ../../src/dialogs/ConfigDialogue.cpp:812
 msgid "Show long expressions:"
 msgstr ""
 
@@ -9473,7 +9524,7 @@ msgstr ""
 msgid "Show max. 50 digits"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:945
+#: ../../src/wxMaximaFrame.cpp:963
 msgid "Show or hide the wxMaxima logging window"
 msgstr ""
 
@@ -9497,7 +9548,7 @@ msgstr ""
 msgid "Show the Copy, Cut and the Paste button?"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:724
+#: ../../src/wxMaximaFrame.cpp:736
 msgid "Show the differences between 2 or 3 files"
 msgstr ""
 
@@ -9525,24 +9576,24 @@ msgstr ""
 msgid "Show tips at Startup"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1117 ../../src/wxMaximaFrame.cpp:1122
+#: ../../src/wxMaximaFrame.cpp:1135 ../../src/wxMaximaFrame.cpp:1140
 msgid "Show used + to-be-freed memory"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1144
+#: ../../src/wxMaximaFrame.cpp:1162
 msgid "Show user definitions"
 msgstr ""
 
 #: ../../src/ToolBar.cpp:544 ../../src/ToolBar.cpp:546
-#: ../../src/wxMaximaFrame.cpp:1991 ../../src/wxMaximaFrame.cpp:1993
+#: ../../src/wxMaximaFrame.cpp:2009 ../../src/wxMaximaFrame.cpp:2011
 msgid "Show wxMaxima help"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1939
+#: ../../src/wxMaximaFrame.cpp:1957
 msgid "Shows how many digits of a numbers are displayed"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:846
+#: ../../src/wxMaximaFrame.cpp:864
 msgid "Sidebars"
 msgstr ""
 
@@ -9562,7 +9613,7 @@ msgstr ""
 msgid "Simplify"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1627
+#: ../../src/wxMaximaFrame.cpp:1645
 msgid "Simplify &Radicals..."
 msgstr ""
 
@@ -9578,19 +9629,19 @@ msgstr ""
 msgid "Simplify Expression"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1682
+#: ../../src/wxMaximaFrame.cpp:1700
 msgid "Simplify Logarithms"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1696
+#: ../../src/wxMaximaFrame.cpp:1714
 msgid "Simplify an expression containing factorials"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1653
+#: ../../src/wxMaximaFrame.cpp:1671
 msgid "Simplify equations"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1628
+#: ../../src/wxMaximaFrame.cpp:1646
 msgid "Simplify expression containing radicals"
 msgstr ""
 
@@ -9598,11 +9649,11 @@ msgstr ""
 msgid "Simplify radicals"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1626
+#: ../../src/wxMaximaFrame.cpp:1644
 msgid "Simplify rational expression"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1652
+#: ../../src/wxMaximaFrame.cpp:1670
 msgid "Simplify sum() commands..."
 msgstr ""
 
@@ -9614,7 +9665,7 @@ msgstr ""
 msgid "Simplify the sum"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1706
+#: ../../src/wxMaximaFrame.cpp:1724
 msgid "Simplify trigonometric expression"
 msgstr ""
 
@@ -9622,15 +9673,15 @@ msgstr ""
 msgid "Since wxMaxima 0.8.2 you can also insert images into your documents. Use 'Cell->Insert Image...' menu command."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1510
+#: ../../src/wxMaximaFrame.cpp:1528
 msgid "Singular Values"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1511 ../../src/wxMaximaFrame.cpp:1514
+#: ../../src/wxMaximaFrame.cpp:1529 ../../src/wxMaximaFrame.cpp:1532
 msgid "Singular values using dgesvd"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1513
+#: ../../src/wxMaximaFrame.cpp:1531
 msgid "Singular values, left + right vectors"
 msgstr ""
 
@@ -9650,19 +9701,19 @@ msgstr ""
 msgid "Size of internal work array. limit/2 is the maximum number of subintervals to use."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2270
+#: ../../src/dialogs/ConfigDialogue.cpp:2610
 msgid "Slanted"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:227
+#: ../../src/dialogs/ConfigDialogue.cpp:231
 msgid "Slovak"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:228
+#: ../../src/dialogs/ConfigDialogue.cpp:232
 msgid "Slovenian"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1749
+#: ../../src/wxMaximaFrame.cpp:1767
 msgid "Smart Substitute..."
 msgstr ""
 
@@ -9683,19 +9734,19 @@ msgstr ""
 msgid "Solve"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1355
+#: ../../src/wxMaximaFrame.cpp:1373
 msgid "Solve &Algebraic System..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1353
+#: ../../src/wxMaximaFrame.cpp:1371
 msgid "Solve &Linear System..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1377
+#: ../../src/wxMaximaFrame.cpp:1395
 msgid "Solve &ODE..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1351
+#: ../../src/wxMaximaFrame.cpp:1369
 msgid "Solve (to_poly)..."
 msgstr ""
 
@@ -9703,7 +9754,7 @@ msgstr ""
 msgid "Solve A*x=b numerically"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1508
+#: ../../src/wxMaximaFrame.cpp:1526
 msgid "Solve Ax=b"
 msgstr ""
 
@@ -9711,7 +9762,7 @@ msgstr ""
 msgid "Solve ODE"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1398
+#: ../../src/wxMaximaFrame.cpp:1416
 msgid "Solve ODE with Lapla&ce..."
 msgstr ""
 
@@ -9719,7 +9770,7 @@ msgstr ""
 msgid "Solve ODE..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1509
+#: ../../src/wxMaximaFrame.cpp:1527
 msgid "Solve a linear equation system using dgesv"
 msgstr ""
 
@@ -9727,11 +9778,11 @@ msgstr ""
 msgid "Solve algebraic system"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1356
+#: ../../src/wxMaximaFrame.cpp:1374
 msgid "Solve algebraic system of equations"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1390
+#: ../../src/wxMaximaFrame.cpp:1408
 msgid "Solve boundary value problem for second degree ODE"
 msgstr ""
 
@@ -9739,11 +9790,11 @@ msgstr ""
 msgid "Solve differential equations using laplace()"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:925 ../../src/wxMaximaFrame.cpp:1349
+#: ../../src/MaximaCommandMenus.cpp:925 ../../src/wxMaximaFrame.cpp:1367
 msgid "Solve equation(s)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1352
+#: ../../src/wxMaximaFrame.cpp:1370
 msgid "Solve equation(s) with to_poly_solve"
 msgstr ""
 
@@ -9755,11 +9806,11 @@ msgstr ""
 msgid "Solve equations to polynom"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1382
+#: ../../src/wxMaximaFrame.cpp:1400
 msgid "Solve initial value problem for first degree ODE"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1386
+#: ../../src/wxMaximaFrame.cpp:1404
 msgid "Solve initial value problem for second degree ODE"
 msgstr ""
 
@@ -9767,19 +9818,19 @@ msgstr ""
 msgid "Solve linear system"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1354
+#: ../../src/wxMaximaFrame.cpp:1372
 msgid "Solve linear system of equations"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1374
+#: ../../src/wxMaximaFrame.cpp:1392
 msgid "Solve numerical, 1 Variable"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1378
+#: ../../src/wxMaximaFrame.cpp:1396
 msgid "Solve ordinary differential equation of maximum degree 2"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1399
+#: ../../src/wxMaximaFrame.cpp:1417
 msgid "Solve ordinary differential equations with Laplace transformation"
 msgstr ""
 
@@ -9795,7 +9846,7 @@ msgstr ""
 msgid "Solve polynomials numerically (real roots)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1360
+#: ../../src/wxMaximaFrame.cpp:1378
 msgid "Solve symbolically"
 msgstr ""
 
@@ -9804,11 +9855,11 @@ msgstr ""
 msgid "Solve..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:2030
+#: ../../src/wxMaximaFrame.cpp:2048
 msgid "Solving differential equations"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:2018
+#: ../../src/wxMaximaFrame.cpp:2036
 msgid "Solving equations with Maxima"
 msgstr ""
 
@@ -9819,7 +9870,7 @@ msgid ""
 "In both cases the '' operator will do what is requested."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1860
+#: ../../src/wxMaximaFrame.cpp:1878
 msgid "Sort"
 msgstr ""
 
@@ -9835,7 +9886,7 @@ msgstr ""
 msgid "Sort all characters in string"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1290
+#: ../../src/wxMaximaFrame.cpp:1308
 msgid "Sort the characters..."
 msgstr ""
 
@@ -9843,7 +9894,7 @@ msgstr ""
 msgid "Source list:"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:229
+#: ../../src/dialogs/ConfigDialogue.cpp:233
 msgid "Spanish"
 msgstr ""
 
@@ -9860,7 +9911,7 @@ msgstr ""
 msgid "Split"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1302
+#: ../../src/wxMaximaFrame.cpp:1320
 msgid "Split on match"
 msgstr ""
 
@@ -9872,15 +9923,15 @@ msgstr ""
 msgid "Split string into tokens"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1282
+#: ../../src/wxMaximaFrame.cpp:1300
 msgid "Split..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:902
+#: ../../src/wxMaximaFrame.cpp:920
 msgid "Square"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1318
+#: ../../src/dialogs/ConfigDialogue.cpp:1390
 msgid "Standard Options"
 msgstr ""
 
@@ -9892,7 +9943,7 @@ msgstr ""
 msgid "Start Animation"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1677
+#: ../../src/dialogs/ConfigDialogue.cpp:1749
 msgid "Start a new maxima for each re-evaluation"
 msgstr ""
 
@@ -9920,7 +9971,7 @@ msgstr ""
 msgid "Start or stop the currently selected animation that has been created with the with_slider class of commands"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:500
+#: ../../src/dialogs/ConfigDialogue.cpp:516
 msgid "Start searching while the phrase to search for is still being typed."
 msgstr ""
 
@@ -9928,15 +9979,15 @@ msgstr ""
 msgid "Start value of the parameter"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:419
+#: ../../src/wxMaxima.cpp:434
 msgid "Starting Maxima process failed"
 msgstr ""
 
-#: ../../src/main.cpp:1019
+#: ../../src/main.cpp:1144
 msgid "Starting a new wxMaxima process for a new window"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:1889 ../../src/wxMaxima.cpp:1915
+#: ../../src/wxMaxima.cpp:1904 ../../src/wxMaxima.cpp:1930
 msgid "Starting evaluation of the document"
 msgstr ""
 
@@ -9949,7 +10000,7 @@ msgstr ""
 msgid "Starting to save the worksheet as .wxmx. Filename: %s"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:288
+#: ../../src/dialogs/ConfigDialogue.cpp:298
 msgid "Startup commands"
 msgstr ""
 
@@ -9957,7 +10008,7 @@ msgstr ""
 msgid "Statistics"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:810
+#: ../../src/wxMaximaFrame.cpp:822
 msgid "Statistics\tAlt+Shift+S"
 msgstr ""
 
@@ -9965,15 +10016,15 @@ msgstr ""
 msgid "Step width:"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:957
+#: ../../src/dialogs/ConfigDialogue.cpp:1029
 msgid "Store filenames in image cells to enable image reloading after re-opening the worksheet"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:908
+#: ../../src/wxMaximaFrame.cpp:926
 msgid "Straight lines"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1217
+#: ../../src/wxMaximaFrame.cpp:1235
 msgid "Stream"
 msgstr ""
 
@@ -9991,11 +10042,11 @@ msgstr ""
 msgid "Stream:"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2274
+#: ../../src/dialogs/ConfigDialogue.cpp:2614
 msgid "Strike Through"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1296
+#: ../../src/wxMaximaFrame.cpp:1314
 msgid "String"
 msgstr ""
 
@@ -10009,7 +10060,7 @@ msgstr ""
 msgid "String #2:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1247
+#: ../../src/wxMaximaFrame.cpp:1265
 msgid "String Tests"
 msgstr ""
 
@@ -10021,7 +10072,7 @@ msgstr ""
 msgid "String to list of char"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1259
+#: ../../src/wxMaximaFrame.cpp:1277
 msgid "String to list of chars..."
 msgstr ""
 
@@ -10029,7 +10080,7 @@ msgstr ""
 msgid "String to octets"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1271
+#: ../../src/wxMaximaFrame.cpp:1289
 msgid "String to octets..."
 msgstr ""
 
@@ -10055,15 +10106,15 @@ msgstr ""
 msgid "Struct type name:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1140
+#: ../../src/wxMaximaFrame.cpp:1158
 msgid "Structs"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:284
+#: ../../src/dialogs/ConfigDialogue.cpp:294
 msgid "Style"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2239
+#: ../../src/dialogs/ConfigDialogue.cpp:2579
 msgid "Styles"
 msgstr ""
 
@@ -10079,7 +10130,7 @@ msgstr ""
 msgid "Subsection cell (Heading 3)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1757
+#: ../../src/wxMaximaFrame.cpp:1775
 msgid "Subst constant t into eq with diff(x,t)..."
 msgstr ""
 
@@ -10093,15 +10144,15 @@ msgstr ""
 
 #: ../../src/MaximaCommandMenus.cpp:715 ../../src/MaximaCommandMenus.cpp:3580
 #: ../../src/MaximaCommandMenus.cpp:4590 ../../src/wizards/SubstituteWiz.cpp:53
-#: ../../src/wxMaximaFrame.cpp:1765
+#: ../../src/wxMaximaFrame.cpp:1783
 msgid "Substitute"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1304
+#: ../../src/wxMaximaFrame.cpp:1322
 msgid "Substitute all matches"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1303
+#: ../../src/wxMaximaFrame.cpp:1321
 msgid "Substitute first match"
 msgstr ""
 
@@ -10109,20 +10160,20 @@ msgstr ""
 msgid "Substitute only in a specific part"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1760
+#: ../../src/wxMaximaFrame.cpp:1778
 msgid "Substitute only in parts..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1761
+#: ../../src/wxMaximaFrame.cpp:1779
 msgid "Substitute only in the elements n_1, n_2,..."
 msgstr ""
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:362
-#: ../../src/wxMaximaFrame.cpp:1747
+#: ../../src/wxMaximaFrame.cpp:1765
 msgid "Substitute..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1755 ../../src/wxMaximaFrame.cpp:1758
+#: ../../src/wxMaximaFrame.cpp:1773 ../../src/wxMaximaFrame.cpp:1776
 msgid "Substitutes until the equation no more changes"
 msgstr ""
 
@@ -10139,7 +10190,7 @@ msgstr ""
 msgid "Substitutes, but makes sure that nothing is substituted into the other substituents."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1752
+#: ../../src/wxMaximaFrame.cpp:1770
 msgid "Substitutes, but not in the other substituents"
 msgstr ""
 
@@ -10167,11 +10218,11 @@ msgstr ""
 msgid "Sum sign"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:230
+#: ../../src/dialogs/ConfigDialogue.cpp:234
 msgid "Swedish"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1665
+#: ../../src/wxMaximaFrame.cpp:1683
 msgid "Switch off simplifications of log(). Set Maxima option variable logexpand:false"
 msgstr ""
 
@@ -10188,11 +10239,11 @@ msgstr ""
 msgid "Symbolic Constant"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:814
+#: ../../src/wxMaximaFrame.cpp:826
 msgid "Symbols\tAlt+Shift+Y"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:476
+#: ../../src/dialogs/ConfigDialogue.cpp:492
 msgid "Symbols that are entered or copied here will appear in the symbols sidebar so they can be entered into the worksheet easily."
 msgstr ""
 
@@ -10216,7 +10267,7 @@ msgstr ""
 msgid "Table of Contents"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:820
+#: ../../src/wxMaximaFrame.cpp:832
 msgid "Table of Contents\tAlt+Shift+T"
 msgstr ""
 
@@ -10224,7 +10275,7 @@ msgstr ""
 msgid "Take surface color from steepness"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:231
+#: ../../src/dialogs/ConfigDialogue.cpp:235
 msgid "Tamil"
 msgstr ""
 
@@ -10236,7 +10287,7 @@ msgstr ""
 msgid "Taylor series"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1588
+#: ../../src/wxMaximaFrame.cpp:1606
 msgid "Taylor series..."
 msgstr ""
 
@@ -10244,7 +10295,7 @@ msgstr ""
 msgid "Taylor series:"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:1519
+#: ../../src/wxMaxima.cpp:1534
 msgid "Telling maxima about the new working directory."
 msgstr ""
 
@@ -10252,19 +10303,19 @@ msgstr ""
 msgid "Tells maxima for an f(x), that f(x=t)=a"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:2059
+#: ../../src/wxMaximaFrame.cpp:2077
 msgid "Tells maxima to show the help for ?, ?? and describe() in a separate browser window"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:2055
+#: ../../src/wxMaximaFrame.cpp:2073
 msgid "Tells maxima to show the help for ?, ?? and describe() in a wxMaxima sidebar"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:2050
+#: ../../src/wxMaximaFrame.cpp:2068
 msgid "Tells maxima to show the help for ?, ?? and describe() on the console"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:150
+#: ../../src/dialogs/ConfigDialogue.cpp:154
 msgid "Tells maxima where to store the result of compiling libraries"
 msgstr ""
 
@@ -10272,11 +10323,11 @@ msgstr ""
 msgid "Text"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:757
+#: ../../src/dialogs/ConfigDialogue.cpp:829
 msgid "Text & Code"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:756
+#: ../../src/dialogs/ConfigDialogue.cpp:828
 msgid "Text Only"
 msgstr ""
 
@@ -10305,7 +10356,7 @@ msgstr ""
 msgid "The .xml file doesn't seem to be valid xml or isn't a content.xml extracted from a .wxmx zip archive"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1952
+#: ../../src/dialogs/ConfigDialogue.cpp:2025
 msgid "The AI Chat sidebar sends the current worksheet's content (read-only -- the AI cannot insert, edit or evaluate anything) and your messages to whichever provider you pick below. This needs an internet connection and an API key from that provider, and nothing is sent unless you actually use the sidebar."
 msgstr ""
 
@@ -10313,7 +10364,7 @@ msgstr ""
 msgid "The Maxima process doesn't offer a shared memory segment we can send an interrupt signal to."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:396
+#: ../../src/dialogs/ConfigDialogue.cpp:412
 msgid "The URL MathJaX.js should be downloaded from by our HTML export."
 msgstr ""
 
@@ -10341,7 +10392,7 @@ msgstr ""
 msgid "The cache for the subjects the manual contains is from a different Maxima version."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1490
+#: ../../src/wxMaximaFrame.cpp:1508
 msgid "The classic operations one typically uses matrices for"
 msgstr ""
 
@@ -10361,19 +10412,19 @@ msgstr ""
 msgid "The command local() allows telling Maxima which functions to make local to the current program when defined."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:344
+#: ../../src/wxMaximaFrame.cpp:356
 msgid "The current Wizard"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:419
+#: ../../src/dialogs/ConfigDialogue.cpp:435
 msgid "The default height for embedded plots. Can be read out or overridden by the maxima variable wxplot_size."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:496
+#: ../../src/dialogs/ConfigDialogue.cpp:512
 msgid "The default port used for communication between Maxima and wxMaxima."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:416
+#: ../../src/dialogs/ConfigDialogue.cpp:432
 msgid "The default width for embedded plots. Can be read out or overridden by the maxima variable wxplot_size"
 msgstr ""
 
@@ -10381,32 +10432,32 @@ msgstr ""
 msgid "The diagram title"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2570
+#: ../../src/dialogs/ConfigDialogue.cpp:2952
 #, c-format
 msgid "The directory %s with maxima's startup file doesn't exist. Trying to create it..."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:152
+#: ../../src/dialogs/ConfigDialogue.cpp:156
 msgid "The directory containing the startup files, any user libraries and, if MAXIMA_OBJDIR isn't set the subdirectory with the results from compiling maxima libraries."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:156
+#: ../../src/dialogs/ConfigDialogue.cpp:160
 msgid "The directory maxima places temporary files in, for example plots that are to be included in the worksheet."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:159
+#: ../../src/dialogs/ConfigDialogue.cpp:163
 msgid "The directory the compiled versions of maxima are placed in"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:161
+#: ../../src/dialogs/ConfigDialogue.cpp:165
 msgid "The directory the maxima manual can be found in"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:162
+#: ../../src/dialogs/ConfigDialogue.cpp:166
 msgid "The directory the user's home directory is in"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:479
+#: ../../src/dialogs/ConfigDialogue.cpp:495
 msgid "The document class LaTeX is instructed to use for our documents."
 msgstr ""
 
@@ -10439,11 +10490,11 @@ msgstr ""
 msgid "The grid in the background of the diagram"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1409
+#: ../../src/wxMaximaFrame.cpp:1427
 msgid "The half of the equation that is to the left of the \"=\""
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1413
+#: ../../src/wxMaximaFrame.cpp:1431
 msgid "The half of the equation that is to the right of the \"=\""
 msgstr ""
 
@@ -10462,7 +10513,7 @@ msgstr ""
 msgid "The image file \"%s\" cannot be found."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:829
+#: ../../src/wxMaximaFrame.cpp:841
 msgid "The integrated help browser"
 msgstr ""
 
@@ -10474,7 +10525,7 @@ msgstr ""
 msgid "The key combination Shift+Space results in a non-breakable space."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:164
+#: ../../src/dialogs/ConfigDialogue.cpp:168
 msgid "The list of directories the operating system looks for programs in"
 msgstr ""
 
@@ -10494,11 +10545,11 @@ msgstr ""
 msgid "The main toolbar"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1996
+#: ../../src/wxMaximaFrame.cpp:2014
 msgid "The manual of Maxima"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1995
+#: ../../src/wxMaximaFrame.cpp:2013
 msgid "The manual of wxMaxima"
 msgstr ""
 
@@ -10538,7 +10589,7 @@ msgstr ""
 msgid "The next plot's title"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:498
+#: ../../src/dialogs/ConfigDialogue.cpp:514
 msgid "The number of recently opened files that is to be remembered."
 msgstr ""
 
@@ -10546,12 +10597,12 @@ msgstr ""
 msgid "The number of the item which is stepped from \"Index Start\" to \"Index End\"."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:481
+#: ../../src/dialogs/ConfigDialogue.cpp:497
 msgid "The options the document class LaTeX is instructed to use for our documents gets."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1083
-#: ../../src/dialogs/ConfigDialogue.cpp:1130
+#: ../../src/dialogs/ConfigDialogue.cpp:1155
+#: ../../src/dialogs/ConfigDialogue.cpp:1202
 msgid "The part of the output of these commands that isn't declared as \"math\" might be suppressed by wxMaxima. As always maxima commands are required to end in a \";\" or a \"$\""
 msgstr ""
 
@@ -10716,12 +10767,12 @@ msgstr ""
 msgid "Third-party notices"
 msgstr ""
 
-#: ../../src/sidebars/AiChatSidebar.cpp:162
-#: ../../src/sidebars/AiChatSidebar.cpp:224
+#: ../../src/sidebars/AiChatSidebar.cpp:185
+#: ../../src/sidebars/AiChatSidebar.cpp:247
 msgid "This build of wxMaxima cannot make network requests."
 msgstr ""
 
-#: ../../src/ai/AiProvider.cpp:373
+#: ../../src/ai/AiProvider.cpp:608
 msgid "This build of wxMaxima was compiled without wxWebRequest support, so it cannot talk to any AI provider."
 msgstr ""
 
@@ -10738,7 +10789,7 @@ msgid ""
 "overwritten if maxima's version changes or the file cannot be read"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1115
+#: ../../src/dialogs/ConfigDialogue.cpp:1187
 msgid "This file won't be read by maxima if maxima is used without wxMaxima. In order to add startup commands that are executed in this case, too, please add them to maxima-init.mac, instead."
 msgstr ""
 
@@ -10783,7 +10834,7 @@ msgstr ""
 msgid "Ticks:"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1377
+#: ../../src/dialogs/ConfigDialogue.cpp:1449
 msgid "Time [in Minutes] between autosaves"
 msgstr ""
 
@@ -10811,11 +10862,11 @@ msgstr ""
 msgid "Title, section and subsection cells can be folded to hide their contents. To fold or unfold, click in the square next to the cell. If you shift-click, all sublevels of that cell will also fold/unfold."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1908
+#: ../../src/wxMaximaFrame.cpp:1926
 msgid "To &Bigfloat"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1905
+#: ../../src/wxMaximaFrame.cpp:1923
 msgid "To &Float"
 msgstr ""
 
@@ -10823,15 +10874,15 @@ msgstr ""
 msgid "To Float"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1911
+#: ../../src/wxMaximaFrame.cpp:1929
 msgid "To Numeri&c\tCtrl+Shift+N"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1917
+#: ../../src/wxMaximaFrame.cpp:1935
 msgid "To exact fraction"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1928
+#: ../../src/wxMaximaFrame.cpp:1946
 msgid "To exact number"
 msgstr ""
 
@@ -10862,7 +10913,7 @@ msgstr ""
 msgid "Toc levels shown here"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:939 ../../src/wxMaximaFrame.cpp:942
+#: ../../src/wxMaximaFrame.cpp:957 ../../src/wxMaximaFrame.cpp:960
 msgid "Toggle full screen editing"
 msgstr ""
 
@@ -10878,11 +10929,11 @@ msgstr ""
 msgid "Toggle vertical scroll synchronization"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1288
+#: ../../src/wxMaximaFrame.cpp:1306
 msgid "Tokenize..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:2023
+#: ../../src/wxMaximaFrame.cpp:2041
 msgid "Tolerance calculations with Maxima"
 msgstr ""
 
@@ -10890,7 +10941,7 @@ msgstr ""
 msgid "Toolbar"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2148
+#: ../../src/dialogs/ConfigDialogue.cpp:2488
 msgid "Top"
 msgstr ""
 
@@ -10898,11 +10949,11 @@ msgstr ""
 msgid "Top end"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2958
+#: ../../src/wxMaxima.cpp:2973
 msgid "Tortoise diff tool"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1189
+#: ../../src/wxMaximaFrame.cpp:1207
 msgid "Trace a function..."
 msgstr ""
 
@@ -10910,11 +10961,11 @@ msgstr ""
 msgid "Trace function(s)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1295
+#: ../../src/wxMaximaFrame.cpp:1313
 msgid "Transformations"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1487
+#: ../../src/wxMaximaFrame.cpp:1505
 msgid "Transpose a matrix"
 msgstr ""
 
@@ -10958,15 +11009,15 @@ msgid ""
 "See also guess_exact_value()"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1292
+#: ../../src/wxMaximaFrame.cpp:1310
 msgid "Trim both ends..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1293
+#: ../../src/wxMaximaFrame.cpp:1311
 msgid "Trim left..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1294
+#: ../../src/wxMaximaFrame.cpp:1312
 msgid "Trim right..."
 msgstr ""
 
@@ -10982,7 +11033,7 @@ msgstr ""
 msgid "Trim string right"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1625
+#: ../../src/wxMaximaFrame.cpp:1643
 msgid "Try to guess which form is &simple"
 msgstr ""
 
@@ -11034,11 +11085,11 @@ msgstr ""
 msgid "Trying to start the socket a Maxima on the local machine can connect to on port %i"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:232
+#: ../../src/dialogs/ConfigDialogue.cpp:236
 msgid "Turkish"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:2042
+#: ../../src/wxMaximaFrame.cpp:2060
 msgid "Tutorials"
 msgstr ""
 
@@ -11062,37 +11113,37 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1249
+#: ../../src/dialogs/ConfigDialogue.cpp:1321
 msgid "URL MathJaX.js is located at:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1257
+#: ../../src/wxMaximaFrame.cpp:1275
 msgid "UTF8 to Unicode code point..."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:233
+#: ../../src/dialogs/ConfigDialogue.cpp:237
 msgid "Ukrainian"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3262
+#: ../../src/wxMaxima.cpp:3277
 msgid "Un-closed parenthesis"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3250
+#: ../../src/wxMaxima.cpp:3265
 msgid "Un-closed parenthesis on encountering ; or $"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3564
+#: ../../src/wxMaxima.cpp:3579
 #, c-format
 msgid "Unable to interpret the version info I got from %s: %s"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3510
+#: ../../src/wxMaxima.cpp:3525
 #, c-format
 msgid "Unable to interpret the version info I got: %s"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1118
+#: ../../src/wxMaximaFrame.cpp:1136
 msgid "Undefine"
 msgstr ""
 
@@ -11101,11 +11152,11 @@ msgstr ""
 msgid "Undefined"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2272
+#: ../../src/dialogs/ConfigDialogue.cpp:2612
 msgid "Underlined"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:763
+#: ../../src/dialogs/ConfigDialogue.cpp:835
 msgid "Underscore converts to subscripts:"
 msgstr ""
 
@@ -11113,7 +11164,7 @@ msgstr ""
 msgid "Undo"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:742
+#: ../../src/wxMaximaFrame.cpp:754
 msgid "Undo\tCtrl+Z"
 msgstr ""
 
@@ -11121,7 +11172,7 @@ msgstr ""
 msgid "Undo and redo button"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:742
+#: ../../src/wxMaximaFrame.cpp:754
 msgid "Undo last change"
 msgstr ""
 
@@ -11130,11 +11181,11 @@ msgstr ""
 msgid "Unexpected text style %li for TextCell"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1035
+#: ../../src/wxMaximaFrame.cpp:1053
 msgid "Unfold All\tCtrl+Alt+]"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1036
+#: ../../src/wxMaximaFrame.cpp:1054
 msgid "Unfold all folded sections"
 msgstr ""
 
@@ -11174,11 +11225,11 @@ msgstr ""
 msgid "Unicode characters"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:816
+#: ../../src/wxMaximaFrame.cpp:828
 msgid "Unicode chars\tAlt+Shift+U"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1255
+#: ../../src/wxMaximaFrame.cpp:1273
 msgid "Unicode code point to UTF8..."
 msgstr ""
 
@@ -11186,7 +11237,7 @@ msgstr ""
 msgid "Unicode code point to char"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1253
+#: ../../src/wxMaximaFrame.cpp:1271
 msgid "Unicode code point to char..."
 msgstr ""
 
@@ -11202,11 +11253,11 @@ msgstr ""
 msgid "Unlike in other programming language return() only exits from the current loop or block(), not from the whole function."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3201
+#: ../../src/wxMaxima.cpp:3216
 msgid "Unterminated comment."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3244
+#: ../../src/wxMaxima.cpp:3259
 msgid "Unterminated string."
 msgstr ""
 
@@ -11218,13 +11269,13 @@ msgstr ""
 msgid "Up"
 msgstr ""
 
-#: ../../src/MaximaEvaluator.cpp:629
+#: ../../src/MaximaEvaluator.cpp:636
 msgid "Updating maxima's configuration"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3503 ../../src/wxMaxima.cpp:3508
-#: ../../src/wxMaxima.cpp:3510 ../../src/wxMaxima.cpp:3557
-#: ../../src/wxMaxima.cpp:3562 ../../src/wxMaxima.cpp:3565
+#: ../../src/wxMaxima.cpp:3518 ../../src/wxMaxima.cpp:3523
+#: ../../src/wxMaxima.cpp:3525 ../../src/wxMaxima.cpp:3572
+#: ../../src/wxMaxima.cpp:3577 ../../src/wxMaxima.cpp:3580
 msgid "Upgrade"
 msgstr ""
 
@@ -11241,11 +11292,11 @@ msgstr ""
 msgid "Upsilon"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:906
+#: ../../src/wxMaximaFrame.cpp:924
 msgid "Use \"<\" and \">\" as parenthesis for matrices"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:511
+#: ../../src/dialogs/ConfigDialogue.cpp:527
 msgid "Use GTK's overlay scrollbars, which appear over the worksheet and fade out when unused. Looks modern, but GTK repaints the whole worksheet on every frame of the fade animation - which runs after every mouse movement - so classic scrollbars are much faster."
 msgstr ""
 
@@ -11261,7 +11312,7 @@ msgstr ""
 msgid "Use Text search filtering"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1822 ../../src/wxMaximaFrame.cpp:1853
+#: ../../src/wxMaximaFrame.cpp:1840 ../../src/wxMaximaFrame.cpp:1871
 msgid "Use a list"
 msgstr ""
 
@@ -11269,47 +11320,47 @@ msgstr ""
 msgid "Use a list as parameter list for a function"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:2085
+#: ../../src/wxMaximaFrame.cpp:2103
 msgid "Use as TortoiseSVN/Git diff tool"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:489
+#: ../../src/dialogs/ConfigDialogue.cpp:505
 msgid "Use centered dot and Minus, not Star and Hyphen"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:867
+#: ../../src/dialogs/ConfigDialogue.cpp:939
 msgid "Use centered dot character for multiplication"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1822
+#: ../../src/wxMaximaFrame.cpp:1840
 msgid "Use list"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1815
+#: ../../src/wxMaximaFrame.cpp:1833
 msgid "Use list as the arguments of a function"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:900
+#: ../../src/wxMaximaFrame.cpp:918
 msgid "Use rounded parenthesis for matrices"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:903
+#: ../../src/wxMaximaFrame.cpp:921
 msgid "Use square parenthesis for matrices"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1194
+#: ../../src/wxMaximaFrame.cpp:1212
 msgid "Use struct field..."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:429
+#: ../../src/dialogs/ConfigDialogue.cpp:445
 msgid "Use the \"partial derivative\" symbol to represent the fraction that represents a diff() when exporting LaTeX"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:2209
+#: ../../src/dialogs/ConfigDialogue.cpp:2549
 msgid "Use unicode Math Symbols, if available"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:909
+#: ../../src/wxMaximaFrame.cpp:927
 msgid "Use vertical lines instead of parenthesis for matrices"
 msgstr ""
 
@@ -11317,9 +11368,9 @@ msgstr ""
 msgid "User labels only"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1266
-#: ../../src/dialogs/ConfigDialogue.cpp:1507
-#: ../../src/dialogs/ConfigDialogue.cpp:1535
+#: ../../src/dialogs/ConfigDialogue.cpp:1338
+#: ../../src/dialogs/ConfigDialogue.cpp:1579
+#: ../../src/dialogs/ConfigDialogue.cpp:1607
 #: ../../src/dialogs/MaximaNotStartingDialog.cpp:54
 msgid "User specified"
 msgstr ""
@@ -11328,7 +11379,7 @@ msgstr ""
 msgid "User-defined labels"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:788
+#: ../../src/dialogs/ConfigDialogue.cpp:860
 msgid "User-defined labels if available"
 msgstr ""
 
@@ -11336,11 +11387,11 @@ msgstr ""
 msgid "Using Maxima help file from wxMaxima configuration file (helpFile=...))"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:1597
+#: ../../src/wxMaxima.cpp:1612
 msgid "Using Maxima path from command line."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:1594
+#: ../../src/wxMaxima.cpp:1609
 msgid "Using configured Maxima path."
 msgstr ""
 
@@ -11367,7 +11418,7 @@ msgstr ""
 msgid "Validated that the XML representation of the document actually is valid XML"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:546
+#: ../../src/dialogs/ConfigDialogue.cpp:562
 #: ../../src/wizards/ActualValuesStorageWiz.cpp:49
 msgid "Value"
 msgstr ""
@@ -11403,7 +11454,7 @@ msgid "Var #2"
 msgstr ""
 
 #: ../../src/MaximaCommandMenus.cpp:1371 ../../src/MaximaCommandMenus.cpp:1755
-#: ../../src/dialogs/ConfigDialogue.cpp:545
+#: ../../src/dialogs/ConfigDialogue.cpp:561
 #: ../../src/sidebars/VariablesPane.cpp:54
 msgid "Variable"
 msgstr ""
@@ -11426,7 +11477,7 @@ msgstr ""
 msgid "Variable name"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1196
+#: ../../src/wxMaximaFrame.cpp:1214
 msgid "Variable name, not contents..."
 msgstr ""
 
@@ -11455,7 +11506,7 @@ msgstr ""
 msgid "Variable:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:304 ../../src/wxMaximaFrame.cpp:831
+#: ../../src/wxMaximaFrame.cpp:304 ../../src/wxMaximaFrame.cpp:843
 msgid "Variables"
 msgstr ""
 
@@ -11472,15 +11523,15 @@ msgstr ""
 msgid "Verified that we are able to read the whole .zip archive we produced."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:234
+#: ../../src/dialogs/ConfigDialogue.cpp:238
 msgid "Vietnamese"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:947
+#: ../../src/wxMaximaFrame.cpp:965
 msgid "View"
 msgstr ""
 
-#: ../../src/sidebars/AiChatSidebar.cpp:158
+#: ../../src/sidebars/AiChatSidebar.cpp:181
 #, c-format
 msgid "Waiting for %s..."
 msgstr ""
@@ -11497,17 +11548,17 @@ msgstr ""
 msgid "Waiting for the thread that parses the maxima manual to finish"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1428
+#: ../../src/dialogs/ConfigDialogue.cpp:1500
 msgid "Warn if an inactive window is idle"
 msgstr ""
 
 #: ../../src/MathParser.cpp:1343 ../../src/MaximaFileIO.cpp:536
 #: ../../src/MaximaProcessManager.cpp:1118
-#: ../../src/MaximaResponseReader.cpp:361 ../../src/wxMaxima.cpp:1616
+#: ../../src/MaximaResponseReader.cpp:361 ../../src/wxMaxima.cpp:1631
 msgid "Warning"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1670
+#: ../../src/wxMaximaFrame.cpp:1688
 msgid "Warning:"
 msgstr ""
 
@@ -11522,7 +11573,7 @@ msgstr ""
 msgid "Warning: Lookalike chars: "
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1660
+#: ../../src/wxMaximaFrame.cpp:1678
 msgid "Warning: No test if the argument of the log is complex, positive or negative"
 msgstr ""
 
@@ -11541,7 +11592,7 @@ msgstr ""
 msgid "WebP (*.webp)|*.webp|"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:1902
+#: ../../src/wxMaxima.cpp:1917
 msgid "Welcome to wxMaxima"
 msgstr ""
 
@@ -11553,7 +11604,7 @@ msgstr ""
 msgid "When applying functions with one argument from menus, the default argument is '%'. To apply the function to some other value, select it in the document before executing a menu command."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1169
+#: ../../src/wxMaximaFrame.cpp:1187
 msgid "When to invoke the lisp compiler's debugger"
 msgstr ""
 
@@ -11561,7 +11612,7 @@ msgstr ""
 msgid "While loop"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1174
+#: ../../src/wxMaximaFrame.cpp:1192
 msgid "While loop..."
 msgstr ""
 
@@ -11573,11 +11624,11 @@ msgstr ""
 msgid "Whole document (*.wxmx)|*.wxmx|The input, readable by load() (maxima > 5.38) (*.wxm)|*.wxm|All Files (*.*)|*"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:333
+#: ../../src/wxMaxima.cpp:335
 msgid "Will try to generate a stack backtrace, if the program ever crashes"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:282
+#: ../../src/dialogs/ConfigDialogue.cpp:292
 msgid "Worksheet"
 msgstr ""
 
@@ -11598,7 +11649,7 @@ msgstr ""
 msgid "Worksheet repaints:"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:432
+#: ../../src/dialogs/ConfigDialogue.cpp:448
 msgid "Wrap equations exported by the \"copy as LaTeX\" feature between \\[ and \\] as equation markers"
 msgstr ""
 
@@ -11632,15 +11683,15 @@ msgstr ""
 msgid "Xi"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:746
+#: ../../src/dialogs/ConfigDialogue.cpp:818
 msgid "Yes"
 msgstr ""
 
-#: ../../src/sidebars/AiChatSidebar.cpp:229
+#: ../../src/sidebars/AiChatSidebar.cpp:252
 msgid "You"
 msgstr ""
 
-#: ../../src/sidebars/AiChatSidebar.cpp:194
+#: ../../src/sidebars/AiChatSidebar.cpp:217
 msgid ""
 "You are an assistant embedded in wxMaxima, a GUI front-end for the Maxima computer algebra system. Below is a read-only snapshot of the user's current worksheet -- you cannot edit, evaluate or otherwise change it; only the user can do that through the wxMaxima UI. A cell marked \"(CURRENT CELL -- the user's cursor is here)\" is where the user's cursor currently is -- that is what they mean by \"this cell,\" \"the current cell,\" or \"the cell above/here.\" A cell marked \"(THIS CELL HAS AN ERROR)\" is one Maxima reported an error in. Use the snapshot only as context.\n"
 "\n"
@@ -11682,7 +11733,7 @@ msgstr ""
 msgid "You got an idea for an improvement of wxMaxima? Great! Please submit your idea at https://github.com/wxMaxima-developers/wxmaxima/issues. "
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3500 ../../src/wxMaxima.cpp:3554
+#: ../../src/wxMaxima.cpp:3515 ../../src/wxMaxima.cpp:3569
 #, c-format
 msgid ""
 "You have version %s. The newest wxMaxima release is %s.\n"
@@ -11690,11 +11741,11 @@ msgid ""
 "Select OK to visit the wxMaxima webpage."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3604
+#: ../../src/wxMaxima.cpp:3619
 msgid "Your changes will be lost if you don't save them."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3508 ../../src/wxMaxima.cpp:3562
+#: ../../src/wxMaxima.cpp:3523 ../../src/wxMaxima.cpp:3577
 msgid "Your version of wxMaxima is up to date."
 msgstr ""
 
@@ -11702,27 +11753,27 @@ msgstr ""
 msgid "Zeta"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:919
+#: ../../src/wxMaximaFrame.cpp:937
 msgid "Zoom &In\tCtrl++"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:920
+#: ../../src/wxMaximaFrame.cpp:938
 msgid "Zoom Ou&t\tCtrl+-"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:919
+#: ../../src/wxMaximaFrame.cpp:937
 msgid "Zoom in 10%"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:920
+#: ../../src/wxMaximaFrame.cpp:938
 msgid "Zoom out 10%"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3300 ../../src/wxMaximaFrame.cpp:208
+#: ../../src/wxMaxima.cpp:3315 ../../src/wxMaximaFrame.cpp:208
 msgid "[ unsaved ]"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3302
+#: ../../src/wxMaxima.cpp:3317
 msgid "[ unsaved* ]"
 msgstr ""
 
@@ -11750,23 +11801,23 @@ msgstr ""
 msgid "antisymmetric"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1804
+#: ../../src/wxMaximaFrame.cpp:1822
 msgid "apply function to each element"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:853
+#: ../../src/wxMaximaFrame.cpp:871
 msgid "as 1D ASCII"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:856
+#: ../../src/wxMaximaFrame.cpp:874
 msgid "as ASCII Art"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:859
+#: ../../src/wxMaximaFrame.cpp:877
 msgid "as ASCII+Unicode Art"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1794
+#: ../../src/wxMaximaFrame.cpp:1812
 msgid "as storage for actual values for variables"
 msgstr ""
 
@@ -11778,7 +11829,7 @@ msgstr ""
 msgid "both sides"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1250
+#: ../../src/wxMaximaFrame.cpp:1268
 msgid "char to Ascii code..."
 msgstr ""
 
@@ -11812,7 +11863,7 @@ msgstr ""
 msgid "diff(x,t)="
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1175 ../../src/wxMaximaFrame.cpp:1816
+#: ../../src/wxMaximaFrame.cpp:1193 ../../src/wxMaximaFrame.cpp:1834
 msgid "do for each element"
 msgstr ""
 
@@ -11848,7 +11899,7 @@ msgstr ""
 msgid "f(x) stays f(x) even if the value of f(x) is computable"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:471
+#: ../../src/dialogs/ConfigDialogue.cpp:487
 msgid ""
 "false=Don't generate subscripts\n"
 "true=Automatically convert underscores to subscript markers if the would-be subscript is a number or a single letter\n"
@@ -11859,19 +11910,19 @@ msgstr ""
 msgid "filename:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1788
+#: ../../src/wxMaximaFrame.cpp:1806
 msgid "from a list"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1785
+#: ../../src/wxMaximaFrame.cpp:1803
 msgid "from a rule"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1799
+#: ../../src/wxMaximaFrame.cpp:1817
 msgid "from function arguments"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1783
+#: ../../src/wxMaximaFrame.cpp:1801
 msgid "from individual elements"
 msgstr ""
 
@@ -11887,7 +11938,7 @@ msgstr ""
 msgid "general"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1685
+#: ../../src/dialogs/ConfigDialogue.cpp:1757
 msgid "gnuplot: Without command console"
 msgstr ""
 
@@ -11899,7 +11950,7 @@ msgstr ""
 msgid "in"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:861
+#: ../../src/wxMaximaFrame.cpp:879
 msgid "in 2D"
 msgstr ""
 
@@ -11946,11 +11997,11 @@ msgstr ""
 msgid "matrix([x_1,x_2,...],[y_1,y_2,...])"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1516
+#: ../../src/wxMaximaFrame.cpp:1534
 msgid "max(abs(A(i,j))) (complex)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1515
+#: ../../src/wxMaximaFrame.cpp:1533
 msgid "max(abs(A(i,j))) (real)"
 msgstr ""
 
@@ -12011,7 +12062,7 @@ msgstr ""
 msgid "noun: Not evaluated by default"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1824
+#: ../../src/wxMaximaFrame.cpp:1842
 msgid "nth"
 msgstr ""
 
@@ -12081,7 +12132,7 @@ msgstr ""
 msgid "printf"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1219
+#: ../../src/wxMaximaFrame.cpp:1237
 msgid "printf..."
 msgstr ""
 
@@ -12101,15 +12152,15 @@ msgstr ""
 msgid "ratsubst works like subst, but it knows some basic maths, if needed."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1222
+#: ../../src/wxMaximaFrame.cpp:1240
 msgid "readbyte..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1221
+#: ../../src/wxMaximaFrame.cpp:1239
 msgid "readchar..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1220
+#: ../../src/wxMaximaFrame.cpp:1238
 msgid "readline..."
 msgstr ""
 
@@ -12222,11 +12273,11 @@ msgstr ""
 msgid "union"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1186
+#: ../../src/wxMaximaFrame.cpp:1204
 msgid "unnamed function (lambda)..."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3592
+#: ../../src/wxMaxima.cpp:3607
 msgid "unsaved"
 msgstr ""
 
@@ -12239,34 +12290,34 @@ msgstr ""
 msgid "upsilon"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1814
+#: ../../src/wxMaximaFrame.cpp:1832
 msgid "use as function arguments"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1810
+#: ../../src/wxMaximaFrame.cpp:1828
 msgid "use the actual values stored"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1688
+#: ../../src/dialogs/ConfigDialogue.cpp:1760
 msgid "wgnuplot: Steals the mouse focus during plotting"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1223
+#: ../../src/wxMaximaFrame.cpp:1241
 msgid "writebyte..."
 msgstr ""
 
 #: ../../src/TrayIcon.cpp:93 ../../src/dialogs/AboutDialog.cpp:64
-#: ../../src/main.cpp:859 ../../src/sidebars/AiChatSidebar.cpp:217
-#: ../../src/sidebars/AiChatSidebar.cpp:223
+#: ../../src/main.cpp:984 ../../src/sidebars/AiChatSidebar.cpp:240
+#: ../../src/sidebars/AiChatSidebar.cpp:246
 msgid "wxMaxima"
 msgstr ""
 
-#: ../../src/main.cpp:868
+#: ../../src/main.cpp:993
 #, c-format
 msgid "wxMaxima %ld"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3289 ../../src/wxMaximaFrame.cpp:206
+#: ../../src/wxMaxima.cpp:3304 ../../src/wxMaximaFrame.cpp:206
 #, c-format
 msgid "wxMaxima %s (%s) "
 msgstr ""
@@ -12283,8 +12334,8 @@ msgstr ""
 msgid "wxMaxima cannot read the xml contents of "
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:144
-#: ../../src/dialogs/ConfigDialogue.cpp:315
+#: ../../src/dialogs/ConfigDialogue.cpp:148
+#: ../../src/dialogs/ConfigDialogue.cpp:331
 msgid "wxMaxima configuration"
 msgstr ""
 
@@ -12313,7 +12364,7 @@ msgstr ""
 msgid "wxMaxima encountered an error loading "
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1995
+#: ../../src/wxMaximaFrame.cpp:2013
 msgid "wxMaxima help"
 msgstr ""
 
@@ -12321,7 +12372,7 @@ msgstr ""
 msgid "wxMaxima is a cross-platform graphical user interface for the computer algebra system Maxima based on wxWidgets.\n"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2950
+#: ../../src/wxMaxima.cpp:2965
 #, c-format
 msgid ""
 "wxMaxima is now the .wxmx diff tool for:%s\n"
@@ -12341,7 +12392,7 @@ msgstr ""
 msgid "wxMaxima needs more translators. We do not speak every language. Help us to translate wxMaxima and the manual to your language. Join the wxMaxima development at: https://github.com/wxMaxima-developers/wxmaxima"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:411
+#: ../../src/dialogs/ConfigDialogue.cpp:427
 msgid "wxMaxima normally stores the gnuplot sources for every plot made using draw() in order to be able to open plots interactively in gnuplot later. This setting defines the limit [in Megabytes per plot] for this feature."
 msgstr ""
 
@@ -12362,19 +12413,19 @@ msgstr ""
 msgid "wxMaxima remembers answers from the last run and is able to offer them as the default answer"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:485
+#: ../../src/dialogs/ConfigDialogue.cpp:501
 msgid "wxMaxima remembers the answers to maxima's questions. If this checkbox is set it automatically offers to enter the last answer to this question the user has input."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:2010
+#: ../../src/wxMaximaFrame.cpp:2028
 msgid "wxMaxima shows help in a browser"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:2008
+#: ../../src/wxMaximaFrame.cpp:2026
 msgid "wxMaxima shows help in the sidebar"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1113
+#: ../../src/dialogs/ConfigDialogue.cpp:1185
 msgid "wxMaxima startup file location: "
 msgstr ""
 
@@ -12387,11 +12438,11 @@ msgstr ""
 msgid "wxMaxima worksheet"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:2074
+#: ../../src/wxMaximaFrame.cpp:2092
 msgid "wxMaxima's ChangeLog"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:2072
+#: ../../src/wxMaximaFrame.cpp:2090
 msgid "wxMaxima's license"
 msgstr ""
 
@@ -12411,22 +12462,22 @@ msgstr ""
 msgid "wxworksheettohtml/totex: no target file name was given."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2236
+#: ../../src/wxMaxima.cpp:2251
 #, c-format
 msgid "wxworksheettohtml: could not write \"%s\"."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2210
+#: ../../src/wxMaxima.cpp:2225
 #, c-format
 msgid "wxworksheettohtml: unknown flavor \"%s\"; using native MathML. Known flavors: mathml, mathjax, svg, bitmap."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2278
+#: ../../src/wxMaxima.cpp:2293
 #, c-format
 msgid "wxworksheettotex: could not write \"%s\"."
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:727
+#: ../../src/dialogs/ConfigDialogue.cpp:799
 msgid "x"
 msgstr ""
 


### PR DESCRIPTION
## Summary

- `compile_latest_and_test`'s POT-coverage step has been failing on every push (including plain pushes to `main`) since the AI Chat sidebar's custom-provider/quick-fill work landed: `xgettext` was never re-run against the source afterward, so the committed `locales/wxMaxima/wxMaxima.pot` was missing several UI strings it introduced (`"(Custom)"`, `"API style:"`, `"Add custom provider..."`, `"Quick fill:"`, `"Remove this custom provider"`, `"Request URL:"`, ...).
- Fixed by running `cmake --build build --target update-locale` and committing only the regenerated `wxMaxima.pot` — the one file `compile_latest_and_test`'s check actually diffs. Per this repo's own convention (see `AGENTS.md`'s translations section), the ~1100 lines of incidental per-language `.po` drift `update-locale` also produces were reverted (`git checkout -- locales/wxMaxima/*.po`) rather than bundled in, since regenerating every language's `.po` against the new template is separate, unrelated translator-facing work, not needed to fix this check.

## Test plan

- [x] Replicated the CI check's exact comparison locally (`strip_pot` + `diff` against `HEAD`'s committed `.pot`, same as `compile_latest_and_test`'s script) — confirms the new file resolves the exact strings the real CI failure listed
- [x] Confirmed only `locales/wxMaxima/wxMaxima.pot` changed (`git status --short` after reverting the `.po` files)
- [ ] Full CI run on this PR, to confirm the check goes green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011iszcZR49S3QXrTKUQjiu6

---
_Generated by [Claude Code](https://claude.ai/code/session_011iszcZR49S3QXrTKUQjiu6)_